### PR TITLE
feat(mixin): add origin injection in the mixin and the bus

### DIFF
--- a/packages/x-components/src/components/x-component.types.ts
+++ b/packages/x-components/src/components/x-component.types.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { XModuleName } from '../x-modules/x-modules.types';
+import { QueryOrigin } from '../types/query-origin';
 import { XComponentModule } from './x-component.utils';
 
 /**
@@ -16,4 +17,10 @@ export interface XComponent extends Vue {
    * @internal
    */
   [XComponentModule]: XModuleName;
+  /**
+   * Property to define the injected origin.
+   *
+   * @internal
+   */
+  origin?: QueryOrigin;
 }

--- a/packages/x-components/src/components/x-component.types.ts
+++ b/packages/x-components/src/components/x-component.types.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { XModuleName } from '../x-modules/x-modules.types';
-import { QueryOrigin } from '../types/query-origin';
 import { XComponentModule } from './x-component.utils';
 
 /**
@@ -17,10 +16,4 @@ export interface XComponent extends Vue {
    * @internal
    */
   [XComponentModule]: XModuleName;
-  /**
-   * Property to define the injected origin.
-   *
-   * @internal
-   */
-  origin?: QueryOrigin;
 }

--- a/packages/x-components/src/plugins/__tests__/x-plugin-mixin.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-mixin.spec.ts
@@ -35,7 +35,7 @@ describe('testing $x component API global mixin', () => {
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener).toHaveBeenCalledWith({
         eventPayload: 'So awesome, much quality, such skill',
-        metadata: { moduleName: null, origin: 'default' }
+        metadata: { moduleName: null }
       });
     });
 

--- a/packages/x-components/src/plugins/__tests__/x-plugin-mixin.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-mixin.spec.ts
@@ -1,5 +1,6 @@
 import { mount, shallowMount, Wrapper } from '@vue/test-utils';
-import { ComponentOptions, default as Vue } from 'vue';
+import { ComponentOptions, CreateElement, VNode, default as Vue } from 'vue';
+import { Component } from 'vue-property-decorator';
 import { installNewXPlugin } from '../../__tests__/utils';
 import { xComponentMixin } from '../../components/x-component.mixin';
 import { searchBoxXModule } from '../../x-modules/search-box/x-module';
@@ -22,6 +23,66 @@ describe('testing $x component API global mixin', () => {
   afterEach(() => {
     componentInstance.destroy();
     jest.clearAllMocks();
+  });
+
+  describe('testing origin', () => {
+    it('includes "default" origin in the $x.emit metadata', () => {
+      const listener = jest.fn();
+
+      componentInstance.vm.$x.on('UserIsTypingAQuery', true).subscribe(listener);
+      componentInstance.vm.$x.emit('UserIsTypingAQuery', 'So awesome, much quality, such skill');
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith({
+        eventPayload: 'So awesome, much quality, such skill',
+        metadata: { moduleName: null, origin: 'default' }
+      });
+    });
+
+    it('overrides the origin in the $x.emit metadata', () => {
+      const listener = jest.fn();
+
+      @Component({
+        template: `<div><slot/></div>`,
+        provide: {
+          origin: 'origin-test'
+        }
+      })
+      class Provider extends Vue {}
+
+      @Component({
+        mixins: [xComponentMixin(searchBoxXModule)]
+      })
+      class Injecter extends Vue {
+        render(createElement: CreateElement): VNode {
+          return createElement();
+        }
+      }
+
+      const wrapper = mount(
+        {
+          template: `<Provider><Injecter /></Provider>`,
+          components: {
+            Provider,
+            Injecter
+          }
+        } as ComponentOptions<any> & ThisType<Vue>,
+        {
+          localVue
+        }
+      );
+
+      wrapper
+        .findComponent(Injecter)
+        .vm.$x.emit('UserIsTypingAQuery', 'So awesome, much quality, such skill');
+      componentInstance.vm.$x.on('UserIsTypingAQuery', true).subscribe(listener);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith({
+        eventPayload: 'So awesome, much quality, such skill',
+        metadata: { moduleName: 'searchBox', origin: 'origin-test' }
+      });
+    });
   });
 
   it('allows emitting and subscribing to events via $x object', () => {

--- a/packages/x-components/src/plugins/__tests__/x-plugin-mixin.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-mixin.spec.ts
@@ -1,5 +1,5 @@
 import { mount, shallowMount, Wrapper } from '@vue/test-utils';
-import { ComponentOptions, CreateElement, VNode, default as Vue } from 'vue';
+import { ComponentOptions, default as Vue } from 'vue';
 import { Component } from 'vue-property-decorator';
 import { installNewXPlugin } from '../../__tests__/utils';
 import { xComponentMixin } from '../../components/x-component.mixin';

--- a/packages/x-components/src/plugins/__tests__/x-plugin-mixin.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-mixin.spec.ts
@@ -26,7 +26,7 @@ describe('testing $x component API global mixin', () => {
   });
 
   describe('testing origin', () => {
-    it('includes "default" origin in the $x.emit metadata', () => {
+    it("doesn't include origin in the $x.emit metadata by default", () => {
       const listener = jest.fn();
 
       componentInstance.vm.$x.on('UserIsTypingAQuery', true).subscribe(listener);
@@ -50,21 +50,15 @@ describe('testing $x component API global mixin', () => {
       })
       class Provider extends Vue {}
 
-      @Component({
-        mixins: [xComponentMixin(searchBoxXModule)]
-      })
-      class Injecter extends Vue {
-        render(createElement: CreateElement): VNode {
-          return createElement();
-        }
-      }
+      @Component({ template: '<div>{{ $origin }}</div>' })
+      class Injector extends Vue {}
 
       const wrapper = mount(
         {
-          template: `<Provider><Injecter /></Provider>`,
+          template: `<Provider><Injector /></Provider>`,
           components: {
             Provider,
-            Injecter
+            Injector
           }
         } as ComponentOptions<any> & ThisType<Vue>,
         {
@@ -73,15 +67,13 @@ describe('testing $x component API global mixin', () => {
       );
 
       wrapper
-        .findComponent(Injecter)
+        .findComponent(Injector)
         .vm.$x.emit('UserIsTypingAQuery', 'So awesome, much quality, such skill');
       componentInstance.vm.$x.on('UserIsTypingAQuery', true).subscribe(listener);
 
       expect(listener).toHaveBeenCalledTimes(1);
-      expect(listener).toHaveBeenCalledWith({
-        eventPayload: 'So awesome, much quality, such skill',
-        metadata: { moduleName: 'searchBox', origin: 'origin-test' }
-      });
+      const { metadata } = listener.mock.calls[0][0];
+      expect(metadata.origin).toBe('origin-test');
     });
   });
 

--- a/packages/x-components/src/plugins/x-plugin.mixin.ts
+++ b/packages/x-components/src/plugins/x-plugin.mixin.ts
@@ -62,10 +62,10 @@ export function getBusAPI(bus: XBus, component: PrivateExtendedVueComponent): XC
       payload?: XEventPayload<Event>,
       metadata: Omit<WireMetadata, 'moduleName' | 'origin'> = {}
     ) => {
-      const rootComponent = component.xComponent;
-      const moduleName = rootComponent ? getXComponentXModuleName(rootComponent) : null;
+      const xComponent = component.xComponent;
+      const moduleName = xComponent ? getXComponentXModuleName(xComponent) : null;
       bus.emit(event, payload as any, { moduleName, origin: component.$origin, ...metadata });
-      rootComponent?.$emit(event, payload);
+      xComponent?.$emit(event, payload);
     },
     on: bus.on.bind(bus)
   };

--- a/packages/x-components/src/plugins/x-plugin.mixin.ts
+++ b/packages/x-components/src/plugins/x-plugin.mixin.ts
@@ -30,7 +30,7 @@ export const createXComponentAPIMixin = (
   ThisType<Vue & { xComponent: XComponent | undefined; origin: QueryOrigin }> => ({
   inject: {
     origin: {
-      default: 'default'
+      default: undefined
     }
   },
   created(): void {
@@ -64,8 +64,9 @@ export function getBusAPI(
       payload?: XEventPayload<Event>,
       metadata: Omit<WireMetadata, 'moduleName'> = {}
     ) => {
+      debugger;
       const moduleName = rootComponent ? getXComponentXModuleName(rootComponent) : null;
-      bus.emit(event, payload as any, { ...metadata, moduleName, origin });
+      bus.emit(event, payload as any, { moduleName, origin, ...metadata });
       rootComponent?.$emit(event, payload);
     },
     on: bus.on.bind(bus)

--- a/packages/x-components/src/plugins/x-plugin.mixin.ts
+++ b/packages/x-components/src/plugins/x-plugin.mixin.ts
@@ -3,6 +3,7 @@ import { XComponent } from '../components/x-component.types';
 import { getXComponentXModuleName, isXComponent } from '../components/x-component.utils';
 import { XEvent, XEventPayload } from '../wiring/events.types';
 import { WireMetadata } from '../wiring/wiring.types';
+import { QueryOrigin } from '../types/query-origin';
 import { XBus } from './x-bus.types';
 import { getAliasAPI } from './x-plugin.alias';
 import { XComponentAPI, XComponentBusAPI } from './x-plugin.types';
@@ -16,18 +17,27 @@ declare module 'vue/types/vue' {
 /**
  * Vue global mixin that adds a `$x` object to every component with the {@link XComponentAPI}.
  *
+ * @remarks It adds an injection property `origin` which value is included in the metadata of each
+ * event emitted with `$x.emit`.
+ *
  * @param bus - The {@link XBus} to use inside the components for emitting events.
  * @returns Mixin options which registers the component as X-Component and the $x.
  * @internal
  */
 export const createXComponentAPIMixin = (
   bus: XBus
-): ComponentOptions<Vue> & ThisType<Vue & { xComponent: XComponent | undefined }> => ({
+): ComponentOptions<Vue> &
+  ThisType<Vue & { xComponent: XComponent | undefined; origin: QueryOrigin }> => ({
+  inject: {
+    origin: {
+      default: 'default'
+    }
+  },
   created(): void {
     this.xComponent = getRootXComponent(this);
 
     const aliasAPI = getAliasAPI(this.$store);
-    const busAPI = getBusAPI(bus, this.xComponent);
+    const busAPI = getBusAPI(bus, this.xComponent, this.origin);
 
     this.$x = Object.assign(aliasAPI, busAPI);
   }
@@ -37,20 +47,26 @@ export const createXComponentAPIMixin = (
  * Creates an object containing the API related to the {@link XBus}.
  *
  * @param bus - The global {@link XBus}.
- * @param xComponent - The root {@link XComponent} that the component that owns this API has.
+ * @param rootComponent - The root {@link XComponent} that the component that owns this API has.
+ * @param origin - The Vue component injected origin.
+ *
  * @returns An object containing the {@link XComponentBusAPI}.
  * @internal
  */
-export function getBusAPI(bus: XBus, xComponent: XComponent | undefined): XComponentBusAPI {
+export function getBusAPI(
+  bus: XBus,
+  rootComponent: XComponent | undefined,
+  origin: QueryOrigin
+): XComponentBusAPI {
   return {
     emit: <Event extends XEvent>(
       event: Event,
       payload?: XEventPayload<Event>,
       metadata: Omit<WireMetadata, 'moduleName'> = {}
     ) => {
-      const moduleName = xComponent ? getXComponentXModuleName(xComponent) : null;
-      bus.emit(event, payload as any, { ...metadata, moduleName });
-      xComponent?.$emit(event, payload);
+      const moduleName = rootComponent ? getXComponentXModuleName(rootComponent) : null;
+      bus.emit(event, payload as any, { ...metadata, moduleName, origin });
+      rootComponent?.$emit(event, payload);
     },
     on: bus.on.bind(bus)
   };


### PR DESCRIPTION
# Description

It adds the origin injection in the mixin and also in the generated bus API.

NOTE: Please, remember to add the task reference EX-4636. I forgot it in the commit message.