### PR TITLE
docs(related-tags): adapt to eDocs guidelines

### DIFF
--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -6,9 +6,9 @@
     :class="dynamicClasses"
   >
     <!--
-      @slot Related Tag content
-          @binding {RelatedTag} relatedTag - Related Tag data
-          @binding {boolean} isSelected - True if the related tag is selected. False otherwise.
+      @slot Custom content that replaces the RelatedTag default content.
+      @binding {RelatedTag} relatedTag - Related tag data.
+      @binding {boolean} isSelected - Related tag status.
       -->
     <slot v-bind="{ relatedTag, isSelected }">{{ relatedTag.tag }}</slot>
   </BaseEventButton>
@@ -26,7 +26,9 @@
   import { relatedTagsXModule } from '../x-module';
 
   /**
-   * Renders a related tag item which receives the related tag that will be rendered as a prop.
+   * This component renders a related tag for a query. A related tag is a descriptive keyword
+   * related to the current query to fine-tune the search. For example, if you are searching
+   * for *lego*, a related tag could be *city*, refining the search with *lego city*.
    *
    * @public
    */
@@ -36,7 +38,7 @@
   })
   export default class RelatedTag extends Vue {
     /**
-     * The related tag to render and use in the default slot.
+     * The related tag model data.
      *
      * @public
      */
@@ -45,16 +47,17 @@
     /**
      * The selected related tags.
      *
-     * @public
+     * @internal
      */
     @State('relatedTags', 'selectedRelatedTags')
     public selectedRelatedTags!: RelatedTagModel[];
+
     /**
-     * Events list which are going to be emitted when a related tag is selected.
+     * Events list which is going to be emitted when a related tag is selected.
      *
      * @returns The {@link XEvent | XEvents} to emit.
      *
-     * @public
+     * @internal
      */
     protected get events(): Partial<RelatedTagsXEvents> {
       return this.isSelected
@@ -67,12 +70,13 @@
             UserSelectedARelatedTag: this.relatedTag
           };
     }
+
     /**
      * Check if the related tag is selected or not.
      *
      * @returns If the related tag is selected.
      *
-     * @public
+     * @internal
      */
     protected get isSelected(): boolean {
       return this.selectedRelatedTags.includes(this.relatedTag);
@@ -83,7 +87,7 @@
      *
      * @returns The class to be added to the component.
      *
-     * @public
+     * @internal
      */
     protected get dynamicClasses(): VueCSSClasses {
       return {
@@ -97,46 +101,140 @@
 <style lang="scss" scoped>
   .x-related-tag {
     white-space: nowrap;
+
     &--is-selected {
       background: lightgrey;
     }
   }
 </style>
 
-<docs>
-  #Example
+<docs lang="mdx">
+## Dynamic classes
 
-  This components expects just a related tag as a prop to be rendered. It has a slot to override
-  the content. By default, it renders the tag of the related tag.
+`RelatedTag` uses the `x-related-tag--is-selected` dynamic CSS class so you can style it when is
+selected.
 
-  ## Basic Usage
+## Events
 
-  Using default slot:
-  ```vue
-  <RelatedTag :relatedTag="relatedTag"/>
-  ```
+This component emits the following events:
 
-  ## Overriding default slot .
+- [`UserDeselectedARelatedTag`](./../../api/x-components.relatedtagsxevents.md)
+- [`UserPickedARelatedTag`](./../../api/x-components.relatedtagsxevents.md)
+- [`UserSelectedARelatedTag`](./../../api/x-components.relatedtagsxevents.md)
 
-  The default slot allows you to replace the content of the related tag.
+## See it in action
 
-  ```vue
-  <RelatedTag :relatedTag="relatedTag">
-    <template #default="{ relatedTag }">
-      <img class="x-related-tag__icon" src="./related-tag.svg" />
-      <span class="x-related-tag__tag" :aria-label="relatedTag.tag">{{ relatedTag.tag }}</span>
-    </template>
+<!-- prettier-ignore-start -->
+:::warning Backend service required
+The QuerySignals microservice must be implemented.
+:::
+<!-- prettier-ignore-end -->
+
+In this example related tag data is passed as a prop.
+
+_Here you can see how the RelatedTag component is rendered._
+
+```vue
+<template>
+  <RelatedTag :relatedTag="tag"></RelatedTag>
+</template>
+
+<script>
+  import { RelatedTag } from '@empathyco/x-components/related-tags';
+
+  export default {
+    name: 'RelatedTagDemo',
+    components: {
+      RelatedTag
+    },
+    data() {
+      return {
+        tag: {
+          modelName: 'RelatedTag',
+          previous: 'toy',
+          query: 'toy story',
+          selected: false,
+          tag: 'story'
+        }
+      };
+    }
+  };
+</script>
+```
+
+### Play with default slot
+
+In this example, an HTML span element is passed in the `default` slot.
+
+_See how the related tag can be rendered._
+
+```vue
+<template>
+  <RelatedTag :relatedTag="tag" #default="{ relatedTag }">
+    <span :aria-label="relatedTag.tag">{{ relatedTag.tag }}</span>
   </RelatedTag>
-  ```
+</template>
 
-  ## Events
+<script>
+  import { RelatedTag } from '@empathyco/x-components/related-tags';
 
-  A list of events that the component will emit:
+  export default {
+    name: 'RelatedTagDemo',
+    components: {
+      RelatedTag
+    },
+    data() {
+      return {
+        tag: {
+          modelName: 'RelatedTag',
+          previous: 'toy',
+          query: 'toy story',
+          selected: false,
+          tag: 'story'
+        }
+      };
+    }
+  };
+</script>
+```
 
-  - `UserPickedARelatedTag`: the event is emitted after the user clicks the button. The event
-  payload is the related tag data.
-  - `UserSelectedARelatedTag`: the event is emitted after the user clicks the button and if the
-  state is not selected. The event payload is the related tag data.
-  - `UserDeselectedARelatedTag`: the event is emitted after the user clicks the button and if the
-  state is selected. The event payload is the related tag data.
+### Play with events
+
+In this example, the [`UserSelectedARelatedTag`](./../../api/x-components.relatedtagsxevents.md)
+event is implemented, as illustrated by the “Tag” message returned.
+
+_See how the event is triggered when the related tag is clicked._
+
+```vue
+<template>
+  <RelatedTag :relatedTag="tag" @UserSelectedARelatedTag="alertRelatedTag"></RelatedTag>
+</template>
+
+<script>
+  import { RelatedTag } from '@empathyco/x-components/related-tags';
+
+  export default {
+    name: 'RelatedTagDemo',
+    components: {
+      RelatedTag
+    },
+    data() {
+      return {
+        tag: {
+          modelName: 'RelatedTag',
+          previous: 'toy',
+          query: 'toy story',
+          selected: false,
+          tag: 'story'
+        }
+      };
+    },
+    methods: {
+      alertRelatedTag(relatedTag) {
+        alert(`You have clicked the related tag: ${relatedTag.query}`);
+      }
+    }
+  };
+</script>
+```
 </docs>

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -42,6 +42,7 @@
   import RelatedTag from './related-tag.vue';
 
   /**
+   * Simple related-tags component that renders a list of related tags.
    * For example, if you are searching for *lego*, different related tags could be *city*,
    * *friends*, or *harry potter*, refining the search with *lego city*, *lego friends*,
    * or *lego harry potter*.

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -156,7 +156,7 @@ _Search for a toy and press Enter to see the related tags with the animation eff
 
 ### Play with related-tag slot
 
-In this example, the [`RelatedTag`](../related-tags/related-tag.md) component is passed in the
+In this example, the [`RelatedTag`](./x-components.related-tag.md) component is passed in the
 `related-tag` slot (although any other component could potentially be passed).
 
 _Search for a toy and see how the related tags can be rendered._
@@ -221,7 +221,7 @@ _Search for a toy and see how the related tags are rendered._
 ## Extending the component
 
 Components can be combined and communicate with each other. The `RelatedTags` component can
-communicate with the [`SearchInput`](../search-box/search-input.md) as follows:
+communicate with the [`SearchInput`](../search-box/x-components.search-input.md) as follows:
 
 _Search for a toy and see how the related tags can be rendered._
 

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -123,7 +123,7 @@ _Search for a toy and press enter._
 ### Play with props
 
 In this example, the number of related tags rendered has been limited to 3. A fade and slide effect
-has been added so that the related tags appear with a delay, then slide upwards and fade
+has been added so that the related tags appear with a delay, then slide upwards and fade.
 
 _Search for a toy and press Enter to see the related tags with the animation effect._
 

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -42,7 +42,7 @@
   import RelatedTag from './related-tag.vue';
 
   /**
-   * Simple related-tags component that renders a list of related tags.
+   * Simple `RelatedTags` component that renders a list of related tags.
    * For example, if you are searching for *lego*, different related tags could be *city*,
    * *friends*, or *harry potter*, refining the search with *lego city*, *lego friends*,
    * or *lego harry potter*.

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -42,7 +42,8 @@
   import RelatedTag from './related-tag.vue';
 
   /**
-   * Simple `RelatedTags` component that renders a list of related tags.
+   * This component renders a set of [`RelatedTag`](./x-components.related-tag) components by
+   * default to select from after a query is performed to fine-tune search.
    * For example, if you are searching for *lego*, different related tags could be *city*,
    * *friends*, or *harry potter*, refining the search with *lego city*, *lego friends*,
    * or *lego harry potter*.

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -13,17 +13,16 @@
       data-test="related-tag-item"
     >
       <!--
-        @slot Related Tag item
-            @binding {RelatedTag} relatedTag - Related Tag data
+        @slot Custom content that replaces the RelatedTag component.
+        @binding {RelatedTag} relatedTag - Related tag data.
        -->
       <slot name="related-tag" :relatedTag="relatedTag">
         <RelatedTag :relatedTag="relatedTag">
           <template #default="{ relatedTag, isSelected }">
             <!--
-              @slot Related Tag content
-                  @binding {RelatedTag} relatedTag - Related Tag data
-                  @binding {boolean} isSelected - True if the related tag is selected.
-                  False otherwise.
+              @slot Custom content that replaces the RelatedTag default content.
+              @binding {RelatedTag} relatedTag - Related tag data.
+              @binding {boolean} isSelected - Related tag status.
             -->
             <slot name="related-tag-content" v-bind="{ relatedTag, isSelected }" />
           </template>
@@ -43,12 +42,9 @@
   import RelatedTag from './related-tag.vue';
 
   /**
-   * Simple related-tags component that renders a list of related tags.
-   *
-   * @remarks
-   * A related tag is just a tag related with the previous query refining it.
-   * I.e. If you are searching for `lego`, a related tag could be `city` and this refine the search
-   * with this new tag, 'lego city'.
+   * For example, if you are searching for *lego*, different related tags could be *city*,
+   * *friends*, or *harry potter*, refining the search with *lego city*, *lego friends*,
+   * or *lego harry potter*.
    *
    * @public
    */
@@ -89,58 +85,166 @@
   }
 </style>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+## See it in action
 
-  ## Basic example
+<!-- prettier-ignore-start -->
+:::warning Backend microservice required
+To use this component, the QuerySignals microservice must be implemented.
+:::
+<!-- prettier-ignore-end -->
 
-  You don't need to pass any props, or slots. Simply add the component, and when it has any related
-  tags it will show them
+This example shows how related tags can be rendered without any additional effects.
 
-  ```vue
-  <RelatedTags />
-  ```
+_Search for a toy and press enter._
 
-  ## Overriding Related Tag's Content
+```vue
+<template>
+  <div>
+    <SearchInput></SearchInput>
+    <RelatedTags></RelatedTags>
+  </div>
+</template>
 
-  You can use your custom implementation of the Related Tag's content.
-  In the example below, instead of using the default Related Tag's content, an icon
-  is added, as well as a span with the query of the Related Tag.
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { RelatedTags } from '@empathyco/x-components/related-tags';
 
-  ```vue
-  <RelatedTags>
-    <template #related-tag-content="{relatedTag}">
-      <img src="./related-tag-icon.svg" class="x-related-tag__icon"/>
-      <span class="x-related-tag__tag">{{ relatedTag.tag }}</span>
-    </template>
-  </RelatedTags>
-  ```
+  export default {
+    name: 'RelatedTagsDemo',
+    components: {
+      SearchInput,
+      RelatedTags
+    }
+  };
+</script>
+```
 
-  ## Adding a custom related tag component
+### Play with props
 
-  You can use your custom implementation of a Related Tag component.
-  In the example below, instead of using the default `button` tag for a Related Tag, an icon is
-  added, and the text of the related tag is wrapped in a `span`
+In this example, the number of related tags rendered has been limited to 3. A fade and slide effect
+has been added so that the related tags appear with a delay, then slide upwards and fade
 
-  ```vue
-  <RelatedTags>
-    <template #related-tag="{relatedTag}">
-      <RelatedTag :relatedTag="relatedTag">
-        <template #default>
-          <img src="./related-tag-icon.svg" class="x-related-tag__icon"/>
-          <span class="x-related-tag__tag">{{ relatedTag.tag }}</span>
-        </template>
-      </RelatedTag>
-      <button>Custom Behaviour</button>
-    </template>
-  </RelatedTags>
-  ```
+_Search for a toy and press Enter to see the related tags with the animation effect._
 
-  ## Limiting the number of rendered related tags
+```vue
+<template>
+  <div>
+    <SearchInput></SearchInput>
+    <RelatedTags animation="StaggeredFadeAndSlide" :maxItemsToRender="3"></RelatedTags>
+  </div>
+</template>
 
-  You can render a maximum number of related tags rendered.
+<script>
+  import Vue from 'vue';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { RelatedTags } from '@empathyco/x-components/related-tags';
+  import { StaggeredFadeAndSlide } from '@empathyco/x-components';
 
-  ```vue
-  <RelatedTags maxItemsToRender="3" />
-  ```
+  Vue.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide);
+  export default {
+    name: 'RelatedTagsDemo',
+    components: {
+      SearchInput,
+      RelatedTags
+    }
+  };
+</script>
+```
+
+### Play with related-tag slot
+
+In this example, the [`RelatedTag`](../related-tags/related-tag.md) component is passed in the
+`related-tag` slot (although any other component could potentially be passed).
+
+_Search for a toy and see how the related tags can be rendered._
+
+```vue
+<template>
+  <div>
+    <SearchInput></SearchInput>
+    <RelatedTags #related-tag="{ relatedTag }">
+      <RelatedTag :relatedTag="relatedTag"></RelatedTag>
+    </RelatedTags>
+  </div>
+</template>
+
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { RelatedTags, RelatedTag } from '@empathyco/x-components/related-tags';
+
+  export default {
+    name: 'RelatedTagsDemo',
+    components: {
+      SearchInput,
+      RelatedTags,
+      RelatedTag
+    }
+  };
+</script>
+```
+
+### Play with related-tag-content slot
+
+To continue the previous example, the [`RelatedTag`](./x-components.related-tag.md) component is
+passed in the `related-tag-content` slot, but in addition, an HTML span tag for the text are also
+passed.
+
+_Search for a toy and see how the related tags are rendered._
+
+```vue
+<template>
+  <div>
+    <SearchInput></SearchInput>
+    <RelatedTags #related-tag-content="{ relatedTag }">
+      <span>{{ relatedTag.tag }}</span>
+    </RelatedTags>
+  </div>
+</template>
+
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { RelatedTags } from '@empathyco/x-components/related-tags';
+
+  export default {
+    name: 'RelatedTagsDemo',
+    components: {
+      SearchInput,
+      RelatedTags
+    }
+  };
+</script>
+```
+
+## Extending the component
+
+Components can be combined and communicate with each other. The `RelatedTags` component can
+communicate with the [`SearchInput`](../search-box/search-input.md) as follows:
+
+_Search for a toy and see how the related tags can be rendered._
+
+```vue
+<template>
+  <div>
+    <SearchInput></SearchInput>
+    <RelatedTags></RelatedTags>
+    <ResultsList></ResultsList>
+  </div>
+</template>
+
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { RelatedTags } from '@empathyco/x-components/related-tags';
+  import { ResultsList } from '@empathyco/x-components/search';
+
+  export default {
+    name: 'RelatedTagsDemo',
+    components: {
+      SearchInput,
+      RelatedTags,
+      ResultsList
+    }
+  };
+</script>
+```
 </docs>


### PR DESCRIPTION
Description
Use new structure and content agreed with Edocs (https://hackmd.io/team/empathy-docs?nav=overview)

I changed links to fit the x-components repository

every method is now internal so it is only visible in the code.

change examples

Context
This will prevent conflicts in the future migration to the Empathy Docs portal.

Test
See if there is something missing https://hackmd.io/team/empathy-docs?nav=overview

Check markdowns generated by build step