### PR TITLE
ci: make releases create a new PR instead of committing in main.

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,9 +30,14 @@ jobs:
           git config --local user.email "x@empathy.co"
           git config --local user.name "empathy/x"
       - name: Prepare the release
-        run: "npm run prepare-release:${{ github.event.inputs.kind }}"
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+        run: npm run prepare-release:${{ github.event.inputs.kind }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
         with:
-          github_token: ${{ secrets.SUPPORT_TOKEN }}
-          branch: ${{ github.ref }}
+          token: ${{ secrets.SUPPORT_TOKEN }}
+          commit-message: "chore(release): prepare ${{ github.event.inputs.kind }} release"
+          committer: Interface X <x@empathy.co>
+          title: ${{ github.event.inputs.kind }} release
+          body: Release preparation
+          branch: release
+          delete-branch: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,8 +1,11 @@
 name: Release a new version
 on:
-  workflow_dispatch:
+  pull_request:
+    types: [ closed ]
+    branches: [ main ]
 jobs:
   release:
+    if: github.event.pull_request.merged == true && github.head_ref == 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,8 +32,8 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish the release
-        run: 'npm run publish-release'
-      - name: Push changes
+        run: npm run publish-release
+      - name: Push tags
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.SUPPORT_TOKEN }}

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -1,9 +1,14 @@
-const { exec } = require('./utils');
+const { exec } = require("./utils");
 
-const [releaseKind = 'stable'] = process.argv.slice(2);
-const releaseKindArgument = releaseKind === 'alpha' ? '--conventional-prerelease' : '--conventional-graduate';
+execLernaVersion();
 
-[
-  `lerna version --conventional-commits --no-git-tag-version --yes ${ releaseKindArgument }`,
-  `git commit -m "chore(release): prepare ${releaseKind} release" -a`
-].forEach(exec);
+function execLernaVersion() {
+  const [releaseKind = "stable"] = process.argv.slice(2);
+  const releaseKindArgument =
+    releaseKind === "alpha"
+      ? "--conventional-prerelease"
+      : "--conventional-graduate";
+  exec(
+    `lerna version --conventional-commits --no-git-tag-version --yes ${releaseKindArgument}`
+  );
+}

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -1,14 +1,10 @@
-const { exec } = require("./utils");
+const { exec } = require('./utils');
 
 execLernaVersion();
 
 function execLernaVersion() {
-  const [releaseKind = "stable"] = process.argv.slice(2);
+  const [releaseKind = 'stable'] = process.argv.slice(2);
   const releaseKindArgument =
-    releaseKind === "alpha"
-      ? "--conventional-prerelease"
-      : "--conventional-graduate";
-  exec(
-    `lerna version --conventional-commits --no-git-tag-version --yes ${releaseKindArgument}`
-  );
+    releaseKind === 'alpha' ? '--conventional-prerelease' : '--conventional-graduate';
+  exec(`lerna version --conventional-commits --no-git-tag-version --yes ${releaseKindArgument}`);
 }

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -1,8 +1,12 @@
-const { exec } = require('./utils');
+const { exec } = require("./utils");
 
-const changedPackages = JSON.parse(exec('lerna changed --json'));
-exec(`lerna publish from-package --yes`);
-changedPackages.forEach(changed => {
-  const tag = `${ changed.name }@${ changed.version }`;
-  exec(`git tag -a ${tag} -m "${tag}"`);
-});
+addVersionTagForChangedPackages();
+
+function addVersionTagForChangedPackages() {
+  const changedPackages = JSON.parse(exec("lerna changed --json"));
+  exec(`lerna publish from-package --yes`);
+  changedPackages.forEach((changed) => {
+    const tag = `${changed.name}@${changed.version}`;
+    exec(`git tag -a ${tag} -m "${tag}"`);
+  });
+}

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -1,11 +1,11 @@
-const { exec } = require("./utils");
+const { exec } = require('./utils');
 
 addVersionTagForChangedPackages();
 
 function addVersionTagForChangedPackages() {
-  const changedPackages = JSON.parse(exec("lerna changed --json"));
+  const changedPackages = JSON.parse(exec('lerna changed --json'));
   exec(`lerna publish from-package --yes`);
-  changedPackages.forEach((changed) => {
+  changedPackages.forEach(changed => {
     const tag = `${changed.name}@${changed.version}`;
     exec(`git tag -a ${tag} -m "${tag}"`);
   });


### PR DESCRIPTION
# Pull Request Template #

Please include a summary of the change and which issue is fixed.

## Motivation and Context ##

After seeing today the proposed release flow we decided to improve it:

1. Manually trigger the `Prepare release` action. This will create a new PR bumping the needed packages versions, and updating its change-logs
2. Review the changes in that PR. If necessary, fix changelogs, version, whatever is needed.
3. When merging the PR (I suggest using the `squash` technique) the `Publish release` action will be automatically invoked.

## Type of change ##

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What is the destination branch of this PR? ##

The `main` branch

## How Has This Been Tested? ##

This flow has been tested at the [Lerna Repo Playground](https://github.com/javieri-empathy/lerna-repo/)

## Checklist: ##

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
