### PR TITLE
feat(facets-next): add all remaining components to Facets Next X-Module

### DIFF
--- a/packages/x-components/src/views/LayoutNext.vue
+++ b/packages/x-components/src/views/LayoutNext.vue
@@ -10,17 +10,21 @@
             "
           >
             <div class="x-input-group x-input-group--card x-list__item--expand">
-              <SearchInput placeholder="Search" aria-label="Search for products" />
+              <SearchInput aria-label="Search for products" placeholder="Search" />
               <ClearSearchInput aria-label="Clear query">Clear</ClearSearchInput>
-              <SearchButton class="x-input-group__action" aria-label="Search">
+              <SearchButton aria-label="Search" class="x-input-group__action">
                 <SearchIcon />
               </SearchButton>
             </div>
 
             <SlidingPanel v-if="$x.relatedTags.length">
-              <template #sliding-panel-left-button><ChevronLeft /></template>
+              <template #sliding-panel-left-button>
+                <ChevronLeft />
+              </template>
               <RelatedTags class="x-tag--card x-list--gap-03" />
-              <template #sliding-panel-right-button><ChevronRight /></template>
+              <template #sliding-panel-right-button>
+                <ChevronRight />
+              </template>
             </SlidingPanel>
           </div>
         </template>
@@ -43,8 +47,8 @@
         <template #toolbar-aside>
           <BaseIdTogglePanelButton
             v-if="$x.totalResults > 0"
-            panelId="aside-panel"
             class="x-button x-button--ghost"
+            panelId="aside-panel"
           >
             Toggle Aside
           </BaseIdTogglePanelButton>
@@ -69,7 +73,7 @@
               <Grid1Col v-else-if="column === 4" />
               <Grid2Col v-else-if="column === 6" />
             </BaseColumnPickerList>
-            <SortDropdown class="x-option-list--bottom" :items="sortValues">
+            <SortDropdown :items="sortValues" class="x-option-list--bottom">
               <template #toggle="{ item }">{{ item || 'default' }}</template>
               <template #item="{ item }">{{ item || 'default' }}</template>
             </SortDropdown>
@@ -79,9 +83,24 @@
         <template #main-aside>
           <div
             v-if="$x.totalResults > 0"
-            class="x-list x-list--padding-05 x-list--padding-top x-list--border x-list--border-top"
+            class="
+              x-list
+              x-list--padding-05
+              x-list--padding-top
+              x-list--gap-06
+              x-list--border
+              x-list--border-top
+            "
           >
             <FacetsProvider :facets="staticFacets" />
+            <ClearFilters />
+            <SelectedFiltersList>
+              <template #default="{ filter }">
+                <SimpleFilter :filter="filter" class="x-tag" />
+              </template>
+            </SelectedFiltersList>
+
+            <!-- Facets -->
             <Facets class="x-list--gap-06">
               <!--  Default Facet    -->
               <template #default="{ facet }">
@@ -90,9 +109,19 @@
                     <span class="x-ellipsis">{{ facet.label }}</span>
                     <ChevronDown />
                   </template>
-                  <FiltersList v-slot="{ filter }" :filters="facet.filters">
-                    <SimpleFilter :filter="filter" />
-                  </FiltersList>
+
+                  <!-- Filters -->
+                  <ExcludeFiltersWithNoResults :filters="facet.filters">
+                    <SortedFilters>
+                      <FiltersSearch>
+                        <SlicedFilters max="4">
+                          <FiltersList v-slot="{ filter }">
+                            <SimpleFilter :filter="filter" />
+                          </FiltersList>
+                        </SlicedFilters>
+                      </FiltersSearch>
+                    </SortedFilters>
+                  </ExcludeFiltersWithNoResults>
                 </BaseHeaderTogglePanel>
               </template>
             </Facets>
@@ -107,11 +136,11 @@
           >
             <BaseVariableColumnGrid
               #default="{ item: result }"
-              :items="recommendations"
               :animation="resultsAnimation"
+              :items="recommendations"
             >
               <article class="result" style="max-width: 300px">
-                <BaseResultImage class="x-picture--colored" :result="result">
+                <BaseResultImage :result="result" class="x-picture--colored">
                   <template #placeholder>
                     <div style="padding-top: 100%; background-color: lightgray"></div>
                   </template>
@@ -131,7 +160,7 @@
                 <BaseVariableColumnGrid :animation="resultsAnimation">
                   <template #Result="{ item: result }">
                     <article class="result" style="max-width: 300px">
-                      <BaseResultImage class="x-picture&#45;&#45;colored" :result="result">
+                      <BaseResultImage :result="result" class="x-picture&#45;&#45;colored">
                         <template #placeholder>
                           <div style="padding-top: 100%; background-color: lightgray"></div>
                         </template>
@@ -157,7 +186,7 @@
         </template>
 
         <template #scroll-to-top>
-          <BaseScrollToTop class="x-button--round" scroll-id="body-scroll" :threshold-px="500">
+          <BaseScrollToTop :threshold-px="500" class="x-button--round" scroll-id="body-scroll">
             <ChevronUp />
           </BaseScrollToTop>
         </template>
@@ -198,8 +227,16 @@
   import { XInstaller } from '../x-installer/x-installer';
   import FacetsProvider from '../x-modules/facets-next/components/facets/facets-provider.vue';
   import Facets from '../x-modules/facets-next/components/facets/facets.vue';
-  import FiltersList from '../x-modules/facets-next/components/lists/filters-list.vue';
   import SimpleFilter from '../x-modules/facets-next/components/filters/simple-filter.vue';
+  import FiltersList from '../x-modules/facets-next/components/lists/filters-list.vue';
+  import FiltersSearch from '../x-modules/facets-next/components/lists/filters-search.vue';
+  // eslint-disable-next-line max-len
+  import SelectedFiltersList from '../x-modules/facets-next/components/lists/selected-filters-list.vue';
+  import SlicedFilters from '../x-modules/facets-next/components/lists/sliced-filters.vue';
+  // eslint-disable-next-line max-len
+  import ExcludeFiltersWithNoResults from '../x-modules/facets-next/components/lists/exclude-filters-with-no-results.vue';
+  import SortedFilters from '../x-modules/facets-next/components/lists/sorted-filters.vue';
+  import ClearFilters from '../x-modules/facets-next/components/clear-filters.vue';
   import HistoryQueries from '../x-modules/history-queries/components/history-queries.vue';
   import NextQueries from '../x-modules/next-queries/components/next-queries.vue';
   import PopularSearches from '../x-modules/popular-searches/components/popular-searches.vue';
@@ -231,6 +268,12 @@
       infiniteScroll
     },
     components: {
+      ClearFilters,
+      SortedFilters,
+      ExcludeFiltersWithNoResults,
+      FiltersSearch,
+      SlicedFilters,
+      SelectedFiltersList,
       FiltersList,
       ChevronUp,
       Promoted,
@@ -276,10 +319,10 @@
     }
   })
   export default class App extends Vue {
-    protected sortValues = ['', 'priceSort asc', 'priceSort desc'];
     protected columnPickerValues = [0, 4, 6];
-    protected selectedColumns = 4;
     protected resultsAnimation = StaggeredFadeAndSlide;
+    protected selectedColumns = 4;
+    protected sortValues = ['', 'priceSort asc', 'priceSort desc'];
     protected staticFacets: Facet[] = [
       {
         modelName: 'SimpleFacet',
@@ -301,8 +344,8 @@
 
 <style lang="scss" scoped>
   .x-modal::v-deep .x-modal__content {
+    overflow: hidden;
     width: 100%;
     height: 100%;
-    overflow: hidden;
   }
 </style>

--- a/packages/x-components/src/views/LayoutNext.vue
+++ b/packages/x-components/src/views/LayoutNext.vue
@@ -237,6 +237,8 @@
   import ExcludeFiltersWithNoResults from '../x-modules/facets-next/components/lists/exclude-filters-with-no-results.vue';
   import SortedFilters from '../x-modules/facets-next/components/lists/sorted-filters.vue';
   import ClearFilters from '../x-modules/facets-next/components/clear-filters.vue';
+  import { FilterEntityFactory } from '../x-modules/facets-next/entities/filter-entity.factory';
+  import { SingleSelectModifier } from '../x-modules/facets-next/entities/single-select.modifier';
   import HistoryQueries from '../x-modules/history-queries/components/history-queries.vue';
   import NextQueries from '../x-modules/next-queries/components/next-queries.vue';
   import PopularSearches from '../x-modules/popular-searches/components/popular-searches.vue';
@@ -262,6 +264,7 @@
           xModules: { recommendations: { config: { maxItemsToRequest: 48 } } }
         })
       ).init(baseSnippetConfig);
+      FilterEntityFactory.instance.registerFilterModifier('brand_facet', [SingleSelectModifier]);
       next();
     },
     directives: {

--- a/packages/x-components/src/x-modules/facets-next/components/__tests__/clear-filters.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/__tests__/clear-filters.spec.ts
@@ -1,0 +1,213 @@
+import { Facet } from '@empathyco/x-types-next';
+import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex, { Store } from 'vuex';
+import {
+  createHierarchicalFacetStub,
+  createSimpleFacetStub
+} from '../../../../__stubs__/facets-stubs.factory';
+import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
+import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
+import { XPlugin } from '../../../../plugins/x-plugin';
+import { RootXStoreState } from '../../../../store/store.types';
+import { DeepPartial } from '../../../../utils/types';
+import { DefaultFacetsService } from '../../service/facets.service';
+import { facetsNextXModule as facetsXModule } from '../../x-module';
+import ClearFilters from '../clear-filters.vue';
+import { resetXFacetsStateWith } from './utils';
+
+/**
+ * Renders the `ClearFilters` component, exposing a basic API for testing.
+ *
+ * @param options - The options to render the component with.
+ * @returns The API for testing the `ClearFilters` component.
+ */
+function renderClearFilters({
+  template = `
+    <ClearFilters v-slot="{ selectedFilters }" :facets-ids="facetsIds">
+      Clear {{ selectedFilters.length }} filters
+    </ClearFilters>
+  `
+}: RenderFiltersOptions = {}): RenderFiltersAPI {
+  const facets = {
+    category: createHierarchicalFacetStub('Category', createFilter => [
+      createFilter('Men', false),
+      createFilter('Women', false)
+    ]),
+    brand: createSimpleFacetStub('Brand', createFilter => [
+      createFilter('Audi', false),
+      createFilter('BMW', false)
+    ])
+  };
+
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const store: Store<DeepPartial<RootXStoreState>> = new Store<DeepPartial<RootXStoreState>>({});
+  installNewXPlugin({ store }, localVue);
+  XPlugin.registerXModule(facetsXModule);
+
+  resetXFacetsStateWith(store, facets);
+  const wrapper = mount(
+    {
+      components: {
+        ClearFilters
+      },
+      template,
+      props: ['facetsIds']
+    },
+    {
+      localVue,
+      store
+    }
+  );
+
+  const clearFiltersWrapper = wrapper.findComponent(ClearFilters);
+
+  return {
+    wrapper,
+    clearFiltersWrapper,
+    setCategoryFacetFiltersAsSelected() {
+      facets.category.filters.forEach(filter => DefaultFacetsService.instance.select(filter));
+      return localVue.nextTick();
+    },
+    setFacetsIds(facetsIds) {
+      wrapper.setProps({ facetsIds });
+      return localVue.nextTick();
+    }
+  };
+}
+
+describe('testing ClearFilters component', () => {
+  it('is an x-component', () => {
+    const { clearFiltersWrapper } = renderClearFilters();
+
+    expect(isXComponent(clearFiltersWrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const { clearFiltersWrapper } = renderClearFilters();
+
+    expect(getXComponentXModuleName(clearFiltersWrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('does not render if there are no selected filters', async () => {
+    const { wrapper, setCategoryFacetFiltersAsSelected } = renderClearFilters();
+
+    expect(wrapper.find(getDataTestSelector('clear-filters')).exists()).toBe(false);
+
+    await setCategoryFacetFiltersAsSelected();
+
+    expect(wrapper.find(getDataTestSelector('clear-filters')).exists()).toBe(true);
+    expect(wrapper.attributes()).not.toHaveProperty('disabled');
+    expect(wrapper.text()).toEqual('Clear 2 filters');
+  });
+
+  it('does not render if there are selected filters with the provided facetIds', async () => {
+    const { wrapper, setCategoryFacetFiltersAsSelected, setFacetsIds } = renderClearFilters();
+
+    await setCategoryFacetFiltersAsSelected();
+    await setFacetsIds(['brand']);
+
+    expect(wrapper.find(getDataTestSelector('clear-filters')).exists()).toBe(false);
+
+    await setFacetsIds(['category']);
+    expect(wrapper.find(getDataTestSelector('clear-filters')).exists()).toBe(true);
+    expect(wrapper.attributes()).not.toHaveProperty('disabled');
+    expect(wrapper.text()).toEqual('Clear 2 filters');
+  });
+
+  it(
+    'is disabled if there are selected filters with the provided facetIds when ' +
+      'the alwaysVisible prop is true',
+    async () => {
+      const { wrapper, setCategoryFacetFiltersAsSelected, setFacetsIds } = renderClearFilters({
+        template: `
+          <ClearFilters v-slot="{ selectedFilters }" :alwaysVisible="true" :facets-ids="facetsIds">
+            Clear {{ selectedFilters.length }} filters
+          </ClearFilters>`
+      });
+
+      expect(wrapper.find(getDataTestSelector('clear-filters')).exists()).toBe(true);
+      expect(wrapper.attributes()).toHaveProperty('disabled');
+      expect(wrapper.text()).toEqual('Clear 0 filters');
+
+      await setCategoryFacetFiltersAsSelected();
+
+      expect(wrapper.attributes()).not.toHaveProperty('disabled');
+      expect(wrapper.text()).toEqual('Clear 2 filters');
+
+      await setFacetsIds(['brand']);
+
+      expect(wrapper.attributes()).toHaveProperty('disabled');
+      expect(wrapper.text()).toEqual('Clear 0 filters');
+
+      await setFacetsIds(['category']);
+      expect(wrapper.attributes()).not.toHaveProperty('disabled');
+      expect(wrapper.text()).toEqual('Clear 2 filters');
+    }
+  );
+
+  it('emits UserClickedClearFacetFilters event with the provided facetIds', async () => {
+    const listenerClearFilterFacets = jest.fn();
+    const facetsIds = ['category'];
+    const { wrapper, setCategoryFacetFiltersAsSelected, setFacetsIds } = renderClearFilters();
+    wrapper.vm.$x.on('UserClickedClearFacetFilters', true).subscribe(listenerClearFilterFacets);
+
+    await setCategoryFacetFiltersAsSelected();
+    await setFacetsIds(facetsIds);
+    wrapper.trigger('click');
+
+    expect(wrapper.find(getDataTestSelector('clear-filters')).exists()).toBe(true);
+    expect(listenerClearFilterFacets).toHaveBeenCalledTimes(1);
+    expect(listenerClearFilterFacets).toHaveBeenCalledWith({
+      eventPayload: facetsIds,
+      metadata: {
+        moduleName: 'facetsNext',
+        target: wrapper.element
+      }
+    });
+  });
+
+  it('emits UserClickedClearAllFilters event', async () => {
+    const listenerClearFilter = jest.fn();
+    const { wrapper, setCategoryFacetFiltersAsSelected } = renderClearFilters();
+    wrapper.vm.$x.on('UserClickedClearAllFilters', true).subscribe(listenerClearFilter);
+
+    await setCategoryFacetFiltersAsSelected();
+    wrapper.trigger('click');
+
+    expect(wrapper.find(getDataTestSelector('clear-filters')).exists()).toBe(true);
+    expect(listenerClearFilter).toHaveBeenCalledTimes(1);
+    expect(listenerClearFilter).toHaveBeenCalledWith({
+      eventPayload: undefined,
+      metadata: {
+        moduleName: 'facetsNext',
+        target: wrapper.element
+      }
+    });
+  });
+});
+
+interface RenderFiltersOptions {
+  /** The template to be rendered. */
+  template?: string;
+}
+
+interface RenderFiltersAPI {
+  /** The wrapper of the container element.*/
+  wrapper: Wrapper<Vue>;
+  /** The `clearFilters` wrapper component. */
+  clearFiltersWrapper: Wrapper<Vue>;
+  /**
+   * Change value property "selected" of some specifics filters.
+   *
+   * @returns A promise that resolves after re-rendering the component.
+   */
+  setCategoryFacetFiltersAsSelected: () => Promise<void>;
+  /**
+   * Set the new facets ids for setting the property "facetsIds".
+   *
+   * @returns A promise that resolves after re-rendering the component.
+   */
+  setFacetsIds: (facetsIds: Array<Facet['id']>) => Promise<void>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/__tests__/utils.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/__tests__/utils.ts
@@ -1,22 +1,43 @@
+import { Facet } from '@empathyco/x-types-next';
 import { Store } from 'vuex';
-import { RootXStoreState } from '../../../../store/store.types';
-import { DeepPartial } from '../../../../utils/types';
 import { resetStoreXModuleState } from '../../../../__tests__/utils';
+import { RootXStoreState } from '../../../../store/store.types';
+import { arrayToObject } from '../../../../utils/array';
+import { reduce } from '../../../../utils/object';
+import { DeepPartial } from '../../../../utils/types';
 import { facetsNextXStoreModule as facetsXStoreModule } from '../../store/module';
-import { FacetsNextState as FacetsState } from '../../store/types';
+import { GroupId } from '../../store/types';
 
 /**
  * Reset facets x-module state with its original state and the partial state passes as
  * parameter.
  *
  * @param store - Root state of the x-modules.
- * @param state - Partial facets store state to use as replacement.
+ * @param facets - Store state facets to use as replacement.
+ * @param groupId - Facets group id to use in replacement.
  *
  * @internal
  */
 export function resetXFacetsStateWith(
   store: Store<DeepPartial<RootXStoreState>>,
-  state?: DeepPartial<FacetsState>
+  facets: Record<Facet['id'], Facet> = {},
+  groupId: GroupId = 'search'
 ): void {
-  resetStoreXModuleState(store, 'facetsNext', facetsXStoreModule.state(), state);
+  const filters = arrayToObject(
+    Object.values(facets)
+      .map(facet => facet.filters)
+      .flat(),
+    'id'
+  );
+  const groups = reduce(
+    facets,
+    (groups, facetId) => Object.assign(groups, { [facetId]: groupId }),
+    {} as Record<Facet['id'], GroupId>
+  );
+
+  resetStoreXModuleState(store, 'facetsNext', facetsXStoreModule.state(), {
+    facets,
+    filters,
+    groups
+  });
 }

--- a/packages/x-components/src/x-modules/facets-next/components/clear-filters.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/clear-filters.vue
@@ -1,0 +1,174 @@
+<template>
+  <BaseEventButton
+    v-if="show"
+    class="x-button x-clear-filters"
+    data-test="clear-filters"
+    :disabled="!areThereSelectedFilters"
+    :events="events"
+    :class="cssClasses"
+  >
+    <slot :selectedFilters="facetsSelectedFilters">Clear Filters</slot>
+  </BaseEventButton>
+</template>
+
+<script lang="ts">
+  import { Facet, Filter, isFacetFilter } from '@empathyco/x-types-next';
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { Getter, xComponentMixin } from '../../../components';
+  import BaseEventButton from '../../../components/base-event-button.vue';
+  import { VueCSSClasses } from '../../../utils';
+  import { XEventsTypes } from '../../../wiring';
+  import { facetsNextXModule as facetsXModule } from '../x-module';
+
+  /**
+   * Renders a simple button, emitting the needed events when clicked.
+   *
+   * @public
+   */
+  @Component({
+    components: { BaseEventButton },
+    mixins: [xComponentMixin(facetsXModule)]
+  })
+  export default class ClearFilters extends Vue {
+    /**
+     * It handles if the ClearFilters button is always visible no matter if there are not
+     * filters selected. If false, the ClearFilters button is not visible whether
+     * there are no filters selected.
+     *
+     * @public
+     */
+    @Prop({ default: false })
+    public alwaysVisible!: boolean;
+
+    /**
+     * Array of facets ids that will be passed to event like payload.
+     *
+     * @public
+     */
+    @Prop()
+    public facetsIds?: Array<Facet['id']>;
+
+    /**
+     * Get the selected filters from store.
+     *
+     * @internal
+     */
+    @Getter('facetsNext', 'selectedFilters')
+    public allSelectedFilters!: Filter[];
+
+    /**
+     * If alwaysVisible prop is true, ClearAllFilters button is always shown, but disabled
+     * if there are no filters selected.
+     * If alwaysVisible prop is false, ClearAllFilters button is shown whether there
+     * are some filter selected.
+     *
+     * @returns True if alwaysVisible is true or in the opposite case true or false depends
+     * on if there are selected filters or not.
+     *
+     * @internal
+     */
+    protected get show(): boolean {
+      return this.alwaysVisible || this.areThereSelectedFilters;
+    }
+
+    /**
+     * Get selected filters.
+     * If there are facets ids, get selected filters whose facet id match with some of facets ids.
+     * If there aren't facets ids, get selected filters.
+     *
+     * @returns Array of selected filters depends on there are facets ids or not.
+     * @internal
+     */
+    protected get facetsSelectedFilters(): Filter[] {
+      if (this.facetsIds) {
+        return this.allSelectedFilters.filter(
+          filter => isFacetFilter(filter) && this.facetsIds!.includes(filter.facetId)
+        );
+      } else {
+        return this.allSelectedFilters;
+      }
+    }
+
+    /**
+     * Check if there are selected filters.
+     *
+     * @returns True or false depends on if there are facets ids and if there are selected filters.
+     * @internal
+     */
+    protected get areThereSelectedFilters(): boolean {
+      return !!this.facetsSelectedFilters.length;
+    }
+
+    /**
+     * The events that will be emitted when the button clear filters is clicked.
+     *
+     * @returns The events to be emitted when the button clear filters is clicked.
+     * @internal
+     */
+    protected get events(): Partial<XEventsTypes> {
+      return this.facetsIds
+        ? {
+            UserClickedClearFacetFilters: this.facetsIds
+          }
+        : {
+            UserClickedClearAllFilters: undefined
+          };
+    }
+
+    /**
+     * Dynamic CSS classes to apply to the component.
+     *
+     * @returns The dynamic CSS classes to apply to the component.
+     * @internal
+     */
+    protected get cssClasses(): VueCSSClasses {
+      return {
+        'x-clear-filters--has-not-selected-filters': !this.areThereSelectedFilters,
+        'x-clear-filters--has-selected-filters': this.areThereSelectedFilters
+      };
+    }
+  }
+</script>
+
+<docs>
+#Example
+
+This component renders a button, which on clicked emits the `UserClickedClearFacetFilters` or
+`UserClickedClearAllFilters` event.
+
+## Basic usage
+
+```vue
+<ClearFilters />
+```
+
+## Customizing its contents
+
+In this example, show the custom message in button.
+
+```vue
+<ClearFilters v-slot="{ selectedFilters }" >
+  Delete {{ selectedFilters.length }} selected
+</ClearFilters>
+```
+
+In this example, show the custom message in button with always visible a true and
+list of facets ids.
+
+```vue
+<ClearFilters v-slot="{ selectedFilters }" :alwaysVisible="true" :facetsIds="facetsIds">
+  Delete {{ selectedFilters.length }} selected
+</ClearFilters>
+```
+
+## Events
+
+A list of events that the component will emit:
+
+- `UserClickedClearFacetFilters`: the event is emitted after the user clicks the button to clear a
+certain facets filter. The event payload is the id of the facets that are going to be cleared.
+- `UserClickedClearAllFilters`: the event is emitted after the user clicks the button. The event
+payload is undefined.
+
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/facets/__tests__/facets-provider.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/facets/__tests__/facets-provider.spec.ts
@@ -12,10 +12,8 @@ import { XPlugin } from '../../../../../plugins/x-plugin';
 import { RootXStoreState } from '../../../../../store/store.types';
 import { arrayToObject } from '../../../../../utils/array';
 import { areNextFiltersDifferent } from '../../../../../utils/filters';
-import { reduce } from '../../../../../utils/object';
 import { DeepPartial, Dictionary } from '../../../../../utils/types';
 import { DefaultFacetsService } from '../../../service/facets.service';
-import { GroupId } from '../../../store/types';
 import { facetsNextXModule as facetsXModule } from '../../../x-module';
 import { resetXFacetsStateWith } from '../../__tests__/utils';
 import FacetsProvider from '../facets-provider.vue';
@@ -131,18 +129,7 @@ function renderFacetsProviderComponent({
   const store = new Store<DeepPartial<RootXStoreState>>({});
   installNewXPlugin({ store }, localVue);
   XPlugin.registerXModule(facetsXModule);
-  const filters = arrayToObject(
-    Object.values(stateFacets)
-      ?.map(facet => facet.filters)
-      .flat(),
-    'id'
-  );
-  const groups = reduce(
-    stateFacets,
-    (groups, facetId) => Object.assign(groups, { [facetId]: 'search' }),
-    {} as Record<Facet['id'], GroupId>
-  );
-  resetXFacetsStateWith(store, { facets: stateFacets, filters, groups });
+  resetXFacetsStateWith(store, stateFacets);
 
   const facetWrapper = mount(
     {

--- a/packages/x-components/src/x-modules/facets-next/components/facets/__tests__/facets.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/facets/__tests__/facets.spec.ts
@@ -10,7 +10,6 @@ import {
 } from '../../../../../components/x-component.utils';
 import { XPlugin } from '../../../../../plugins/x-plugin';
 import { RootXStoreState } from '../../../../../store/store.types';
-import { arrayToObject } from '../../../../../utils/array';
 import { DeepPartial, Dictionary } from '../../../../../utils/types';
 import { facetsNextXModule as facetsXModule } from '../../../x-module';
 import { resetXFacetsStateWith } from '../../__tests__/utils';
@@ -222,13 +221,7 @@ function renderFacetsComponent({
   const store = new Store<DeepPartial<RootXStoreState>>({});
   installNewXPlugin({ store }, localVue);
   XPlugin.registerXModule(facetsXModule);
-  const filters = arrayToObject(
-    Object.values(facets)
-      ?.map(facet => facet.filters)
-      .flat(),
-    'id'
-  );
-  resetXFacetsStateWith(store, { facets, filters });
+  resetXFacetsStateWith(store, facets);
 
   const facetWrapper = mount(
     {

--- a/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/all-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/filters/__tests__/all-filter.spec.ts
@@ -6,7 +6,6 @@ import { createNextSimpleFacetStub } from '../../../../../__stubs__/facets-stubs
 import { installNewXPlugin } from '../../../../../__tests__/utils';
 import { getXComponentXModuleName, isXComponent } from '../../../../../components';
 import { RootXStoreState } from '../../../../../store/store.types';
-import { arrayToObject } from '../../../../../utils/array';
 import { facetsNextXModule } from '../../../x-module';
 import { resetXFacetsStateWith } from '../../__tests__/utils';
 import AllFilter from '../all-filter.vue';
@@ -29,12 +28,7 @@ function renderAllFilter({
   localVue.use(Vuex);
   const store = new Store<RootXStoreState>({});
   installNewXPlugin({ store, initialXModules: [facetsNextXModule] }, localVue);
-  resetXFacetsStateWith(store, {
-    facets: {
-      [facet.id]: facet
-    },
-    filters: arrayToObject(facet.filters, 'id')
-  });
+  resetXFacetsStateWith(store, { category: facet });
 
   const wrapper = mount(
     {

--- a/packages/x-components/src/x-modules/facets-next/components/index.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/index.ts
@@ -11,5 +11,15 @@ export { default as RenderlessFilter } from './filters/renderless-filter.vue';
 export { default as SimpleFilter } from './filters/simple-filter.vue';
 
 // Lists
+// eslint-disable-next-line max-len
+export { default as ExcludeFiltersWithNoResults } from './lists/exclude-filters-with-no-results.vue';
 export { default as FiltersInjectionMixin } from './lists/filters-injection.mixin';
 export { default as FiltersList } from './lists/filters-list.vue';
+export { default as FiltersSearch } from './lists/filters-search.vue';
+export { default as SelectedFilters } from './lists/selected-filters.vue';
+export { default as SelectedFiltersList } from './lists/selected-filters-list.vue';
+export { default as SlicedFilters } from './lists/sliced-filters.vue';
+export { default as SortedFilters } from './lists/sorted-filters.vue';
+
+// Others
+export { default as ClearFilters } from './clear-filters.vue';

--- a/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/exclude-filters-with-no-results.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/exclude-filters-with-no-results.spec.ts
@@ -1,0 +1,90 @@
+import { Filter } from '@empathyco/x-types-next';
+import { createLocalVue, mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import Vue from 'vue';
+import { getSimpleFilterStub } from '../../../../../__stubs__/filters-stubs.factory';
+import { getXComponentXModuleName, isXComponent } from '../../../../../components';
+import ExcludeFiltersWithNoResults from '../exclude-filters-with-no-results.vue';
+
+/**
+ * Renders a {@link ExcludeFiltersWithNoResults} component with the provided options, and returns
+ * a small API to test it.
+ *
+ * @param options - Options to test the {@link ExcludeFiltersWithNoResults} component with.
+ * @returns A {@link RenderExcludeFiltersWithNoResultsAPI} object to test the
+ * {@link ExcludeFiltersWithNoResults}.
+ */
+function renderExcludeFiltersWithNoResults({
+  filters = [],
+  template = `
+    <ExcludeFiltersWithNoResults :filters="filters" v-slot="{ filters }">
+      <div>
+        <span class="filter" v-for="filter in filters">{{ filter.label }}</span>
+      </div>
+    </ExcludeFiltersWithNoResults>`
+}: RenderExcludeFiltersWithNoResultsOptions = {}): RenderExcludeFiltersWithNoResultsAPI {
+  const localVue = createLocalVue();
+
+  const templateWrapper = mount(
+    {
+      props: ['filters'],
+      components: {
+        ExcludeFiltersWithNoResults
+      },
+      template
+    },
+    {
+      localVue,
+      propsData: { filters }
+    }
+  );
+
+  const wrapper = templateWrapper.findComponent(ExcludeFiltersWithNoResults);
+  return {
+    wrapper,
+    getRenderedFilters() {
+      return templateWrapper.findAll('.filter');
+    }
+  };
+}
+
+describe('testing Filters component', () => {
+  it('is an x-component', () => {
+    const { wrapper } = renderExcludeFiltersWithNoResults();
+
+    expect(isXComponent(wrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const { wrapper } = renderExcludeFiltersWithNoResults();
+
+    expect(getXComponentXModuleName(wrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('excludes filters with totalResults=0', () => {
+    const { getRenderedFilters } = renderExcludeFiltersWithNoResults({
+      filters: [
+        getSimpleFilterStub({ label: 'Men', totalResults: 0 }),
+        getSimpleFilterStub({ label: 'Women', totalResults: 10 }),
+        getSimpleFilterStub({ label: 'Kids', totalResults: undefined })
+      ]
+    });
+    const renderedFilters = getRenderedFilters();
+    expect(renderedFilters).toHaveLength(2);
+    expect(renderedFilters.wrappers.map(wrapper => wrapper.text())).toEqual(['Women', 'Kids']);
+  });
+});
+
+interface RenderExcludeFiltersWithNoResultsOptions {
+  /** The filters data to render. */
+  filters?: Filter[];
+  /** The template to render. Receives the `filters` via prop, and has registered the
+   * {@link ExcludeFiltersWithNoResults} component. */
+  template?: string;
+}
+
+interface RenderExcludeFiltersWithNoResultsAPI {
+  /** Retrieves the testing wrappers of the filters. */
+  getRenderedFilters: () => WrapperArray<Vue>;
+  /** The Vue testing utils wrapper for the {@link ExcludeFiltersWithNoResults} component. */
+  wrapper: Wrapper<Vue>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/filters-search.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/filters-search.spec.ts
@@ -1,0 +1,175 @@
+import { Filter } from '@empathyco/x-types-next';
+import { mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import Vue from 'vue';
+import { getXComponentXModuleName, isXComponent } from '../../../../../components';
+import { Dictionary } from '../../../../../utils/types';
+import { getSimpleFilterStub } from '../../../../../__stubs__/filters-stubs.factory';
+import { getDataTestSelector } from '../../../../../__tests__/utils';
+import FiltersSearch from '../filters-search.vue';
+
+const filtersMock: Filter[] = [
+  'Lego city',
+  'Lego CITY 2',
+  'Lego Star Wars"',
+  'LEGO BATMAN',
+  'Lego batman 2',
+  'LEGO Construcción',
+  'Lego Coleccionista',
+  'Lego Españita'
+].map(label => getSimpleFilterStub({ label }));
+
+const queries: Dictionary<number> = {
+  '   ConsTRUCcióN  ': 1,
+  a: 5,
+  bat: 2,
+  lego: 8,
+  'go c': 4,
+  '"': 1,
+  ñ: 5
+};
+
+function renderFiltersSearch(
+  dataTestInputSelector = 'filters-search-input',
+  template?: string
+): FiltersSearchAPI {
+  const wrapper = mount(
+    {
+      components: { FiltersSearch },
+      props: ['filters', 'debounceInMs'],
+      template:
+        template ??
+        `
+          <FiltersSearch :filters="filters" :debounceInMs="debounceInMs">
+            <template #default="{ siftedFilters }">
+              <ul v-for="filter in siftedFilters" data-test="filters-search-list">
+                <li data-test="filters-search-list-item">{{ filter.label }}</li>
+              </ul>
+            </template>
+          </FiltersSearch>
+        `
+    },
+    {
+      propsData: {
+        filters: filtersMock
+      }
+    }
+  );
+
+  const filterWrapper = wrapper.findComponent(FiltersSearch);
+
+  return {
+    wrapper,
+    filterWrapper,
+    componentWrapper: wrapper.find(getDataTestSelector('filters-search')),
+    inputWrapper: wrapper.find(getDataTestSelector(dataTestInputSelector)),
+    getFiltersWrapper: () => wrapper.findAll(getDataTestSelector('filters-search-list-item'))
+  };
+}
+
+describe('testing FiltersSearch', () => {
+  beforeAll(jest.useFakeTimers);
+  afterEach(jest.clearAllTimers);
+
+  it('is an x-component', () => {
+    const { filterWrapper } = renderFiltersSearch();
+
+    expect(isXComponent(filterWrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const { filterWrapper } = renderFiltersSearch();
+
+    expect(getXComponentXModuleName(filterWrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('renders the search input and provided filters', () => {
+    const { wrapper, componentWrapper, inputWrapper, getFiltersWrapper } = renderFiltersSearch();
+
+    expect(componentWrapper.element).toBeDefined();
+    expect(inputWrapper.element).toBeDefined();
+    expect(wrapper.classes()).not.toContain('x-filters-search--is-sifted');
+    expect(getFiltersWrapper()).toHaveLength(filtersMock.length);
+  });
+
+  it('sifts provided filters with the input query', async () => {
+    const filtersSearch = renderFiltersSearch();
+
+    for (const [query, occurrences] of Object.entries(queries)) {
+      await expectFiltersSearch(filtersSearch, query, occurrences);
+      expect(filtersSearch.wrapper.classes()).toContain('x-filters-search--is-sifted');
+    }
+  });
+
+  it('allows changing the debounce time', async () => {
+    const filtersSearch = renderFiltersSearch();
+
+    await filtersSearch.wrapper.setProps({ debounceInMs: 2000 });
+    for (const [query, occurrences] of Object.entries(queries)) {
+      await expectFiltersSearch(filtersSearch, query, filtersMock.length);
+      expect(filtersSearch.wrapper.classes()).not.toContain('x-filters-search--is-sifted');
+
+      jest.advanceTimersByTime(1800);
+      await Vue.nextTick();
+      expect(filtersSearch.getFiltersWrapper()).toHaveLength(occurrences);
+      expect(filtersSearch.wrapper.classes()).toContain('x-filters-search--is-sifted');
+
+      await filtersSearch.inputWrapper.setValue('');
+      jest.advanceTimersByTime(2000);
+      await Vue.nextTick();
+      expect(filtersSearch.getFiltersWrapper()).toHaveLength(filtersMock.length);
+    }
+  });
+
+  it('replaces the search slot content by a custom one', async () => {
+    const filtersSearch = renderFiltersSearch(
+      'custom-input',
+      `
+      <FiltersSearch :filters="filters" :debounceInMs="debounceInMs">
+        <template #search="{ query, setQuery, clearQuery }">
+          <input
+            @input="setQuery($event.target.value)"
+            :value="query"
+            data-test="custom-input"/>
+          <button @click="clearQuery" data-test="custom-clear-button">X</button>
+        </template>
+        <template #default="{ siftedFilters }">
+          <ul v-for="filter in siftedFilters" data-test="filters-search-list">
+            <li data-test="filters-search-list-item">{{ filter.label }}</li>
+          </ul>
+        </template>
+      </FiltersSearch>
+      `
+    );
+
+    for (const [query, occurrences] of Object.entries(queries)) {
+      await expectFiltersSearch(filtersSearch, query, occurrences);
+      expect(filtersSearch.wrapper.classes()).toContain('x-filters-search--is-sifted');
+    }
+
+    const clearButton = filtersSearch.wrapper.find(getDataTestSelector('custom-clear-button'));
+    await clearButton.trigger('click');
+    expect(filtersSearch.getFiltersWrapper()).toHaveLength(filtersMock.length);
+    expect((filtersSearch.inputWrapper.element as HTMLInputElement).value).toEqual('');
+  });
+});
+
+async function expectFiltersSearch(
+  { inputWrapper, getFiltersWrapper }: FiltersSearchAPI,
+  query: string,
+  occurrences: number
+): Promise<void> {
+  await inputWrapper.setValue(query);
+  expect((inputWrapper.element as HTMLInputElement).value).toEqual(query);
+  jest.advanceTimersByTime(200);
+  await Vue.nextTick();
+  expect((inputWrapper.element as HTMLInputElement).value).toEqual(query);
+  expect(getFiltersWrapper()).toHaveLength(occurrences);
+}
+
+interface FiltersSearchAPI {
+  wrapper: Wrapper<Vue>;
+  filterWrapper: Wrapper<Vue>;
+  componentWrapper: Wrapper<Vue>;
+  inputWrapper: Wrapper<Vue>;
+  getFiltersWrapper: () => WrapperArray<Vue>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/selected-filters-list.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/selected-filters-list.spec.ts
@@ -1,0 +1,159 @@
+import { BooleanFilter, Facet } from '@empathyco/x-types-next';
+import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex, { Store } from 'vuex';
+import { createSimpleFacetStub } from '../../../../../__stubs__/facets-stubs.factory';
+import { getDataTestSelector, installNewXPlugin } from '../../../../../__tests__/utils';
+import { getXComponentXModuleName, isXComponent } from '../../../../../components';
+import { XPlugin } from '../../../../../plugins';
+import { RootXStoreState } from '../../../../../store';
+import { DeepPartial } from '../../../../../utils';
+import { facetsNextXModule as facetsXModule } from '../../../x-module';
+import { resetXFacetsStateWith } from '../../__tests__/utils';
+import SelectedFiltersList from '../../lists/selected-filters-list.vue';
+
+/**
+ * Renders the `SelectedFiltersList` component, exposing a basic API for testing.
+ *
+ * @param options - The options to render the component with.
+ * @returns The API for testing the `SelectedFiltersList` component.
+ */
+function renderSelectedFiltersList({
+  template = '<SelectedFiltersList />'
+}: RenderSelectedFiltersListOptions = {}): RenderSelectedFiltersAPI {
+  const facets: Record<Facet['id'], Facet> = {
+    gender: createSimpleFacetStub('gender', createFilter => [
+      createFilter('Men', false),
+      createFilter('Women', false)
+    ]),
+    brand: createSimpleFacetStub('brand', createFilter => [
+      createFilter('Audi', false),
+      createFilter('BMW', false)
+    ])
+  };
+
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const store = new Store<DeepPartial<RootXStoreState>>({});
+  installNewXPlugin({ store }, localVue);
+  XPlugin.registerXModule(facetsXModule);
+  resetXFacetsStateWith(store, facets);
+
+  const wrapper = mount(
+    {
+      components: {
+        SelectedFiltersList
+      },
+      template
+    },
+    {
+      localVue,
+      store
+    }
+  );
+
+  const selectedFiltersListWrapper = wrapper.findComponent(SelectedFiltersList);
+
+  return {
+    wrapper,
+    selectedFiltersListWrapper,
+    toggleFacetNthFilter(facetId, nth) {
+      const filter = (store.getters['x/facetsNext/facets']![facetId].filters as BooleanFilter[])[
+        nth
+      ];
+      filter.selected = !filter.selected;
+      return localVue.nextTick();
+    }
+  };
+}
+
+describe('testing SelectedFiltersList component', () => {
+  it('is an x-component', () => {
+    const { selectedFiltersListWrapper } = renderSelectedFiltersList();
+    expect(isXComponent(selectedFiltersListWrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const { selectedFiltersListWrapper } = renderSelectedFiltersList();
+    expect(getXComponentXModuleName(selectedFiltersListWrapper.vm)).toEqual('facetsNext');
+  });
+
+  it("doesn't render anything if no filters are selected", () => {
+    const { selectedFiltersListWrapper } = renderSelectedFiltersList();
+    expect(selectedFiltersListWrapper.html()).toBe('');
+  });
+
+  it('renders filters label by default', async () => {
+    const { selectedFiltersListWrapper, toggleFacetNthFilter } = renderSelectedFiltersList();
+    await toggleFacetNthFilter('gender', 0);
+    await toggleFacetNthFilter('brand', 1);
+
+    const selectedFiltersItems = selectedFiltersListWrapper.findAll(
+      getDataTestSelector('selected-filters-list-item')
+    );
+
+    expect(selectedFiltersItems.at(0).text()).toBe('Men');
+    expect(selectedFiltersItems.at(1).text()).toBe('BMW');
+  });
+
+  it('renders custom default slot and custom facetId slot', async () => {
+    const { selectedFiltersListWrapper, toggleFacetNthFilter } = renderSelectedFiltersList({
+      template: `
+        <SelectedFiltersList>
+          <template #default="{ filter }">{{ filter.label }} selected!</template>
+          <template #brand="{ filter }">Which one? {{ filter.label }}</template>
+        </SelectedFiltersList>
+      `
+    });
+
+    await toggleFacetNthFilter('gender', 0);
+    await toggleFacetNthFilter('brand', 1);
+
+    const selectedFiltersItems = selectedFiltersListWrapper.findAll(
+      getDataTestSelector('selected-filters-list-item')
+    );
+
+    expect(selectedFiltersItems.at(0).text()).toBe('Men selected!');
+    expect(selectedFiltersItems.at(1).text()).toBe('Which one? BMW');
+  });
+
+  it('renders selectedFilters of the facet id provided', async () => {
+    const { selectedFiltersListWrapper, toggleFacetNthFilter } = renderSelectedFiltersList({
+      template: '<SelectedFiltersList facetId="brand" />'
+    });
+    expect(selectedFiltersListWrapper.text()).toBe('');
+    await toggleFacetNthFilter('brand', 0);
+    expect(selectedFiltersListWrapper.text()).toBe('Audi');
+    await toggleFacetNthFilter('gender', 1);
+    expect(selectedFiltersListWrapper.text()).toBe('Audi');
+  });
+
+  it('renders the component if alwaysVisible is true and no selected filters', () => {
+    const { selectedFiltersListWrapper } = renderSelectedFiltersList({
+      template: '<SelectedFiltersList :alwaysVisible="true" />'
+    });
+
+    expect(
+      selectedFiltersListWrapper.find(getDataTestSelector('selected-filters-list')).exists()
+    ).toBe(true);
+  });
+
+  it("doesn't render the component if alwaysVisible is false and no selected filters", () => {
+    const { selectedFiltersListWrapper } = renderSelectedFiltersList();
+    expect(selectedFiltersListWrapper.html()).toBe('');
+  });
+});
+
+interface RenderSelectedFiltersListOptions {
+  /** The template to be rendered. */
+  template?: string;
+}
+
+interface RenderSelectedFiltersAPI {
+  /** The wrapper of the container element. */
+  wrapper: Wrapper<Vue>;
+  /** The `selectedFilters` wrapper component. */
+  selectedFiltersListWrapper: Wrapper<Vue>;
+  /** Toggle nth filter of the facet provided. */
+  toggleFacetNthFilter: (facetId: string, nth: number) => Promise<void>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/selected-filters.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/selected-filters.spec.ts
@@ -1,0 +1,174 @@
+import { Facet } from '@empathyco/x-types-next';
+import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex, { Store } from 'vuex';
+import { createSimpleFacetStub } from '../../../../../__stubs__/facets-stubs.factory';
+import { installNewXPlugin } from '../../../../../__tests__/utils';
+import { getXComponentXModuleName, isXComponent } from '../../../../../components';
+import { XPlugin } from '../../../../../plugins';
+import { RootXStoreState } from '../../../../../store';
+import { DeepPartial } from '../../../../../utils';
+import { DefaultFacetsService } from '../../../service/facets.service';
+import { facetsNextXModule as facetsXModule } from '../../../x-module';
+import { resetXFacetsStateWith } from '../../__tests__/utils';
+import SelectedFilters from '../selected-filters.vue';
+
+/**
+ * Renders the `SelectedFilters` component, exposing a basic API for testing.
+ *
+ * @param options - The options to render the component with.
+ * @returns The API for testing the `SelectedFilters` component.
+ */
+function renderSelectedFilters({
+  template = '<SelectedFilters />'
+}: RenderSelectedFiltersOptions = {}): RenderSelectedFiltersAPI {
+  const facets: Record<Facet['id'], Facet> = {
+    gender: createSimpleFacetStub('gender', createFilter => [
+      createFilter('Men', false),
+      createFilter('Women', false)
+    ]),
+    brand: createSimpleFacetStub('brand', createFilter => [
+      createFilter('Audi', false),
+      createFilter('BMW', false)
+    ])
+  };
+
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const store = new Store<DeepPartial<RootXStoreState>>({});
+  installNewXPlugin({ store }, localVue);
+  XPlugin.registerXModule(facetsXModule);
+  resetXFacetsStateWith(store, facets);
+
+  const wrapper = mount(
+    {
+      components: {
+        SelectedFilters
+      },
+      template
+    },
+    {
+      localVue,
+      store
+    }
+  );
+
+  const selectedFiltersWrapper = wrapper.findComponent(SelectedFilters);
+
+  return {
+    wrapper,
+    selectedFiltersWrapper,
+    toggleFacetNthFilter(facetId, nth) {
+      const filter = store.getters['x/facetsNext/facets'][facetId].filters[nth];
+      DefaultFacetsService.instance.toggle(filter);
+      return localVue.nextTick();
+    }
+  };
+}
+
+describe('testing SelectedFilters component', () => {
+  it('is an x-component', () => {
+    const { selectedFiltersWrapper } = renderSelectedFilters();
+    expect(isXComponent(selectedFiltersWrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const { selectedFiltersWrapper } = renderSelectedFilters();
+    expect(getXComponentXModuleName(selectedFiltersWrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('renders "nth" by default', async () => {
+    const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters({
+      template: '<SelectedFilters :alwaysVisible="true" />'
+    });
+    expect(selectedFiltersWrapper.text()).toBe('0');
+    await toggleFacetNthFilter('brand', 0);
+    expect(selectedFiltersWrapper.text()).toBe('1');
+    await toggleFacetNthFilter('brand', 1);
+    expect(selectedFiltersWrapper.text()).toBe('2');
+    await toggleFacetNthFilter('gender', 0);
+    expect(selectedFiltersWrapper.text()).toBe('3');
+  });
+
+  it('renders "nth selected" in its customized slot', async () => {
+    const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters({
+      template: `
+        <SelectedFilters :alwaysVisible="true">
+          <template #default="{ selectedFilters }">
+            {{ selectedFilters.length }} selected
+          </template>
+        </SelectedFilters>`
+    });
+    expect(selectedFiltersWrapper.text()).toBe('0 selected');
+    await toggleFacetNthFilter('brand', 0);
+    expect(selectedFiltersWrapper.text()).toBe('1 selected');
+    await toggleFacetNthFilter('brand', 1);
+    expect(selectedFiltersWrapper.text()).toBe('2 selected');
+    await toggleFacetNthFilter('gender', 0);
+    expect(selectedFiltersWrapper.text()).toBe('3 selected');
+  });
+
+  it('renders "nth" by default of the facet id provided', async () => {
+    const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters({
+      template: '<SelectedFilters facetId="brand" :alwaysVisible="true" />'
+    });
+    expect(selectedFiltersWrapper.text()).toBe('0');
+    await toggleFacetNthFilter('brand', 0);
+    expect(selectedFiltersWrapper.text()).toBe('1');
+    await toggleFacetNthFilter('brand', 1);
+    expect(selectedFiltersWrapper.text()).toBe('2');
+    await toggleFacetNthFilter('gender', 0);
+    expect(selectedFiltersWrapper.text()).toBe('2');
+  });
+
+  it('renders "nth selected" in its customized slot of the facet id provided', async () => {
+    const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters({
+      template: `
+        <SelectedFilters facetId="brand" :alwaysVisible="true">
+          <template #default="{ selectedFilters }">
+            {{ selectedFilters.length }} selected
+          </template>
+        </SelectedFilters>`
+    });
+
+    expect(selectedFiltersWrapper.text()).toBe('0 selected');
+    await toggleFacetNthFilter('brand', 0);
+    expect(selectedFiltersWrapper.text()).toBe('1 selected');
+    await toggleFacetNthFilter('brand', 1);
+    expect(selectedFiltersWrapper.text()).toBe('2 selected');
+    await toggleFacetNthFilter('gender', 0);
+    expect(selectedFiltersWrapper.text()).toBe('2 selected');
+  });
+
+  it('always renders the component if alwaysVisible is true without selected filters', async () => {
+    const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters({
+      template: '<SelectedFilters :alwaysVisible="true" />'
+    });
+
+    expect(selectedFiltersWrapper.text()).toBe('0');
+    await toggleFacetNthFilter('brand', 0);
+    expect(selectedFiltersWrapper.text()).toBe('1');
+  });
+
+  it("doesn't render the component if alwaysVisible is false and no selected filters", async () => {
+    const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters();
+
+    expect(selectedFiltersWrapper.html()).toBe('');
+    await toggleFacetNthFilter('brand', 0);
+    expect(selectedFiltersWrapper.text()).toBe('1');
+  });
+});
+
+interface RenderSelectedFiltersOptions {
+  /** The template to be rendered. */
+  template?: string;
+}
+
+interface RenderSelectedFiltersAPI {
+  /** The wrapper of the container element. */
+  wrapper: Wrapper<Vue>;
+  /** The `selectedFilters` wrapper component. */
+  selectedFiltersWrapper: Wrapper<Vue>;
+  /** Toggle nth filter of the facet provided. */
+  toggleFacetNthFilter: (facetId: string, nth: number) => Promise<void>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/sliced-filters.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/sliced-filters.spec.ts
@@ -1,0 +1,129 @@
+import { Filter } from '@empathyco/x-types-next';
+import { mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import Vue from 'vue';
+import { createCategorySimpleFilter } from '../../../../../__stubs__/filters-stubs.factory';
+import { getDataTestSelector } from '../../../../../__tests__/utils';
+import { getXComponentXModuleName, isXComponent } from '../../../../../components';
+import SlicedFilters from '../sliced-filters.vue';
+
+/**
+ * Renders the `BaseShowMoreFilters` component, exposing a basic API for testing.
+ *
+ * @param max - The number filters to show.
+ * @returns The API for testing the `BaseShowMoreFilters` component.
+ */
+function renderBaseShowMoreFilters(max = 10): BaseShowMoreFiltersAPI {
+  const filtersMock: Filter[] = [
+    'Lego city',
+    'Lego city 2',
+    'Lego star wars"',
+    'Lego batman',
+    'Lego batman 2',
+    'Lego construccion',
+    'Lego coleccionista',
+    'Lego nuevo'
+  ].map(label => createCategorySimpleFilter(label));
+
+  const wrapper = mount(
+    {
+      components: { SlicedFilters },
+      props: ['filters', 'max'],
+      template: `
+          <SlicedFilters :filters="filters" :max="max">
+            <template #default="{ slicedFilters }">
+              <ul v-for="filter in slicedFilters" data-test="sliced-filters-list">
+                <li data-test="sliced-filters-list-item">{{ filter.label }}</li>
+              </ul>
+            </template>
+            <template #show-more="{ difference }">Expand {{ difference }} more filters</template>
+            <template #show-less="{ difference }">Expand {{ difference }} less filters</template>
+          </SlicedFilters>
+        `
+    },
+    {
+      propsData: {
+        filters: filtersMock,
+        max: max
+      }
+    }
+  );
+
+  const filterWrapper = wrapper.findComponent(SlicedFilters);
+
+  return {
+    wrapper,
+    filterWrapper,
+    getFiltersWrapper: () => wrapper.findAll(getDataTestSelector('sliced-filters-list-item')),
+    getShowMoreButton: () => wrapper.find(getDataTestSelector('sliced-filters-show-more-button')),
+    getShowLessButton: () => wrapper.find(getDataTestSelector('sliced-filters-show-less-button'))
+  };
+}
+
+describe('testing BaseShowMoreFilters', () => {
+  it('is an x-component', () => {
+    const { filterWrapper } = renderBaseShowMoreFilters();
+
+    expect(isXComponent(filterWrapper.vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const { filterWrapper } = renderBaseShowMoreFilters();
+
+    expect(getXComponentXModuleName(filterWrapper.vm)).toEqual('facetsNext');
+  });
+
+  it('renders all filters if they are less than the max prop', () => {
+    const { wrapper, getFiltersWrapper } = renderBaseShowMoreFilters();
+
+    expect(getFiltersWrapper()).toHaveLength(8);
+    expect(wrapper.find(getDataTestSelector('sliced-filters-show-more-button')).exists()).toBe(
+      false
+    );
+    expect(wrapper.find(getDataTestSelector('sliced-filters-show-less-button')).exists()).toBe(
+      false
+    );
+  });
+
+  it('slices the filters when the show more/less buttons are clicked', async () => {
+    const { getFiltersWrapper, getShowMoreButton, getShowLessButton } =
+      renderBaseShowMoreFilters(2);
+
+    expect(getFiltersWrapper()).toHaveLength(2);
+    expect(getShowMoreButton().text()).toEqual('Expand 6 more filters');
+
+    await getShowMoreButton().trigger('click');
+
+    expect(getFiltersWrapper()).toHaveLength(8);
+    expect(getShowLessButton().text()).toEqual('Expand 6 less filters');
+
+    await getShowLessButton().trigger('click');
+
+    expect(getFiltersWrapper()).toHaveLength(2);
+  });
+
+  it('emits Vue events when the show more/less buttons are clicked', async () => {
+    const { filterWrapper, getShowMoreButton, getShowLessButton } = renderBaseShowMoreFilters(2);
+
+    expect(filterWrapper.emitted('click:show-more')).toBeUndefined();
+    expect(filterWrapper.emitted('click:show-less')).toBeUndefined();
+
+    await getShowMoreButton().trigger('click');
+    expect(filterWrapper.emitted('click:show-more')).toEqual([[expect.any(MouseEvent)]]);
+
+    await getShowLessButton().trigger('click');
+    expect(filterWrapper.emitted('click:show-less')).toEqual([[expect.any(MouseEvent)]]);
+  });
+});
+
+interface BaseShowMoreFiltersAPI {
+  /** The wrapper of the container element. */
+  wrapper: Wrapper<Vue>;
+  /** The wrapper of the container element. */
+  filterWrapper: Wrapper<Vue>;
+  /** The filters of the wrapper element. */
+  getFiltersWrapper: () => WrapperArray<Vue>;
+  /** The show more button of the wrapper element. */
+  getShowMoreButton: () => Wrapper<Vue>;
+  /** The show less button of the wrapper element. */
+  getShowLessButton: () => Wrapper<Vue>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/sorted-filters.spec.ts
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/__tests__/sorted-filters.spec.ts
@@ -1,0 +1,111 @@
+import { BooleanFilter, Filter } from '@empathyco/x-types-next';
+import { createLocalVue, mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import Vue from 'vue';
+import { getSimpleFilterStub } from '../../../../../__stubs__/filters-stubs.factory';
+import { getXComponentXModuleName, isXComponent } from '../../../../../components';
+import SortedFilters from '../sorted-filters.vue';
+import { getDataTestSelector } from '../../../../../__tests__/utils';
+
+const filterLabels: string[] = [
+  'Lego city',
+  'Lego CITY 2',
+  'Lego city marvel',
+  'Lego city juego',
+  'Lego city 3',
+  'LEGO BATMAN',
+  'Lego batman 2'
+];
+
+function getFiltersMock(): Filter[] {
+  return filterLabels.map((label, index) => getSimpleFilterStub({ label, id: index }));
+}
+
+function renderBaseSortedFilters(filters: Filter[]): BaseSortedFiltersAPI {
+  const localVue = createLocalVue();
+  Vue.observable(filters);
+
+  const wrapper = mount(
+    {
+      components: {
+        SortedFilters
+      },
+      props: ['filters'],
+      template: `
+        <SortedFilters :filters="filters" v-slot="{ filters }">
+          <div>
+            <button
+              v-for="filter in filters"
+              data-test="sorted-filter"
+              :aria-checked="filter.selected.toString()"
+              role="checkbox"
+            >
+              {{ filter.label }}
+            </button>
+          </div>
+        </SortedFilters>`
+    },
+    {
+      localVue,
+      propsData: {
+        filters
+      }
+    }
+  );
+
+  return {
+    getFiltersWrapperArray: () => wrapper.findAll(getDataTestSelector('sorted-filter')),
+    getSortedFiltersWrapper: () => wrapper.findComponent(SortedFilters),
+    selectFilter: index => {
+      (filters[index] as BooleanFilter).selected = true;
+      return Vue.nextTick();
+    }
+  };
+}
+
+describe('testing SortedFilters', () => {
+  it('is an x-component', () => {
+    const filters = getFiltersMock();
+    const { getSortedFiltersWrapper } = renderBaseSortedFilters(filters);
+
+    expect(isXComponent(getSortedFiltersWrapper().vm)).toEqual(true);
+  });
+
+  it('belongs to the `facets` x-module', () => {
+    const filters = getFiltersMock();
+    const { getSortedFiltersWrapper } = renderBaseSortedFilters(filters);
+
+    expect(getXComponentXModuleName(getSortedFiltersWrapper().vm)).toEqual('facetsNext');
+  });
+
+  it('does not render any filter if filters array is empty', () => {
+    const filters: Filter[] = [];
+    const { getFiltersWrapperArray } = renderBaseSortedFilters(filters);
+
+    expect(getFiltersWrapperArray()).toHaveLength(0);
+  });
+
+  it('should show first the selected filters of the filter list', async () => {
+    const filters = getFiltersMock();
+    const { getFiltersWrapperArray, selectFilter } = renderBaseSortedFilters(filters);
+    const expectedLabel = 'Lego CITY 2';
+
+    const filterToSelect = getFiltersWrapperArray().at(1);
+    expect(filterToSelect.text()).toEqual(expectedLabel);
+    expect(filterToSelect.attributes()).toHaveProperty('aria-checked', 'false');
+
+    await selectFilter(1);
+
+    const selectedFilter = getFiltersWrapperArray().at(0);
+    expect(selectedFilter.text()).toEqual(expectedLabel);
+    expect(selectedFilter.attributes()).toHaveProperty('aria-checked', 'true');
+  });
+});
+
+interface BaseSortedFiltersAPI {
+  /** The filters of the wrapper element. */
+  getFiltersWrapperArray: () => WrapperArray<Vue>;
+  /** The wrapper of the component. */
+  getSortedFiltersWrapper: () => Wrapper<Vue>;
+  /** Sets the index filter selected property to true. */
+  selectFilter: (index: number) => Promise<void>;
+}

--- a/packages/x-components/src/x-modules/facets-next/components/lists/exclude-filters-with-no-results.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/exclude-filters-with-no-results.vue
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import { Filter, isBooleanFilter } from '@empathyco/x-types-next';
+  import { CreateElement, VNode } from 'vue';
+  import { mixins } from 'vue-class-component';
+  import { Component } from 'vue-property-decorator';
+  import { xComponentMixin, XProvide } from '../../../../components';
+  import { facetsNextXModule as facetsXModule } from '../../x-module';
+  import FiltersInjectionMixin from './filters-injection.mixin';
+
+  /**
+   * The `ExcludeFiltersWithNoResults` component filters the provided list of filters, excluding
+   * those which have the `totalResults` property exactly equal to `0`. It won't remove filters with
+   * no `totalResults` property.
+   *
+   * The new list of filters is bound to the default scoped slot. As this component does not render
+   * no root element, this default slot must contain a single root node.
+   *
+   * @public
+   */
+  @Component({
+    mixins: [xComponentMixin(facetsXModule)]
+  })
+  export default class ExcludeFiltersWithNoResults extends mixins(FiltersInjectionMixin) {
+    /**
+     * Removes the filters that have exactly 0 results associated.
+     *
+     * @returns A sublist of the filters prop, excluding the ones with no results.
+     * @internal
+     */
+    @XProvide('filters')
+    public get filtersWithResults(): Filter[] {
+      return this.renderedFilters.filter(
+        filter => !isBooleanFilter(filter) || filter.totalResults !== 0
+      );
+    }
+
+    render(h: CreateElement): VNode {
+      return this.$scopedSlots.default?.({ filters: this.filtersWithResults })?.[0] ?? h();
+    }
+  }
+</script>
+
+<docs lang="mdx">
+# Example
+
+The `ExcludeFiltersWithNoResults` component filters the provided list of filter, excluding those
+which have the `totalResults` property exactly equal to `0`. It won't remove filters with no
+`totalResults` property.
+
+The new list of filters is bound to the default scoped slot. As this component does not render no
+root element, this default slot must contain a single root node.
+
+## Important
+
+The component has two ways of receive the filters list, it can be injected by another component or
+be send it as a prop. If the component doesnt have a parent component that receive and exposed a
+filters list to their children, it is mandatory to send it as prop.
+
+## Basic Usage
+
+```vue
+<template>
+  <ExcludeFiltersWithNoResults v-slot="{ filters }" :filters="filters">
+    <div>
+      <span v-for="filter in filters" :key="filter.id">{{ filter.label }}</span>
+    </div>
+  </ExcludeFiltersWithNoResults>
+</template>
+
+<script>
+  import { ExcludeFiltersWithNoResults } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      ExcludeFiltersWithNoResults
+    },
+    data() {
+      return {
+        filters: [
+          {
+            // This is the only filter that will be removed.
+            facetId: 'category',
+            id: 'category:men',
+            modelName: 'SimpleFilter',
+            selected: false,
+            callbackInfo: {},
+            label: 'Men',
+            value: 'category:men',
+            totalResults: 0
+          },
+          {
+            facetId: 'category',
+            id: 'category:women',
+            modelName: 'SimpleFilter',
+            selected: false,
+            callbackInfo: {},
+            label: 'Women',
+            value: 'category:women',
+            totalResults: 10
+          },
+          {
+            facetId: 'category',
+            id: 'category:kids',
+            modelName: 'SimpleFilter',
+            selected: false,
+            callbackInfo: {},
+            label: 'Kids',
+            value: 'category:kids',
+            totalResults: undefined
+          }
+        ]
+      };
+    }
+  };
+</script>
+```
+
+> **Using injection**: It can receive the filters list by injection. It only works if it has a
+> parent component that receives and exposes the filters list. Using the injection, It is not
+> necessary to send the prop to the child components, it has to be send it in the parent component,
+> the rest of components will inject this list.
+
+```vue
+<template>
+  <ExcludeFiltersWithNoResults :filters="filters">
+    <FiltersSearch>
+      <Filters v-slot="{ filter }">
+        <SimpleFilter :filter="filter" data-test="brand-filter" />
+      </Filters>
+    </FiltersSearch>
+  </ExcludeFiltersWithNoResults>
+</template>
+
+<script>
+  import {
+    ExcludeFiltersWithNoResults,
+    FiltersSearch,
+    Filters,
+    SimpleFilter
+  } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      ExcludeFiltersWithNoResults,
+      FiltersSearch,
+      Filters,
+      SimpleFilter
+    },
+    data() {
+      return {
+        filters: [
+          {
+            // This is the only filter that will be removed.
+            facetId: 'category',
+            id: 'category:men',
+            modelName: 'SimpleFilter',
+            selected: false,
+            callbackInfo: {},
+            label: 'Men',
+            value: 'category:men',
+            totalResults: 0
+          },
+          {
+            facetId: 'category',
+            id: 'category:women',
+            modelName: 'SimpleFilter',
+            selected: false,
+            callbackInfo: {},
+            label: 'Women',
+            value: 'category:women',
+            totalResults: 10
+          },
+          {
+            facetId: 'category',
+            id: 'category:kids',
+            modelName: 'SimpleFilter',
+            selected: false,
+            callbackInfo: {},
+            label: 'Kids',
+            value: 'category:kids',
+            totalResults: undefined
+          }
+        ]
+      };
+    }
+  };
+</script>
+```
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/lists/filters-search.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/filters-search.vue
@@ -1,0 +1,209 @@
+<template>
+  <div class="x-list x-filters-search" :class="cssClasses" data-test="filters-search">
+    <!--
+      @slot Search content. It is the content which triggers the filters sifting.
+        @binding {string} query - The query to search in filters.
+        @binding {Function} setQuery - The function to set the query. The query is passed as
+        parameter.
+        @binding {Function} clearQuery - The function to clear the query.
+    -->
+    <slot name="search" v-bind="{ query, setQuery, clearQuery }">
+      <input
+        @input="setQuery($event.target.value)"
+        :value="query"
+        type="search"
+        class="x-input x-filters-search__input"
+        data-test="filters-search-input"
+      />
+    </slot>
+    <!--
+      @slot (Required) Sifted filters content.
+        @binding {Filter[]} siftedFilters - Sifted filters data.
+    -->
+    <slot :siftedFilters="siftedFilters"></slot>
+  </div>
+</template>
+
+<script lang="ts">
+  import { Filter, isBooleanFilter } from '@empathyco/x-types-next';
+  import { mixins } from 'vue-class-component';
+  import { Component, Prop, Watch } from 'vue-property-decorator';
+  import { xComponentMixin, XProvide } from '../../../../components';
+  import { debounce } from '../../../../utils/debounce';
+  import { normalizeString } from '../../../../utils/normalize';
+  import { DebouncedFunction, VueCSSClasses } from '../../../../utils/types';
+  import { facetsNextXModule as facetsXModule } from '../../x-module';
+  import FiltersInjectionMixin from './filters-injection.mixin';
+
+  /**
+   * Renders the filters sifted with the input query.
+   *
+   * @public
+   */
+  @Component({
+    mixins: [xComponentMixin(facetsXModule)]
+  })
+  export default class FiltersSearch extends mixins(FiltersInjectionMixin) {
+    /** The debounce time for applying the filter sifting. */
+    @Prop({ default: 200 })
+    protected debounceInMs!: number;
+
+    protected query = '';
+    protected setQueryDebounced!: DebouncedFunction<[string]>;
+
+    /**
+     * Set the debounce function for setting the query debounced.
+     *
+     * @internal
+     */
+    @Watch('debounceInMs', { immediate: true })
+    updateSetQueryDebounced(): void {
+      this.setQueryDebounced = debounce(query => {
+        this.query = query;
+      }, this.debounceInMs);
+    }
+
+    /**
+     * Sift the array of filters which matches with the query.
+     *
+     * @returns Array of sifted filters.
+     * @internal
+     */
+    @XProvide('filters')
+    public get siftedFilters(): Filter[] {
+      const normalizedQuery = normalizeString(this.query);
+      return this.renderedFilters.filter(
+        filter => isBooleanFilter(filter) && normalizeString(filter.label).includes(normalizedQuery)
+      );
+    }
+
+    /**
+     * Adds the dynamic css classes to the component.
+     *
+     * @returns The class to be added to the component.
+     * @internal
+     */
+    protected get cssClasses(): VueCSSClasses {
+      return {
+        'x-filters-search--is-sifted': !!this.query
+      };
+    }
+
+    /**
+     * Set the query through the debounced function.
+     *
+     * @param query - The query to sift filters.
+     * @internal
+     */
+    protected setQuery(query: string): void {
+      this.setQueryDebounced(query);
+    }
+
+    /**
+     * Clear the query.
+     *
+     * @internal
+     */
+    protected clearQuery(): void {
+      this.query = '';
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .x-filters-search__input {
+    &::-ms-clear {
+      display: none;
+      width: 0;
+      height: 0;
+    }
+
+    &::-ms-reveal {
+      display: none;
+      width: 0;
+      height: 0;
+    }
+
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      display: none;
+    }
+  }
+</style>
+
+<docs lang="mdx">
+#Example
+
+It renders an input and a list of filters passed as prop or being injected. The list of filters can
+be sifted with the query typed in the input. This component has also a debounce prop to set the time
+in milliseconds to apply the filters search. Moreover, it has two scoped slots. The first one for
+customize the search triggering with three slot props; the query, a function to set the query by
+sifting and a third one for cleaning the query. The second scoped slot is required and it is for
+displaying the list of filters sifted. It has a slot prop with these filters sifted.
+
+## Important
+
+The component has two ways of receive the filters list, it can be injected by another component or
+be send it as a prop. If the component doesnt have a parent component that receive and exposed a
+filters list to their children, it is mandatory to send it as prop.
+
+## Basic usage
+
+Using default and required slot:
+
+```vue
+<FiltersSearch :filters="filters" v-slot="{ siftedFilters }">
+  <ul v-for="filter in siftedFilters">
+    <li :key="filter.id">{{ filter.label }}</li>
+  </ul>
+</FiltersSearch>
+```
+
+Setting debounce time:
+
+```vue
+<FiltersSearch :filters="filters" :debounceInMs="500" v-slot="{ siftedFilters }">
+  <ul v-for="filter in siftedFilters">
+    <li :key="filter.id">{{ filter.label }}</li>
+  </ul>
+</FiltersSearch>
+```
+
+Replacing search triggering:
+
+```vue
+<FiltersSearch :filters="filters">
+  <template #search="{ query, setQuery, clearQuery }">
+    <input
+      @input="setQuery($event.target.value)"
+      :value="query"
+      class="x-input x-filters-search__input"/>
+    <button @click="clearQuery">X</button>
+  </template>
+  <template #default="{ siftedFilters }">
+    <ul v-for="filter in siftedFilters">
+      <li :key="filter.id">{{ filter.label }}</li>
+    </ul>
+  </template>
+</FiltersSearch>
+```
+
+> **Using injection**: It can receive the filters list by injection. It only works if it has a
+> parent component that receives and exposes the filters list. Using the injection, It is not
+> necessary to send the prop to the child components, it has to be send it in the parent component,
+> the rest of components will inject this list.
+
+```vue
+<Facets v-slot="{ facet }">
+  <SlicedFilters :filters="facet.filters" :max="8">
+    <FiltersSearch >
+        <Filters v-slot="{ filter }">
+          <SimpleFilter :filter="filter" data-test="brand-filter" />
+        </Filters>
+    </FiltersSearch>
+  </SlicedFilters>
+</Facets>
+```
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/lists/selected-filters-list.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/selected-filters-list.vue
@@ -1,0 +1,186 @@
+<template>
+  <SelectedFilters v-slot="{ selectedFilters }" :facetId="facetId" :alwaysVisible="alwaysVisible">
+    <component
+      :is="animation"
+      class="x-list x-selected-filters-list"
+      data-test="selected-filters-list"
+      tag="ul"
+    >
+      <li
+        v-for="selectedFilter in selectedFilters"
+        :key="selectedFilter.id"
+        class="x-selected-filters-list__item"
+        data-test="selected-filters-list-item"
+      >
+        <!--
+          @slot Custom filter rendering. Dynamic slot defined in the template with the filter
+          facet id. It renders the filter label by default.
+              @binding {Filter} filter - Filter to render.
+        -->
+        <slot
+          v-if="$scopedSlots[selectedFilter.facetId]"
+          :name="selectedFilter.facetId"
+          :filter="selectedFilter"
+        >
+          <span class="x-tag">{{ selectedFilter.label }}</span>
+        </slot>
+
+        <!--
+          @slot Default filter rendering. It renders the filter label by default.
+              @binding {Filter} filter - Filter to render.
+        -->
+        <slot v-else name="default" :filter="selectedFilter">
+          {{ selectedFilter.label }}
+        </slot>
+      </li>
+    </component>
+  </SelectedFilters>
+</template>
+
+<script lang="ts">
+  import { Component, Prop, Vue } from 'vue-property-decorator';
+  import { Facet } from '@empathyco/x-types';
+  import { xComponentMixin } from '../../../../components/index';
+  import { facetsNextXModule as facetsXModule } from '../../x-module';
+  import SelectedFilters from './selected-filters.vue';
+
+  /**
+   * This component renders a list of selected filters from every facet, or from the facet
+   * which facet id is passed as property. It uses the SelectedFilters component (state).
+   *
+   * It provides two slots: a scoped one which name is the filter facet id; and a default one.
+   * Both exposes the filter and renders the filter label by default.
+   *
+   * The property "alwaysVisible" handles if the component is rendered if no filters are selected.
+   *
+   * @public
+   */
+  @Component({
+    components: { SelectedFilters },
+    mixins: [xComponentMixin(facetsXModule)]
+  })
+  export default class SelectedFiltersList extends Vue {
+    /**
+     * It is directly passed to the selected filters component. If a facet id is passed as prop,
+     * the component filters the selected filters for that facet.
+     *
+     * @public
+     */
+    @Prop()
+    protected facetId: Facet['id'] | undefined;
+
+    /**
+     * It is directly passed to the selected filters component. It handles if the SelectedFilters
+     * component is always rendered no matter if no filters are selected.
+     *
+     * If true, the SelectedFilters component is always rendered.
+     * If false, the SelectedFilters component is not rendered whether no filters are selected.
+     *
+     * @public
+     */
+    @Prop({ default: false })
+    protected alwaysVisible!: boolean;
+
+    /**
+     * Animation component that will be used to animate the selected filters list.
+     *
+     * @public
+     */
+    @Prop({ default: 'ul' })
+    protected animation!: Vue | string;
+  }
+</script>
+
+<docs lang="mdx">
+# Example
+
+This component renders a list of selected filters from every facet, or from the facet which facet id
+is passed as property. It uses the SelectedFilters component (state).
+
+It provides two slots: a scoped one which name is the filter facet id; and a default one. Both
+exposes the filter and renders the filter label by default.
+
+The property "alwaysVisible" handles if the component is rendered if no filters are selected.
+
+## Default usage
+
+```vue
+<template>
+  <SelectedFiltersList />
+</template>
+
+<script>
+  import { SelectedFiltersList } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      SelectedFiltersList
+    }
+  };
+</script>
+```
+
+## Customized usage
+
+```vue
+<template>
+  <SelectedFiltersList #default="{ filter }">Default: {{ filter.label }}</SelectedFiltersList>
+</template>
+
+<script>
+  import { SelectedFilters } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      SelectedFilters
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <SelectedFiltersList>
+    <template #default="{ filter }">Default: {{ filter.label }}</template>
+    <template #brand_facet="{ filter }">Brand: {{ filter.label }}</template>
+    <template #age_facet="{ filter }">Age: {{ filter.label }}</template>
+    <template #price_facet="{ filter }">Price: {{ filter.label }}</template>
+  </SelectedFiltersList>
+</template>
+
+<script>
+  import { SelectedFilters } from '@empathyco/x-components/facets';
+
+  export default {
+    components: {
+      SelectedFilters
+    }
+  };
+</script>
+```
+
+## Always visible
+
+If "alwaysVisible" is true, the component is rendered no matter if there are some filter selected.
+If "alwaysVisible" is false (default), the component is rendered if there are some filter selected.
+
+```vue
+<SelectedFiltersList :alwaysVisible="true" />
+```
+
+Output:
+
+```html
+<div class="x-selected-filters">
+  <ul class="x-selected-filters-list" data-test="selected-filters-list"></ul>
+</div>
+```
+
+## Providing a facet id
+
+In this example, the selected filters computed are the ones that match the facet passed as property.
+
+```vue
+<SelectedFilters facetId="brand_facet" />
+```
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/lists/selected-filters.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/selected-filters.vue
@@ -1,0 +1,156 @@
+<template>
+  <NoElement v-if="show" class="x-selected-filters">
+    <slot v-bind="{ selectedFilters }">{{ selectedFilters.length }}</slot>
+  </NoElement>
+</template>
+
+<script lang="ts">
+  import { Facet, Filter } from '@empathyco/x-types-next';
+  import { Component, Prop, Vue } from 'vue-property-decorator';
+  import { Getter, NoElement, xComponentMixin } from '../../../../components';
+  import { FiltersByFacetNext } from '../../store/types';
+  import { facetsNextXModule as facetsXModule } from '../../x-module';
+
+  /**
+   * Provides a scoped slot with the selected filters from every facet, or from the facet which
+   * facet id is passed as property.
+   *
+   * The default slot renders the length of the selected filters array.
+   * The property "alwaysVisible" handles if the component is rendered if no filters are selected.
+   *
+   * @public
+   */
+  @Component({
+    mixins: [xComponentMixin(facetsXModule)],
+    components: {
+      NoElement
+    }
+  })
+  export default class SelectedFilters extends Vue {
+    /**
+     * If a facet id is passed as prop, the component filters the selected filters for that facet.
+     *
+     * @public
+     */
+    @Prop()
+    protected facetId: Facet['id'] | undefined;
+
+    /**
+     * It handles if the SelectedFilters component is always rendered no matter if no filters are
+     * selected.
+     * If true, the SelectedFilters component is always rendered.
+     * If false, the SelectedFilters component is not rendered whether no filters are selected.
+     *
+     * @public
+     */
+    @Prop({ default: false })
+    protected alwaysVisible!: boolean;
+
+    /**
+     * Array of selected filters from every facet.
+     *
+     * @public
+     */
+    @Getter('facetsNext', 'selectedFilters')
+    public selectedFiltersGetter!: Filter[];
+
+    /**
+     * Dictionary of selected filters grouped by facet.
+     *
+     * @public
+     */
+    @Getter('facetsNext', 'selectedFiltersByFacet')
+    public selectedFiltersByFacet!: FiltersByFacetNext;
+
+    /**
+     * It returns an array of selected filters. If a facet id is passed as prop to the component,
+     * only the selected filters of that facet are returned. If not, it returns selected filters of
+     * every facet.
+     *
+     * @returns Array of selected filters.
+     *
+     * @internal
+     */
+    protected get selectedFilters(): Filter[] {
+      return this.facetId === undefined
+        ? this.selectedFiltersGetter
+        : this.selectedFiltersByFacet[this.facetId] ?? [];
+    }
+
+    /**
+     * If "alwaysVisible" prop is true, returns true.
+     * If "alwaysVisible" prop is false, returns true or false depending on if there are some
+     * filter selected.
+     *
+     * @returns True if "alwaysVisible" is true. True or false depending on if there are some filter
+     * selected.
+     *
+     * @internal
+     */
+    protected get show(): boolean {
+      return this.alwaysVisible || this.selectedFilters.length > 0;
+    }
+  }
+</script>
+
+<docs lang="mdx">
+#Example
+
+Provides a scoped slot with the selected filters from every facet, or from the facet which facet id
+is passed as property.
+
+The default slot renders the length of the selected filters array.
+
+## Basic usage
+
+```vue
+<SelectedFilters />
+```
+
+## Always visible
+
+If "alwaysVisible" is true, the component is rendered no matter if there are some filter selected.
+If "alwaysVisible" is false (default), the component is rendered if there are some filter selected.
+
+```vue
+<SelectedFilters />
+```
+
+Output:
+
+```html
+<div class="x-selected-filters">1</div>
+```
+
+## Customizing its content
+
+In this example, renders a custom message using the default scoped slot.
+
+```vue
+<SelectedFilters>
+  <template #default="{ selectedFilters }">
+    Selected filters: {{ selectedFilters.length }}
+  </template>
+</SelectedFilters>
+```
+
+Output:
+
+```html
+<div class="x-selected-filters">Selected filters: 1</div>
+```
+
+In this example, the selected filters computed are the ones that match the facet passed as property.
+
+```vue
+<SelectedFilters facetId="brand_facet" />
+```
+
+```vue
+<SelectedFilters facetId="brand_facet">
+  <template #default="{ selectedFilters }">
+    Selected filters: {{ selectedFilters.length }}
+  </template>
+</SelectedFilters>
+```
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/lists/sliced-filters.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/sliced-filters.vue
@@ -1,0 +1,194 @@
+<template>
+  <div class="x-sliced-filters" :class="cssClasses" data-test="filters-show-more">
+    <!--
+      @slot (Required) Sliced filters content.
+        @binding {Filter[]} slicedFilters - Sliced filters..
+    -->
+    <slot :slicedFilters="slicedFilters" />
+    <template v-if="showButton">
+      <button
+        v-if="showMoreFilters"
+        @click="toggleShowMoreFilters"
+        class="x-filter x-sliced-filters__button x-sliced-filters__button--show-more"
+        data-test="sliced-filters-show-more-button"
+      >
+        <!--
+          @slot Button show more filters.
+            @binding {number} difference - The difference between the filters and max to show.
+        -->
+        <slot name="show-more" :difference="difference">Show {{ difference }} more filters</slot>
+      </button>
+      <button
+        v-else
+        @click="toggleShowMoreFilters"
+        class="x-filter x-sliced-filters__button x-sliced-filters__button--show-less"
+        data-test="sliced-filters-show-less-button"
+      >
+        <!--
+          @slot Button show less filters.
+            @binding {number} difference - The difference between the filters and max to show.
+        -->
+        <slot name="show-less" :difference="difference">Show {{ difference }} less filters</slot>
+      </button>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+  import { Filter } from '@empathyco/x-types-next';
+  import { mixins } from 'vue-class-component';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { xComponentMixin, XProvide } from '../../../../components';
+  import { VueCSSClasses } from '../../../../utils';
+  import { facetsNextXModule as facetsXModule } from '../../x-module';
+  import FiltersInjectionMixin from './filters-injection.mixin';
+
+  /**
+   * Component that slices a list of filters and returns them using the default scoped slot,
+   * allowing the user to show the full list of them or slicing them again using the
+   * show more/less buttons.
+   *
+   * @public
+   */
+  @Component({
+    mixins: [xComponentMixin(facetsXModule)]
+  })
+  export default class SlicedFilters extends mixins(FiltersInjectionMixin) {
+    /** The maximum number of filters to show.
+     *
+     * @public
+     * */
+    @Prop({ required: true })
+    protected max!: number;
+
+    /** For showing the remaining filters. */
+    public showMoreFilters = true;
+
+    /**
+     * Show the buttons template when length filters is greater than property max.
+     *
+     * @returns Boolean if length filters is greater than property max.
+     * @internal
+     */
+    protected get showButton(): boolean {
+      return this.renderedFilters.length > this.max;
+    }
+
+    /**
+     * Sliced the array of filters depends on click button show more.
+     *
+     * @returns Array of sliced filters or all filters.
+     * @internal
+     */
+    @XProvide('filters')
+    public get slicedFilters(): Filter[] {
+      return this.showMoreFilters ? this.renderedFilters.slice(0, this.max) : this.renderedFilters;
+    }
+
+    /**
+     * The difference between length filters and max to show.
+     *
+     * @returns Number of remaining filters to show.
+     * @internal
+     */
+    protected get difference(): number {
+      return this.renderedFilters.length - this.max;
+    }
+
+    /**
+     * Show or hide the remaining filters. It also emits a Vue event based on the clicked button.
+     *
+     * @param event - The click event.
+     *
+     * @internal
+     */
+    protected toggleShowMoreFilters(event: MouseEvent): void {
+      this.showMoreFilters = !this.showMoreFilters;
+      this.$emit(this.showMoreFilters ? 'click:show-less' : 'click:show-more', event);
+    }
+
+    /**
+     * Adds the dynamic css classes to the component.
+     *
+     * @returns The classes to be added to the component.
+     * @internal
+     */
+    protected get cssClasses(): VueCSSClasses {
+      return {
+        'x-sliced-filters--is-sliced': this.showButton
+      };
+    }
+  }
+</script>
+
+<docs>
+  # Example
+
+  The sliced filters component, takes a list of filters, and the maximum number of filters to
+  render as prop. Then, it slices the list of filters using the `max` prop, and returns this new
+  filters list using the default scoped slot.
+
+  The user can click the show more button if he wants to see the full list of filters, or the show
+  less button when he wants to reset the filters. This buttons text or icons can be configured
+  via slot too. They receive a `difference` prop which can be useful for writing friendlier
+  messages.
+
+  This component is usually integrated with the `Facets` and `Filters` component. It is useful
+  when there are lots of available filters for a single facet, helping to improve the
+  app performance, as less nodes are rendered.
+
+  ## Important
+
+  The component has two ways of receive the filters list, it can be injected by another component or
+  be send it as a prop. If the component doesnt have a parent component that receive and exposed a
+  filters list to their children, it is mandatory to send it as prop.
+
+
+  ## Basic usage
+
+  ```vue
+  <template>
+    <Facets v-slot="{ facet }">
+      <SlicedFilters :filters="facet.filters" :max="4">
+        <template #default="{ slicedFilters }">
+          <Filters :items="slicedFilters" v-slot="{ filter }">
+            <SimpleFilter :filter="filter"/>
+          </Filters>
+        </template>
+        <template #show-more="{ difference }">Show {{ difference }} more filters</template>
+        <template #show-less="{ difference }">Show {{ difference }} less filters</template>
+      </SlicedFilters>
+    </Facets>
+  </template>
+  <script>
+    import { BaseShowMoreFilters} from "@empathyco/x-components";
+    import { Facets, SimpleFilter, Filters } from "@empathyco/x-components";
+
+    export default {
+      components: {
+        Facets,
+        BaseShowMoreFilters,
+        Filters,
+        SimpleFilter
+      }
+    }
+  </script>
+  ```
+
+  > **Using injection**: It can receive the filters list by injection. It only works if it has a
+  > parent component that receives and exposes the filters list. Using the injection, It is not
+  > necessary to send the prop to the child components, it has to be send it in the parent component
+  > , the rest of components will inject this list.
+
+  ```vue
+  <Facets v-slot="{ facet }">
+    <SlicedFilters :filters="facet.filters" :max="4">
+        <Filters v-slot="{ filter }">
+          <SimpleFilter :filter="filter"/>
+        </Filters>
+      <template #show-more="{ difference }">Show {{ difference }} more filters</template>
+      <template #show-less="{ difference }">Show {{ difference }} less filters</template>
+    </SlicedFilters>
+  </Facets>
+  ```
+</docs>

--- a/packages/x-components/src/x-modules/facets-next/components/lists/sorted-filters.vue
+++ b/packages/x-components/src/x-modules/facets-next/components/lists/sorted-filters.vue
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import { BooleanFilter, Filter, isBooleanFilter } from '@empathyco/x-types-next';
+  import { mixins } from 'vue-class-component';
+  import { Component } from 'vue-property-decorator';
+  import { CreateElement, VNode } from 'vue';
+  import { xComponentMixin, XProvide } from '../../../../components';
+  import { isArrayEmpty } from '../../../../utils';
+  import { facetsNextXModule as facetsXModule } from '../../x-module';
+  import FiltersInjectionMixin from './filters-injection.mixin';
+
+  /**
+   * Component that sorts a list of filters and returns them using the default scoped slot.
+   *
+   * @public
+   */
+  @Component({
+    mixins: [xComponentMixin(facetsXModule)]
+  })
+  export default class SortedFilters extends mixins(FiltersInjectionMixin) {
+    /**
+     * An array of filters with the selected filters at the beginning of the list.
+     *
+     * @returns Array of filters.
+     * @internal
+     */
+    @XProvide('filters')
+    public get sortedFilters(): Filter[] {
+      if (!isArrayEmpty(this.renderedFilters) && isBooleanFilter(this.renderedFilters[0])) {
+        return ([...this.renderedFilters] as BooleanFilter[]).sort(({ selected }) => {
+          return selected ? -1 : 1;
+        });
+      }
+
+      return this.renderedFilters;
+    }
+
+    render(h: CreateElement): VNode {
+      return this.$scopedSlots.default?.({ filters: this.sortedFilters })?.[0] ?? h();
+    }
+  }
+</script>
+
+<docs>
+  # Example
+
+  The sorted filters component takes a list of filters and returns this new filters list sorted by
+  the `selected` filter property.
+
+  ## Remarks
+
+  - The component can receive the filters list by property or using the XInjection feature.
+  - It also provides the resultant list bound in the default slot or with the XProvide feature.
+
+  Both XInjection and XProvide features are from the extended FiltersInjectionMixin. You don't have
+  to use XInjection and XProvide together, e.g. you can use pass the filters using a prop and then
+  returns the result with XProvide.
+
+  ## Basic usage
+
+  ### Using props and binding the result
+
+  ```vue
+  <template>
+    <Facets v-slot="{ facet }">
+      <SortedFilters :filters="facet.filters" #default="{ sortedFilters }">
+        <Filters :items="sortedFilters" v-slot="{ filter }">
+          <SimpleFilter :filter="filter"/>
+        </Filters>
+      </SortedFilters>
+    </Facets>
+  </template>
+
+  <script>
+    import { Facets, SimpleFilter, Filters } from "@empathyco/x-components";
+
+    export default {
+      components: {
+        Facets,
+        Filters,
+        SimpleFilter
+      }
+    }
+  </script>
+  ```
+
+  ### Using XInject and XProvide
+
+  ```vue
+  <Facets v-slot="{ facet }">
+    <FiltersSearch :filters="facet.filters">
+      <SortedFilters>
+        <Filters v-slot="{ filter }">
+          <SimpleFilter :filter="filter"/>
+        </Filters>
+      </SortedFilters>
+    </FiltersSearch>
+  </Facets>
+
+  <script>
+    import { Facets, FiltersSearch, SimpleFilter, Filters } from "@empathyco/x-components";
+
+    export default {
+      components: {
+        Facets,
+        FiltersSearch,
+        Filters,
+        SimpleFilter
+      }
+    }
+  </script>
+  ```
+</docs>


### PR DESCRIPTION
Add `ClearFilters`, `ExcludeFiltersWithNoResults`, `SortedFilters`, `FiltersSearch`,
`SlicedFilters`, `SelectedFilters` and  `SelectedFiltersList` components.

EX-4615

# Pull Request Template #

Add all pending components to `NextFacets` X-Module. (Except `HierarchicalFIlter`, which has its own PR).
Also used these new components in the `LayoutNext` view to check them working.


## Motivation and Context ##

The motivation is to move all pending things from the old `Facets` X-Module to the new `FacetsNext`X-Module, before removing the old and replace it with the new.

## How to test ##
Use the `LayoutNext` view to check it working.

**REMARK:** All the facets are multiselect by default. The `MultiSelectFilters` component disappears. Now it is a modifier in the Entities which modifies the facet to be "Single Select":

```
      FilterEntityFactory.instance.registerFilterModifier('brand_facet', [SingleSelectModifier]);
```

As in Juguettos the facets are not configured as multiselected in back, and we don't do the "OR" transform in the adapter any more, some filters will return no results if you select more than one.

We will keep this way at the moment until we mock all the tests and move to the Platform Backend in the X-Components project.



