### PR TITLE
feat: modify search function in XAPI to open X

### DIFF
--- a/packages/x-components/src/components/decorators/__tests__/bus.decorators.spec.ts
+++ b/packages/x-components/src/components/decorators/__tests__/bus.decorators.spec.ts
@@ -42,22 +42,22 @@ describe('testing @XOn decorator', () => {
       dataListener(this, payload);
     }
 
-    @XOn(['UserClickedOpenX', 'UserClickedCloseX'])
+    @XOn(['UserClickedOpenEventsModal', 'UserClickedCloseEventsModal'])
     testingXOnMultiple(): void {
       multipleListener(this);
     }
 
-    @XOn('UserClickedCloseX', { moduleName: 'searchBox', origin: 'default' })
+    @XOn('UserClickedCloseEventsModal', { moduleName: 'searchBox', origin: 'default' })
     testingXOnMultipleOptionsFiltered(): void {
       filteredWithMultipleOptionsListener(this);
     }
 
-    @XOn('UserClickedOpenX', { moduleName: 'searchBox' })
+    @XOn('UserClickedOpenEventsModal', { moduleName: 'searchBox' })
     testingXOnOptions(): void {
       optionsListener(this);
     }
 
-    @XOn('UserClickedCloseX', { moduleName: 'empathize' })
+    @XOn('UserClickedCloseEventsModal', { moduleName: 'empathize' })
     testingXOnOptionsFiltered(): void {
       filteredOptionsListener(this);
     }
@@ -106,8 +106,8 @@ describe('testing @XOn decorator', () => {
   });
 
   it('subscribes to a defined array of events', () => {
-    component.vm.$x.emit('UserClickedOpenX');
-    component.vm.$x.emit('UserClickedCloseX');
+    component.vm.$x.emit('UserClickedOpenEventsModal');
+    component.vm.$x.emit('UserClickedCloseEventsModal');
 
     expect(multipleListener).toHaveBeenCalledTimes(2);
   });
@@ -136,8 +136,8 @@ describe('testing @XOn decorator', () => {
     component.vm.$x.emit('UserAcceptedAQuery', 'que pasara que misterios habra');
     component.vm.$x.emit('UserIsTypingAQuery', 'estare escribiendo?');
     component.vm.$x.emit('UserTalked', 'no he dicho nada');
-    component.vm.$x.emit('UserClickedOpenX');
-    component.vm.$x.emit('UserClickedCloseX');
+    component.vm.$x.emit('UserClickedOpenEventsModal');
+    component.vm.$x.emit('UserClickedCloseEventsModal');
 
     expect(singleListener).not.toHaveBeenCalled();
     expect(multipleListener).not.toHaveBeenCalled();
@@ -145,16 +145,16 @@ describe('testing @XOn decorator', () => {
   });
 
   it('filters out callback based on options passed to the decorator', () => {
-    component.vm.$x.emit('UserClickedOpenX');
+    component.vm.$x.emit('UserClickedOpenEventsModal');
     expect(optionsListener).toHaveBeenCalled();
-    component.vm.$x.emit('UserClickedCloseX');
+    component.vm.$x.emit('UserClickedCloseEventsModal');
     expect(filteredOptionsListener).not.toHaveBeenCalled();
   });
 
   it('filters out callback based on multiple options passed to the decorator', () => {
-    component.vm.$x.emit('UserClickedCloseX', undefined, { origin: 'empathize_term' });
+    component.vm.$x.emit('UserClickedCloseEventsModal', undefined, { origin: 'empathize_term' });
     expect(filteredWithMultipleOptionsListener).not.toHaveBeenCalled();
-    component.vm.$x.emit('UserClickedCloseX', undefined, { origin: 'default' });
+    component.vm.$x.emit('UserClickedCloseEventsModal', undefined, { origin: 'default' });
     expect(filteredWithMultipleOptionsListener).toHaveBeenCalled();
   });
 });

--- a/packages/x-components/src/components/modals/__tests__/base-events-close-button.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-events-close-button.spec.ts
@@ -37,10 +37,10 @@ function renderBaseEventsModalClose({
 }
 
 describe('testing Close Button component', () => {
-  it('emits UserClickedCloseX by default when clicked', async () => {
+  it('emits UserClickedCloseEventsModal by default when clicked', async () => {
     const { wrapper, click } = renderBaseEventsModalClose();
     const listener = jest.fn();
-    wrapper.vm.$x.on('UserClickedCloseX').subscribe(listener);
+    wrapper.vm.$x.on('UserClickedCloseEventsModal').subscribe(listener);
 
     await click();
 

--- a/packages/x-components/src/components/modals/__tests__/base-events-modal-open-button.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-events-modal-open-button.spec.ts
@@ -40,7 +40,7 @@ describe('testing Open Button component', () => {
   it('emits UserClickedOpenX by default when clicked', async () => {
     const { wrapper, click } = renderBaseEventsModalOpen();
     const listener = jest.fn();
-    wrapper.vm.$x.on('UserClickedOpenX').subscribe(listener);
+    wrapper.vm.$x.on('UserClickedOpenEventsModal').subscribe(listener);
 
     await click();
 

--- a/packages/x-components/src/components/modals/__tests__/base-events-modal.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-events-modal.spec.ts
@@ -55,17 +55,17 @@ describe('testing Base Events Modal  component', () => {
     const { emit, getModalContent } = mountBaseEventsModal();
     expect(getModalContent().exists()).toBe(false);
 
-    await emit('UserClickedOpenX');
+    await emit('UserClickedOpenEventsModal');
     expect(getModalContent().exists()).toBe(true);
 
-    await emit('UserClickedCloseX');
+    await emit('UserClickedCloseEventsModal');
     expect(getModalContent().exists()).toBe(false);
   });
 
   it('closes when clicking on the modal overlay', async () => {
     const { clickModalOverlay, emit, getModalContent } = mountBaseEventsModal();
 
-    await emit('UserClickedOpenX');
+    await emit('UserClickedOpenEventsModal');
     expect(getModalContent().exists()).toBe(true);
 
     await clickModalOverlay();
@@ -75,7 +75,7 @@ describe('testing Base Events Modal  component', () => {
   it('closes when focusing any other element out of the modal', async () => {
     const { emit, fakeFocusIn, getModalContent } = mountBaseEventsModal();
 
-    await emit('UserClickedOpenX');
+    await emit('UserClickedOpenEventsModal');
     expect(getModalContent().exists()).toBe(true);
 
     await fakeFocusIn();
@@ -89,7 +89,7 @@ describe('testing Base Events Modal  component', () => {
       `
     });
 
-    await emit('UserClickedOpenX');
+    await emit('UserClickedOpenEventsModal');
     expect(getModalContent().exists()).toBe(true);
 
     await wrapper.find(getDataTestSelector('test-button')).trigger('click');
@@ -127,7 +127,7 @@ describe('testing Base Events Modal  component', () => {
     const listener = jest.fn();
     wrapper.vm.$x.on(bodyClickEvent).subscribe(listener);
 
-    await emit('UserClickedOpenX');
+    await emit('UserClickedOpenEventsModal');
     expect(getModalContent().exists()).toBe(true);
 
     await clickModalOverlay();

--- a/packages/x-components/src/components/modals/base-events-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-close.vue
@@ -18,8 +18,9 @@
   import BaseEventButton from '../base-event-button.vue';
 
   /**
-   * Component containing an event button that emits {@link XEventsTypes.UserClickedCloseEventsModal} when
-   * clicked. It has a default slot to customize its contents.
+   * Component containing an event button that emits
+   * {@link XEventsTypes.UserClickedCloseEventsModal} when clicked. It has a default slot to
+   * customize its contents.
    *
    * @public
    */

--- a/packages/x-components/src/components/modals/base-events-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-close.vue
@@ -18,7 +18,7 @@
   import BaseEventButton from '../base-event-button.vue';
 
   /**
-   * Component containing an event button that emits {@link XEventsTypes.UserClickedCloseX} when
+   * Component containing an event button that emits {@link XEventsTypes.UserClickedCloseEventsModal} when
    * clicked. It has a default slot to customize its contents.
    *
    * @public
@@ -27,7 +27,7 @@
     components: { BaseEventButton }
   })
   export default class BaseEventsModalClose extends Vue {
-    @Prop({ default: 'UserClickedCloseX' })
+    @Prop({ default: 'UserClickedCloseEventsModal' })
     protected closingEvent!: PropsWithType<XEventsTypes, void>;
 
     protected get events(): Partial<XEventsTypes> {
@@ -92,5 +92,5 @@ This event can be changed using the `closingEvent` prop.
 
 A list of events that the component will emit:
 
-- `UserClickedCloseX`: the event is emitted after the user clicks the button.
+- `UserClickedCloseEventsModal`: the event is emitted after the user clicks the button.
 </docs>

--- a/packages/x-components/src/components/modals/base-events-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-close.vue
@@ -18,9 +18,8 @@
   import BaseEventButton from '../base-event-button.vue';
 
   /**
-   * Component containing an event button that emits
-   * {@link XEventsTypes.UserClickedCloseEventsModal} when clicked. It has a default slot to
-   * customize its contents.
+   * Component contains an event button that emits {@link XEventsTypes.UserClickedCloseEventsModal}
+   * when clicked. It has a default slot to customize its contents.
    *
    * @public
    */

--- a/packages/x-components/src/components/modals/base-events-modal-open.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-open.vue
@@ -18,7 +18,7 @@
   import BaseEventButton from '../base-event-button.vue';
 
   /**
-   * Component containing an event button that emits {@link XEventsTypes.UserClickedOpenEventsModal}
+   * Component contains an event button that emits {@link XEventsTypes.UserClickedOpenEventsModal}
    * when clicked. It has a default slot to customize its contents.
    *
    * @public

--- a/packages/x-components/src/components/modals/base-events-modal-open.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-open.vue
@@ -18,8 +18,8 @@
   import BaseEventButton from '../base-event-button.vue';
 
   /**
-   * Component containing an event button that emits {@link XEventsTypes.UserClickedOpenX} when
-   * clicked. It has a default slot to customize its contents.
+   * Component containing an event button that emits {@link XEventsTypes.UserClickedOpenEventsModal}
+   * when clicked. It has a default slot to customize its contents.
    *
    * @public
    */
@@ -27,7 +27,7 @@
     components: { BaseEventButton }
   })
   export default class BaseEventsModalOpen extends Vue {
-    @Prop({ default: 'UserClickedOpenX' })
+    @Prop({ default: 'UserClickedOpenEventsModal' })
     protected openingEvent!: PropsWithType<XEventsTypes, void>;
 
     protected get events(): Partial<XEventsTypes> {
@@ -96,5 +96,5 @@ This event can be changed using the `openingEvent` prop, but remember to change 
 
 A list of events that the component will emit:
 
-- `UserClickedOpenX`: the event is emitted after the user clicks the button.
+- `UserClickedOpenEventsModal`: the event is emitted after the user clicks the button.
 </docs>

--- a/packages/x-components/src/components/modals/base-events-modal.vue
+++ b/packages/x-components/src/components/modals/base-events-modal.vue
@@ -19,7 +19,7 @@
   import BaseModal from './base-modal.vue';
 
   /**
-   * Component containing a modal that emits a {@link XEventsTypes.UserClickedCloseX} when
+   * Component containing a modal that emits a {@link XEventsTypes.UserClickedCloseEventsModal} when
    * clicking outside the content rendered in the default slot and can receive, through the
    * eventsToCloseModal prop, a list of {@link XEvent | xEvents} to listen to in order to close
    * also the modal, eventsToOpenModal prop,  another list of {@link XEvent | xEvents} to customize
@@ -41,19 +41,21 @@
     /**
      * Array of {@link XEvent | xEvents} to listen to open the modal.
      */
-    @Prop({ default: (): XEvent[] => ['UserClickedOpenX'] })
+    @Prop({ default: (): XEvent[] => ['UserClickedOpenEventsModal'] })
     public eventsToOpenModal!: XEvent[];
 
     /**
      * Array of {@link XEvent | xEvents} to listen to close the modal.
      */
-    @Prop({ default: (): XEvent[] => ['UserClickedCloseX', 'UserClickedOutOfXModal'] })
+    @Prop({
+      default: (): XEvent[] => ['UserClickedCloseEventsModal', 'UserClickedOutOfEventsModal']
+    })
     public eventsToCloseModal!: XEvent[];
 
     /**
      * Event to emit when any part of the website out of the modal has been clicked.
      */
-    @Prop({ default: 'UserClickedOutOfXModal' })
+    @Prop({ default: 'UserClickedOutOfEventsModal' })
     public bodyClickEvent!: XEvent;
 
     /**
@@ -194,7 +196,7 @@ see a full example on how this would work with custom events.
 
 A list of events that the component will emit:
 
-- `UserClickedCloseX`: the event is emitted after clicking outside the content rendered in the
-  default slot.
+- `UserClickedCloseEventsModal`: the event is emitted after clicking outside the content rendered in
+  the default slot.
 - Custom events to open or close the modal.
 </docs>

--- a/packages/x-components/src/components/modals/base-events-modal.vue
+++ b/packages/x-components/src/components/modals/base-events-modal.vue
@@ -198,5 +198,6 @@ A list of events that the component will emit:
 
 - `UserClickedCloseEventsModal`: the event is emitted after clicking outside the content rendered in
   the default slot.
+- `UserClickedOutOfEventsModal`: the event is emitted after clicking outside the modal.
 - Custom events to open or close the modal.
 </docs>

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -144,7 +144,7 @@ export interface XEventsTypes
    */
   UserClickedScrollToTop: string;
   /**
-   * The user has open X with the API.
+   * The user opened X programmatically.
    * * Payload: none.
    */
   UserOpenXProgrammatically: void;

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -99,10 +99,10 @@ export interface XEventsTypes
    */
   UserClickedCloseModal: string;
   /**
-   * The user clicked the button to close the XComponents modal.
+   * The user clicked the button to close the events modal.
    * * Payload: none.
    */
-  UserClickedCloseX: void;
+  UserClickedCloseEventsModal: void;
   /**
    * The user clicked the button to select the number of columns.
    * * Payload: the column number.
@@ -114,20 +114,20 @@ export interface XEventsTypes
    */
   UserClickedOpenModal: string;
   /**
-   * The user clicked the button to open the XComponents modal.
+   * The user clicked the button to open the events modal.
    * * Payload: none.
    */
-  UserClickedOpenX: void;
+  UserClickedOpenEventsModal: void;
   /**
    * The user clicked out of a modal while it was opened.
    * * Payload: the id of the modal.
    */
   UserClickedOutOfModal: string;
   /**
-   * The user clicked out of the X Modal while it is opened.
+   * The user clicked out of the events modal while it is opened.
    * * Payload: none.
    */
-  UserClickedOutOfXModal: void;
+  UserClickedOutOfEventsModal: void;
   /**
    * The user clicked the button to toggle a panel.
    * * Payload: the id of the panel to toggle.
@@ -143,6 +143,11 @@ export interface XEventsTypes
    * * Payload: The scroll id which has scrolled to top.
    */
   UserClickedScrollToTop: string;
+  /**
+   * The user has open X with the API.
+   * * Payload: none.
+   */
+  UserOpenXProgrammatically: void;
   /**
    * The user pressed an {@link ArrowKey | arrow key} with the focus on the search-box.
    * * Payload: the pressed {@link ArrowKey | arrow key}.

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -33,7 +33,7 @@ export interface XAPI {
    *
    * @public
    */
-  search(query: string): void;
+  search(query?: string): void;
 
   /**
    * Method to initialize the XComponents app.

--- a/packages/x-components/src/x-installer/api/base-api.ts
+++ b/packages/x-components/src/x-installer/api/base-api.ts
@@ -56,9 +56,12 @@ export class BaseXAPI implements XAPI {
    *
    * @public
    */
-  search(query: string): void {
+  search(query?: string): void {
     // TODO - It should do more things like emit the query was changed out of the normal user flow
-    this.bus?.emit('UserAcceptedAQuery', query);
+    if (query) {
+      this.bus?.emit('UserAcceptedAQuery', query);
+    }
+    this.bus?.emit('UserOpenXProgrammatically');
   }
 
   /**

--- a/packages/x-components/src/x-installer/api/base-api.ts
+++ b/packages/x-components/src/x-installer/api/base-api.ts
@@ -57,7 +57,6 @@ export class BaseXAPI implements XAPI {
    * @public
    */
   search(query?: string): void {
-    // TODO - It should do more things like emit the query was changed out of the normal user flow
     if (query) {
       this.bus?.emit('UserAcceptedAQuery', query);
     }


### PR DESCRIPTION
This PR modifies the current XAPI to use the search function to open X when it's called without query.

To make this event works with the current X components, you have to use de BaseEventsModal instead of the BaseIdModal, this modal will be opened when an event that it's been listened to by it, its called.

Some of the events were renamed to be more accurate.

To test this, you can go to the BaseEventsModal view and change the events to open the modal:

`<BaseEventsModal :eventsToOpenModal=['UserClickedOpenEventsModal, 'UserOpenXProgramatically']>`

EX-3555