### PR TITLE
test: mock search-box e2e tests

### DIFF
--- a/packages/x-components/src/__stubs__/results-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/results-stubs.factory.ts
@@ -11,7 +11,9 @@ import { toKebabCase } from '../utils/string';
  * @internal
  */
 export function getResultsStub(amount = 3): Result[] {
-  return Array.from({ length: amount }, (_, index) => createResultStub(`Product ${index + 1}`));
+  return Array.from<number, Result>({ length: amount }, (_, index) =>
+    createResultStub(`Product ${index + 1}`)
+  );
 }
 
 /**

--- a/packages/x-components/src/adapter/mocked-adapter.ts
+++ b/packages/x-components/src/adapter/mocked-adapter.ts
@@ -5,6 +5,8 @@ import {
   NextQueriesResponse,
   RelatedTagsRequest,
   RelatedTagsResponse,
+  SearchRequest,
+  SearchResponse,
   SearchAdapter,
   SuggestionsRequest,
   SuggestionsResponse,
@@ -59,6 +61,10 @@ class E2ETestsAdapter extends EmpathyAdapter {
 
   getRelatedTags(request: RelatedTagsRequest): Promise<RelatedTagsResponse> {
     return mockFetch(request, 'getRelatedTags');
+  }
+
+  search(request: SearchRequest): Promise<SearchResponse> {
+    return mockFetch(request, 'search');
   }
 }
 

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
@@ -1,6 +1,8 @@
+
 Feature: Search-box component
 
   Background:
+    Given a results API with a known response
     Given a next queries API
     Given a suggestions API
     Given a related tags API
@@ -17,8 +19,8 @@ Feature: Search-box component
     And   "<query>" is displayed in history queries is not <hideIfEqualsQuery>
     Examples:
       | hideIfEqualsQuery | instantDebounceInMs | instant | query     | buttonOrKey  |
-      | true              | 5000                | false   | lego      | searchButton |
-      | false             | 5000                | false   | star wars | enterKey     |
+      | true              | 500                 | false   | lego      | searchButton |
+      | false             | 500                 | false   | star wars | enterKey     |
 
   Scenario Outline: 2. Query with results exists and it's cleared by <cleared> (search-box is not empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>
@@ -32,9 +34,9 @@ Feature: Search-box component
     And   related tags are cleared
     And   the searched query is displayed in history queries
     Examples:
-      | hideIfEqualsQuery | instantDebounceInMs | instant | query | hideIfEqualsQuery | cleared     |
-      | true              | 500                 | true    | lego  | false             | clickButton |
-      | false             | 500                 | true    | funko | false             | manually    |
+      | hideIfEqualsQuery | instantDebounceInMs  | instant | query | cleared     |
+      | true              | 1000                 | true    | lego  | clickButton |
+      | false             | 1000                 | true    | lego  | manually    |
 
   Scenario Outline: 3. Query with results is typed and no button or key is pressed or clicked (search-box is empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>
@@ -46,8 +48,8 @@ Feature: Search-box component
     And   related tags are displayed after instantDebounceInMs is <instant>
     Examples:
       | hideIfEqualsQuery | instantDebounceInMs | instant | query     |
-      | true              | 1000                | true    | playmobil |
-      | true              | 1000                | false   | lego      |
+      | true              | 1500                | true    | lego      |
+      | true              | 1500                | false   | lego      |
 
   Scenario Outline: 4. Adding or deleting words from a query (search-box is empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>
@@ -55,14 +57,16 @@ Feature: Search-box component
     When  a "<firstQuery>" with results is typed - timestamp needed
     Then  no related results are displayed before <instantDebounceInMs>
     And   related results are displayed after <instantDebounceInMs> is <instant>
+    Given a second results API with a known response
     When  "<secondQuery>" is added to the search
     Then  new related results are not displayed before <instantDebounceInMs>
     And   new related results are displayed after <instantDebounceInMs> is <instant>
     And   new related results are different from previous ones
+    Given a results API with a known response
     When  "<secondQuery>" is deleted from the search
     Then  old related results are not displayed before <instantDebounceInMs>
     And   related results are displayed after <instantDebounceInMs> is <instant>
     And   new related results are different from previous ones
     Examples:
       | hideIfEqualsQuery | instantDebounceInMs | instant | firstQuery | secondQuery |
-      | true              | 1000                | true    | lego       | mickey      |
+      | true              | 2000                | true    | lego       | mickey      |


### PR DESCRIPTION
## Motivation and Context ##
We needed to have a reliable method of doing e2e tests without relying on APIs outside of our control. This PR implements a version of that solution for the search.box tests.

- mocked-adapter changed so the search can be intercepted by Cypress
- e2e test for the search-box changed to make use of Cypress' intercept

## What is the destination branch of this PR? ##
EX-4474

## How Has This Been Tested? ##
Run the tests in Cypress to see the intercept working.
In cypress.json you can change the testFiles property's first element to "cucumber/**/*.features" to be able to select the test to run.