### PR TITLE
Feature/ex 3546 as a developer user i want to be

### DIFF
--- a/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
+++ b/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
@@ -123,7 +123,7 @@ describe('testing BaseCurrency component', () => {
       template: '<div><slot /></div>'
     })
     class Provider extends Vue {
-      @XProvide('currency')
+      @XProvide('currencyFormat')
       public providedFormat = '$i,iii.ddd';
     }
 

--- a/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
+++ b/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
@@ -99,8 +99,8 @@ describe('testing BaseCurrency component', () => {
   });
 
   it(
-    'renders the provided format correctly filling decimals with non-significant zeros and' +
-      ' hideIntegerDecimals as false',
+    'renders the provided format correctly filling decimals with non-significant zeros for an' +
+      'integer',
     () => {
       const wrapper = renderBaseCurrency({
         value: 12345678,
@@ -123,7 +123,7 @@ describe('testing BaseCurrency component', () => {
       template: '<div><slot /></div>'
     })
     class Provider extends Vue {
-      @XProvide('format')
+      @XProvide('currency')
       public providedFormat = '$i,iii.ddd';
     }
 

--- a/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
+++ b/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
@@ -1,26 +1,23 @@
 import { mount, Wrapper } from '@vue/test-utils';
+import Component from 'vue-class-component';
+import Vue from 'vue';
 import BaseCurrency from '../base-currency.vue';
+import { XProvide } from '../../decorators/injection.decorators';
 
-function renderBaseCurrency({
-  value,
-  format,
-  hideIntegerDecimals
-}: RenderBaseCurrencyOptions): Wrapper<BaseCurrency> {
+function renderBaseCurrency({ value, format }: RenderBaseCurrencyOptions): Wrapper<BaseCurrency> {
   return mount(BaseCurrency, {
     propsData: {
       value,
-      format,
-      hideIntegerDecimals
+      format
     }
   });
 }
 
 describe('testing BaseCurrency component', () => {
-  it('renders the provided format correctly with hideIntegerDecimals set as true', () => {
+  it('renders the provided format correctly with "?" (hideIntegerDecimals) in the format', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678,
-      format: 'i.iii,ddd €',
-      hideIntegerDecimals: true
+      format: 'i.iii,?ddd €'
     });
     expect(wrapper.text()).toEqual('12.345.678 €');
   });
@@ -28,8 +25,7 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided currency at the start of the format', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87654321,
-      format: '$ i.iii,dd',
-      hideIntegerDecimals: false
+      format: '$ i.iii,dd'
     });
     expect(wrapper.text()).toEqual('$ 12.345.678,87');
   });
@@ -37,8 +33,7 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided currency at the start of the format without space', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87654321,
-      format: '$i.iii,dd',
-      hideIntegerDecimals: false
+      format: '$i.iii,dd'
     });
     expect(wrapper.text()).toEqual('$12.345.678,87');
   });
@@ -46,8 +41,7 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided currency at the end of the format', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87654321,
-      format: 'i.iii,dd €',
-      hideIntegerDecimals: false
+      format: 'i.iii,dd €'
     });
     expect(wrapper.text()).toEqual('12.345.678,87 €');
   });
@@ -55,8 +49,7 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided currency at the end of the format without space', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87654321,
-      format: 'i.iii,dd€',
-      hideIntegerDecimals: false
+      format: 'i.iii,dd€'
     });
     expect(wrapper.text()).toEqual('12.345.678,87€');
   });
@@ -64,8 +57,7 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided format with comma for thousands and dot for decimals', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87654321,
-      format: 'i,iii.dd €',
-      hideIntegerDecimals: false
+      format: 'i,iii.dd €'
     });
     expect(wrapper.text()).toEqual('12,345,678.87 €');
   });
@@ -73,8 +65,7 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided format with spaces for thousands separators', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87654321,
-      format: 'i iii.dd €',
-      hideIntegerDecimals: false
+      format: 'i iii.dd €'
     });
     expect(wrapper.text()).toEqual('12 345 678.87 €');
   });
@@ -85,8 +76,7 @@ describe('testing BaseCurrency component', () => {
     () => {
       const wrapper = renderBaseCurrency({
         value: 12345678.87654321,
-        format: 'i iii - dd €',
-        hideIntegerDecimals: false
+        format: 'i iii - dd €'
       });
       expect(wrapper.text()).toEqual('12 345 678 - 87 €');
     }
@@ -95,8 +85,7 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided format correctly with a larger number of decimals', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87654321,
-      format: 'i.iii,dddddd €',
-      hideIntegerDecimals: false
+      format: 'i.iii,dddddd €'
     });
     expect(wrapper.text()).toEqual('12.345.678,876543 €');
   });
@@ -104,8 +93,7 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided format correctly filling decimals with non-significant zeros', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87,
-      format: 'i.iii,dddddd €',
-      hideIntegerDecimals: false
+      format: 'i.iii,dddddd €'
     });
     expect(wrapper.text()).toEqual('12.345.678,870000 €');
   });
@@ -116,8 +104,7 @@ describe('testing BaseCurrency component', () => {
     () => {
       const wrapper = renderBaseCurrency({
         value: 12345678,
-        format: 'i.iii,dddddd €',
-        hideIntegerDecimals: false
+        format: 'i.iii,dddddd €'
       });
       expect(wrapper.text()).toEqual('12.345.678,000000 €');
     }
@@ -126,15 +113,46 @@ describe('testing BaseCurrency component', () => {
   it('renders the provided format correctly which only contains integer part', () => {
     const wrapper = renderBaseCurrency({
       value: 12345678.87654321,
-      format: 'i.iii €',
-      hideIntegerDecimals: false
+      format: 'i.iii €'
     });
     expect(wrapper.text()).toEqual('12.345.678 €');
+  });
+
+  it('renders the injected format', () => {
+    @Component({
+      template: '<div><slot /></div>'
+    })
+    class Provider extends Vue {
+      @XProvide('format')
+      public providedFormat = '$i,iii.ddd';
+    }
+
+    const wrapper = mount(
+      {
+        template: `
+          <Provider>
+            <BaseCurrency :value="value" />
+          </Provider>
+        `,
+        components: {
+          Provider,
+          BaseCurrency
+        }
+      },
+      {
+        data: function () {
+          return {
+            value: 12345678.87654321
+          };
+        }
+      }
+    );
+
+    expect(wrapper.text()).toBe('$12,345,678.876');
   });
 });
 
 interface RenderBaseCurrencyOptions {
   value: number;
   format: string;
-  hideIntegerDecimals: boolean;
 }

--- a/packages/x-components/src/components/currency/base-currency.vue
+++ b/packages/x-components/src/components/currency/base-currency.vue
@@ -71,7 +71,7 @@
      *
      * @public
      */
-    @XInject('format')
+    @XInject('currency')
     public injectedFormat!: string;
 
     /**

--- a/packages/x-components/src/components/currency/base-currency.vue
+++ b/packages/x-components/src/components/currency/base-currency.vue
@@ -6,11 +6,28 @@
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
   import { currencyFormatter } from '../../utils/currency-formatter';
+  import { XInject } from '../decorators/injection.decorators';
 
   /**
-   * Renders the value received as a property, which always must be a JavaScript number, with the
-   * proper format provided as string property. The rendered tag is a span in order to render a
-   * default inline HTML element.
+   * Renders the value received as a property which always must be a JavaScript number, with the
+   * proper format provided as string property or by injection. The rendered tag is a span in order
+   * to render a default inline HTML element.
+   *
+   * Regarding the format or mask to be defined as string:
+   * - Use 'i' to define integer numbers.
+   * - Use 'd' to define decimal numbers. You can define the length of the decimal part. If the
+   * doesn't include decimals, it is filled with zeros until reach the length defined with 'd's.
+   * - Integer separator must be defined between the 3rd and the 4th integer 'i' of a group.
+   * - Decimal separator must be defined between the last 'i' and the first 'd'. It can be more
+   * than one character.
+   * - If you want to hide the decimal part if it's zero, you can add the `?` symbol after the
+   * decimal separator (e.g. 'i.iii,?dd', for `1234` you would get `1.234` instead of `1.234,00`).
+   * - Set whatever you need around the integers and decimals marks.
+   * - Default mask: 'i.iii,dd' which returns '1.345,67'.
+   *
+   * @remarks The number of 'd', which is the maximum decimal length, MUST match with the length
+   * of decimals provided from the adapter. Otherwise, when the component truncate the decimal
+   * part, delete significant digits.
    *
    * @example
    * Basic example:
@@ -42,35 +59,37 @@
     protected value!: number;
 
     /**
-     * Format or mask to be defined as string.
-     * - Use 'i' to define integer numbers.
-     * - Use 'd' to define decimal numbers. You can define the length of the decimal part. If the
-     * doesn't include decimals, it is filled with zeros until reach the length defined with 'd's.
-     * - Integer separator must be defined between the 3rd and the 4th integer 'i' of a group.
-     * - Decimal separator must be defined between the last 'i' and the first 'd'. It can be more
-     * than one character.
-     * - Set whatever you need around the integers and decimals marks.
-     * - Default mask: 'i.iii,dd' which returns '1.345,67'.
-     *
-     * @remarks The number of 'd', which is the maximum decimal length, MUST match with the length
-     * of decimals provided from the adapter. Otherwise, when the component truncate the decimal
-     * part, delete significant digits.
+     * The format as string.
      *
      * @public
      */
-    @Prop({ default: 'i.iii,dd' })
-    protected format!: string;
+    @Prop()
+    protected format?: string;
 
     /**
-     * If true and the value is an integer without decimals, the decimal part is hidden including
-     * the decimal separator.
-     * If false, the default behaviour will fill with zeros the remaining length until getting
-     * the one defined with the 'd's.
+     * The injected format as string.
      *
      * @public
      */
-    @Prop({ default: false })
-    protected hideIntegerDecimals!: boolean;
+    @XInject('format')
+    public injectedFormat!: string;
+
+    /**
+     * A format which can be passed through prop or injected.
+     *
+     * @returns A format as string.
+     *
+     * @internal
+     */
+    protected get renderedFormat(): string {
+      return (
+        this.format ??
+        this.injectedFormat ??
+        //TODO: add here logger
+        //eslint-disable-next-line no-console
+        console.warn('It is necessary to pass a prop or inject the format')
+      );
+    }
 
     /**
      * Returns the formatted result as string.
@@ -80,7 +99,7 @@
      * @internal
      */
     protected get currency(): string {
-      return currencyFormatter(this.value, this.format, this.hideIntegerDecimals);
+      return currencyFormatter(this.value, this.renderedFormat);
     }
   }
 </script>
@@ -97,33 +116,33 @@ HTML element.
 ### Example
 
 ```vue
-<BaseCurrency :value="12345678.87654321" format="i.iii,ddd €" :hide-integer-decimals="true" />
+<BaseCurrency :value="12345678.87654321" format="i.iii,?ddd €" />
 <!-- output: '12.345.678,876 €' -->
-<BaseCurrency :value="12345678" format="i.iii,ddd €" :hide-integer-decimals="true" />
+<BaseCurrency :value="12345678" format="i.iii,?ddd €" />
 <!-- output: '12.345.678 €' -->
-<BaseCurrency :value="12345678.87654321" format="$ i.iii,dd" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="$ i.iii,dd" />
 <!-- output: '$ 12.345.678,87' -->
-<BaseCurrency :value="12345678.87654321" format="$i.iii,dd" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="$i.iii,dd" />
 <!-- output: '$12.345.678,87' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,dd €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="i.iii,dd €" />
 <!-- output: '12.345.678,87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,dd€" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="i.iii,dd€" />
 <!-- output: '12.345.678,87€' -->
-<BaseCurrency :value="12345678.87654321" format="i,iii.dd €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="i,iii.dd €" />
 <!-- output: '12,345,678.87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i iii.dd €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="i iii.dd €" />
 <!-- output: '12 345 678.87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i iii - dd €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="i iii - dd €" />
 <!-- output: '12 345 678 - 87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,dddddd €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="i.iii,dddddd €" />
 <!-- output: '12.345.678,876543 €' -->
-<BaseCurrency :value="12345678.87" format="i.iii,dddddd €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87" format="i.iii,dddddd €" />
 <!-- output: '12.345.678,870000 €' -->
-<BaseCurrency :value="12345678" format="i.iii,dddddd €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678" format="i.iii,dddddd €" />
 <!-- output: '12.345.678,000000 €' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,dd €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="i.iii,dd €" />
 <!-- output: '12.345.678,87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii €" :hide-integer-decimals="false" />
+<BaseCurrency :value="12345678.87654321" format="i.iii €" />
 <!-- output: '12.345.678 €' -->
 ```
 </docs>

--- a/packages/x-components/src/components/currency/base-currency.vue
+++ b/packages/x-components/src/components/currency/base-currency.vue
@@ -71,7 +71,7 @@
      *
      * @public
      */
-    @XInject('currency')
+    @XInject('currencyFormat')
     public injectedFormat!: string;
 
     /**

--- a/packages/x-components/src/components/filters/labels/__tests__/base-price-label.spec.ts
+++ b/packages/x-components/src/components/filters/labels/__tests__/base-price-label.spec.ts
@@ -5,7 +5,6 @@ import BasePriceFilterLabel from '../base-price-filter-label.vue';
 
 function renderBasePriceLabel({
   filter,
-  hideIntegerDecimals,
   format,
   lessThan = 'Less than {max}',
   from = 'More than {min}',
@@ -14,7 +13,6 @@ function renderBasePriceLabel({
   return mount(BasePriceFilterLabel, {
     propsData: {
       filter,
-      hideIntegerDecimals,
       format,
       lessThan,
       from,
@@ -37,8 +35,7 @@ describe('testing BasePriceLabel component', () => {
     const filter = getNumberRangeFilterStub({ range: { min: 0, max: 10 } });
     const wrapper = renderBasePriceLabel({
       filter,
-      format: 'i,dd €',
-      hideIntegerDecimals: false
+      format: 'i,dd €'
     });
     expect(wrapper.text()).toEqual('From 0,00 € to 10,00 €');
   });
@@ -59,7 +56,6 @@ describe('testing BasePriceLabel component', () => {
 interface RenderBasePriceLabelOptions {
   filter: NumberRangeFilter;
   format?: string;
-  hideIntegerDecimals?: boolean;
   lessThan?: string;
   fromTo?: string;
   from?: string;

--- a/packages/x-components/src/components/filters/labels/__tests__/base-price-label.spec.ts
+++ b/packages/x-components/src/components/filters/labels/__tests__/base-price-label.spec.ts
@@ -28,8 +28,7 @@ describe('testing BasePriceLabel component', () => {
     const filter = getNumberRangeFilterStub({ range: { min: null, max: 10 } });
     const wrapper = renderBasePriceLabel({
       filter,
-      format: '$i.dd',
-      hideIntegerDecimals: true
+      format: '$i,iii'
     });
     expect(wrapper.text()).toEqual('Less than $10');
   });

--- a/packages/x-components/src/components/filters/labels/base-price-filter-label.vue
+++ b/packages/x-components/src/components/filters/labels/base-price-filter-label.vue
@@ -22,9 +22,6 @@
     @Prop()
     public format?: string;
 
-    @Prop()
-    public hideIntegerDecimals?: boolean;
-
     /**
      * Message shown when the filter hasn't got the min value defined.
      *
@@ -72,7 +69,6 @@
             props: {
               value: this.filter.range.min,
               format: this.format,
-              hideIntegerDecimals: this.hideIntegerDecimals
             }
           });
         } else if (partMessage === '{max}') {
@@ -80,7 +76,6 @@
             props: {
               value: this.filter.range.max,
               format: this.format,
-              hideIntegerDecimals: this.hideIntegerDecimals
             }
           });
         }

--- a/packages/x-components/src/components/result/__tests__/base-result-current-price.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-current-price.spec.ts
@@ -15,9 +15,8 @@ const mockedResult: Pick<Result, 'price'> = {
 
 function renderBaseCurrentPrice({
   format = 'i,iii.dd',
-  hideIntegerDecimals = false,
   // eslint-disable-next-line max-len
-  template = `<BaseResultCurrentPrice :result="result" :format="format" :hideIntegerDecimals="hideIntegerDecimals" />`,
+  template = `<BaseResultCurrentPrice :result="result" :format="format" />`,
   result = mockedResult
 }: RenderBaseCurrentPriceOptions = {}): RenderBaseCurrentPriceAPI {
   const wrapperComponent: ComponentOptions<Vue> = {
@@ -31,7 +30,6 @@ function renderBaseCurrentPrice({
   const wrapper = mount(wrapperComponent, {
     propsData: {
       format,
-      hideIntegerDecimals,
       result
     }
   });
@@ -57,7 +55,7 @@ describe('testing BaseCurrentPrice component', () => {
 
   it('renders the current price hiding integer decimals', () => {
     const { wrapper } = renderBaseCurrentPrice({
-      hideIntegerDecimals: true
+      format: 'i,iii'
     });
 
     expect(wrapper.text()).toBe('19');
@@ -100,8 +98,6 @@ describe('testing BaseCurrentPrice component', () => {
 interface RenderBaseCurrentPriceOptions {
   /** The format to apply to the value. */
   format?: string;
-  /** Hide or show decimals. */
-  hideIntegerDecimals?: boolean;
   /** The result with the price to display. */
   result?: Pick<Result, 'price'>;
   /** The template to render. Receives the 'result', 'format' and 'hideIntegerDecimals' props and

--- a/packages/x-components/src/components/result/__tests__/base-result-current-price.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-current-price.spec.ts
@@ -15,7 +15,6 @@ const mockedResult: Pick<Result, 'price'> = {
 
 function renderBaseCurrentPrice({
   format = 'i,iii.dd',
-  // eslint-disable-next-line max-len
   template = `<BaseResultCurrentPrice :result="result" :format="format" />`,
   result = mockedResult
 }: RenderBaseCurrentPriceOptions = {}): RenderBaseCurrentPriceAPI {
@@ -24,7 +23,7 @@ function renderBaseCurrentPrice({
     components: {
       BaseResultCurrentPrice
     },
-    props: ['format', 'hideIntegerDecimals', 'result']
+    props: ['format', 'result']
   };
 
   const wrapper = mount(wrapperComponent, {
@@ -100,7 +99,7 @@ interface RenderBaseCurrentPriceOptions {
   format?: string;
   /** The result with the price to display. */
   result?: Pick<Result, 'price'>;
-  /** The template to render. Receives the 'result', 'format' and 'hideIntegerDecimals' props and
+  /** The template to render. Receives the 'result', 'format' props and
    * has registered a {@link BaseCurrency | BaseCurrency component}. */
   template?: string;
 }

--- a/packages/x-components/src/components/result/__tests__/base-result-previous-price.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-previous-price.spec.ts
@@ -57,7 +57,7 @@ describe('testing BaseResultPreviousPrice component', () => {
 
   it('renders the previous price hiding integer decimals', () => {
     const { wrapper } = renderBasePreviousPrice({
-      hideIntegerDecimals: true
+      format: 'i.iii'
     });
 
     expect(wrapper.text()).toBe('29');

--- a/packages/x-components/src/components/result/base-result-current-price.vue
+++ b/packages/x-components/src/components/result/base-result-current-price.vue
@@ -8,7 +8,6 @@
       <BaseCurrency
         :value="result.price.value"
         :format="format"
-        :hideIntegerDecimals="hideIntegerDecimals"
       />
     </slot>
   </div>
@@ -56,19 +55,8 @@
      *
      * @public
      */
-    @Prop({ default: 'i.iii,dd' })
-    protected format!: string;
-
-    /**
-     * If true and the value is an integer without decimals, the decimal part is hidden including
-     * the decimal separator.
-     * If false, the default behaviour will fill with zeros the remaining length until getting
-     * the one defined with the 'd's.
-     *
-     * @public
-     */
-    @Prop({ default: false })
-    protected hideIntegerDecimals!: boolean;
+    @Prop()
+    protected format?: string;
 
     /**
      * Dynamic CSS classes to add to the root element of this component.
@@ -90,15 +78,14 @@
 
   ## Basic example
 
-  This component shows the current price formatted. The component has two
-  optional props. `format` to select the currency format to be applied and
-  `hideIntegerDecimals` to hide or not the decimal part.
+  This component shows the current price formatted. You can provide the `format` by property or let
+  the `BaseCurrency` component use an injected one.
 
   ```vue
   <BaseResultCurrentPrice
     :value="result"
     :format="'i.iii,ddd €'"
-    :hideIntegerDecimals="true" />
+  />
   ```
 
   ## Overriding default slot

--- a/packages/x-components/src/components/result/base-result-previous-price.vue
+++ b/packages/x-components/src/components/result/base-result-previous-price.vue
@@ -12,7 +12,6 @@
       <BaseCurrency
         :value="result.price.originalValue"
         :format="format"
-        :hideIntegerDecimals="hideIntegerDecimals"
       />
     </slot>
   </div>
@@ -60,17 +59,6 @@
      */
     @Prop({ default: 'i.iii,dd' })
     protected format!: string;
-
-    /**
-     * If true and the value is an integer without decimals, the decimal part is hidden including
-     * the decimal separator.
-     * If false, the default behaviour will fill with zeros the remaining length until getting
-     * the one defined with the 'd's.
-     *
-     * @public
-     */
-    @Prop({ default: false })
-    protected hideIntegerDecimals!: boolean;
   }
 </script>
 
@@ -80,14 +68,13 @@
   ## Basic example
 
   This component shows the previous price formatted if it has discount. The component has two
-  optional props. `format` to select the currency format to be applied and
-  `hideIntegerDecimals` to hide or not the decimal part.
+  optional props. `format` to select the currency format to be applied.
 
   ```vue
   <BaseResultPreviousPrice
     :value="result"
     :format="'i.iii,ddd €'"
-    :hideIntegerDecimals="true" />
+  />
   ```
   ## Overriding default slot
   ```vue

--- a/packages/x-components/src/utils/__tests__/currency-formatter.spec.ts
+++ b/packages/x-components/src/utils/__tests__/currency-formatter.spec.ts
@@ -25,8 +25,14 @@ describe('testing Currency formatter', () => {
     expect(format(1234.2345, 'i.iii,d')).toBe('1.234,2');
   });
 
-  it('allows to hide decimals', () => {
-    expect(format(1234.56, 'i.iii,d', true)).toBe('1.234');
+  it('allows to hide the decimal part', () => {
+    expect(format(1234.56, 'i.iii')).toBe('1.234');
+  });
+
+  it("allows to hide the decimal part if it's zero with the '?' symbol within the format", () => {
+    expect(format(1234, 'i.iii,dd')).toBe('1.234,00');
+    expect(format(1234, 'i.iii,?dd')).toBe('1.234');
+    expect(format(1234.56, 'i.iii,?dd')).toBe('1.234,56');
   });
 
   it('adds thousands separator successfully when the number has decimals', () => {
@@ -47,7 +53,7 @@ describe('testing Currency formatter', () => {
     expect(format(123456)).toBe('123.456,00');
   });
 
-  function format(value: number, format?: string, hideIntegerDecimals?: boolean): string {
-    return currencyFormatter(value, format, hideIntegerDecimals);
+  function format(value: number, format?: string): string {
+    return currencyFormatter(value, format);
   }
 });

--- a/packages/x-components/src/utils/currency-formatter.ts
+++ b/packages/x-components/src/utils/currency-formatter.ts
@@ -1,7 +1,7 @@
 /**
  * Regex to detect the format.
  */
-const FORMAT_REGEX = /(i([^id]+))?i+(([^id]+)(d+))?/;
+const FORMAT_REGEX = /(i([^id]+))?i+(([^id?]+)(\?)?(d+))?/;
 
 /**
  * Configuration for format currency.
@@ -14,6 +14,8 @@ interface CurrencyConfig {
   decimalSeparator: string;
   /** Length of decimals numbers. It counts the number of 'd's after the integer part. */
   decimalsNumber: number;
+  /** Boolean value to hide or show the decimal part when it has 0. */
+  hideIntegerDecimals: boolean;
 }
 
 /**
@@ -31,7 +33,6 @@ interface NumberParts {
  *
  * @param value - Numeric value to be formatted.
  * @param format - Format or mask to be defined as string.
- * @param hideIntegerDecimals - Boolean value to hide or show the decimal part when it has 0.
  *
  * @remarks
  * Format:
@@ -55,21 +56,19 @@ interface NumberParts {
  *
  * @public
  */
-export function currencyFormatter(
-  value: number,
-  format = 'i.iii,dd',
-  hideIntegerDecimals = false
-): string {
+export function currencyFormatter(value: number, format = 'i.iii,dd'): string {
   const { integer, decimal } = numberParts(value);
-  const { decimalSeparator, decimalsNumber, integerSeparator } = currencyConfig(format);
+  const { decimalSeparator, decimalsNumber, integerSeparator, hideIntegerDecimals } =
+    currencyConfig(format);
 
   const formattedInteger = formatInteger(integer, integerSeparator);
   const formattedDecimalsSeparator = formatDecimalSeparator(
-    decimalsNumber,
+    decimal,
     decimalSeparator,
     hideIntegerDecimals
   );
   const formattedDecimal = formatDecimal(decimal, decimalsNumber, hideIntegerDecimals);
+  debugger;
   return format.replace(
     FORMAT_REGEX,
     `${formattedInteger}${formattedDecimalsSeparator}${formattedDecimal}`
@@ -98,7 +97,7 @@ function formatInteger(integer: string, integerSeparator: string): string {
  * Returns the decimal separator set or empty string if the option 'hideIntegerDecimals' is true
  * and the value is an integer, or if there are no decimals number defined.
  *
- * @param decimalsNumber - Amount of decimal numbers.
+ * @param decimal - Decimal part of the number.
  * @param decimalSeparator - Decimal separator.
  * @param hideIntegerDecimals - Boolean value to hide or show the decimal part.
  *
@@ -107,11 +106,11 @@ function formatInteger(integer: string, integerSeparator: string): string {
  * @internal
  */
 function formatDecimalSeparator(
-  decimalsNumber: number,
+  decimal: string,
   decimalSeparator: string,
   hideIntegerDecimals: boolean
 ): string {
-  return !hideIntegerDecimals && decimalsNumber ? decimalSeparator : '';
+  return hideIntegerDecimals && !+decimal ? '' : decimalSeparator;
 }
 
 /**
@@ -134,9 +133,10 @@ function formatDecimal(
   decimalsNumber: number,
   hideIntegerDecimals: boolean
 ): string {
-  return !hideIntegerDecimals
-    ? decimal.padEnd(decimalsNumber, '0').substring(0, decimalsNumber)
-    : '';
+  debugger;
+  return hideIntegerDecimals && !+decimal
+    ? ''
+    : decimal.padEnd(decimalsNumber, '0').substring(0, decimalsNumber);
 }
 
 /**
@@ -150,12 +150,21 @@ function formatDecimal(
  * @internal
  */
 function currencyConfig(format: string): CurrencyConfig {
-  const [, , integerSeparator = '', , decimalSeparator = '', decimals = ''] =
-    FORMAT_REGEX.exec(format) ?? [];
+  const [
+    ,
+    ,
+    integerSeparator = '',
+    ,
+    decimalSeparator = '',
+    hideIntegerDecimals = '',
+    decimals = ''
+  ] = FORMAT_REGEX.exec(format) ?? [];
+  debugger;
   return {
     integerSeparator,
     decimalSeparator,
-    decimalsNumber: decimals.length
+    decimalsNumber: decimals.length,
+    hideIntegerDecimals: !!hideIntegerDecimals
   };
 }
 

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -19,5 +19,6 @@ export const baseInstallXOptions: InstallXOptions = {
         identifierDetectionRegexp: '^[a-zA-Z][0-9]+'
       }
     }
-  }
+  },
+  app: {}
 };

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -65,6 +65,8 @@ export interface SnippetConfig {
   consent?: boolean;
   /** Document direction. */
   documentDirection?: DocumentDirection;
+  /** Currency format. */
+  currency?: string;
   /** Any extra param to send in all backend calls. */
   [extra: string]: any;
 }

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -65,7 +65,7 @@ export interface SnippetConfig {
   consent?: boolean;
   /** Document direction. */
   documentDirection?: DocumentDirection;
-  /** Currency format. */
+  /** Currency. */
   currency?: string;
   /** Any extra param to send in all backend calls. */
   [extra: string]: any;


### PR DESCRIPTION
# Description

USER STORY: https://searchbroker.atlassian.net/browse/EX-3546

The description of the user story is a little bit outdated. This task could be split in different smaller tasks:

- Modify util currency-formatter: remove `hideIntegerDecimals` parameter. The regex has been modified and now the format accepts a `?` symbol to remove the non-significant zeroes if they are not needed. E.g: number: 1234 -> i.iii,?dd = 1.234; i.iii,dd = 1.234,00.
- Add 'currency' to the 'snippetConfig' of X-Components which accepts a string with the current currency. E.g. 'EUR', 'USD', etc.
- Modify `BaseCurrency` to allow injection for the `currencyFormat`. Now the component can use injection or the prop. 
- Remove required and default property 'format' for components that use `BaseCurrency` nested.

We'll need to release this in order to have it available in the X-Archetype which will have another PR.

X-Archetype will have a local configuration for the currencies:

```
const currencies: Record<string, string> = {
  EUR: 'i.iii,dd €',
  USD: '$i,iii.dd'
};
```

And then, the X-Archetype injects, using @XInject with the name "currentFormat", from the App to the rest of nested components, the format of the current currency.

This will be also available in the reactive config (snippetConfig).

# Test

- Check all the **TESTS** and **DOCUMENTATION** of the modified components.
- Check the functionality and tests of the new features.
- You can also build X-Components and import it in the X-Archetype. This feature is WIP in another branch from the X-Archetype but you can easily add this to App.vue component:

```
    const currencies: Record<string, string> = {
      EUR: 'i.iii,dd €',
      USD: '$i,iii.dd'
    };

    @XProvide('currencyFormat')
    public get currencyFormat(): string {
      return currencies[this.snippetConfig.currency!];
    }
```

Then you can:
- Modify the format of the current, which is 'EUR' by default.
- Modify it from the console to see the reactive config in action: `window.initX.currency = "USD"`.

NOTE: this approach is temporal. There'd be a intermediate project between X-Components and the X-Archetype that will have these default configuration.

