### PR TITLE
fix(animations): disable `StaggeringTransitionGroup` leaving elements listening to click events

### DIFF
--- a/packages/x-components/src/components/__tests__/staggering-transition-group.spec.ts
+++ b/packages/x-components/src/components/__tests__/staggering-transition-group.spec.ts
@@ -117,6 +117,23 @@ describe('testing Staggering Transition Group component', () => {
     });
   });
 
+  it('disables pointer-events when a node leaves.', async () => {
+    const staggering = 100;
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const { getChildren, setChildren } = renderStaggeringTransitionGroup({
+      appear: false,
+      children: [1, 2, 3],
+      staggering
+    });
+    setChildren([]);
+    await Vue.nextTick();
+    const childrenWrapper = getChildren();
+    expect(childrenWrapper).toHaveLength(3);
+    childrenWrapper.wrappers.forEach(child => {
+      expect(child.element.style.pointerEvents).toEqual('none');
+    });
+  });
+
   it(
     'applies enter classes when a new element enters and one element stay in ' +
       'same position after doing a search',

--- a/packages/x-components/src/components/staggering-transition-group.vue
+++ b/packages/x-components/src/components/staggering-transition-group.vue
@@ -153,7 +153,10 @@
       this.newChildren.forEach(this.recordNewPosition);
       const { leavingNodes, stayingNodes, enteringNodes } = this.getNodesByTransitionType();
 
-      leavingNodes.forEach(this.applyStagger);
+      leavingNodes.forEach(vNode => {
+        this.applyStagger(vNode);
+        this.disableClickingEvents(vNode);
+      });
       const movedChildren = stayingNodes.filter(this.applyTranslation);
       const movedStagger = movedChildren.map(this.getNextTransitionDelay);
       enteringNodes.forEach(this.applyStagger);
@@ -316,6 +319,19 @@
      */
     protected applyStagger(vNode: TransitionVNode): void {
       vNode.elm.style.transitionDelay = this.getNextTransitionDelay();
+    }
+
+    /**
+     * Disables listening to click events in a virtual node element.
+     *
+     * @remarks This is done to avoid letting the user click elements that are performing the moving
+     * animation to leave the DOM but are still rendered.
+     *
+     * @param vNode - The virtual node to disable listening to click events.
+     * @internal
+     */
+    protected disableClickingEvents(vNode: TransitionVNode): void {
+      vNode.elm.style.pointerEvents = 'none';
     }
 
     /**


### PR DESCRIPTION
EX-4504

## Motivation and Context ##

This solves an issue detected in `Kroger` where, clicking on multiple `related tags` too fast, the user could have more than one `related tag` selected but only the first one is being used to refine the query. 

## Type of change ##

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##

I've included a new unit test. It can also be tested in any of our views, for example, in the `Layout` view, adding the `StaggeringFadeAndSlide`  animation to the `RelatedTags` component.

## Checklist: ##

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
