### PR TITLE
Feature/ex 4592 move old facets components

### DIFF
--- a/packages/x-components/src/__tests__/utils.ts
+++ b/packages/x-components/src/__tests__/utils.ts
@@ -163,6 +163,7 @@ export function installNewXPlugin(
   options: Partial<XPluginOptions> = {},
   localVue: typeof Vue = createLocalVue()
 ): [XPlugin, typeof Vue] {
+  XPlugin.resetInstance();
   const xPlugin = new XPlugin(new BaseXBus());
   const installOptions: XPluginOptions = { adapter: SearchAdapterDummy, ...options };
   localVue.use(xPlugin, installOptions);

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/all-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/all-filter.spec.ts
@@ -1,4 +1,4 @@
-import { Facet } from '@empathyco/x-types';
+import { Facet } from '@empathyco/x-types-next';
 import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/all-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/all-filter.spec.ts
@@ -1,0 +1,151 @@
+import { Facet } from '@empathyco/x-types';
+import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex, { Store } from 'vuex';
+import { createNextSimpleFacetStub } from '../../../../../__stubs__/facets-stubs.factory';
+import { installNewXPlugin } from '../../../../../__tests__/utils';
+import { getXComponentXModuleName, isXComponent } from '../../../../../components';
+import { RootXStoreState } from '../../../../../store/store.types';
+import { arrayToObject } from '../../../../../utils/array';
+import { facetsNextXModule } from '../../../x-module';
+import { resetXFacetsStateWith } from '../../__tests__/utils';
+import AllFilter from '../all-filter.vue';
+
+/**
+ * Renders the `AllFilter` component, exposing a basic API for testing.
+ *
+ * @param options - The options to render the component with.
+ * @returns The API for testing the `AllFilter` component.
+ */
+function renderAllFilter({
+  template = `<AllFilter :facet="facet"></AllFilter>`
+}: RenderAllFilterOptions = {}): RenderAllFilterAPI {
+  const facet = createNextSimpleFacetStub('category', createFilter => [
+    createFilter('men'),
+    createFilter('women')
+  ]);
+
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const store = new Store<RootXStoreState>({});
+  installNewXPlugin({ store, initialXModules: [facetsNextXModule] }, localVue);
+  resetXFacetsStateWith(store, {
+    facets: {
+      [facet.id]: facet
+    },
+    filters: arrayToObject(facet.filters, 'id')
+  });
+
+  const wrapper = mount(
+    {
+      components: {
+        AllFilter
+      },
+      template,
+      props: ['facet']
+    },
+    {
+      store,
+      localVue,
+      propsData: {
+        facet
+      }
+    }
+  );
+
+  const allFilterWrapper = wrapper.findComponent(AllFilter);
+
+  return {
+    wrapper,
+    allFilterWrapper,
+    facet,
+    toggleFirstFilter() {
+      wrapper.vm.$x.emit(
+        'UserClickedANextFilter',
+        store.state.x.facetsNext.filters[facet.filters[0].id]
+      );
+      return wrapper.vm.$nextTick();
+    },
+    clickAllFilter() {
+      allFilterWrapper.trigger('click');
+      return wrapper.vm.$nextTick();
+    }
+  };
+}
+
+describe('testing AllFilter component', () => {
+  it('is an x-component', () => {
+    const { allFilterWrapper } = renderAllFilter();
+
+    expect(isXComponent(allFilterWrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facetsNext` x-module', () => {
+    const { allFilterWrapper } = renderAllFilter();
+
+    expect(getXComponentXModuleName(allFilterWrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('has x-all-filter--is-selected class while no filters are selected', async () => {
+    const { allFilterWrapper, toggleFirstFilter } = renderAllFilter();
+    expect(allFilterWrapper.classes('x-all-filter--is-selected')).toBe(true);
+    // Some filter should be selected now, so the all filter should be deselected.
+    await toggleFirstFilter();
+    expect(allFilterWrapper.classes('x-all-filter--is-selected')).toBe(false);
+    // No filter should be selected now, so the all filter should be selected.
+    await toggleFirstFilter();
+    expect(allFilterWrapper.classes('x-all-filter--is-selected')).toBe(true);
+  });
+
+  it('emits `UserClickedAllFilter` event with the facet id as payload', async () => {
+    const { wrapper, toggleFirstFilter, clickAllFilter, facet } = renderAllFilter();
+    const listenerAllFilter = jest.fn();
+    wrapper.vm.$x.on('UserClickedAllFilter', true).subscribe(listenerAllFilter);
+    await toggleFirstFilter();
+    expect(listenerAllFilter).toHaveBeenCalledTimes(0);
+
+    await clickAllFilter();
+    expect(listenerAllFilter).toHaveBeenCalledTimes(1);
+    expect(listenerAllFilter).toHaveBeenNthCalledWith(1, {
+      eventPayload: [facet.id],
+      metadata: {
+        moduleName: 'facetsNext',
+        target: wrapper.element
+      }
+    });
+  });
+
+  it('renders default content', () => {
+    const { allFilterWrapper } = renderAllFilter();
+    expect(allFilterWrapper.text()).toBe('all');
+  });
+
+  it('renders default slot custom content', () => {
+    const { allFilterWrapper, facet } = renderAllFilter({
+      template: `
+        <AllFilter v-slot="{ facet }" :facet="facet" >
+          Select all {{ facet.label }}
+        </AllFilter>
+      `
+    });
+    expect(allFilterWrapper.text()).toBe(`Select all ${facet.label}`);
+  });
+});
+
+interface RenderAllFilterOptions {
+  /** The template to be rendered. */
+  template?: string;
+}
+
+interface RenderAllFilterAPI {
+  /** The `AllFilter` wrapper component. */
+  allFilterWrapper: Wrapper<Vue>;
+  /** Function that clicks all filter button. */
+  clickAllFilter: () => Promise<void>;
+  /** Current facet passed as prop to the AllFilter component. */
+  facet: Facet;
+  /** Function that toggles first filter selected property. */
+  toggleFirstFilter: () => Promise<void>;
+  /** The wrapper of the container element.*/
+  wrapper: Wrapper<Vue>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/base-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/base-filter.spec.ts
@@ -1,0 +1,165 @@
+import { BooleanFilter } from '@empathyco/x-types-next';
+import { mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import { getXComponentXModuleName, isXComponent } from '../../../../../components';
+import { XEventsTypes } from '../../../../../wiring/events.types';
+import {
+  createNextSimpleFilter,
+  createSimpleFilter,
+  getSimpleFilterStub
+} from '../../../../../__stubs__/filters-stubs.factory';
+import { getDataTestSelector } from '../../../../../__tests__/utils';
+import BaseFilter from '../base-filter.vue';
+
+function renderBaseFilter({
+  template = '<BaseFilter :filter="filter" :clickEvents="clickEvents"/>',
+  filter = createNextSimpleFilter('category', 'men'),
+  clickEvents
+}: RenderBaseFilterOptions = {}): RenderBaseFilterAPI {
+  Vue.observable(filter);
+  const emit = jest.fn();
+  const wrapper = mount(
+    {
+      components: { BaseFilter },
+      props: ['filter', 'clickEvents'],
+      template
+    },
+    {
+      propsData: {
+        filter,
+        clickEvents
+      },
+      mocks: {
+        $x: {
+          emit
+        }
+      }
+    }
+  );
+
+  const baseFilterWrapper = wrapper.findComponent(BaseFilter);
+
+  return {
+    wrapper: baseFilterWrapper,
+    emit,
+    filter,
+    clickFilter() {
+      baseFilterWrapper.trigger('click');
+    },
+    selectFilter() {
+      filter.selected = true;
+      return Vue.nextTick();
+    }
+  };
+}
+
+describe('testing Filter component', () => {
+  it('is an x-component', () => {
+    const { wrapper } = renderBaseFilter();
+
+    expect(isXComponent(wrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const { wrapper } = renderBaseFilter();
+
+    expect(getXComponentXModuleName(wrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('renders the provided filter by default', () => {
+    const { wrapper, filter } = renderBaseFilter();
+
+    expect(wrapper.text()).toEqual(filter.label);
+  });
+
+  it('emits UserClickedAFilter when clicked', () => {
+    const { wrapper, clickFilter, emit, filter } = renderBaseFilter();
+
+    clickFilter();
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith('UserClickedANextFilter', filter, {
+      target: wrapper.element
+    });
+  });
+
+  it('emits UserClickedAFilter and other custom events when clicked', () => {
+    const filter = getSimpleFilterStub();
+    const { wrapper, clickFilter, emit } = renderBaseFilter({
+      filter,
+      clickEvents: {
+        UserClickedASimpleFilter: filter
+      }
+    });
+
+    clickFilter();
+
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenCalledWith('UserClickedANextFilter', filter, {
+      target: wrapper.element
+    });
+    expect(emit).toHaveBeenCalledWith('UserClickedASimpleFilter', filter, {
+      target: wrapper.element
+    });
+  });
+
+  it('allows customizing the rendered content with an slot', () => {
+    const { wrapper, filter } = renderBaseFilter({
+      template: `
+      <BaseFilter :filter="filter" v-slot="{ filter }">
+        <span data-test="custom-label">{{ filter.label }}</span>
+      </BaseFilter>
+      `
+    });
+
+    const customLabel = wrapper.find(getDataTestSelector('custom-label'));
+    expect(customLabel.text()).toEqual(filter.label);
+  });
+
+  it('adds selected classes to the rendered element when the filter is selected', async () => {
+    const { wrapper, selectFilter } = renderBaseFilter();
+
+    expect(wrapper.classes()).not.toContain('x-filter--is-selected');
+
+    await selectFilter();
+
+    expect(wrapper.classes()).toContain('x-filter--is-selected');
+  });
+
+  it('disables the filter when it has no results', async () => {
+    const filter = createSimpleFilter('category', 'men', false);
+    const { wrapper } = renderBaseFilter({ filter });
+
+    expect(wrapper.classes()).not.toContain('x-filter--is-disabled');
+    expect(wrapper.attributes('disabled')).toBeUndefined();
+
+    filter.totalResults = 0;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.classes()).toContain('x-filter--is-disabled');
+    expect(wrapper.attributes('disabled')).toBe('disabled');
+  });
+});
+
+interface RenderBaseFilterOptions {
+  /** The template containing the {@link BaseFilter} component to render. */
+  template?: string;
+  /** The filter data. Passed as prop to the {@link BaseFilter} component. */
+  filter?: BooleanFilter;
+  /** Additional events to emit when the filter is clicked.
+   * Passed as prop to the {@link BaseFilter} component. */
+  clickEvents?: Partial<XEventsTypes>;
+}
+
+interface RenderBaseFilterAPI {
+  /** Wrapper of the {@link BaseFilter} component. */
+  wrapper: Wrapper<Vue>;
+  /** Mock of the {@link XBus.emit} function. */
+  emit: jest.Mock;
+  /** The rendered filter data. */
+  filter: BooleanFilter;
+  /** Fakes a click on the filter component. */
+  clickFilter: () => void;
+  /** Sets the {@link RenderBaseFilterAPI.filter} `selected` property to `true`. */
+  selectFilter: () => Promise<void>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -9,7 +9,6 @@ import {
   getXComponentXModuleName,
   isXComponent
 } from '../../../../../components/x-component.utils';
-import { XPlugin } from '../../../../../plugins/x-plugin';
 import { RootXStoreState } from '../../../../../store/store.types';
 import { DeepPartial } from '../../../../../utils/types';
 import { facetsNextXModule } from '../../../x-module';
@@ -41,10 +40,7 @@ function renderEditableNumberRangeFilter({
   const localVue = createLocalVue();
   localVue.use(Vuex);
   const store = new Store<DeepPartial<RootXStoreState>>({});
-  installNewXPlugin({ store }, localVue);
-
-  XPlugin.resetInstance();
-  XPlugin.registerXModule(facetsNextXModule);
+  installNewXPlugin({ store, initialXModules: [facetsNextXModule] }, localVue);
 
   resetXFacetsStateWith(store, {});
   const wrapper = mount<EditableNumberRangeFilterComponent>(
@@ -111,8 +107,8 @@ describe('testing BaseNumberRangeFilter component', () => {
     expect(
       (filterWrapper.find(getDataTestSelector('range-max')).element as HTMLInputElement).value
     ).toBe('5');
-    expect(applyButtonWrapper.text()).toBe('✅');
-    expect(clearButtonWrapper.text()).toBe('🗑');
+    expect(applyButtonWrapper.text()).toBe('✓');
+    expect(clearButtonWrapper.text()).toBe('𐄂');
   });
 
   // eslint-disable-next-line max-len

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -20,7 +20,6 @@ Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
   get() {
     return parseFloat(this.value);
   },
-  writable: false,
   configurable: true,
   enumerable: true
 });

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -16,13 +16,14 @@ import { facetsNextXModule } from '../../../x-module';
 import { resetXFacetsStateWith } from '../../__tests__/utils';
 import EditableNumberRangeFilterComponent from '../editable-number-range-filter.vue';
 
-if (!HTMLInputElement.prototype.valueAsNumber) {
-  Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
-    get() {
-      return parseFloat(this.value);
-    }
-  });
-}
+Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
+  get() {
+    return parseFloat(this.value);
+  },
+  writable: true,
+  configurable: true,
+  enumerable: true
+});
 
 function renderEditableNumberRangeFilter({
   template = `

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -1,0 +1,341 @@
+import { EditableNumberRangeFilter, RangeValue } from '@empathyco/x-types-next';
+import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex, { Store } from 'vuex';
+// eslint-disable-next-line max-len
+import { createNextEditableNumberRangeFilter } from '../../../../../__stubs__/filters-stubs.factory';
+import { getDataTestSelector, installNewXPlugin } from '../../../../../__tests__/utils';
+import {
+  getXComponentXModuleName,
+  isXComponent
+} from '../../../../../components/x-component.utils';
+import { XPlugin } from '../../../../../plugins/x-plugin';
+import { RootXStoreState } from '../../../../../store/store.types';
+import { DeepPartial } from '../../../../../utils/types';
+import { facetsNextXModule } from '../../../x-module';
+import { resetXFacetsStateWith } from '../../__tests__/utils';
+import EditableNumberRangeFilterComponent from '../editable-number-range-filter.vue';
+
+Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
+  get() {
+    return parseFloat(this.value);
+  }
+});
+
+function renderEditableNumberRangeFilter({
+  template = `
+    <EditableNumberRangeFilterComponent
+      :filter="filter"
+      :isInstant="isInstant"
+      :hasClearButton="hasClearButton"
+    />
+  `,
+  range,
+  filter = createNextEditableNumberRangeFilter('age', range),
+  isInstant = false,
+  hasClearButton = true
+}: EditableNumberRangeFilterOptions = {}): EditableNumberRangeFilterAPI {
+  Vue.observable(filter);
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const store = new Store<DeepPartial<RootXStoreState>>({});
+  installNewXPlugin({ store }, localVue);
+
+  XPlugin.resetInstance();
+  XPlugin.registerXModule(facetsNextXModule);
+
+  resetXFacetsStateWith(store, {});
+  const wrapper = mount<EditableNumberRangeFilterComponent>(
+    {
+      components: { EditableNumberRangeFilterComponent },
+      props: ['filter', 'isInstant', 'hasClearButton'],
+      template
+    },
+    {
+      propsData: {
+        filter,
+        isInstant,
+        hasClearButton
+      },
+      localVue
+    }
+  );
+
+  const filterWrapper = wrapper.findComponent(EditableNumberRangeFilterComponent);
+  const minInputWrapper = filterWrapper.find(getDataTestSelector('range-min'));
+  const maxInputWrapper = filterWrapper.find(getDataTestSelector('range-max'));
+  const applyButtonWrapper = filterWrapper.find(getDataTestSelector('range-apply'));
+  const clearButtonWrapper = filterWrapper.find(getDataTestSelector('range-clear'));
+
+  return {
+    filterWrapper,
+    minInputWrapper,
+    maxInputWrapper,
+    applyButtonWrapper,
+    clearButtonWrapper,
+    filter,
+    typeMin: value => {
+      minInputWrapper.setValue(value);
+      minInputWrapper.trigger('change');
+      return localVue.nextTick();
+    },
+    typeMax: value => {
+      maxInputWrapper.setValue(value);
+      maxInputWrapper.trigger('change');
+      return localVue.nextTick();
+    }
+  };
+}
+
+describe('testing BaseNumberRangeFilter component', () => {
+  it('is an x-component', () => {
+    const { filterWrapper } = renderEditableNumberRangeFilter();
+    expect(isXComponent(filterWrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const { filterWrapper } = renderEditableNumberRangeFilter();
+    expect(getXComponentXModuleName(filterWrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('renders the provided filter by default', () => {
+    const { filterWrapper, applyButtonWrapper, clearButtonWrapper } =
+      renderEditableNumberRangeFilter({
+        range: { min: 1, max: 5 }
+      });
+    expect(
+      (filterWrapper.find(getDataTestSelector('range-min')).element as HTMLInputElement).value
+    ).toBe('1');
+    expect(
+      (filterWrapper.find(getDataTestSelector('range-max')).element as HTMLInputElement).value
+    ).toBe('5');
+    expect(applyButtonWrapper.text()).toBe('✅');
+    expect(clearButtonWrapper.text()).toBe('🗑');
+  });
+
+  // eslint-disable-next-line max-len
+  it('does not emit UserModifiedEditableNumberRangeNextFilter event when values are invalid', async () => {
+    const { filterWrapper, typeMin } = renderEditableNumberRangeFilter({
+      range: { min: 1, max: 5 },
+      isInstant: true
+    });
+
+    const listener = jest.fn();
+    filterWrapper.vm.$x.on('UserModifiedEditableNumberRangeNextFilter').subscribe(listener);
+
+    await typeMin(6);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  // eslint-disable-next-line max-len
+  it('emits UserModifiedEditableNumberRangeNextFilter event when isInstant is true and an input is changed', async () => {
+    const { filterWrapper, typeMin, typeMax, filter } = renderEditableNumberRangeFilter({
+      range: { min: 1, max: 5 },
+      isInstant: true
+    });
+
+    const listener = jest.fn();
+    filterWrapper.vm.$x.on('UserModifiedEditableNumberRangeNextFilter').subscribe(listener);
+
+    await typeMin(2);
+
+    expect(listener).toHaveBeenNthCalledWith(1, {
+      ...filter,
+      range: {
+        min: 2,
+        max: 5
+      }
+    });
+
+    await typeMax(7);
+
+    expect(listener).toHaveBeenNthCalledWith(2, {
+      ...filter,
+      range: {
+        min: 2,
+        max: 7
+      }
+    });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  // eslint-disable-next-line max-len
+  it('does not emit UserModifiedEditableNumberRangeNextFilter event when isInstant is false and an input is changed', async () => {
+    const { filterWrapper, typeMin, typeMax } = renderEditableNumberRangeFilter({
+      range: { min: 1, max: 5 }
+    });
+
+    const listener = jest.fn();
+    filterWrapper.vm.$x.on('UserModifiedEditableNumberRangeNextFilter', true).subscribe(listener);
+
+    await typeMin(2);
+    await typeMax(5);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  describe('clear button testing', () => {
+    it('sets min and max component values to null on clear button click', () => {
+      const { filterWrapper, filter, clearButtonWrapper, applyButtonWrapper } =
+        renderEditableNumberRangeFilter({ range: { min: 1, max: 5 } });
+
+      const listener = jest.fn();
+      filterWrapper.vm.$x.on('UserModifiedEditableNumberRangeNextFilter').subscribe(listener);
+
+      clearButtonWrapper.trigger('click');
+      applyButtonWrapper.trigger('click');
+      expect(listener).toHaveBeenNthCalledWith(1, {
+        ...filter,
+        range: { min: null, max: null }
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render a clear button if hasClearButton is false', () => {
+      const { clearButtonWrapper } = renderEditableNumberRangeFilter({
+        range: { min: 1, max: 5 },
+        hasClearButton: false
+      });
+
+      expect(clearButtonWrapper.exists()).toBe(false);
+    });
+
+    it('does not render a clear button if hasClearButton is true and there are no values', () => {
+      const { clearButtonWrapper } = renderEditableNumberRangeFilter({
+        range: { min: null, max: null },
+        hasClearButton: true
+      });
+
+      expect(clearButtonWrapper.exists()).toBe(false);
+    });
+  });
+
+  describe('slots testing', () => {
+    it('allows to customize apply-content slot', () => {
+      const { applyButtonWrapper } = renderEditableNumberRangeFilter({
+        template: `<EditableNumberRangeFilterComponent :filter="filter">
+                     <template slot="apply-content">Apply</template>
+                   </EditableNumberRangeFilterComponent>`,
+        range: { min: 1, max: 5 }
+      });
+
+      expect(applyButtonWrapper.text()).toBe('Apply');
+    });
+
+    it('allows to customize clear-content slot', () => {
+      const { clearButtonWrapper } = renderEditableNumberRangeFilter({
+        template: `<EditableNumberRangeFilterComponent :filter="filter">
+                     <template slot="clear-content">Clear</template>
+                   </EditableNumberRangeFilterComponent>`,
+        range: { min: 1, max: 5 }
+      });
+
+      expect(clearButtonWrapper.text()).toBe('Clear');
+    });
+
+    it('allows to customize the default slot', async () => {
+      const { filter, filterWrapper, applyButtonWrapper, clearButtonWrapper, typeMin, typeMax } =
+        renderEditableNumberRangeFilter({
+          template: `
+                    <EditableNumberRangeFilterComponent
+                      :filter="filter"
+                      #default="{
+                        min,
+                        max,
+                        setMin,
+                        setMax,
+                        emitUserModifiedFilter,
+                        clearValues,
+                        hasError
+                      }"
+                    >
+                      <button @click="emitUserModifiedFilter" data-test="range-apply">
+                        ✅ Apply!
+                      </button>
+                      <button @click="clearValues" data-test="range-clear">🗑 Clear!</button>
+                      <input
+                        :value="min"
+                        @change="setMin($event.target.valueAsNumber)"
+                        data-test="range-min"
+                      />
+                      <input
+                        :value="max"
+                        @change="setMax($event.target.valueAsNumber)"
+                        data-test="range-max"
+                      />
+                      <div data-test="has-error" v-if="hasError">⚠️ Invalid range values</div>
+                    </EditableNumberRangeFilterComponent>
+                  `,
+          range: { min: 7, max: 4 }
+        });
+
+      const listener = jest.fn();
+      filterWrapper.vm.$x.on('UserModifiedEditableNumberRangeNextFilter').subscribe(listener);
+
+      expect(applyButtonWrapper.text()).toBe('✅ Apply!');
+      expect(clearButtonWrapper.text()).toBe('🗑 Clear!');
+
+      expect(filterWrapper.find(getDataTestSelector('has-error')).text()).toBe(
+        '⚠️ Invalid range values'
+      );
+
+      await typeMin(4);
+      await typeMax(6);
+      await applyButtonWrapper.trigger('click');
+      expect(listener).toHaveBeenNthCalledWith(1, {
+        ...filter,
+        range: {
+          min: 4,
+          max: 6
+        }
+      });
+
+      await clearButtonWrapper.trigger('click');
+      await applyButtonWrapper.trigger('click');
+      expect(listener).toHaveBeenNthCalledWith(2, {
+        ...filter,
+        range: {
+          min: null,
+          max: null
+        }
+      });
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+interface EditableNumberRangeFilterOptions {
+  /**
+   * The {@link @empathyco/x-types#EditableNumberRangeFilter | EditableNumberRangeFilter} object
+   * to be passed to the component.
+   */
+  filter?: EditableNumberRangeFilter;
+  /** `hasClearButton` property to init the component. */
+  hasClearButton?: boolean;
+  /** `isInstant` property to init the component. */
+  isInstant?: boolean;
+  /** The {@link @empathyco/x-types#RangeValue | RangeValue} object to init the filter. */
+  range?: RangeValue;
+  /** The template to be rendered. */
+  template?: string;
+}
+
+interface EditableNumberRangeFilterAPI {
+  /** Apply button wrapper. */
+  applyButtonWrapper: Wrapper<Vue>;
+  /** Clear button wrapper. */
+  clearButtonWrapper: Wrapper<Vue>;
+  /** The filter passed to the component. */
+  filter: EditableNumberRangeFilter;
+  /** Filter component wrapper. */
+  filterWrapper: Wrapper<Vue>;
+  /** Max input element wrapper. */
+  maxInputWrapper: Wrapper<Vue>;
+  /** Min input element wrapper. */
+  minInputWrapper: Wrapper<Vue>;
+  /** It sets max value and triggers change event in the wrapper. */
+  typeMax: (value: number) => Promise<any>;
+  /** It sets min value and triggers change event in the wrapper. */
+  typeMin: (value: number) => Promise<any>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -20,7 +20,7 @@ Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
   get() {
     return parseFloat(this.value);
   },
-  writable: true,
+  writable: false,
   configurable: true,
   enumerable: true
 });

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -16,11 +16,13 @@ import { facetsNextXModule } from '../../../x-module';
 import { resetXFacetsStateWith } from '../../__tests__/utils';
 import EditableNumberRangeFilterComponent from '../editable-number-range-filter.vue';
 
-Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
-  get() {
-    return parseFloat(this.value);
-  }
-});
+if (!HTMLInputElement.prototype.valueAsNumber) {
+  Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
+    get() {
+      return parseFloat(this.value);
+    }
+  });
+}
 
 function renderEditableNumberRangeFilter({
   template = `

--- a/packages/x-components/src/x-modules/facets-next/components/filters/all-filter.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/all-filter.vue
@@ -140,6 +140,6 @@ facet label but this content is customizable through the default slot.
 
 A list of events that the component will emit:
 
-- `UserClickedFacetAllFilter`: the event is emitted after the user clicks the button. The event
+- `UserClickedAllFilter`: the event is emitted after the user clicks the button. The event
 payload is the id of the facet that this `AllFilter` component corresponds to.
 </docs>

--- a/packages/x-components/src/x-modules/facets-next/components/filters/all-filter.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/all-filter.vue
@@ -1,0 +1,145 @@
+<template>
+  <BaseEventButton
+    class="x-filter x-all-filter"
+    data-test="all-filter"
+    role="checkbox"
+    :aria-checked="facet.label.toString()"
+    :events="clickEvent"
+    :class="cssClasses"
+  >
+    <!--
+        @slot The content to render inside the button
+            @binding {Facet} Facet - The facet data
+      -->
+    <slot :facet="facet" :isSelected="isSelected">all</slot>
+  </BaseEventButton>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { Facet } from '@empathyco/x-types-next';
+  import { Getter, xComponentMixin } from '../../../../components';
+  import BaseEventButton from '../../../../components/base-event-button.vue';
+  import { isArrayEmpty } from '../../../../utils/array';
+  import { VueCSSClasses } from '../../../../utils/types';
+  import { XEventsTypes } from '../../../../wiring/events.types';
+  import { FiltersByFacetNext } from '../../store';
+  import { facetsNextXModule } from '../../x-module';
+
+  /**
+   * This component receives a required `facet` with
+   * {@link @empathyco/x-types#BooleanFilter | BooleanFilter} as prop and renders a button, which
+   * on clicked emits the {@link FacetsXEvents.UserClickedFacetAllFilter} event. By default
+   * the rendered button displays a message with the facet label but this content is customizable
+   * through the default slot.
+   *
+   * @public
+   */
+  @Component({
+    components: { BaseEventButton },
+    mixins: [xComponentMixin(facetsNextXModule)]
+  })
+  export default class AllFilter extends Vue {
+    /** The facet data. */
+    @Prop({ required: true })
+    public facet!: Facet;
+
+    /** The getter of the selectedFiltersByFacet. */
+    @Getter('facetsNext', 'selectedFiltersByFacet')
+    public selectedFiltersByFacet!: FiltersByFacetNext;
+
+    /**
+     * The event that will be emitted when the all filter button is clicked.
+     *
+     * @returns The event to emit on click.
+     * @internal
+     */
+    protected get clickEvent(): Partial<XEventsTypes> {
+      return {
+        UserClickedAllFilter: [this.facet.id]
+      };
+    }
+
+    /**
+     * Computed to retrieve the selected state of this component.
+     *
+     * @returns True if is selected false otherwise.
+     */
+    protected get isSelected(): boolean {
+      return isArrayEmpty(this.selectedFiltersByFacet?.[this.facet.id]);
+    }
+
+    /**
+     * Dynamic CSS classes to apply to the component.
+     *
+     * @remarks This is only valid considering that in the case of HierarchicalFilters, ancestors
+     * of nested selected filters are also selected.
+     *
+     * @returns The dynamic CSS classes to apply to the component.
+     * @internal
+     */
+    protected get cssClasses(): VueCSSClasses {
+      return {
+        'x-filter--is-selected': this.isSelected,
+        'x-all-filter--is-selected': this.isSelected
+      };
+    }
+  }
+</script>
+
+<docs>
+#Example
+
+This component receives a required `facet` as prop and renders a button, which on clicked emits the
+UserClickedFacetAllFilter event. By default the rendered button displays a message with the
+facet label but this content is customizable through the default slot.
+
+## Basic usage
+
+```vue
+<AllFilter :facet="facet" />
+```
+
+## Customizing its content
+
+```vue
+<AllFilter v-slot="{ facet }" :facet="facet">
+  Select all {{ facet.label }}
+</AllFilter>
+```
+
+## Basic example within facets
+
+```vue
+<Facets>
+  <template #default="{ facet }">
+    <AllFilter :facet="facet" />
+    <Filters v-slot="{ filter }" :filters="facet.filters">
+      <SimpleFilter :filter="filter" />
+    </Filters>
+  </template>
+</Facets>
+```
+
+## Custom example within facets
+
+```vue
+<Facets>
+  <template #default="{ facet }">
+    <AllFilter v-slot="{ facet }" :facet="facet">
+      Select all {{ facet.label }}
+    </AllFilter>
+    <Filters v-slot="{ filter }" :filters="facet.filters">
+      <SimpleFilter :filter="filter" />
+    </Filters>
+  </template>
+</Facets>
+```
+## Events
+
+A list of events that the component will emit:
+
+- `UserClickedFacetAllFilter`: the event is emitted after the user clicks the button. The event
+payload is the id of the facet that this `AllFilter` component corresponds to.
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/filters/base-filter.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/base-filter.vue
@@ -1,0 +1,141 @@
+<template>
+  <BaseEventButton
+    class="x-filter"
+    data-test="filter"
+    role="checkbox"
+    :aria-checked="filter.selected.toString()"
+    :events="events"
+    :disabled="isDisabled"
+    :class="cssClasses"
+  >
+    <!--
+        @slot The content to render inside the button
+            @binding {Filter} filter - The filter data
+      -->
+    <slot :filter="filter">{{ filter.label }}</slot>
+  </BaseEventButton>
+</template>
+
+<script lang="ts">
+  import { BooleanFilter } from '@empathyco/x-types-next';
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { xComponentMixin } from '../../../../components';
+  import BaseEventButton from '../../../../components/base-event-button.vue';
+  import { VueCSSClasses } from '../../../../utils/types';
+  import { XEventsTypes } from '../../../../wiring/events.types';
+  import { facetsNextXModule } from '../../x-module';
+
+  /**
+   * Renders a button with a default slot. It receives a
+   * {@link @empathyco/x-types#BooleanFilter | BooleanFilter} that will be used in the
+   * default slot and the {@link XEvent | XEvents} that will be emitted when clicking the button.
+   *
+   * @public
+   */
+  @Component({
+    components: { BaseEventButton },
+    mixins: [xComponentMixin(facetsNextXModule)]
+  })
+  export default class BaseFilter extends Vue {
+    /** The filter data to render. */
+    @Prop({ required: true })
+    public filter!: BooleanFilter;
+
+    /** Additional events with its payload to emit when the filter is clicked. */
+    @Prop()
+    public clickEvents?: Partial<XEventsTypes>;
+
+    /**
+     * The events that will be emitted when the filter is clicked.
+     *
+     * @returns The events to be emitted when the filter is clicked.
+     * @internal
+     */
+    protected get events(): Partial<XEventsTypes> {
+      return {
+        UserClickedANextFilter: this.filter,
+        ...this.clickEvents
+      };
+    }
+
+    /**
+     * Returns `true` when the filter should be disabled.
+     *
+     * @returns `true` if the filter should be disabled.
+     * @internal
+     */
+    protected get isDisabled(): boolean {
+      return this.filter.totalResults === 0;
+    }
+
+    /**
+     * Dynamic CSS classes to apply to the component.
+     *
+     * @returns The dynamic CSS classes to apply to the component.
+     * @internal
+     */
+    protected get cssClasses(): VueCSSClasses {
+      return {
+        'x-filter--is-selected': this.filter.selected,
+        'x-filter--is-disabled': this.isDisabled
+      };
+    }
+  }
+</script>
+
+<docs>
+#Example
+
+This component receives a `filter` as prop and renders a button, which on clicked emits the
+`UserClickedAFilter` event. If more events are needed to be emitted they can be passed using the
+`clickEvents` prop. By default it renders the filter label as the button text.
+
+## Basic usage
+
+```vue
+<BaseFilter :filter="filter"/>
+```
+
+## Customizing its contents
+
+```vue
+<BaseFilter :filter="filter" v-slot="{ filter }">
+  <img src="checkbox.png"/>
+  <span>{{ filter.label }}</span>
+</BaseFilter>
+```
+
+## Extending the emitted events
+
+```vue
+<template>
+  <BaseFilter :filter="filter" :clickEvents="clickEvents"/>
+</template>
+
+<script>
+  import { BaseFilter } from '@empathyco/x-components';
+
+  export default {
+    components: {
+      BaseFilter
+    },
+    props: ['filter'], // Imagine this filter is of type HierarchicalFilter
+    computed: {
+      clickEvents() {
+        return { UserClickedAHierarchicalFilter: this.filter };
+      }
+    }
+  };
+</script>
+```
+
+## Events
+
+A list of events that the component will emit:
+
+- `UserClickedANextFilter`: the event is emitted after the user clicks the filter. The event payload
+is
+the filter data.
+- Custom events defined in the `clickEvents` prop.
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/filters/editable-number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/editable-number-range-filter.vue
@@ -1,0 +1,463 @@
+<template>
+  <div
+    class="x-editable-number-range-filter"
+    :class="cssClasses"
+    data-test="editable-number-range-filter"
+  >
+    <!--
+        @slot Empty slot used to customize the whole component.
+          @binding {min} number - Component min value.
+          @binding {max} number - Component max value.
+          @binding {setMin} function - Component min setter.
+          @binding {setMax} function - Component max setter.
+          @binding {emitUserModifiedFilter} function - It emits the
+          `UserModifiedEditableNumberRangeFilter` X event.
+          @binding {clearValues} function - It sets component min and max values to null.
+          @binding {hasError} boolean - Returns true when there is an error with component values.
+    -->
+    <slot v-bind="{ min, max, setMin, setMax, emitUserModifiedFilter, clearValues, hasError }">
+      <!-- eslint-disable max-len -->
+      <input
+        @change="setMin($event.target.valueAsNumber)"
+        name="min"
+        type="number"
+        class="
+          x-input
+          x-editable-number-range-filter__input x-editable-number-range-filter__input--min
+        "
+        :value="min"
+        data-test="range-min"
+      />
+
+      <input
+        @change="setMax($event.target.valueAsNumber)"
+        name="max"
+        type="number"
+        class="
+          x-input
+          x-editable-number-range-filter__input x-editable-number-range-filter__input--max
+        "
+        :value="max"
+        data-test="range-max"
+      />
+      <!-- eslint-enable max-len -->
+
+      <button
+        v-if="!isInstant"
+        @click="emitUserModifiedFilter"
+        class="x-button x-editable-number-range-filter__apply"
+        :disabled="hasError"
+        data-test="range-apply"
+      >
+        <!--
+            @slot Slot used to customize the apply button content.
+        -->
+        <slot name="apply-content">✅</slot>
+      </button>
+
+      <button
+        v-if="renderClearButton"
+        @click="clearValues"
+        class="x-button x-editable-number-range-filter__clear"
+        data-test="range-clear"
+      >
+        <!--
+            @slot Slot used to customize the clear button content.
+        -->
+        <slot name="clear-content">🗑</slot>
+      </button>
+    </slot>
+  </div>
+</template>
+
+<script lang="ts">
+  import {
+    EditableNumberRangeFilter as EditableNumberRangeFilterModel,
+    RangeValue
+  } from '@empathyco/x-types-next';
+  import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+  import { VueCSSClasses } from '../../../../utils/types';
+  import { facetsNextXModule } from '../../x-module';
+  import { xComponentMixin } from '../../../../components/x-component.mixin';
+
+  /**
+   * Renders an editable number range filter. It has two input fields to handle min and max values,
+   * emitting the needed events when clicked.
+   *
+   * It provides a default slot, with some utils bind, to customize the whole component; and two
+   * named slots `apply-content` and `clear-content` to override each button content.
+   *
+   * If `instant` prop is true, the needed events are emitted immediately; else, apply button is
+   * rendered to confirm to do it. False by default.
+   *
+   * If `clear` prop is true, clear button, which sets to null component min and max values, is
+   * rendered. True by default.
+   *
+   * @public
+   */
+  @Component({
+    mixins: [xComponentMixin(facetsNextXModule)]
+  })
+  export default class EditableNumberRangeFilter extends Vue {
+    /**
+     * Component min value.
+     *
+     * @internal
+     */
+    protected min: RangeValue['min'] = null;
+    /**
+     * Component max value.
+     *
+     * @internal
+     */
+    protected max: RangeValue['max'] = null;
+
+    /**
+     * The filter data to render and edit.
+     *
+     * @public
+     */
+    @Prop({ required: true })
+    public filter!: EditableNumberRangeFilterModel;
+
+    /**
+     * If `instant` prop is true, the needed events are emitted immediately; else, apply button is
+     * rendered to confirm to do it. False by default.
+     *
+     * @public
+     */
+    @Prop({ default: false })
+    public isInstant!: boolean;
+
+    /**
+     * If `clear` prop is true, clear button, which sets to null component min and max values, is
+     * rendered. True by default.
+     *
+     * @public
+     */
+    @Prop({ default: true })
+    public hasClearButton!: boolean;
+
+    /**
+     * It watches the filter range values passed as property and updates component range values if
+     * they change.
+     *
+     * @param newRange - New range value.
+     *
+     * @internal
+     */
+    @Watch('filter.range', { immediate: true, deep: true })
+    onFilterChanged(newRange: RangeValue): void {
+      this.min = newRange.min;
+      this.max = newRange.max;
+    }
+
+    /**
+     * It watches range values in order to emit the event with the change if `isInstant`
+     * property is true.
+     *
+     * @internal
+     */
+    @Watch('range', { deep: true })
+    protected instantEmitUserModifiedFilter(): void {
+      if (this.isInstant) {
+        this.emitUserModifiedFilter();
+      }
+    }
+
+    /**
+     * Dynamic CSS classes.
+     *
+     * @returns Object which contains dynamic CSS classes.
+     *
+     * @internal
+     */
+    protected get cssClasses(): VueCSSClasses {
+      return { 'x-editable-number-range-filter--error': this.hasError };
+    }
+
+    /**
+     * Returns {@link @empathyco/x-types#RangeValue | RangeValue} with component min and max
+     * values.
+     *
+     * @returns Range value object with component values.
+     *
+     * @internal
+     */
+    protected get range(): RangeValue {
+      return { min: this.min, max: this.max };
+    }
+
+    /**
+     * It returns true if the property `hasClearButton` is true and there are values to clear.
+     *
+     * @returns True if the clear button has to be rendered.
+     *
+     * @internal
+     */
+    protected get renderClearButton(): boolean {
+      return this.hasClearButton && (this.min !== null || this.max !== null);
+    }
+
+    /**
+     * It checks if component min and max values are valid.
+     *
+     * @returns True if there is any error in the component min and max values.
+     *
+     * @internal
+     */
+    protected get hasError(): boolean {
+      return this.min !== null && this.max !== null && this.min > this.max;
+    }
+
+    /**
+     * It checks if component min and max values are different than the ones within the filter
+     * provided as property.
+     *
+     * @returns True if they are different.
+     *
+     * @internal
+     */
+    protected get areValuesDifferent(): boolean {
+      return this.min !== this.filter.range.min || this.max !== this.filter.range.max;
+    }
+
+    /**
+     * It returns the number if possible or null otherwise.
+     *
+     * @param value - Value.
+     * @returns The element value as a number if possible or null.
+     *
+     * @internal
+     */
+    protected parseRangeValue(value: number): number | null {
+      return isNaN(value) ? null : value;
+    }
+
+    /**
+     * `min` setter.
+     *
+     * @param value - The component `min` value to be set.
+     *
+     * @internal
+     */
+    protected setMin(value: number): void {
+      this.min = this.parseRangeValue(value);
+    }
+
+    /**
+     * `max` setter.
+     *
+     * @param value - The component `max` value to be set.
+     *
+     * @internal
+     */
+    protected setMax(value: number): void {
+      this.max = this.parseRangeValue(value);
+    }
+
+    /**
+     * It sets component `min` and `max` values to null and it emits the change if component is
+     * working in instant mode.
+     *
+     * @internal
+     */
+    protected clearValues(): void {
+      this.min = null;
+      this.max = null;
+    }
+
+    /**
+     * It emits {@link FacetsXEvents.UserModifiedEditableNumberRangeFilter} event if there are no
+     * errors and component `min` and `max` values are different than `filter.range` ones.
+     *
+     * @internal
+     */
+    protected emitUserModifiedFilter(): void {
+      if (!this.hasError && this.areValuesDifferent) {
+        this.$x.emit('UserModifiedEditableNumberRangeNextFilter', {
+          ...this.filter,
+          range: this.range
+        });
+      }
+    }
+  }
+</script>
+
+<style lang="scss">
+  .x-editable-number-range-filter {
+    &--error {
+      .x-editable-number-range-filter__input {
+        border-color: red;
+      }
+    }
+  }
+</style>
+
+<docs lang="mdx">
+# Example
+
+Renders an editable number range filter. It has two input fields to handle min and max values,
+emitting the needed events when clicked.
+
+It provides a default slot, with some utils bind, to customize the whole component; and two named
+slots `apply-content` and `clear-content` to override each button content.
+
+If `instant` prop is true, the needed events are emitted immediately; else, apply button is rendered
+to confirm to do it. False by default.
+
+If `clear` prop is true, clear button, which sets to null component min and max values, is rendered.
+True by default.
+
+## Basic usage
+
+```vue
+<template>
+  <EditableNumberRangeFilter :filter="editableFilter" />
+</template>
+
+<script>
+  import { EditableNumberRangeFilter } from '@empathyco/x-components/facets-next';
+
+  export default {
+    components: {
+      EditableNumberRangeFilter
+    },
+    data() {
+      return {
+        editableFilter: {
+          facetId: 'age',
+          id: 'age:primary',
+          label: 'primary',
+          modelName: 'EditableNumberRangeFilter',
+          range: {
+            min: null,
+            max: null
+          },
+          callbackInfo: {}
+        }
+      };
+    }
+  };
+</script>
+```
+
+## Properties
+
+```vue
+<template>
+  <EditableNumberRangeFilter :filter="editableFilter" :isInstant="true" :hasClearButton="false" />
+</template>
+
+<script>
+  import { EditableNumberRangeFilter } from '@empathyco/x-components/facets-next';
+
+  export default {
+    components: {
+      EditableNumberRangeFilter
+    },
+    data() {
+      return {
+        editableFilter: {
+          facetId: 'age',
+          id: 'age:primary',
+          label: 'primary',
+          modelName: 'EditableNumberRangeFilter',
+          range: {
+            min: null,
+            max: null
+          },
+          callbackInfo: {}
+        }
+      };
+    }
+  };
+</script>
+```
+
+## Customizing content slots
+
+```vue
+<template>
+  <EditableNumberRangeFilter :filter="editableFilter">
+    <template name="apply-content">Apply</template>
+    <template name="clear-content">Clear</template>
+  </EditableNumberRangeFilter>
+</template>
+
+<script>
+  import { EditableNumberRangeFilter } from '@empathyco/x-components/facets-next';
+
+  export default {
+    components: {
+      EditableNumberRangeFilter
+    },
+    data() {
+      return {
+        editableFilter: {
+          facetId: 'age',
+          id: 'age:primary',
+          label: 'primary',
+          modelName: 'EditableNumberRangeFilter',
+          range: {
+            min: null,
+            max: null
+          },
+          callbackInfo: {}
+        }
+      };
+    }
+  };
+</script>
+```
+
+## Customizing default slot
+
+```vue
+<template>
+  <EditableNumberRangeFilter
+    :filter="editableFilter"
+    #default="{ min, max, setMin, setMax, emitUserModifiedFilter, clearValues, hasError }"
+  >
+    <button @click="emitUserModifiedFilter">✅ Apply!</button>
+    <button @click="clearValues">🗑 Clear!</button>
+    <input :value="min" @change="setMin($event.target.valueAsNumber)" />
+    <input :value="max" @change="setMax($event.target.valueAsNumber)" />
+    <div class="has-error" v-if="hasError">⚠️ Invalid range values</div>
+  </EditableNumberRangeFilter>
+</template>
+
+<script>
+  import { EditableNumberRangeFilter } from '@empathyco/x-components/facets-next';
+
+  export default {
+    components: {
+      EditableNumberRangeFilter
+    },
+    data() {
+      return {
+        editableFilter: {
+          facetId: 'age',
+          id: 'age:primary',
+          label: 'primary',
+          modelName: 'EditableNumberRangeFilter',
+          range: {
+            min: null,
+            max: null
+          },
+          callbackInfo: {}
+        }
+      };
+    }
+  };
+</script>
+```
+
+## Events
+
+A list of events that the component will emit:
+
+- `UserModifiedEditableNumberRangeNextFilter`: this event is emitted instantly after typing the
+  value or clicking the submit button. The event payload in both cases is an object containing the
+  filter and the new value for the range.
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/filters/editable-number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/editable-number-range-filter.vue
@@ -52,7 +52,7 @@
         <!--
             @slot Slot used to customize the apply button content.
         -->
-        <slot name="apply-content">✅</slot>
+        <slot name="apply-content">✓</slot>
       </button>
 
       <button
@@ -64,7 +64,7 @@
         <!--
             @slot Slot used to customize the clear button content.
         -->
-        <slot name="clear-content">🗑</slot>
+        <slot name="clear-content">𐄂</slot>
       </button>
     </slot>
   </div>

--- a/packages/x-components/src/x-modules/facets-next/components/index.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/index.ts
@@ -4,6 +4,7 @@ export { default as Facets } from './facets/facets.vue';
 // Filters
 export { default as AllFilter } from './filters/all-filter.vue';
 export { default as BaseFilter } from './filters/base-filter.vue';
+export { default as EditableNumberRangeFilter } from './filters/editable-number-range-filter.vue';
 
 // Lists
 export { default as FiltersInjectionMixin } from './lists/filters-injection.mixin';

--- a/packages/x-components/src/x-modules/facets-next/components/index.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/index.ts
@@ -2,6 +2,7 @@
 export { default as Facets } from './facets/facets.vue';
 
 // Filters
+export { default as AllFilter } from './filters/all-filter.vue';
 
 // Lists
 export { default as FiltersInjectionMixin } from './lists/filters-injection.mixin';

--- a/packages/x-components/src/x-modules/facets-next/components/index.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/index.ts
@@ -3,6 +3,7 @@ export { default as Facets } from './facets/facets.vue';
 
 // Filters
 export { default as AllFilter } from './filters/all-filter.vue';
+export { default as BaseFilter } from './filters/base-filter.vue';
 
 // Lists
 export { default as FiltersInjectionMixin } from './lists/filters-injection.mixin';

--- a/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -19,7 +19,6 @@ Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
   get() {
     return parseFloat(this.value);
   },
-  writable: false,
   configurable: true,
   enumerable: true
 });

--- a/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -15,11 +15,13 @@ import { XPlugin } from '../../../../../plugins/x-plugin';
 import { facetsXModule } from '../../../x-module';
 import { resetXFacetsStateWith } from '../../__tests__/utils';
 
-Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
-  get() {
-    return parseFloat(this.value);
-  }
-});
+if (!HTMLInputElement.prototype.valueAsNumber) {
+  Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
+    get() {
+      return parseFloat(this.value);
+    }
+  });
+}
 
 function renderEditableNumberRangeFilter({
   template = `

--- a/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -15,13 +15,14 @@ import { XPlugin } from '../../../../../plugins/x-plugin';
 import { facetsXModule } from '../../../x-module';
 import { resetXFacetsStateWith } from '../../__tests__/utils';
 
-if (!HTMLInputElement.prototype.valueAsNumber) {
-  Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
-    get() {
-      return parseFloat(this.value);
-    }
-  });
-}
+Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
+  get() {
+    return parseFloat(this.value);
+  },
+  writable: true,
+  configurable: true,
+  enumerable: true
+});
 
 function renderEditableNumberRangeFilter({
   template = `

--- a/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -19,7 +19,7 @@ Object.defineProperty(HTMLInputElement.prototype, 'valueAsNumber', {
   get() {
     return parseFloat(this.value);
   },
-  writable: true,
+  writable: false,
   configurable: true,
   enumerable: true
 });


### PR DESCRIPTION
# Description

This PR moves 3 facets components from the old to the new module. It tries to touch as minimum code as possible to make them work.

> feat(facets-next): add `AllFilter`, `BaseFilter`, `EditableNumberRangeFilter` components to the `facets-next` x-module.