### PR TITLE
feat(facets-next): add facets component to FacetsNext module

### DIFF
--- a/packages/x-components/src/router.ts
+++ b/packages/x-components/src/router.ts
@@ -20,6 +20,11 @@ const routes: RouteConfig[] = [
     component: () => import('./views/Layout.vue')
   },
   {
+    path: '/layout-next',
+    name: 'Layout Next',
+    component: () => import('./views/LayoutNext.vue')
+  },
+  {
     path: '/empathize',
     name: 'empathize',
     component: () => import('./views/empathize.vue')

--- a/packages/x-components/src/views/LayoutNext.vue
+++ b/packages/x-components/src/views/LayoutNext.vue
@@ -193,7 +193,6 @@
   import BaseScrollToTop from '../components/scroll/base-scroll-to-top.vue';
   import SlidingPanel from '../components/sliding-panel.vue';
   import { infiniteScroll } from '../directives/infinite-scroll/infinite-scroll';
-  import { XPlugin } from '../plugins/x-plugin';
   import { XInstaller } from '../x-installer/x-installer';
   import Facets from '../x-modules/facets-next/components/facets/facets.vue';
   import SimpleFilter from '../x-modules/facets/components/filters/simple-filter.vue';
@@ -214,12 +213,10 @@
   import ResultsList from '../x-modules/search/components/results-list.vue';
   import SortDropdown from '../x-modules/search/components/sort-dropdown.vue';
   import SortList from '../x-modules/search/components/sort-list.vue';
-  import { searchXModule } from '../x-modules/search/x-module';
   import { baseInstallXOptions, baseSnippetConfig } from './base-config';
 
   @Component({
     beforeRouteEnter(_to, _from, next: () => void): void {
-      XPlugin.registerXModule(searchXModule);
       new XInstaller(
         deepMerge(baseInstallXOptions, {
           xModules: { recommendations: { config: { maxItemsToRequest: 48 } } }

--- a/packages/x-components/src/views/LayoutNext.vue
+++ b/packages/x-components/src/views/LayoutNext.vue
@@ -1,0 +1,291 @@
+<template>
+  <div>
+    <BaseIdModalOpen modal-id="x-app">Start</BaseIdModalOpen>
+    <BaseIdModal modal-id="x-app">
+      <Layout>
+        <template #header-middle>
+          <div
+            class="
+              x-list x-list--vertical x-list--gap-05 x-list--align-stretch x-list__item--expand
+            "
+          >
+            <div class="x-input-group x-input-group--card x-list__item--expand">
+              <SearchInput placeholder="Search" aria-label="Search for products" />
+              <ClearSearchInput aria-label="Clear query">Clear</ClearSearchInput>
+              <SearchButton class="x-input-group__action" aria-label="Search">
+                <SearchIcon />
+              </SearchButton>
+            </div>
+
+            <SlidingPanel v-if="$x.relatedTags.length">
+              <template #sliding-panel-left-button><ChevronLeft /></template>
+              <RelatedTags class="x-tag--card x-list--gap-03" />
+              <template #sliding-panel-right-button><ChevronRight /></template>
+            </SlidingPanel>
+          </div>
+        </template>
+
+        <template #header-end>
+          <BaseIdModalClose class="x-button--ghost" modal-id="x-app">
+            <CrossIcon />
+          </BaseIdModalClose>
+        </template>
+
+        <template #empathize>
+          <div class="x-list x-list--horizontal x-list--gap-06">
+            <PopularSearches max-items-to-render="10" />
+            <HistoryQueries max-items-to-render="10" />
+            <QuerySuggestions max-items-to-render="10" />
+            <NextQueries max-items-to-render="10" />
+          </div>
+        </template>
+
+        <template #toolbar-aside>
+          <BaseIdTogglePanelButton
+            v-if="$x.totalResults > 0"
+            panelId="aside-panel"
+            class="x-button x-button--ghost"
+          >
+            Toggle Aside
+          </BaseIdTogglePanelButton>
+        </template>
+
+        <template #toolbar-body>
+          <div
+            v-if="$x.totalResults > 0"
+            class="x-list x-list--horizontal x-list--align-center x-list--gap-04"
+          >
+            <span>{{ $x.totalResults }} Results</span>
+            <BaseColumnPickerList
+              #default="{ column }"
+              v-model="selectedColumns"
+              :columns="columnPickerValues"
+            >
+              <template v-if="column === 0">
+                <ChevronTinyRight />
+                <Grid1Col />
+                <ChevronTinyLeft />
+              </template>
+              <Grid1Col v-else-if="column === 4" />
+              <Grid2Col v-else-if="column === 6" />
+            </BaseColumnPickerList>
+            <SortDropdown class="x-option-list--bottom" :items="sortValues">
+              <template #toggle="{ item }">{{ item || 'default' }}</template>
+              <template #item="{ item }">{{ item || 'default' }}</template>
+            </SortDropdown>
+          </div>
+        </template>
+
+        <template #main-aside>
+          <div
+            v-if="$x.totalResults > 0"
+            class="x-list x-list--padding-05 x-list--padding-top x-list--border x-list--border-top"
+          >
+            <Facets class="x-list--gap-06">
+              <!--  Default Facet    -->
+              <template #default="{ facet }">
+                <BaseHeaderTogglePanel class="x-facet">
+                  <template #header-content>
+                    <span class="x-ellipsis">{{ facet.label }}</span>
+                    <ChevronDown />
+                  </template>
+                  <MultiSelectFilters v-slot="{ filter }" :filters="facet.filters">
+                    <SimpleFilter :filter="filter" />
+                  </MultiSelectFilters>
+                </BaseHeaderTogglePanel>
+              </template>
+            </Facets>
+          </div>
+        </template>
+
+        <template #main-body>
+          <!-- Recommendations -->
+          <Recommendations
+            v-if="!$x.query.search || $x.totalResults === 0"
+            #layout="{ recommendations }"
+          >
+            <BaseVariableColumnGrid
+              #default="{ item: result }"
+              :items="recommendations"
+              :animation="resultsAnimation"
+            >
+              <article class="result" style="max-width: 300px">
+                <BaseResultImage class="x-picture--colored" :result="result">
+                  <template #placeholder>
+                    <div style="padding-top: 100%; background-color: lightgray"></div>
+                  </template>
+                  <template #fallback>
+                    <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                  </template>
+                </BaseResultImage>
+                <h1 class="x-title3">{{ result.name }}</h1>
+              </article>
+            </BaseVariableColumnGrid>
+          </Recommendations>
+
+          <!-- Results -->
+          <ResultsList v-infinite-scroll:body-scroll>
+            <BannersList>
+              <PromotedsList>
+                <BaseVariableColumnGrid :animation="resultsAnimation">
+                  <template #Result="{ item: result }">
+                    <article class="result" style="max-width: 300px">
+                      <BaseResultImage class="x-picture&#45;&#45;colored" :result="result">
+                        <template #placeholder>
+                          <div style="padding-top: 100%; background-color: lightgray"></div>
+                        </template>
+                        <template #fallback>
+                          <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                        </template>
+                      </BaseResultImage>
+                      <h1 class="x-title3">{{ result.name }}</h1>
+                    </article>
+                  </template>
+
+                  <template #Banner="{ item: banner }">
+                    <Banner :banner="banner" />
+                  </template>
+
+                  <template #Promoted="{ item: promoted }">
+                    <Promoted :promoted="promoted" />
+                  </template>
+                </BaseVariableColumnGrid>
+              </PromotedsList>
+            </BannersList>
+          </ResultsList>
+        </template>
+
+        <template #scroll-to-top>
+          <BaseScrollToTop class="x-button--round" scroll-id="body-scroll" :threshold-px="500">
+            <ChevronUp />
+          </BaseScrollToTop>
+        </template>
+      </Layout>
+    </BaseIdModal>
+  </div>
+</template>
+
+<script lang="ts">
+  import { deepMerge } from '@empathyco/x-deep-merge';
+  import Vue from 'vue';
+  import { Component } from 'vue-property-decorator';
+  import { BaseIdTogglePanelButton } from '../components';
+  import StaggeredFadeAndSlide from '../components/animations/staggered-fade-and-slide.vue';
+  import BaseGrid from '../components/base-grid.vue';
+  import BaseVariableColumnGrid from '../components/base-variable-column-grid.vue';
+  import BaseColumnPickerList from '../components/column-picker/base-column-picker-list.vue';
+  import ChevronDown from '../components/icons/chevron-down.vue';
+  import ChevronLeft from '../components/icons/chevron-left.vue';
+  import ChevronRight from '../components/icons/chevron-right.vue';
+  import ChevronTinyLeft from '../components/icons/chevron-tiny-left.vue';
+  import ChevronTinyRight from '../components/icons/chevron-tiny-right.vue';
+  import ChevronUp from '../components/icons/chevron-up.vue';
+  import CrossIcon from '../components/icons/cross.vue';
+  import Grid1Col from '../components/icons/grid-1-col.vue';
+  import Grid2Col from '../components/icons/grid-2-col.vue';
+  import SearchIcon from '../components/icons/search.vue';
+  import Layout from '../components/layouts/layout.vue';
+  import BaseIdModalClose from '../components/modals/base-id-modal-close.vue';
+  import BaseIdModalOpen from '../components/modals/base-id-modal-open.vue';
+  import BaseIdModal from '../components/modals/base-id-modal.vue';
+  import BaseHeaderTogglePanel from '../components/panels/base-header-toggle-panel.vue';
+  import BaseResultImage from '../components/result/base-result-image.vue';
+  import BaseScrollToTop from '../components/scroll/base-scroll-to-top.vue';
+  import SlidingPanel from '../components/sliding-panel.vue';
+  import { infiniteScroll } from '../directives/infinite-scroll/infinite-scroll';
+  import { XPlugin } from '../plugins/x-plugin';
+  import { XInstaller } from '../x-installer/x-installer';
+  import Facets from '../x-modules/facets-next/components/facets/facets.vue';
+  import SimpleFilter from '../x-modules/facets/components/filters/simple-filter.vue';
+  import MultiSelectFilters from '../x-modules/facets/components/lists/multi-select-filters.vue';
+  import HistoryQueries from '../x-modules/history-queries/components/history-queries.vue';
+  import NextQueries from '../x-modules/next-queries/components/next-queries.vue';
+  import PopularSearches from '../x-modules/popular-searches/components/popular-searches.vue';
+  import QuerySuggestions from '../x-modules/query-suggestions/components/query-suggestions.vue';
+  import Recommendations from '../x-modules/recommendations/components/recommendations.vue';
+  import RelatedTags from '../x-modules/related-tags/components/related-tags.vue';
+  import ClearSearchInput from '../x-modules/search-box/components/clear-search-input.vue';
+  import SearchButton from '../x-modules/search-box/components/search-button.vue';
+  import SearchInput from '../x-modules/search-box/components/search-input.vue';
+  import Banner from '../x-modules/search/components/banner.vue';
+  import BannersList from '../x-modules/search/components/banners-list.vue';
+  import Promoted from '../x-modules/search/components/promoted.vue';
+  import PromotedsList from '../x-modules/search/components/promoteds-list.vue';
+  import ResultsList from '../x-modules/search/components/results-list.vue';
+  import SortDropdown from '../x-modules/search/components/sort-dropdown.vue';
+  import SortList from '../x-modules/search/components/sort-list.vue';
+  import { searchXModule } from '../x-modules/search/x-module';
+  import { baseInstallXOptions, baseSnippetConfig } from './base-config';
+
+  @Component({
+    beforeRouteEnter(_to, _from, next: () => void): void {
+      XPlugin.registerXModule(searchXModule);
+      new XInstaller(
+        deepMerge(baseInstallXOptions, {
+          xModules: { recommendations: { config: { maxItemsToRequest: 48 } } }
+        })
+      ).init(baseSnippetConfig);
+      next();
+    },
+    directives: {
+      infiniteScroll
+    },
+    components: {
+      ChevronUp,
+      Promoted,
+      PromotedsList,
+      Banner,
+      BannersList,
+      BaseIdTogglePanelButton,
+      BaseScrollToTop,
+      ChevronDown,
+      ChevronRight,
+      ChevronLeft,
+      ChevronTinyRight,
+      ChevronTinyLeft,
+      Grid2Col,
+      Grid1Col,
+      CrossIcon,
+      SearchIcon,
+      NextQueries,
+      QuerySuggestions,
+      HistoryQueries,
+      RelatedTags,
+      SlidingPanel,
+      Recommendations,
+      BaseResultImage,
+      BaseVariableColumnGrid,
+      BaseGrid,
+      ResultsList,
+      SortList,
+      BaseColumnPickerList,
+      SortDropdown,
+      SimpleFilter,
+      MultiSelectFilters,
+      BaseHeaderTogglePanel,
+      Facets,
+      SearchButton,
+      ClearSearchInput,
+      BaseIdModalClose,
+      BaseIdModalOpen,
+      BaseIdModal,
+      SearchInput,
+      PopularSearches,
+      Layout
+    }
+  })
+  export default class App extends Vue {
+    protected sortValues = ['', 'priceSort asc', 'priceSort desc'];
+    protected columnPickerValues = [0, 4, 6];
+    protected selectedColumns = 4;
+    protected resultsAnimation = StaggeredFadeAndSlide;
+  }
+</script>
+
+<style lang="scss" scoped>
+  .x-modal::v-deep .x-modal__content {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+</style>

--- a/packages/x-components/src/wiring/__tests__/wires-operators.spec.ts
+++ b/packages/x-components/src/wiring/__tests__/wires-operators.spec.ts
@@ -8,6 +8,7 @@ import {
   filterFalsyPayload,
   filterTruthyPayload,
   filterWhitelistedModules,
+  mapWire,
   throttle
 } from '../wires.operators';
 import { WireParams, WirePayload } from '../wiring.types';
@@ -282,6 +283,24 @@ describe('testing wires operators', () => {
         jest.advanceTimersByTime(1);
         expect(executeFunction).toHaveBeenCalledTimes(2);
       });
+    });
+
+    describe('testing operator ' + mapWire.name, () => {
+      test(
+        mapWire.name + ' emits the valued transformed by the function passed by parameter',
+        () => {
+          const mappedWire = mapWire(wire, (payload: number) => payload + 1);
+
+          mappedWire(subjectHandler.subject, storeMock, busOnMock);
+          const emittedValues = [1, 2, 3, 4, 5];
+          subjectHandler.emit(emittedValues);
+
+          expect(executeFunction).toHaveBeenCalledTimes(5);
+          executeFunction.mock.calls.forEach(([payload], index) => {
+            expect(payload).toEqual(getExpectedWirePayload(emittedValues[index] + 1, storeMock));
+          });
+        }
+      );
     });
 
     function replaceDebouncedTimeInStore(debounceInMs: number): void {

--- a/packages/x-components/src/x-modules/facets-next/components/__tests__/utils.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/__tests__/utils.ts
@@ -1,0 +1,22 @@
+import { Store } from 'vuex';
+import { RootXStoreState } from '../../../../store/store.types';
+import { DeepPartial } from '../../../../utils/types';
+import { resetStoreXModuleState } from '../../../../__tests__/utils';
+import { facetsNextXStoreModule as facetsXStoreModule } from '../../store/module';
+import { FacetsNextState as FacetsState } from '../../store/types';
+
+/**
+ * Reset facets x-module state with its original state and the partial state passes as
+ * parameter.
+ *
+ * @param store - Root state of the x-modules.
+ * @param state - Partial facets store state to use as replacement.
+ *
+ * @internal
+ */
+export function resetXFacetsStateWith(
+  store: Store<DeepPartial<RootXStoreState>>,
+  state?: DeepPartial<FacetsState>
+): void {
+  resetStoreXModuleState(store, 'facetsNext', facetsXStoreModule.state(), state);
+}

--- a/packages/x-components/src/x-modules/facets-next/components/facets/__tests__/facets.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/facets/__tests__/facets.spec.ts
@@ -1,0 +1,279 @@
+import { Facet } from '@empathyco/x-types-next';
+import { createLocalVue, mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex, { Store } from 'vuex';
+import { createSimpleFacetStub } from '../../../../../__stubs__/facets-stubs.factory';
+import { getDataTestSelector, installNewXPlugin } from '../../../../../__tests__/utils';
+import {
+  getXComponentXModuleName,
+  isXComponent
+} from '../../../../../components/x-component.utils';
+import { XPlugin } from '../../../../../plugins/x-plugin';
+import { RootXStoreState } from '../../../../../store/store.types';
+import { arrayToObject } from '../../../../../utils/array';
+import { DeepPartial, Dictionary } from '../../../../../utils/types';
+import { facetsNextXModule } from '../../../x-module';
+import { resetXFacetsStateWith } from '../../__tests__/utils';
+import Facets from '../facets.vue';
+
+describe('testing Facets component', () => {
+  it('is an XComponent', () => {
+    const { wrapper } = renderFacetsComponent();
+    expect(isXComponent(wrapper.vm)).toEqual(true);
+  });
+
+  it('has FacetsModule as XModule', () => {
+    const { wrapper } = renderFacetsComponent();
+    expect(getXComponentXModuleName(wrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('does not render anything when facets are empty', () => {
+    const { wrapper } = renderFacetsComponent({ facets: {} });
+    expect(wrapper.find('facets').exists()).toBe(false);
+  });
+
+  it('renders the state facets', () => {
+    const { getDefaultFacets, getStateFacets, getDefaultSelectedFilters } = renderFacetsComponent({
+      facets: {
+        color_facet: createSimpleFacetStub('color_facet', createSimpleFilter => [
+          createSimpleFilter('Red', false),
+          createSimpleFilter('Blue', true)
+        ]),
+        brand_facet: createSimpleFacetStub('brand_facet', createSimpleFilter => [
+          createSimpleFilter('Adidas', false),
+          createSimpleFilter('Nike', false)
+        ])
+      }
+    });
+    const facetWrappers = getDefaultFacets();
+    const stateFacets = getStateFacets();
+    const facetLabels = stateFacets.map(facet => facet.label);
+    const selectedFiltersWrappers = getDefaultSelectedFilters();
+
+    expect(facetWrappers.wrappers).toHaveLength(stateFacets.length);
+    facetWrappers.wrappers.forEach((facetWrapper: Wrapper<Vue>) => {
+      expect(facetLabels).toContain(facetWrapper.element.innerHTML);
+    });
+
+    expect(selectedFiltersWrappers.wrappers).toHaveLength(1);
+    expect(selectedFiltersWrappers.wrappers[0].text()).toEqual('Blue');
+  });
+
+  it('allows customizing a facet using a slot named with the facet.id', () => {
+    const customFacetId = 'color_facet';
+
+    const { wrapper, getDefaultFacets } = renderFacetsComponent({
+      customFacetSlot: `
+          <template #${customFacetId}="{ facet, selectedFilters }">
+            <p data-test="custom-facet">{{ facet.label }}</p>
+            <div data-test="custom-facet-selected-filters">
+              <span v-for="filter in selectedFilters">{{ filter.label }}</span>
+            </div>
+          </template>`,
+      facets: {
+        [customFacetId]: createSimpleFacetStub(customFacetId, createSimpleFilter => [
+          createSimpleFilter('Red', true),
+          createSimpleFilter('Blue', true)
+        ]),
+        brand_facet: createSimpleFacetStub('brand_facet', createSimpleFilter => [
+          createSimpleFilter('Adidas', false),
+          createSimpleFilter('Nike', false)
+        ])
+      }
+    });
+    const customFacetWrapper = wrapper.get(getDataTestSelector('custom-facet'));
+    const customSelectedFiltersWrapper = wrapper.get(
+      getDataTestSelector('custom-facet-selected-filters')
+    );
+
+    expect(customFacetWrapper.exists()).toBe(true);
+    expect(customFacetWrapper.text()).toBe(customFacetId);
+    getDefaultFacets().wrappers.forEach(facet => {
+      expect(facet.text()).not.toBe(customFacetId);
+    });
+    expect(customSelectedFiltersWrapper.text()).toEqual('RedBlue');
+  });
+
+  describe('filters facets based on renderableFacets prop', () => {
+    it('renders all facets when its value is omitted', () => {
+      const { getDefaultFacets } = renderFacetsComponent({
+        facets: {
+          color: createSimpleFacetStub('color', createSimpleFilter => [
+            createSimpleFilter('Red', false),
+            createSimpleFilter('Blue', false)
+          ]),
+          size: createSimpleFacetStub('size', createSimpleFilter => [
+            createSimpleFilter('Big', false),
+            createSimpleFilter('Small', false)
+          ])
+        }
+      });
+
+      const facetWrappers = getDefaultFacets();
+      expect(facetWrappers).toHaveLength(2);
+      getDefaultFacets().wrappers.forEach(facetWrapper => {
+        expect(['color', 'size']).toContain(facetWrapper.text());
+      });
+    });
+
+    it('renders only included facets', () => {
+      const { getDefaultFacets } = renderFacetsComponent({
+        facets: {
+          color_facet: createSimpleFacetStub('color_facet', createSimpleFilter => [
+            createSimpleFilter('Red', false),
+            createSimpleFilter('Blue', true)
+          ]),
+          brand_facet: createSimpleFacetStub('brand_facet', createSimpleFilter => [
+            createSimpleFilter('Adidas', false),
+            createSimpleFilter('Nike', false)
+          ]),
+          price_facet: createSimpleFacetStub('price_facet', createSimpleFilter => [
+            createSimpleFilter('< 10 €', false),
+            createSimpleFilter('10 - 50 €', false)
+          ])
+        },
+        renderableFacets: 'color_facet'
+      });
+
+      const facetWrappers = getDefaultFacets();
+      expect(facetWrappers).toHaveLength(1);
+      getDefaultFacets().wrappers.forEach(facetWrapper => {
+        expect(['color_facet']).toContain(facetWrapper.text());
+      });
+    });
+
+    it('does not render excluded facets', () => {
+      const { getDefaultFacets } = renderFacetsComponent({
+        facets: {
+          color: createSimpleFacetStub('color', createSimpleFilter => [
+            createSimpleFilter('Red', false),
+            createSimpleFilter('Blue', false)
+          ]),
+          size: createSimpleFacetStub('size', createSimpleFilter => [
+            createSimpleFilter('Big', false),
+            createSimpleFilter('Small', false)
+          ]),
+          price: createSimpleFacetStub('price', createSimpleFilter => [
+            createSimpleFilter('< 10 €', false),
+            createSimpleFilter('10 - 50 €', false)
+          ])
+        },
+        renderableFacets: '!color'
+      });
+
+      const facetWrappers = getDefaultFacets();
+      expect(facetWrappers).toHaveLength(2);
+      getDefaultFacets().wrappers.forEach(facetWrapper => {
+        expect(['size', 'price']).toContain(facetWrapper.text());
+      });
+    });
+
+    it('renders only included facets when combining with excluded ones', () => {
+      const { getDefaultFacets } = renderFacetsComponent({
+        facets: {
+          color: createSimpleFacetStub('color', createSimpleFilter => [
+            createSimpleFilter('Red', false),
+            createSimpleFilter('Blue', false)
+          ]),
+          size: createSimpleFacetStub('size', createSimpleFilter => [
+            createSimpleFilter('Big', false),
+            createSimpleFilter('Small', false)
+          ]),
+          price: createSimpleFacetStub('price', createSimpleFilter => [
+            createSimpleFilter('< 10 €', false),
+            createSimpleFilter('10 - 50 €', false)
+          ])
+        },
+        renderableFacets: 'color,!price'
+      });
+
+      const facetWrappers = getDefaultFacets();
+      expect(facetWrappers).toHaveLength(1);
+      getDefaultFacets().wrappers.forEach(facetWrapper => {
+        expect(['color']).toContain(facetWrapper.text());
+      });
+    });
+  });
+});
+
+function renderFacetsComponent({
+  customFacetSlot = '',
+  components,
+  // TODO remove cast after facets refactor
+  facets = {},
+  renderableFacets,
+  template = `
+       <Facets
+        :renderableFacets="renderableFacets"
+       >
+          ${customFacetSlot ?? ''}
+          <template #default="{ facet, selectedFilters }">
+            <p data-test="default-slot-facet">{{ facet.label }}</p>
+            <div v-if="selectedFilters.length > 0" data-test="default-slot-selected-filters">
+              <span v-for="filter in selectedFilters">
+                {{ filter.label }}
+              </span>
+            </div>
+          </template>
+       </Facets>`
+}: FacetsRenderOptions = {}): FacetsComponentAPI {
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const store = new Store<DeepPartial<RootXStoreState>>({});
+  installNewXPlugin({ store }, localVue);
+  XPlugin.registerXModule(facetsNextXModule);
+  const filters = arrayToObject(
+    Object.values(facets)
+      ?.map(facet => facet.filters)
+      .flat(),
+    'id'
+  );
+  resetXFacetsStateWith(store, { facets, filters });
+
+  const facetWrapper = mount(
+    {
+      components: {
+        Facets,
+        ...components
+      },
+      props: ['renderableFacets'],
+      template
+    },
+    {
+      localVue,
+      store,
+      propsData: {
+        renderableFacets
+      }
+    }
+  );
+  const wrapper = facetWrapper.findComponent(Facets);
+
+  return {
+    wrapper,
+    getStateFacets() {
+      return Object.values(facets);
+    },
+    getDefaultFacets() {
+      return wrapper.findAll(getDataTestSelector('default-slot-facet'));
+    },
+    getDefaultSelectedFilters() {
+      return wrapper.findAll(getDataTestSelector('default-slot-selected-filters'));
+    }
+  };
+}
+
+interface FacetsRenderOptions {
+  components?: Dictionary<typeof Vue>;
+  customFacetSlot?: string;
+  facets?: Dictionary<Facet>;
+  renderableFacets?: string;
+  template?: string;
+}
+
+interface FacetsComponentAPI {
+  getDefaultFacets: () => WrapperArray<Vue>;
+  getDefaultSelectedFilters: () => WrapperArray<Vue>;
+  getStateFacets: () => Facet[];
+  wrapper: Wrapper<Vue>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/facets/facets.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/facets/facets.vue
@@ -1,0 +1,403 @@
+<template>
+  <component
+    :is="animation"
+    v-if="hasFacets"
+    class="x-list x-facets-list"
+    data-test="facets"
+    tag="ul"
+  >
+    <li
+      v-for="(facet, facetId) in facetsToRender"
+      :key="facetId"
+      class="x-facets-list__item"
+      data-test="facets-facet"
+    >
+      <!--
+        @slot Customized Facet rendering. Specifying a slot with the facet's name will result in the
+        facet using that slot composition to render.
+            @binding {Facet} facet - Facet to render
+      -->
+      <slot
+        v-if="$scopedSlots[facetId]"
+        v-bind="{ facet, selectedFilters: selectedFiltersByFacet[facetId] || [] }"
+        :name="facetId"
+      />
+      <!--
+        @slot (required) Default Facet rendering. This slot will be used by default for rendering
+        the facets without an specific slot implementation.
+            @binding {Facet} facet - Facet to render
+      -->
+      <slot v-else v-bind="{ facet, selectedFilters: selectedFiltersByFacet[facetId] || [] }">
+        This is the {{ facet.label }} facet. Pass something into its slot to display content.
+      </slot>
+    </li>
+  </component>
+</template>
+
+<script lang="ts">
+  import { Facet } from '@empathyco/x-types-next';
+  import { Component, Prop, Vue } from 'vue-property-decorator';
+  import { Getter } from '../../../../components/decorators/store.decorators';
+  import { xComponentMixin } from '../../../../components/x-component.mixin';
+  import { objectFilter } from '../../../../utils/object';
+  import { Dictionary } from '../../../../utils/types';
+  import { FiltersByFacetNext } from '../../store/types';
+  import { facetsNextXModule as facetsXModule } from '../../x-module';
+
+  /**
+   * This component renders the list of facets stored in the Facets module. This facets can be set
+   * either emitting the `BackendFacetsChanged` and/or `FrontendFacetsChanged` events, or by using
+   * the `backendFacets` and/or `frontendFacets` props. Facets can be rendered differently based on
+   * their purpose and this can be achieved using the exposed slots:
+   * - A default and required slot.
+   * - A custom slot for each facet with the facetId as its name. This allows each facet to be
+   * rendered differently based on its needs.
+   *
+   * @public
+   */
+  @Component({
+    mixins: [xComponentMixin(facetsXModule)]
+  })
+  export default class Facets extends Vue {
+    /**
+     * Animation component that will be used to animate the facets.
+     *
+     * @public
+     */
+    @Prop({ default: 'ul' })
+    public animation!: Vue | string;
+
+    /**
+     * Discriminates the facets rendered by this component. It expects a string containing facets
+     * ids, comma separated. This property will include or exclude facets based on its value.
+     * The default value is an empty string and the component will render all existing facets.
+     *
+     * @remarks
+     * To behave as a `include`, simply set the facets ids, comma separated:
+     * `existingFacets=[{ brand: ... }, category: { ... }, color: { ... }, price: { ... }]`
+     * `renderableFacets="brand, category"`
+     *
+     * The component will render brand and category facets.
+     *
+     * On the other hand, to simulate an `exclude` behaviour and exclude a facet from being
+     * rendered, append a '!' before its id:
+     * `existingFacets=[{ brand: ... }, category: { ... }, color: { ... }, price: { ... }]`
+     * `renderableFacets="!brand,!price"`
+     *
+     * The component will render category and color facets.
+     *
+     * @public
+     */
+    @Prop()
+    public renderableFacets!: string | undefined;
+
+    /**
+     * Array of selected filters from every facet.
+     *
+     * @internal
+     */
+    @Getter('facetsNext', 'selectedFiltersByFacet')
+    public selectedFiltersByFacet!: FiltersByFacetNext;
+
+    /**
+     * Dictionary of facets in the state.
+     *
+     * @internal
+     */
+    @Getter('facetsNext', 'facets')
+    public facets!: Record<Facet['id'], Facet>;
+
+    /**
+     * The facets to be rendered after filtering {@link Facets.stateFacets} by
+     * {@link Facets.renderableFacets} content.
+     *
+     * @returns The list of facets to be rendered.
+     *
+     * @internal
+     */
+    protected get facetsToRender(): Dictionary<Facet> {
+      if (!this.renderableFacets) {
+        return this.facets;
+      } else {
+        const excludedRegExp = /^!/;
+        const facetIds: string[] = this.renderableFacets.split(',').map(facetId => facetId.trim());
+        const included: string[] = [];
+        const excluded: string[] = [];
+        facetIds.forEach(facetId => {
+          if (excludedRegExp.test(facetId)) {
+            excluded.push(facetId.replace(excludedRegExp, ''));
+          } else {
+            included.push(facetId);
+          }
+        });
+
+        return this.filterFacetsToRender(included, excluded);
+      }
+    }
+
+    /**
+     * Indicates if there are facets available to show.
+     *
+     * @returns True if there are facets available and false otherwise.
+     * @internal
+     */
+    protected get hasFacets(): boolean {
+      return !!Object.keys(this.facetsToRender).length;
+    }
+
+    /**
+     * Filter facets dictionary retrieving those included and/or removing excluded.
+     *
+     * @param included - List of facets to render.
+     * @param excluded - List of not renderable facets.
+     *
+     * @returns The filtered list of facets to render.
+     *
+     * @internal
+     */
+    private filterFacetsToRender(included: string[], excluded: string[]): Dictionary<Facet> {
+      const hasAnyFacetIncluded = included.length > 0;
+      return objectFilter(this.facets, facetKey => {
+        const isIncluded = included.includes(String(facetKey));
+        const isExcluded = excluded.includes(String(facetKey));
+
+        return hasAnyFacetIncluded ? isIncluded && !isExcluded : !isExcluded;
+      });
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .x-facets-list {
+    list-style-type: none;
+  }
+</style>
+
+<docs lang="mdx">
+# Example
+
+This component renders the list of facets stored in the Facets module. Facets can be rendered
+differently based on their purpose and this can be achieved using the exposed slots:
+
+- A default and required slot.
+- A custom slot for each facet with the facetId as its name. This allows each facet to be rendered
+  differently based on its needs.
+
+Below, there are some examples showing how to use the component with its different configurations.
+
+## Default usage
+
+The default slot of this component is mandatory. If no other slot is defined, every Facet will be
+rendered as specified in the default slot.
+
+```vue
+<template>
+  <Facets>
+    <template #default="{ facet, selectedFilters }">
+      <h1>{{ ${facet.label} }}</h1>
+      <span v-if="selectedFilters.length > 0">{{ `${selectedFilters.length} selected` }}</span>
+
+      <ul>
+        <li v-for="filter in facet.filters" :key="filter.id">
+          {{ filter.label }}
+        </li>
+      </ul>
+    </template>
+  </Facets>
+</template>
+
+<script>
+  import { Facets } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      Facets
+    }
+  };
+</script>
+```
+
+## Customized usage
+
+Customized compositions for a specific Facet can be achieved by using a slot with the same id as the
+facet to customize. For example, the Facet with the id "color" requires a composition that differs
+from the rest of the Facets. Doing it in a slot with the name "color" will apply this customization
+just to the "color" Facet. The other facets will fallback to the composition of the default slot.
+
+```vue
+<template>
+  <Facets>
+    <template #color="{ facet, selectedFilters }">
+      <span v-if="selectedFilters.length > 0">{{ `${selectedFilters.length} colors chosen` }}</span>
+
+      <ul v-for="filter in facet.filters" :key="filter.id">
+        <li v-if="!filter.selected">
+          {{ filter.label }}
+        </li>
+      </ul>
+    </template>
+
+    <template #default="{ facet }">
+      <h1>{{ facet.label }}</h1>
+
+      <ul>
+        <li v-for="filter in facet.filters" :key="filter.id">
+          {{ filter.label }}
+        </li>
+      </ul>
+    </template>
+  </Facets>
+</template>
+
+<script>
+  import { Facets } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      Facets
+    }
+  };
+</script>
+```
+
+## Render specific facets I
+
+By default, this component will render all existing facets. However, it has the renderableFacets
+prop to filter which facets will be rendered. Its value is a string containing the different facets
+ids. This value is treated as an include or exclude list (to exclude a facet from being rendered,
+just prefix its id with a `!`). The component will only render included facets and discard excluded
+ones. In the following example, the component will only render color and category facets.
+
+```vue
+<template>
+  <Facets renderableFacets="color, category">
+    <template #default="{ facet }">
+      <h1>{{ facet.label }}</h1>
+
+      <ul>
+        <li v-for="filter in facet.filters" :key="filter.id">
+          {{ filter.label }}
+        </li>
+      </ul>
+    </template>
+  </Facets>
+</template>
+
+<script>
+  import { Facets } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      Facets
+    }
+  };
+</script>
+```
+
+## Render specific facets II
+
+Exclude facets so the component does not render them. In the following example, the component will
+render every facet except color and price.
+
+```vue
+<template>
+  <Facets renderableFacets="!color, !price">
+    <template #default="{ facet }">
+      <h1>{{ facet.label }}</h1>
+
+      <ul>
+        <li v-for="filter in facet.filters" :key="filter.id">
+          {{ filter.label }}
+        </li>
+      </ul>
+    </template>
+  </Facets>
+</template>
+
+<script>
+  import { Facets } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      Facets
+    }
+  };
+</script>
+```
+
+## Integrating with the filters components
+
+There are many components that will help you build your own awesome filters list. `Facets` just
+renders the list, but what to render for each facet is up to you. Below you can see an example. of
+the `Facets` component using the `FiltersSearch` `MultiSelectFilters`, `SimpleFilter`, `Filters`,
+`HierarchicalFilter`, `NumberRangeFilter` and `BasePriceFilterLabel`.
+
+```vue
+<template>
+  <Facets>
+    <template #default="{ facet, selectedFilters }">
+      <h1>{{ facet.label }}</h1>
+      <FiltersSearch :filters="facet.filters">
+        <MultiSelectFilters v-slot="{ filter }">
+          <SimpleFilter :filter="filter" />
+        </MultiSelectFilters>
+      </FiltersSearch>
+    </template>
+
+    <template #category="{ facet }">
+      <h1>{{ facet.label }}</h1>
+      <Filters v-slot="{ filter }" :filters="facet.filters">
+        <HierarchicalFilter :filter="filter" />
+      </Filters>
+    </template>
+
+    <template #price="{ facet }">
+      <h1>{{ facet.label }}</h1>
+      <Filters v-slot="{ filter }" :filters="facet.filters">
+        <NumberRangeFilter :filter="filter">
+          <BasePriceFilterLabel :filter="filter" />
+        </NumberRangeFilter>
+      </Filters>
+    </template>
+  </Facets>
+</template>
+
+<script>
+  import {
+    Facets,
+    Filters,
+    FiltersSearch,
+    HierarchicalFilter,
+    MultiSelectFilters,
+    NumberRangeFilter,
+    SimpleFilter
+  } from '@empathyco/x-components/facets';
+
+  import { BasePriceFilterLabel } from '@empathyco/x-components';
+
+  export default {
+    components: {
+      Facets,
+      MultiSelectFilters,
+      FiltersSearch,
+      SimpleFilter,
+      Filters,
+      HierarchicalFilter,
+      NumberRangeFilter,
+      BasePriceFilterLabel
+    }
+  };
+</script>
+```
+
+## Events
+
+A list of events that the component will emit:
+
+- `UserChangedSelectedFilters`: the event is emitted after the user performed an action that changed
+  the selected filters. The payload is the new list of selected filters.
+- `BackendFacetsProvided`: the event is emitted after updating the backendFacets prop with a new
+  list of facets. The payload contains a copy of the backendFacets prop.
+- `FrontendFacetsProvided`: the event is emitted after updating the frontendFacets prop with a new
+  list of facets. The payload contains a copy of the frontendFacets prop.
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/facets/facets.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/facets/facets.vue
@@ -389,15 +389,4 @@ the `Facets` component using the `FiltersSearch` `MultiSelectFilters`, `SimpleFi
   };
 </script>
 ```
-
-## Events
-
-A list of events that the component will emit:
-
-- `UserChangedSelectedFilters`: the event is emitted after the user performed an action that changed
-  the selected filters. The payload is the new list of selected filters.
-- `BackendFacetsProvided`: the event is emitted after updating the backendFacets prop with a new
-  list of facets. The payload contains a copy of the backendFacets prop.
-- `FrontendFacetsProvided`: the event is emitted after updating the frontendFacets prop with a new
-  list of facets. The payload contains a copy of the frontendFacets prop.
 </docs>

--- a/packages/x-components/src/x-modules/facets-next/components/index.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/index.ts
@@ -1,0 +1,7 @@
+// Facets
+export { default as Facets } from './facets/facets.vue';
+
+// Filters
+
+// Lists
+export { default as FiltersInjectionMixin } from './lists/filters-injection.mixin';

--- a/packages/x-components/src/x-modules/facets-next/wiring.ts
+++ b/packages/x-components/src/x-modules/facets-next/wiring.ts
@@ -1,5 +1,7 @@
+import { Facet } from '@empathyco/x-types-next';
 import { namespacedWireCommit } from '../../wiring/namespaced-wires.factory';
 import { wireService, wireServiceWithoutPayload } from '../../wiring/wires.factory';
+import { mapWire } from '../../wiring/wires.operators';
 import { createWiring } from '../../wiring/wiring.utils';
 import { DefaultFacetsService } from './service/facets.service';
 
@@ -21,12 +23,18 @@ const wireFacetsServiceWithoutPayload = wireServiceWithoutPayload(DefaultFacetsS
 const facetsNextWireCommit = namespacedWireCommit('facetsNext');
 
 /**
- * Saves the facets contained in the group, removing the previous ones, and keeping the previous
- * filters selected state.
+ * Saves the facets contained in the `search` group, removing the previous ones, and keeping the
+ * previous filters selected state.
  *
  * @public
  */
-const updateFacetsGroupWire = wireFacetsService('updateFacets');
+const updateFacetsGroupWithSearchFacetsWire = mapWire(
+  wireFacetsService('updateFacets'),
+  (facets: Facet[]) => ({
+    facets,
+    id: 'search'
+  })
+);
 
 /**
  * Saves the facets contained in the group, removing the previous ones, and keeping the new filters
@@ -78,8 +86,8 @@ const setFacetsQuery = facetsNextWireCommit('setQuery');
  * @internal
  */
 export const facetsNextWiring = createWiring({
-  FacetsGroupChanged: {
-    updateFacetsGroupWire
+  FacetsChangedNext: {
+    updateFacetsGroupWithSearchFacetsWire
   },
   FacetsGroupProvided: {
     setFacetsGroupWire

--- a/packages/x-components/src/x-modules/search/events.types.ts
+++ b/packages/x-components/src/x-modules/search/events.types.ts
@@ -1,5 +1,6 @@
 import { SearchRequest } from '@empathyco/x-adapter';
 import { Facet, Result, Sort } from '@empathyco/x-types';
+import { Facet as FacetNext } from '@empathyco/x-types-next';
 
 /**
  * Dictionary of the events of Search XModule, where each key is the event name, and the value is
@@ -8,6 +9,17 @@ import { Facet, Result, Sort } from '@empathyco/x-types';
  * @public
  */
 export interface SearchXEvents {
+  //TODO remove when facets refactor is done
+  /**
+   * The backend facets have changed.
+   * * Payload: The {@link @empathyco/x-types#Facet | facets} array.
+   */
+  FacetsChangedNext: FacetNext[];
+  /**
+   * The backend facets have changed.
+   * * Payload: The {@link @empathyco/x-types#Facet | facets} array.
+   */
+  FacetsChanged: Facet[];
   /**
    * The backend facets have changed.
    * * Payload: The {@link @empathyco/x-types#Facet | facets} array.

--- a/packages/x-components/src/x-modules/search/store/emitters.ts
+++ b/packages/x-components/src/x-modules/search/store/emitters.ts
@@ -1,3 +1,4 @@
+import { Facet as FacetNext } from '@empathyco/x-types-next';
 import { createStoreEmitters } from '../../../store';
 import { searchXStoreModule } from './module';
 
@@ -10,5 +11,7 @@ export const searchEmitters = createStoreEmitters(searchXStoreModule, {
   ResultsChanged: state => state.results,
   SearchRequestChanged: (_, getters) => getters.request,
   BackendFacetsChanged: state => state.facets,
+  //TODO remove when facets refactor is done
+  FacetsChangedNext: state => state.facets as unknown as FacetNext[],
   SpellcheckChanged: state => state.spellcheckedQuery
 });


### PR DESCRIPTION
EX-3661

# Pull Request Template #

Please include a summary of the change and which issue is fixed.

## Motivation and Context ##

This PR consists on:
- Include the `Facets.vue` component into the `NextFacets` X-Module.
- Remove the Provided Facets logic from `Facets.vue` component. (This will be included in a new coming soon Provider Component)
- Modify wiring to make the facets work with the new Vuex Store in `NextFacets` X-Module.
- Modify (Temporally) the `Search` X-Module wiring to "send" the API facets to `NextFacets` module.
- Modify the `Facets.vue` component tests to test only the remaining logic.
- Adds new `LayoutNext.vue` view using the new `Facets.vue` component to check it working.
