### PR TITLE
feat(facets-next): add wiring. add new `wireService` and `wireService…

### DIFF
--- a/packages/x-components/src/utils/types.ts
+++ b/packages/x-components/src/utils/types.ts
@@ -86,8 +86,7 @@ export type MonadicFunction = (someParam: any) => any;
  *
  * @public
  */
-export type FirstParameter<SomeFunction extends (...args: any[]) => any> =
-  Parameters<SomeFunction>[0];
+export type FirstParameter<SomeFunction extends AnyFunction> = Parameters<SomeFunction>[0];
 
 /**
  * Extracts the return type of each property of the T object.

--- a/packages/x-components/src/utils/types.ts
+++ b/packages/x-components/src/utils/types.ts
@@ -81,6 +81,11 @@ export type NiladicFunction = () => any;
  */
 export type MonadicFunction = (someParam: any) => any;
 
+/**
+ * Alias to retrieve the first parameter type of a function.
+ *
+ * @public
+ */
 export type FirstParameter<SomeFunction extends (...args: any[]) => any> =
   Parameters<SomeFunction>[0];
 

--- a/packages/x-components/src/utils/types.ts
+++ b/packages/x-components/src/utils/types.ts
@@ -68,6 +68,23 @@ export type Primitive = string | number | boolean | undefined | null | symbol | 
 export type AnyFunction = (...args: any[]) => any;
 
 /**
+ * A function with no parameters that can return anything.
+ *
+ * @public
+ */
+export type NiladicFunction = () => any;
+
+/**
+ * A function with a single parameter that can return anything.
+ *
+ * @public
+ */
+export type MonadicFunction = (someParam: any) => any;
+
+export type FirstParameter<SomeFunction extends (...args: any[]) => any> =
+  Parameters<SomeFunction>[0];
+
+/**
  * Extracts the return type of each property of the T object.
  *
  * @param T - The dictionary of functions to extract its return type.

--- a/packages/x-components/src/wiring/__tests__/wires-factory.spec.ts
+++ b/packages/x-components/src/wiring/__tests__/wires-factory.spec.ts
@@ -1,10 +1,13 @@
 import { BaseXBus } from '../../plugins/x-bus';
+import { noOp } from '../../utils/function';
 import {
   createWireFromFunction,
   wireCommit,
   wireCommitWithoutPayload,
   wireDispatch,
-  wireDispatchWithoutPayload
+  wireDispatchWithoutPayload,
+  wireService,
+  wireServiceWithoutPayload
 } from '../wires.factory';
 import { createQuerySuggestionsStoreMock, getExpectedWirePayload, SubjectHandler } from './utils';
 
@@ -185,5 +188,130 @@ describe('testing wires factory', () => {
         expect(storeMock.dispatch).toHaveBeenCalledWith(actionName);
       }
     );
+  });
+
+  describe('testing wire service factories', () => {
+    class TestService {
+      public noParametersMethod = jest.fn(noOp);
+      public oneOptionalParameterMethod = jest.fn((parameter?: string) => parameter);
+      public oneParameterMethod = jest.fn((parameter: string) => parameter);
+      public restParametersMethod = jest.fn((...parameters: number[]) => parameters);
+      public multipleParametersMethod = jest.fn((a: number, b: number) => a + b);
+    }
+
+    describe(`testing ${wireService.name}`, () => {
+      it('allows calling methods with no parameters', () => {
+        const service = new TestService();
+        const wireTestService = wireService(service);
+        const wire = wireTestService('noParametersMethod');
+        wire(subjectHandler.subject, storeMock, busOnMock);
+        subjectHandler.emit('something');
+
+        expect(service.noParametersMethod).toHaveBeenCalledTimes(1);
+        // Methods that have no parameters will be invoked with the payload.
+        expect(service.noParametersMethod).toHaveBeenCalledWith('something');
+      });
+
+      it('allows calling methods with one parameter', () => {
+        const service = new TestService();
+        const wireTestService = wireService(service);
+        const wire = wireTestService('oneParameterMethod');
+        wire(subjectHandler.subject, storeMock, busOnMock);
+        subjectHandler.emit('milk');
+
+        expect(service.oneParameterMethod).toHaveBeenCalledTimes(1);
+        expect(service.oneParameterMethod).toHaveBeenCalledWith('milk');
+      });
+
+      it('allows calling methods with one parameter passed statically', () => {
+        const service = new TestService();
+        const wireTestService = wireService(service);
+        const wire = wireTestService('oneParameterMethod', 'torreznos');
+        wire(subjectHandler.subject, storeMock, busOnMock);
+        subjectHandler.emit('lettuce');
+
+        expect(service.oneParameterMethod).toHaveBeenCalledTimes(1);
+        expect(service.oneParameterMethod).toHaveBeenCalledWith('torreznos');
+      });
+
+      it('allows calling methods with rest parameters', () => {
+        const service = new TestService();
+        const wireTestService = wireService(service);
+        const wire = wireTestService('restParametersMethod');
+        wire(subjectHandler.subject, storeMock, busOnMock);
+        subjectHandler.emit(10);
+
+        expect(service.restParametersMethod).toHaveBeenCalledTimes(1);
+        expect(service.restParametersMethod).toHaveBeenCalledWith(10);
+      });
+
+      it('allows calling methods with rest parameters passed statically', () => {
+        const service = new TestService();
+        const wireTestService = wireService(service);
+        const wire = wireTestService('restParametersMethod', 5);
+        wire(subjectHandler.subject, storeMock, busOnMock);
+        subjectHandler.emit(10);
+
+        expect(service.restParametersMethod).toHaveBeenCalledTimes(1);
+        expect(service.restParametersMethod).toHaveBeenCalledWith(5);
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("doesn't allow calling methods with multiple parameters", () => {
+        // This check is just
+        const wireTestService = wireService(new TestService());
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        wireTestService('multipleParametersMethod');
+      });
+    });
+
+    describe(`testing ${wireServiceWithoutPayload.name}`, () => {
+      it('invokes service methods with no parameters', () => {
+        const service = new TestService();
+        const wireTestService = wireServiceWithoutPayload(service);
+        const wire = wireTestService('noParametersMethod');
+        wire(subjectHandler.subject, storeMock, busOnMock);
+        subjectHandler.emit('something');
+
+        expect(service.noParametersMethod).toHaveBeenCalledTimes(1);
+        expect(service.noParametersMethod).toHaveBeenCalledWith();
+      });
+
+      it('allows calling methods with optional parameters', () => {
+        const service = new TestService();
+        const wireTestService = wireServiceWithoutPayload(service);
+        const wire = wireTestService('oneOptionalParameterMethod');
+        wire(subjectHandler.subject, storeMock, busOnMock);
+        subjectHandler.emit(10);
+
+        expect(service.oneOptionalParameterMethod).toHaveBeenCalledTimes(1);
+        expect(service.oneOptionalParameterMethod).toHaveBeenCalledWith();
+      });
+
+      it('allows calling methods with rest parameters', () => {
+        const service = new TestService();
+        const wireTestService = wireServiceWithoutPayload(service);
+        const wire = wireTestService('restParametersMethod');
+        wire(subjectHandler.subject, storeMock, busOnMock);
+        subjectHandler.emit(10);
+
+        expect(service.restParametersMethod).toHaveBeenCalledTimes(1);
+        expect(service.restParametersMethod).toHaveBeenCalledWith();
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("doesn't allow calling methods with one or more parameters", () => {
+        // This check is just
+        const wireTestService = wireServiceWithoutPayload(new TestService());
+
+        /* eslint-disable @typescript-eslint/ban-ts-comment */
+        // @ts-expect-error
+        wireTestService('oneParameterMethod');
+        // @ts-expect-error
+        wireTestService('multipleParametersMethod');
+        /* eslint-enable @typescript-eslint/ban-ts-comment */
+      });
+    });
   });
 });

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -3,6 +3,7 @@ import { ScrollDirection } from '../components/scroll/scroll.types';
 import { ArrowKey, PropsWithType } from '../utils';
 import { DeviceXEvents } from '../x-modules/device';
 import { EmpathizeXEvents } from '../x-modules/empathize/events.types';
+import { FacetsNextXEvents } from '../x-modules/facets-next/events.types';
 import { FacetsXEvents } from '../x-modules/facets/events.types';
 import { HistoryQueriesXEvents } from '../x-modules/history-queries/events.types';
 import { IdentifierResultsXEvents } from '../x-modules/identifier-results/events.types';
@@ -39,6 +40,7 @@ export interface XEventsTypes
   extends DeviceXEvents,
     EmpathizeXEvents,
     FacetsXEvents,
+    FacetsNextXEvents,
     HistoryQueriesXEvents,
     IdentifierResultsXEvents,
     NextQueriesXEvents,

--- a/packages/x-components/src/wiring/wires.factory.ts
+++ b/packages/x-components/src/wiring/wires.factory.ts
@@ -1,6 +1,13 @@
 import { Store } from 'vuex';
 import { RootStoreStateAndGetters, RootXStoreState } from '../store/store.types';
-import { AnyWire, Wire, WireParams, WirePayload } from './wiring.types';
+import {
+  AnyWire,
+  Wire,
+  WireParams,
+  WirePayload,
+  WireService,
+  WireServiceWithoutPayload
+} from './wiring.types';
 
 /**
  * Creates a wire that executes the function passed. This function will receive a
@@ -127,6 +134,40 @@ export function wireDispatch<Payload>(action: string, payload?: Payload): Wire<P
  */
 export function wireDispatchWithoutPayload(action: string): AnyWire {
   return (observable, store) => observable.subscribe(() => store.dispatch(action));
+}
+
+/**
+ * Creates a wires factory that can create wires that will invoke the service methods.
+ *
+ * @param service - The service to invoke its methods.
+ * @returns A factory to create wires that invoke the service methods.
+ * @public
+ */
+export function wireService<SomeService>(service: SomeService): WireService<SomeService> {
+  return (method, payload?) => {
+    return observable =>
+      observable.subscribe(
+        payload !== undefined
+          ? () => service[method](payload)
+          : observablePayload => service[method](observablePayload.eventPayload)
+      );
+  };
+}
+
+/**
+ * Creates a wires factory that can create wires that will invoke the service methods but
+ * without payload.
+ *
+ * @param service - The service to invoke its methods.
+ * @returns A factory to create wires that invoke the service methods without payload.
+ * @public
+ */
+export function wireServiceWithoutPayload<SomeService>(
+  service: SomeService
+): WireServiceWithoutPayload<SomeService> {
+  return method => {
+    return observable => observable.subscribe(() => service[method]());
+  };
 }
 
 /**

--- a/packages/x-components/src/wiring/wiring.types.ts
+++ b/packages/x-components/src/wiring/wiring.types.ts
@@ -125,7 +125,7 @@ export interface WireService<SomeService> {
    *
    * @param method - The method to invoke.
    * @param payload - The payload to invoke the service with.
-   * @returns A Wire that expects to receive the function parameter as payload.
+   * @returns A Wire that can be used anywhere.
    */
   <SomeMethod extends PropsWithType<SomeService, MonadicFunction>>(
     method: SomeMethod,

--- a/packages/x-components/src/x-modules/facets-next/events.types.ts
+++ b/packages/x-components/src/x-modules/facets-next/events.types.ts
@@ -1,5 +1,4 @@
-import { Facet } from '@empathyco/x-types';
-import { Filter, EditableNumberRangeFilter } from '@empathyco/x-types-next';
+import { Filter, EditableNumberRangeFilter, Facet } from '@empathyco/x-types-next';
 import { FacetsGroup } from './service/types';
 
 /**
@@ -36,7 +35,7 @@ export interface FacetsNextXEvents {
    * The user has clicked facet select all filters button.
    * * Payload: Facet id.
    */
-  UserClickedFacetAllNextFilter: Array<Facet['id']>;
+  UserClickedAllFilter: [Facet['id']];
   /**
    * The user has modified a filter which is of editable number range filter type.
    * * Payload: An {@link EditableNumberRangeFilterChange | object}.

--- a/packages/x-components/src/x-modules/facets-next/events.types.ts
+++ b/packages/x-components/src/x-modules/facets-next/events.types.ts
@@ -1,0 +1,45 @@
+import { Facet } from '@empathyco/x-types';
+import { Filter, EditableNumberRangeFilter } from '@empathyco/x-types-next';
+import { FacetsGroup } from './service/types';
+
+/**
+ * Dictionary of the events of Facets XModule, where each key is the event name, and the
+ * value is the event payload type or `void` if it has no payload.
+ *
+ * @public
+ */
+export interface FacetsNextXEvents {
+  /**
+   * The facets from a group have changed
+   * * Payload: The group id and the new list of facets for it.
+   */
+  FacetsGroupChanged: FacetsGroup;
+  /**
+   * A new set of facets for the group has been provided.
+   * * Payload: The group id and the new list of facets for it.
+   **/
+  FacetsGroupProvided: FacetsGroup;
+  /**
+   * The selected filters have changed.
+   * * Payload: the new list of selected filters.
+   */
+  SelectedFiltersNextChanged: Filter[];
+  /**
+   * The user has clicked any kind of filter.
+   * * Payload: The clicked filter.
+   *
+   * @remarks This event does not imply changing the selection state of the filter. Business logic
+   * can prevent the filter from changing its state.
+   */
+  UserClickedANextFilter: Filter;
+  /**
+   * The user has clicked facet select all filters button.
+   * * Payload: Facet id.
+   */
+  UserClickedFacetAllNextFilter: Array<Facet['id']>;
+  /**
+   * The user has modified a filter which is of editable number range filter type.
+   * * Payload: An {@link EditableNumberRangeFilterChange | object}.
+   */
+  UserModifiedEditableNumberRangeNextFilter: EditableNumberRangeFilter;
+}

--- a/packages/x-components/src/x-modules/facets-next/service/__tests__/facets-service.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/service/__tests__/facets-service.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../../__stubs__/filters-stubs.factory';
 import { installNewXPlugin } from '../../../../__tests__/utils';
 import { XPlugin } from '../../../../plugins/x-plugin';
-import { BaseFacetsService } from '../facets.service';
+import { DefaultFacetsService } from '../facets.service';
 import {
   getStoreEditableNumberRangeFilter,
   getStoreFilter,
@@ -25,9 +25,9 @@ import { FacetsService } from '../types';
 import { facetsNextXModule } from '../../x-module';
 
 /**
- * Creates a fresh new {@link BaseFacetsService} with some helpful test methods.
+ * Creates a fresh new {@link DefaultFacetsService} with some helpful test methods.
  *
- * @returns An object containing methods for testing {@link BaseFacetsService}.
+ * @returns An object containing methods for testing {@link DefaultFacetsService}.
  */
 function prepareFacetsService(): FacetsServiceTestAPI {
   XPlugin.resetInstance();
@@ -35,7 +35,7 @@ function prepareFacetsService(): FacetsServiceTestAPI {
   XPlugin.registerXModule(facetsNextXModule);
 
   return {
-    service: new BaseFacetsService(),
+    service: new DefaultFacetsService(),
     isFilterSelected(filter) {
       return isFilterSelected(XPlugin.store, filter.id);
     },
@@ -358,7 +358,7 @@ describe('testing facets service', () => {
 
       // Save a fresh new facets group. Because there
       // are no previous filters, all filters should be deselected.
-      service.saveFacets({
+      service.updateFacets({
         id: 'backend',
         facets: [colorFacet, categoryFacet, ageFacet, priceFacet]
       });
@@ -408,7 +408,7 @@ describe('testing facets service', () => {
         createFilter({ min: null, max: 10 }, true)
       );
 
-      service.saveFacets({
+      service.updateFacets({
         id: 'backend',
         facets: [newColorFacet, newCategoryFacet, newAgeFacet, newPriceFacet]
       });
@@ -434,7 +434,7 @@ describe('testing facets service', () => {
         createFilter('In store', true),
         createFilter('Express')
       ]);
-      service.saveFacets({
+      service.updateFacets({
         id: 'static',
         facets: [shipmentFacet]
       });
@@ -470,7 +470,7 @@ describe('testing facets service', () => {
         ])
       ]);
 
-      service.saveFacets({
+      service.updateFacets({
         id: 'static',
         facets: [categoryFacet]
       });

--- a/packages/x-components/src/x-modules/facets-next/service/facets.service.ts
+++ b/packages/x-components/src/x-modules/facets-next/service/facets.service.ts
@@ -40,23 +40,23 @@ export class DefaultFacetsService implements FacetsService {
     this.createEntity(filter).deselect(filter);
   }
 
-  updateFacets(facetGroup: FacetsGroup): void {
-    const previousFilters = this.removeGroupFilters(facetGroup.id);
-    facetGroup.facets.forEach(facet => {
+  updateFacets(facetsGroup: FacetsGroup): void {
+    const previousFilters = this.removeGroupFilters(facetsGroup.id);
+    facetsGroup.facets.forEach(facet => {
       this.setFacetGroup({
         facetId: facet.id,
-        groupId: facetGroup.id
+        groupId: facetsGroup.id
       });
-      this.saveFilters(facet.filters, previousFilters);
+      this.saveFiltersWithPreviousState(facet.filters, previousFilters);
     });
   }
 
-  setFacets(facetGroup: FacetsGroup): void {
-    this.removeGroupFilters(facetGroup.id);
-    facetGroup.facets.forEach(facet => {
+  setFacets(facetsGroup: FacetsGroup): void {
+    this.removeGroupFilters(facetsGroup.id);
+    facetsGroup.facets.forEach(facet => {
       this.setFacetGroup({
         facetId: facet.id,
-        groupId: facetGroup.id
+        groupId: facetsGroup.id
       });
       facet.filters.forEach(filter => {
         if (filter.selected) {
@@ -138,7 +138,7 @@ export class DefaultFacetsService implements FacetsService {
    * @param previousFilters - The list of old filters, used to set the `newFilters`
    * selected state.
    */
-  protected saveFilters(newFilters: Filter[], previousFilters: Filter[]): void {
+  protected saveFiltersWithPreviousState(newFilters: Filter[], previousFilters: Filter[]): void {
     const filterEntity = FilterEntityFactory.instance.createFilterEntity(this.store, newFilters[0]);
     const previousFiltersMap = arrayToObject(previousFilters, 'id');
     newFilters.forEach(filter => {

--- a/packages/x-components/src/x-modules/facets-next/service/types.ts
+++ b/packages/x-components/src/x-modules/facets-next/service/types.ts
@@ -12,7 +12,7 @@ import { Facet, Filter } from '@empathyco/x-types-next';
  *
  * @public
  */
-export interface FacetGroup {
+export interface FacetsGroup {
   /** The list of facets that belong to the group. */
   facets: Facet[];
   /** The group unique identifier. */
@@ -53,7 +53,15 @@ export interface FacetsService {
    * @param facetGroup - An objet containing the id of the facets group, and the list of new facets
    * to store.
    */
-  saveFacets(facetGroup: FacetGroup): void;
+  updateFacets(facetGroup: FacetsGroup): void;
+  /**
+   * Sets the facets of the group. This method just replaces the facets, and keeps the given facet's
+   * filters selected state as it is.
+   *
+   * @param facetGroup - An objet containing the id of the facets group, and the list of new facets
+   * to store.
+   */
+  setFacets(facetGroup: FacetsGroup): void;
   /**
    * Selects filter, adding it to the store if it was not present.
    *

--- a/packages/x-components/src/x-modules/facets-next/service/types.ts
+++ b/packages/x-components/src/x-modules/facets-next/service/types.ts
@@ -50,18 +50,18 @@ export interface FacetsService {
    * Replaces the facets of the group with the new ones. It ignores the provided filters selected
    * state, replacing it with the previous selected filter.
    *
-   * @param facetGroup - An objet containing the id of the facets group, and the list of new facets
-   * to store.
+   * @param facetsGroup - An object containing the id of the facets group, and the list of new
+   * facets to store.
    */
-  updateFacets(facetGroup: FacetsGroup): void;
+  updateFacets(facetsGroup: FacetsGroup): void;
   /**
    * Sets the facets of the group. This method just replaces the facets, and keeps the given facet's
    * filters selected state as it is.
    *
-   * @param facetGroup - An objet containing the id of the facets group, and the list of new facets
-   * to store.
+   * @param facetsGroup - An object containing the id of the facets group, and the list of new
+   * facets to store.
    */
-  setFacets(facetGroup: FacetsGroup): void;
+  setFacets(facetsGroup: FacetsGroup): void;
   /**
    * Selects filter, adding it to the store if it was not present.
    *

--- a/packages/x-components/src/x-modules/facets-next/store/emitters.ts
+++ b/packages/x-components/src/x-modules/facets-next/store/emitters.ts
@@ -1,4 +1,6 @@
 import { createStoreEmitters } from '../../../store/store.utils';
+import { isNewQuery } from '../../facets/utils';
+import { DefaultFacetsService } from '../service/facets.service';
 import { facetsNextXStoreModule } from './module';
 
 /**
@@ -6,4 +8,13 @@ import { facetsNextXStoreModule } from './module';
  *
  * @internal
  */
-export const facetsNextEmitters = createStoreEmitters(facetsNextXStoreModule, {});
+export const facetsNextEmitters = createStoreEmitters(facetsNextXStoreModule, {
+  SelectedFiltersNextChanged: {
+    selector: (_, getters) => getters.selectedFilters,
+    filter: DefaultFacetsService.instance.areFiltersDifferent.bind(DefaultFacetsService.instance)
+  },
+  FacetsQueryChanged: {
+    selector: state => state.query,
+    filter: isNewQuery
+  }
+});

--- a/packages/x-components/src/x-modules/facets-next/store/module.ts
+++ b/packages/x-components/src/x-modules/facets-next/store/module.ts
@@ -11,7 +11,8 @@ import { FacetGroupEntry, FacetsNextXStoreModule } from './types';
 export const facetsNextXStoreModule: FacetsNextXStoreModule = {
   state: () => ({
     filters: {},
-    groups: {}
+    groups: {},
+    query: ''
   }),
   getters: {
     selectedFilters,
@@ -26,6 +27,9 @@ export const facetsNextXStoreModule: FacetsNextXStoreModule = {
     },
     setFacetGroup(state, { facetId, groupId }: FacetGroupEntry) {
       Vue.set(state.groups, facetId, groupId);
+    },
+    setQuery(state, query) {
+      state.query = query;
     }
   },
   actions: {}

--- a/packages/x-components/src/x-modules/facets-next/store/types.ts
+++ b/packages/x-components/src/x-modules/facets-next/store/types.ts
@@ -11,6 +11,8 @@ export interface FacetsNextState {
   filters: Record<Filter['id'], Filter>;
   /** Record specifying the group each facet belongs to. */
   groups: Record<Facet['id'], GroupId>;
+  /** The query this facets belong to. */
+  query: string;
 }
 
 /**
@@ -36,12 +38,6 @@ export interface FacetsNextGetters {
  */
 export interface FacetsNextMutations {
   /**
-   * Adds the filter to the {@link FacetsNextState.filters | filters} record.
-   *
-   * @param filter - The filter to add.
-   */
-  setFilter(filter: Filter): void;
-  /**
    * Removes the filter from the {@link FacetsNextState.filters | filters} record.
    *
    * @param filter - The filter to remove.
@@ -54,6 +50,18 @@ export interface FacetsNextMutations {
    * update.
    */
   setFacetGroup(facetGroupEntry: FacetGroupEntry): void;
+  /**
+   * Adds the filter to the {@link FacetsNextState.filters | filters} record.
+   *
+   * @param filter - The filter to add.
+   */
+  setFilter(filter: Filter): void;
+  /**
+   * Sets the {@link FacetsState.query} property.
+   *
+   * @param query - The new {@link FacetsState.query}.
+   */
+  setQuery(query: string): void;
 }
 
 /**

--- a/packages/x-components/src/x-modules/facets-next/store/types.ts
+++ b/packages/x-components/src/x-modules/facets-next/store/types.ts
@@ -57,9 +57,9 @@ export interface FacetsNextMutations {
    */
   setFilter(filter: Filter): void;
   /**
-   * Sets the {@link FacetsState.query} property.
+   * Sets the {@link FacetsNextState.query} property.
    *
-   * @param query - The new {@link FacetsState.query}.
+   * @param query - The new {@link FacetsNextState.query}.
    */
   setQuery(query: string): void;
 }

--- a/packages/x-components/src/x-modules/facets-next/wiring.ts
+++ b/packages/x-components/src/x-modules/facets-next/wiring.ts
@@ -93,7 +93,7 @@ export const facetsNextWiring = createWiring({
   UserModifiedEditableNumberRangeNextFilter: {
     selectFilterWire
   },
-  UserClickedFacetAllNextFilter: {
+  UserClickedAllFilter: {
     clearFiltersWire
   },
   UserAcceptedAQuery: {

--- a/packages/x-components/src/x-modules/facets-next/wiring.ts
+++ b/packages/x-components/src/x-modules/facets-next/wiring.ts
@@ -1,8 +1,108 @@
+import { namespacedWireCommit } from '../../wiring/namespaced-wires.factory';
+import { wireService, wireServiceWithoutPayload } from '../../wiring/wires.factory';
 import { createWiring } from '../../wiring/wiring.utils';
+import { DefaultFacetsService } from './service/facets.service';
+
+/**
+ * Wires factory for {@link DefaultFacetsService}.
+ */
+const wireFacetsService = wireService(DefaultFacetsService.instance);
+
+/**
+ * Wires without payload factory for {@link DefaultFacetsService}.
+ */
+const wireFacetsServiceWithoutPayload = wireServiceWithoutPayload(DefaultFacetsService.instance);
+
+/**
+ * WireCommit for {@link FacetsNextXModule}.
+ *
+ * @internal
+ */
+const facetsNextWireCommit = namespacedWireCommit('facetsNext');
+
+/**
+ * Saves the facets contained in the group, removing the previous ones, and keeping the previous
+ * filters selected state.
+ *
+ * @public
+ */
+const updateFacetsGroupWire = wireFacetsService('updateFacets');
+
+/**
+ * Saves the facets contained in the group, removing the previous ones, and keeping the new filters
+ * selected state.
+ *
+ * @public
+ */
+const setFacetsGroupWire = wireFacetsService('setFacets');
+
+/**
+ * Toggles the selected state of a filter.
+ *
+ * @public
+ */
+const toggleFilterWire = wireFacetsService('toggle');
+
+/**
+ * Deselects all the filters. Optionally, it can accept a list of facets ids as payload, and it will
+ * only deselect the filters from those facets.
+ *
+ * @public
+ */
+const clearFiltersWire = wireFacetsService('clearFilters');
+
+/**
+ * Deselects all selected filters.
+ *
+ * @public
+ */
+const clearAllFiltersWire = wireFacetsServiceWithoutPayload('clearFilters');
+
+/**
+ * Selects the filter passed by payload.
+ *
+ * @public
+ */
+const selectFilterWire = wireFacetsService('select');
+
+/**
+ * Sets the facets state `query`.
+ *
+ * @public
+ */
+const setFacetsQuery = facetsNextWireCommit('setQuery');
 
 /**
  * Wiring configuration for the {@link FacetsNextXModule | facets module}.
  *
  * @internal
  */
-export const facetsNextWiring = createWiring({});
+export const facetsNextWiring = createWiring({
+  FacetsGroupChanged: {
+    updateFacetsGroupWire
+  },
+  FacetsGroupProvided: {
+    setFacetsGroupWire
+  },
+  UserClickedANextFilter: {
+    toggleFilterWire
+  },
+  UserClickedClearAllFilters: {
+    clearFiltersWire
+  },
+  UserModifiedEditableNumberRangeNextFilter: {
+    selectFilterWire
+  },
+  UserClickedFacetAllNextFilter: {
+    clearFiltersWire
+  },
+  UserAcceptedAQuery: {
+    setFacetsQuery
+  },
+  UserClearedQuery: {
+    setFacetsQuery
+  },
+  FacetsQueryChanged: {
+    clearAllFiltersWire
+  }
+});

--- a/packages/x-components/src/x-modules/facets-next/x-module.ts
+++ b/packages/x-components/src/x-modules/facets-next/x-module.ts
@@ -1,5 +1,4 @@
 import { XModule } from '../x-modules.types';
-import { BaseFacetsService } from './service/facets.service';
 import { facetsNextEmitters } from './store/emitters';
 import { facetsNextXStoreModule } from './store/module';
 import { FacetsNextXStoreModule } from './store/types';
@@ -11,13 +10,6 @@ import { facetsNextWiring } from './wiring';
  * @public
  */
 export type FacetsNextXModule = XModule<FacetsNextXStoreModule>;
-
-/**
- * The facets service instance.
- *
- * @public
- */
-export const facetsService = new BaseFacetsService();
 
 /**
  * Facets {@link XModule} implementation. This module is auto-registered as soon as you

--- a/packages/x-components/src/x-modules/facets/events.types.ts
+++ b/packages/x-components/src/x-modules/facets/events.types.ts
@@ -5,6 +5,7 @@ import {
   NumberRangeFilter,
   SimpleFilter
 } from '@empathyco/x-types';
+import { Filter as FilterNext } from '@empathyco/x-types-next';
 import { EditableNumberRangeFilterChange, MultiSelectChange } from './store/types';
 
 /**
@@ -57,7 +58,7 @@ export interface FacetsXEvents {
    * @remarks This event does not imply changing the selection state of the filter. Business logic
    * can prevent the filter from changing its state.
    */
-  UserClickedAFilter: Filter;
+  UserClickedAFilter: Filter | FilterNext;
   /**
    * The user has clicked a filter which is of hierarchical type.
    * * Payload: The clicked filter.
@@ -86,12 +87,14 @@ export interface FacetsXEvents {
    * The user has clicked button clear filters.
    * * Payload: array the facets ids.
    */
-  UserClickedClearAllFilters: void;
+  UserClickedClearAllFilters: Array<Facet['id']> | undefined;
   /**
    * The user has clicked button clear filters when there are facets ids.
    * * Payload: array the facets ids.
+   *
+   * @deprecated Use {@link FacetsXEvents.UserClickedClearAllFilters}.
    */
-  UserClickedClearFacetFilters: Array<Facet['id']>;
+  UserClickedClearFacetFilters: Array<Facet['id']> | undefined;
   /**
    * The user has clicked facet select all filters button.
    * * Payload: Facet id.

--- a/packages/x-components/src/x-modules/facets/events.types.ts
+++ b/packages/x-components/src/x-modules/facets/events.types.ts
@@ -5,7 +5,6 @@ import {
   NumberRangeFilter,
   SimpleFilter
 } from '@empathyco/x-types';
-import { Filter as FilterNext } from '@empathyco/x-types-next';
 import { EditableNumberRangeFilterChange, MultiSelectChange } from './store/types';
 
 /**
@@ -58,7 +57,7 @@ export interface FacetsXEvents {
    * @remarks This event does not imply changing the selection state of the filter. Business logic
    * can prevent the filter from changing its state.
    */
-  UserClickedAFilter: Filter | FilterNext;
+  UserClickedAFilter: Filter;
   /**
    * The user has clicked a filter which is of hierarchical type.
    * * Payload: The clicked filter.

--- a/packages/x-components/src/x-modules/facets/store/actions/clear-selected-filters.action.ts
+++ b/packages/x-components/src/x-modules/facets/store/actions/clear-selected-filters.action.ts
@@ -28,9 +28,12 @@ export class ClearSelectedFilters implements ActionsClass<FacetsXStoreModule> {
    */
   clearFacetsSelectedFilters(
     { getters, commit }: FacetsActionsContext,
-    facetIds: Facet['id'][]
+    facetIds?: Facet['id'][]
   ): void {
-    getters.selectedFilters.filter(this.belongsToFacets(facetIds)).forEach(this.deselect(commit));
+    const filtersToDeselect = facetIds
+      ? getters.selectedFilters.filter(this.belongsToFacets(facetIds))
+      : getters.selectedFilters;
+    filtersToDeselect.forEach(this.deselect(commit));
   }
 
   /**

--- a/packages/x-components/src/x-modules/facets/store/types.ts
+++ b/packages/x-components/src/x-modules/facets/store/types.ts
@@ -142,7 +142,7 @@ export interface FacetsActions {
    *
    * @param facetsIds - A list of facet ids from whom deselect all the filters.
    */
-  clearFacetsSelectedFilters(facetsIds: Array<Facet['id']>): void;
+  clearFacetsSelectedFilters(facetsIds?: Array<Facet['id']>): void;
   /**
    * Deselects all the filters.
    */


### PR DESCRIPTION
# Description

Adds the wiring for the `facets-next` module. To do so, two new wires factories have been created, `wireService` and `wireServiceWithoutPayload`. These two new factories receive a service, and return a method to create type safe wires that will invoke the passed service name.

# Context

This is needed for the new facets module. Business logic is now shared between a standard service and the filters entities & modifiers, so we need a way to create wires from a given service.

# Test

Several use cases have been provided for the wires factories. The  facets next wiring has also been simplified.