### PR TITLE
test(facets-next): add missing service tests

### DIFF
--- a/packages/x-components/src/x-modules/facets-next/service/__tests__/facets-service.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/service/__tests__/facets-service.spec.ts
@@ -380,10 +380,10 @@ describe('testing facets service', () => {
       ).toBe(false);
       expect(getSelectedFilters()).toEqual([]);
       expect(getFacets()).toEqual({
-        [colorFacet.id]: excludeFiltersProperty(colorFacet),
-        [categoryFacet.id]: excludeFiltersProperty(categoryFacet),
-        [ageFacet.id]: excludeFiltersProperty(ageFacet),
-        [priceFacet.id]: excludeFiltersProperty(priceFacet)
+        [colorFacet.id]: omitFiltersProperty(colorFacet),
+        [categoryFacet.id]: omitFiltersProperty(categoryFacet),
+        [ageFacet.id]: omitFiltersProperty(ageFacet),
+        [priceFacet.id]: omitFiltersProperty(priceFacet)
       });
 
       // Select some filters, and save a new group of facets
@@ -469,11 +469,11 @@ describe('testing facets service', () => {
         ])
       ).toBe(false);
       expect(getFacets()).toEqual({
-        [colorFacet.id]: excludeFiltersProperty(colorFacet),
-        [categoryFacet.id]: excludeFiltersProperty(categoryFacet),
-        [ageFacet.id]: excludeFiltersProperty(ageFacet),
-        [priceFacet.id]: excludeFiltersProperty(priceFacet),
-        [shipmentFacet.id]: excludeFiltersProperty(shipmentFacet)
+        [colorFacet.id]: omitFiltersProperty(colorFacet),
+        [categoryFacet.id]: omitFiltersProperty(categoryFacet),
+        [ageFacet.id]: omitFiltersProperty(ageFacet),
+        [priceFacet.id]: omitFiltersProperty(priceFacet),
+        [shipmentFacet.id]: omitFiltersProperty(shipmentFacet)
       });
     });
 
@@ -557,10 +557,10 @@ describe('testing facets service', () => {
         ])
       );
       expect(getFacets()).toEqual({
-        [colorFacet.id]: excludeFiltersProperty(colorFacet),
-        [categoryFacet.id]: excludeFiltersProperty(categoryFacet),
-        [ageFacet.id]: excludeFiltersProperty(ageFacet),
-        [priceFacet.id]: excludeFiltersProperty(priceFacet)
+        [colorFacet.id]: omitFiltersProperty(colorFacet),
+        [categoryFacet.id]: omitFiltersProperty(categoryFacet),
+        [ageFacet.id]: omitFiltersProperty(ageFacet),
+        [priceFacet.id]: omitFiltersProperty(priceFacet)
       });
 
       // Set a new group of facets
@@ -639,11 +639,11 @@ describe('testing facets service', () => {
         ])
       ).toBe(false);
       expect(getFacets()).toEqual({
-        [colorFacet.id]: excludeFiltersProperty(colorFacet),
-        [categoryFacet.id]: excludeFiltersProperty(categoryFacet),
-        [ageFacet.id]: excludeFiltersProperty(ageFacet),
-        [priceFacet.id]: excludeFiltersProperty(priceFacet),
-        [shipmentFacet.id]: excludeFiltersProperty(shipmentFacet)
+        [colorFacet.id]: omitFiltersProperty(colorFacet),
+        [categoryFacet.id]: omitFiltersProperty(categoryFacet),
+        [ageFacet.id]: omitFiltersProperty(ageFacet),
+        [priceFacet.id]: omitFiltersProperty(priceFacet),
+        [shipmentFacet.id]: omitFiltersProperty(shipmentFacet)
       });
     });
   });
@@ -714,6 +714,12 @@ interface FacetsServiceTestAPI {
   service: FacetsService;
 }
 
-function excludeFiltersProperty({ filters, ...facet }: Facet): Omit<Facet, 'filters'> {
+/**
+ * Excludes the filters property from the given facet.
+ *
+ * @param facet - The full facet from whom exclude its filter property.
+ * @returns The given facet without the `filters` property.
+ */
+function omitFiltersProperty({ filters, ...facet }: Facet): Omit<Facet, 'filters'> {
   return facet;
 }

--- a/packages/x-components/src/x-modules/facets-next/service/__tests__/facets-service.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/service/__tests__/facets-service.spec.ts
@@ -1,4 +1,4 @@
-import { EditableNumberRangeFilter, Filter } from '@empathyco/x-types-next';
+import { EditableNumberRangeFilter, Filter, Facet } from '@empathyco/x-types-next';
 import {
   createNextEditableNumberRangeFacetStub,
   createNextHierarchicalFacetStub,
@@ -56,6 +56,9 @@ function prepareFacetsService(): FacetsServiceTestAPI {
     },
     getFilters() {
       return Object.values(XPlugin.store.state.x.facetsNext.filters);
+    },
+    getFacets() {
+      return XPlugin.store.state.x.facetsNext.facets;
     }
   };
 }
@@ -330,8 +333,13 @@ describe('testing facets service', () => {
 
   describe('saves a group of facets', () => {
     it('saves groups of facets keeping its previous selected states', () => {
-      const { service, getSelectedFilters, getFilters, getStoreEditableNumberRangeFilter } =
-        prepareFacetsService();
+      const {
+        service,
+        getSelectedFilters,
+        getFilters,
+        getStoreEditableNumberRangeFilter,
+        getFacets
+      } = prepareFacetsService();
 
       const colorFacet = createNextSimpleFacetStub('color', createFilter => [
         createFilter('red', true),
@@ -371,6 +379,12 @@ describe('testing facets service', () => {
         ])
       ).toBe(false);
       expect(getSelectedFilters()).toEqual([]);
+      expect(getFacets()).toEqual({
+        [colorFacet.id]: excludeFiltersProperty(colorFacet),
+        [categoryFacet.id]: excludeFiltersProperty(categoryFacet),
+        [ageFacet.id]: excludeFiltersProperty(ageFacet),
+        [priceFacet.id]: excludeFiltersProperty(priceFacet)
+      });
 
       // Select some filters, and save a new group of facets
       service.select(redColorFilter);
@@ -454,6 +468,13 @@ describe('testing facets service', () => {
           age10To18Filter
         ])
       ).toBe(false);
+      expect(getFacets()).toEqual({
+        [colorFacet.id]: excludeFiltersProperty(colorFacet),
+        [categoryFacet.id]: excludeFiltersProperty(categoryFacet),
+        [ageFacet.id]: excludeFiltersProperty(ageFacet),
+        [priceFacet.id]: excludeFiltersProperty(priceFacet),
+        [shipmentFacet.id]: excludeFiltersProperty(shipmentFacet)
+      });
     });
 
     // eslint-disable-next-line max-len
@@ -478,12 +499,166 @@ describe('testing facets service', () => {
       expect(getSelectedFilters()).toEqual([]);
     });
   });
+
+  describe('sets a group of facets', () => {
+    it('sets groups of facets', () => {
+      const {
+        service,
+        getSelectedFilters,
+        getFilters,
+        getStoreEditableNumberRangeFilter,
+        getFacets
+      } = prepareFacetsService();
+
+      const colorFacet = createNextSimpleFacetStub('color', createFilter => [
+        createFilter('red', true),
+        createFilter('blue')
+      ]);
+      const redColorFilter = colorFacet.filters[0];
+      const categoryFacet = createNextHierarchicalFacetStub('category', createFilter => [
+        ...createFilter('men'),
+        ...createFilter('women', true, createFilter => [
+          ...createFilter('skirt', true),
+          ...createFilter('dress')
+        ])
+      ]);
+      const [, womenCategoryFilter, skirtCategoryFilter] = categoryFacet.filters;
+      const ageFacet = createNextNumberRangeFacetStub('age', createFilter => [
+        createFilter({ min: 0, max: 10 }, true),
+        createFilter({ min: 10, max: 18 })
+      ]);
+      const age10To18Filter = ageFacet.filters[0];
+      const priceFacet = createNextEditableNumberRangeFacetStub('price', createFilter =>
+        createFilter({ min: null, max: 10 }, true)
+      );
+      const priceUpTo10Filter = priceFacet.filters[0];
+
+      // Set a fresh new facets group. Filters should keep the selected state they have
+      service.setFacets({
+        id: 'backend',
+        facets: [colorFacet, categoryFacet, ageFacet, priceFacet]
+      });
+      expect(
+        service.areFiltersDifferent(getFilters(), [
+          ...colorFacet.filters,
+          ...categoryFacet.filters,
+          ...ageFacet.filters,
+          getStoreEditableNumberRangeFilter(priceUpTo10Filter)
+        ])
+      ).toBe(false);
+      expect(getSelectedFilters()).toHaveLength(5);
+      expect(getSelectedFilters()).toEqual(
+        expect.arrayContaining([
+          redColorFilter,
+          womenCategoryFilter,
+          skirtCategoryFilter,
+          age10To18Filter,
+          getStoreEditableNumberRangeFilter(priceUpTo10Filter)
+        ])
+      );
+      expect(getFacets()).toEqual({
+        [colorFacet.id]: excludeFiltersProperty(colorFacet),
+        [categoryFacet.id]: excludeFiltersProperty(categoryFacet),
+        [ageFacet.id]: excludeFiltersProperty(ageFacet),
+        [priceFacet.id]: excludeFiltersProperty(priceFacet)
+      });
+
+      // Set a new group of facets
+      const newColorFacet = createNextSimpleFacetStub('color', createFilter => [
+        createFilter('red'),
+        createFilter('blue'),
+        createFilter('green', true)
+      ]);
+      const greenColorFilter = newColorFacet.filters[2];
+      const newCategoryFacet = createNextHierarchicalFacetStub('category', createFilter => [
+        ...createFilter('men'),
+        ...createFilter('women', false, createFilter => [
+          ...createFilter('skirt'),
+          ...createFilter('dress')
+        ]),
+        ...createFilter('kids', true)
+      ]);
+      const kidsCategoryFilter = newCategoryFacet.filters[4];
+      const newAgeFacet = createNextNumberRangeFacetStub('age', createFilter => [
+        createFilter({ min: 0, max: 10 }),
+        createFilter({ min: 10, max: 18 }),
+        createFilter({ min: 18, max: null }, true)
+      ]);
+      const ageMoreThan18Filter = newAgeFacet.filters[2];
+      const newPriceFacet = createNextEditableNumberRangeFacetStub('price', createFilter =>
+        createFilter({ min: null, max: 10 }, true)
+      );
+
+      service.setFacets({
+        id: 'backend',
+        facets: [newColorFacet, newCategoryFacet, newAgeFacet, newPriceFacet]
+      });
+      expect(
+        service.areFiltersDifferent(getFilters(), [
+          ...newColorFacet.filters,
+          ...newCategoryFacet.filters,
+          ...newAgeFacet.filters,
+          getStoreEditableNumberRangeFilter(priceUpTo10Filter)
+        ])
+      ).toBe(false);
+      expect(
+        service.areFiltersDifferent(getSelectedFilters(), [
+          greenColorFilter,
+          kidsCategoryFilter,
+          ageMoreThan18Filter,
+          getStoreEditableNumberRangeFilter(priceUpTo10Filter)
+        ])
+      ).toBe(false);
+
+      // Saving a new group of facets shouldn't affect previous ones
+      const shipmentFacet = createNextSimpleFacetStub('shipment', createFilter => [
+        createFilter('In store', true),
+        createFilter('Express')
+      ]);
+      const inStoreShipmentFilter = shipmentFacet.filters[0];
+      service.setFacets({
+        id: 'static',
+        facets: [shipmentFacet]
+      });
+      expect(
+        service.areFiltersDifferent(getFilters(), [
+          ...newColorFacet.filters,
+          ...newCategoryFacet.filters,
+          ...newAgeFacet.filters,
+          getStoreEditableNumberRangeFilter(priceUpTo10Filter),
+          ...shipmentFacet.filters
+        ])
+      ).toBe(false);
+      expect(
+        service.areFiltersDifferent(getSelectedFilters(), [
+          greenColorFilter,
+          kidsCategoryFilter,
+          ageMoreThan18Filter,
+          getStoreEditableNumberRangeFilter(priceUpTo10Filter),
+          inStoreShipmentFilter
+        ])
+      ).toBe(false);
+      expect(getFacets()).toEqual({
+        [colorFacet.id]: excludeFiltersProperty(colorFacet),
+        [categoryFacet.id]: excludeFiltersProperty(categoryFacet),
+        [ageFacet.id]: excludeFiltersProperty(ageFacet),
+        [priceFacet.id]: excludeFiltersProperty(priceFacet),
+        [shipmentFacet.id]: excludeFiltersProperty(shipmentFacet)
+      });
+    });
+  });
 });
 
 /**
  * Utilities to test the facets service.
  */
 interface FacetsServiceTestAPI {
+  /**
+   * Gets the stored facets.
+   *
+   * @returns A list containing the facets of the store.
+   */
+  getFacets: () => Record<Facet['id'], Omit<Facet, 'filters'>>;
   /**
    * Gets the stored filters.
    *
@@ -537,4 +712,8 @@ interface FacetsServiceTestAPI {
    * The facets service to test.
    */
   service: FacetsService;
+}
+
+function excludeFiltersProperty({ filters, ...facet }: Facet): Omit<Facet, 'filters'> {
+  return facet;
 }


### PR DESCRIPTION
# Description

Just adds a similar test for the `FacetsService.setFacets` method, and adds assertion for the new facets property to be set.