### PR TITLE
feat(next-queries): add `NextQueriesList` component.

### DIFF
--- a/packages/x-components/src/components/__tests__/base-variable-column-grid.spec.ts
+++ b/packages/x-components/src/components/__tests__/base-variable-column-grid.spec.ts
@@ -2,7 +2,7 @@ import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import { getSearchResponseStub } from '../../__stubs__/search-response-stubs.factory';
 import { getDataTestSelector, installNewXPlugin } from '../../__tests__/utils';
-import { SearchItem } from '../../utils/types';
+import { ListItem } from '../../utils/types';
 import BaseVariableColumnGrid from '../base-variable-column-grid.vue';
 
 const searchResponse = getSearchResponseStub();
@@ -75,7 +75,7 @@ describe('testing BaseVariableColumnGrid component', () => {
 
 interface RenderOptions {
   /** The array of items to render in the grid. */
-  items?: SearchItem[];
+  items?: ListItem[];
 }
 
 interface RenderAPI {

--- a/packages/x-components/src/components/__tests__/items-list.spec.ts
+++ b/packages/x-components/src/components/__tests__/items-list.spec.ts
@@ -39,7 +39,7 @@ describe('testing ItemsList component', () => {
       items: []
     });
 
-    expect(wrapper.find(getDataTestSelector('search-items-list')).exists()).toBe(false);
+    expect(wrapper.find(getDataTestSelector('items-list')).exists()).toBe(false);
   });
 
   it('renders the items list passed as property', () => {
@@ -47,7 +47,7 @@ describe('testing ItemsList component', () => {
       items: resultsStub
     });
 
-    const itemsWrapperArray = wrapper.findAll('.x-search-items-list__item');
+    const itemsWrapperArray = wrapper.findAll('.x-items-list__item');
     expect(itemsWrapperArray).toHaveLength(resultsStub.length);
     resultsStub.forEach((result, index: number) => {
       expect(itemsWrapperArray.at(index).text()).toBe(result.id);
@@ -61,24 +61,15 @@ describe('testing ItemsList component', () => {
 
     const resultItemWrapper = wrapper.find(getDataTestSelector('results-list-item'));
     expect(resultItemWrapper.exists()).toBe(true);
-    expect(resultItemWrapper.classes()).toEqual([
-      'x-search-items-list__item',
-      'x-results-list-item'
-    ]);
+    expect(resultItemWrapper.classes()).toEqual(['x-items-list__item', 'x-results-list-item']);
 
     const bannerItemWrapper = wrapper.find(getDataTestSelector('banners-list-item'));
     expect(bannerItemWrapper.exists()).toBe(true);
-    expect(bannerItemWrapper.classes()).toEqual([
-      'x-search-items-list__item',
-      'x-banners-list-item'
-    ]);
+    expect(bannerItemWrapper.classes()).toEqual(['x-items-list__item', 'x-banners-list-item']);
 
     const promotedItemWrapper = wrapper.find(getDataTestSelector('promoteds-list-item'));
     expect(promotedItemWrapper.exists()).toBe(true);
-    expect(promotedItemWrapper.classes()).toEqual([
-      'x-search-items-list__item',
-      'x-promoteds-list-item'
-    ]);
+    expect(promotedItemWrapper.classes()).toEqual(['x-items-list__item', 'x-promoteds-list-item']);
   });
 
   it('allows to customize each item using the slot', () => {

--- a/packages/x-components/src/components/__tests__/items-list.spec.ts
+++ b/packages/x-components/src/components/__tests__/items-list.spec.ts
@@ -1,25 +1,25 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
-import { SearchItem } from '../../utils/types';
+import { ListItem } from '../../utils/types';
 import { getDataTestSelector } from '../../__tests__/utils';
 import { getBannersStub } from '../../__stubs__/banners-stubs.factory';
 import { getResultsStub } from '../../__stubs__/results-stubs.factory';
-import SearchItemsList from '../search-items-list.vue';
+import ItemsList from '../items-list.vue';
 import { getPromotedsStub } from '../../__stubs__/promoteds-stubs.factory';
 
 /**
- * Renders the `SearchItemsList` component, exposing a basic API for testing.
+ * Renders the `ItemsList` component, exposing a basic API for testing.
  *
  * @param options - The options to render the component with.
  * @returns The API for testing the `BannersList` component.
  */
-function renderSearchItemsList({
-  searchItems = [],
+function renderItemsList({
+  items = [],
   scopedSlots
-}: RenderSearchItemsListOptions = {}): RendersSearchItemsListAPI {
-  const wrapper = mount(SearchItemsList, {
+}: RenderItemsListOptions = {}): RendersItemsListAPI {
+  const wrapper = mount(ItemsList, {
     propsData: {
-      searchItems
+      items
     },
     scopedSlots
   });
@@ -29,22 +29,22 @@ function renderSearchItemsList({
   };
 }
 
-describe('testing SearchItemsList component', () => {
+describe('testing ItemsList component', () => {
   const resultsStub = getResultsStub();
   const promotedsStub = getPromotedsStub();
   const bannersStub = getBannersStub();
 
-  it("doesn't render the list if `searchItems` are provided", () => {
-    const { wrapper } = renderSearchItemsList({
-      searchItems: []
+  it("doesn't render the list if `items` are provided", () => {
+    const { wrapper } = renderItemsList({
+      items: []
     });
 
     expect(wrapper.find(getDataTestSelector('search-items-list')).exists()).toBe(false);
   });
 
   it('renders the items list passed as property', () => {
-    const { wrapper } = renderSearchItemsList({
-      searchItems: resultsStub
+    const { wrapper } = renderItemsList({
+      items: resultsStub
     });
 
     const itemsWrapperArray = wrapper.findAll('.x-search-items-list__item');
@@ -55,8 +55,8 @@ describe('testing SearchItemsList component', () => {
   });
 
   it('renders item attributes depending on the item `modelName`', () => {
-    const { wrapper } = renderSearchItemsList({
-      searchItems: [resultsStub[0], promotedsStub[0], bannersStub[0]]
+    const { wrapper } = renderItemsList({
+      items: [resultsStub[0], promotedsStub[0], bannersStub[0]]
     });
 
     const resultItemWrapper = wrapper.find(getDataTestSelector('results-list-item'));
@@ -82,13 +82,13 @@ describe('testing SearchItemsList component', () => {
   });
 
   it('allows to customize each item using the slot', () => {
-    const { wrapper } = renderSearchItemsList({
+    const { wrapper } = renderItemsList({
       scopedSlots: {
-        result: `<template #result="{ searchItem }">Result: {{ searchItem.name }}</template>`,
-        banner: `<template #banner="{ searchItem }">Banner: {{ searchItem.title }}</template>`,
-        promoted: `<template #promoted="{ searchItem }">Promoted: {{ searchItem.title }}</template>`
+        result: `<template #result="{ item }">Result: {{ item.name }}</template>`,
+        banner: `<template #banner="{ item }">Banner: {{ item.title }}</template>`,
+        promoted: `<template #promoted="{ item }">Promoted: {{ item.title }}</template>`
       },
-      searchItems: [resultsStub[0], promotedsStub[0], bannersStub[0]]
+      items: [resultsStub[0], promotedsStub[0], bannersStub[0]]
     });
 
     expect(wrapper.find(getDataTestSelector('results-list-item')).text()).toBe(
@@ -105,14 +105,14 @@ describe('testing SearchItemsList component', () => {
   });
 });
 
-interface RenderSearchItemsListOptions {
+interface RenderItemsListOptions {
   /** Items to be passed to the component. */
-  searchItems?: SearchItem[];
+  items?: ListItem[];
   /** Scoped slots to be passed to the mount function. */
   scopedSlots?: Record<string, string>;
 }
 
-interface RendersSearchItemsListAPI {
+interface RendersItemsListAPI {
   /** The `wrapper` wrapper component. */
   wrapper: Wrapper<Vue>;
 }

--- a/packages/x-components/src/components/__tests__/search-items-list.spec.ts
+++ b/packages/x-components/src/components/__tests__/search-items-list.spec.ts
@@ -4,7 +4,7 @@ import { SearchItem } from '../../utils/types';
 import { getDataTestSelector } from '../../__tests__/utils';
 import { getBannersStub } from '../../__stubs__/banners-stubs.factory';
 import { getResultsStub } from '../../__stubs__/results-stubs.factory';
-import { SearchItemsList } from '../../x-modules/search/components';
+import SearchItemsList from '../search-items-list.vue';
 import { getPromotedsStub } from '../../__stubs__/promoteds-stubs.factory';
 
 /**

--- a/packages/x-components/src/components/__tests__/search-items-list.spec.ts
+++ b/packages/x-components/src/components/__tests__/search-items-list.spec.ts
@@ -1,11 +1,11 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
-import { SearchItem } from '../../../../utils/types';
-import { getDataTestSelector } from '../../../../__tests__/utils';
-import { getBannersStub } from '../../../../__stubs__/banners-stubs.factory';
-import { getResultsStub } from '../../../../__stubs__/results-stubs.factory';
-import { SearchItemsList } from '../index';
-import { getPromotedsStub } from '../../../../__stubs__/promoteds-stubs.factory';
+import { SearchItem } from '../../utils/types';
+import { getDataTestSelector } from '../../__tests__/utils';
+import { getBannersStub } from '../../__stubs__/banners-stubs.factory';
+import { getResultsStub } from '../../__stubs__/results-stubs.factory';
+import { SearchItemsList } from '../../x-modules/search/components';
+import { getPromotedsStub } from '../../__stubs__/promoteds-stubs.factory';
 
 /**
  * Renders the `SearchItemsList` component, exposing a basic API for testing.

--- a/packages/x-components/src/components/base-grid.vue
+++ b/packages/x-components/src/components/base-grid.vue
@@ -33,9 +33,9 @@
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
   import { toKebabCase } from '../utils/string';
-  import { SearchItem, VueCSSClasses } from '../utils/types';
+  import { ListItem, VueCSSClasses } from '../utils/types';
   import { XInject } from './decorators/injection.decorators';
-  import { SEARCH_ITEMS_KEY } from './decorators/injection.consts';
+  import { LIST_ITEMS_KEY } from './decorators/injection.consts';
 
   /**
    * Grid component that is able to render different items based on their modelName value. In order
@@ -74,15 +74,15 @@
      * @public
      */
     @Prop()
-    protected items!: SearchItem[];
+    protected items!: ListItem[];
 
     /**
-     * It injects {@link SearchItem} provided by an ancestor.
+     * It injects {@link ListItem} provided by an ancestor.
      *
      * @internal
      */
-    @XInject(SEARCH_ITEMS_KEY)
-    public injectedSearchItems!: SearchItem[];
+    @XInject(LIST_ITEMS_KEY)
+    public injectedListItems!: ListItem[];
 
     /**
      * It returns the items passed as props or the injected ones.
@@ -91,10 +91,10 @@
      *
      * @public
      */
-    protected get computedItems(): SearchItem[] {
+    protected get computedItems(): ListItem[] {
       return (
         this.items ??
-        this.injectedSearchItems ??
+        this.injectedListItems ??
         //TODO: add here logger
         //eslint-disable-next-line no-console
         console.warn('It is necessary to pass a prop or inject the list of filters')
@@ -137,7 +137,7 @@
      * @internal
      */
     protected get itemsWithCSSClass(): {
-      item: SearchItem;
+      item: ListItem;
       cssClass: VueCSSClasses;
     }[] {
       return this.computedItems.map(item => ({

--- a/packages/x-components/src/components/base-variable-column-grid.vue
+++ b/packages/x-components/src/components/base-variable-column-grid.vue
@@ -14,7 +14,7 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { SearchItem } from '../utils/types';
+  import { ListItem } from '../utils/types';
   import BaseGrid from './base-grid.vue';
   import { XOn } from './decorators/bus.decorators';
 
@@ -47,7 +47,7 @@
      * @public
      */
     @Prop()
-    protected items?: SearchItem[];
+    protected items?: ListItem[];
 
     /**
      * The columns to render in the grid.

--- a/packages/x-components/src/components/decorators/injection.consts.ts
+++ b/packages/x-components/src/components/decorators/injection.consts.ts
@@ -1,9 +1,9 @@
-import { SearchItem } from '../../utils/types';
+import { ListItem } from '../../utils/types';
 import { XInjectKey } from './injection.decorators';
 
 /**
- * It's used to identify the provided and injected `searchItems`.
+ * It's used to identify the provided and injected `items`.
  *
  * @internal
  */
-export const SEARCH_ITEMS_KEY: XInjectKey<SearchItem[] | undefined> = 'searchItems';
+export const LIST_ITEMS_KEY: XInjectKey<ListItem[] | undefined> = 'listItems';

--- a/packages/x-components/src/components/index.ts
+++ b/packages/x-components/src/components/index.ts
@@ -18,7 +18,7 @@ export { default as BaseRating } from './base-rating.vue';
 export { default as BaseVariableColumnGrid } from './base-variable-column-grid.vue';
 export { NoElement } from './no-element';
 export { default as SlidingPanel } from './sliding-panel.vue';
-export { default as SearchItemsList } from './search-items-list.vue';
+export { default as ItemsList } from './items-list.vue';
 export { default as StaggeringTransitionGroup } from './staggering-transition-group.vue';
 export { default as Layout } from './layouts/layout.vue';
 
@@ -27,7 +27,7 @@ export * from './decorators/bus.decorators';
 export * from './decorators/debounce.decorators';
 export * from './decorators/injection.decorators';
 export * from './decorators/store.decorators';
-export * from './search-items-injection.mixin';
+export * from './items-list-injection.mixin';
 export * from './x-component.mixin';
 export * from './x-component.types';
 export * from './x-component.utils';

--- a/packages/x-components/src/components/index.ts
+++ b/packages/x-components/src/components/index.ts
@@ -18,6 +18,7 @@ export { default as BaseRating } from './base-rating.vue';
 export { default as BaseVariableColumnGrid } from './base-variable-column-grid.vue';
 export { NoElement } from './no-element';
 export { default as SlidingPanel } from './sliding-panel.vue';
+export { default as SearchItemsList } from './search-items-list.vue';
 export { default as StaggeringTransitionGroup } from './staggering-transition-group.vue';
 export { default as Layout } from './layouts/layout.vue';
 
@@ -26,6 +27,7 @@ export * from './decorators/bus.decorators';
 export * from './decorators/debounce.decorators';
 export * from './decorators/injection.decorators';
 export * from './decorators/store.decorators';
+export * from './search-items-injection.mixin';
 export * from './x-component.mixin';
 export * from './x-component.types';
 export * from './x-component.utils';

--- a/packages/x-components/src/components/items-list-injection.mixin.ts
+++ b/packages/x-components/src/components/items-list-injection.mixin.ts
@@ -1,17 +1,17 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { SearchItem } from '../utils/types';
+import { ListItem } from '../utils/types';
 import { XInject, XProvide } from './decorators/injection.decorators';
-import { SEARCH_ITEMS_KEY } from './decorators/injection.consts';
+import { LIST_ITEMS_KEY } from './decorators/injection.consts';
 
 /**
  * Mixin to facilitate providing and injecting a list of search items. Injected list is
- * available at `injectedSearchItems`, and the provided list should be stored in `items`.
+ * available at `injectedListItems`, and the provided list should be stored in `items`.
  *
  * @public
  */
 @Component
-export class SearchItemsInjectionMixin extends Vue {
+export class ItemsListInjectionMixin extends Vue {
   /**
    * The search items of the entity that uses the mixin from the state.
    *
@@ -20,7 +20,7 @@ export class SearchItemsInjectionMixin extends Vue {
    *
    * @internal
    */
-  protected stateItems!: SearchItem[];
+  protected stateItems!: ListItem[];
 
   /**
    * The computed search items of the entity that uses the mixin.
@@ -30,16 +30,16 @@ export class SearchItemsInjectionMixin extends Vue {
    * @returns An empty array as fallback in case it is not overridden.
    * @internal
    */
-  @XProvide(SEARCH_ITEMS_KEY)
-  public get items(): SearchItem[] {
+  @XProvide(LIST_ITEMS_KEY)
+  public get items(): ListItem[] {
     return [];
   }
 
   /**
-   * It injects {@link SearchItem} provided by an ancestor as injectedItems.
+   * It injects {@link ListItem} provided by an ancestor as injectedListItems.
    *
    * @internal
    */
-  @XInject(SEARCH_ITEMS_KEY)
-  public injectedSearchItems: SearchItem[] | undefined;
+  @XInject(LIST_ITEMS_KEY)
+  public injectedListItems: ListItem[] | undefined;
 }

--- a/packages/x-components/src/components/items-list-injection.mixin.ts
+++ b/packages/x-components/src/components/items-list-injection.mixin.ts
@@ -5,7 +5,7 @@ import { XInject, XProvide } from './decorators/injection.decorators';
 import { LIST_ITEMS_KEY } from './decorators/injection.consts';
 
 /**
- * Mixin to facilitate providing and injecting a list of search items. Injected list is
+ * Mixin to facilitate providing and injecting a list of list items. Injected list is
  * available at `injectedListItems`, and the provided list should be stored in `items`.
  *
  * @public
@@ -13,7 +13,7 @@ import { LIST_ITEMS_KEY } from './decorators/injection.consts';
 @Component
 export class ItemsListInjectionMixin extends Vue {
   /**
-   * The search items of the entity that uses the mixin from the state.
+   * The list items of the entity that uses the mixin from the state.
    *
    * @remarks It should be defined in the component that uses the mixin and it's intended to be
    * filled with items from the state. Vue doesn't allow mixins as abstract classes.
@@ -23,7 +23,7 @@ export class ItemsListInjectionMixin extends Vue {
   protected stateItems!: ListItem[];
 
   /**
-   * The computed search items of the entity that uses the mixin.
+   * The computed list items of the entity that uses the mixin.
    *
    * @remarks It should be overridden in the component that uses the mixin and it's intended to be
    * filled with items from the state. Vue doesn't allow mixins as abstract classes.

--- a/packages/x-components/src/components/items-list.vue
+++ b/packages/x-components/src/components/items-list.vue
@@ -3,7 +3,7 @@
     :is="animation"
     v-if="items.length"
     tag="ul"
-    class="x-search-items-list"
+    class="x-items-list"
     data-test="items-list"
   >
     <li
@@ -14,7 +14,7 @@
       :data-test="item.dataTest"
     >
       <!--
-        @slot Customized Search items list search item.
+        @slot Custom item to render.
           @binding {ListItem} item - Item data.
       -->
       <slot :item="item" :name="item.slotName">{{ item.id }}</slot>
@@ -45,7 +45,7 @@
     protected animation!: Vue | string;
 
     /**
-     * List of search items.
+     * List of items.
      *
      * @public
      */
@@ -55,7 +55,7 @@
     /**
      * The list of the items with additional properties.
      *
-     * @returns A list of search items with `dataTest`, `class` and the `slotName` for each item.
+     * @returns A list of items with `dataTest`, `class` and the `slotName` for each item.
      *
      * @internal
      */

--- a/packages/x-components/src/components/items-list.vue
+++ b/packages/x-components/src/components/items-list.vue
@@ -1,23 +1,23 @@
 <template>
   <component
     :is="animation"
-    v-if="searchItems.length"
+    v-if="items.length"
     tag="ul"
     class="x-search-items-list"
     data-test="search-items-list"
   >
     <li
-      v-for="searchItem in computedSearchItems"
-      :key="searchItem.id"
+      v-for="item in computedItems"
+      :key="item.id"
       class="x-search-items-list__item"
-      :class="searchItem.class"
-      :data-test="searchItem.dataTest"
+      :class="item.class"
+      :data-test="item.dataTest"
     >
       <!--
         @slot Customized Search items list search item.
-          @binding {SearchItem} searchItem - Search item data.
+          @binding {SearchItem} item - Search item data.
       -->
-      <slot :searchItem="searchItem" :name="searchItem.slotName">{{ searchItem.id }}</slot>
+      <slot :item="item" :name="item.slotName">{{ item.id }}</slot>
     </li>
   </component>
 </template>
@@ -25,17 +25,17 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { SearchItem } from '../utils/types';
+  import { ListItem } from '../utils/types';
   import { toKebabCase } from '../utils/string';
 
   /**
-   * It renders a list of {@link SearchItem} providing a slot for each `slotName` which depends on
-   * the `modelName`of the searchItem.
+   * It renders a list of {@link ListItem} providing a slot for each `slotName` which depends on
+   * the `modelName`of the item.
    *
    * @public
    */
   @Component
-  export default class SearchItemsList extends Vue {
+  export default class ItemsList extends Vue {
     /**
      * Animation component that will be used to animate the list.
      *
@@ -50,7 +50,7 @@
      * @public
      */
     @Prop({ required: true })
-    protected searchItems!: SearchItem[];
+    protected items!: ListItem[];
 
     /**
      * The list of the search items with additional properties.
@@ -59,14 +59,14 @@
      *
      * @internal
      */
-    protected get computedSearchItems(): {
+    protected get computedItems(): {
       dataTest: string;
       class: string[];
     }[] {
-      return this.searchItems.map(searchItem => {
-        const modelName = toKebabCase(searchItem.modelName);
+      return this.items.map(item => {
+        const modelName = toKebabCase(item.modelName);
         return {
-          ...searchItem,
+          ...item,
           dataTest: `${modelName}s-list-item`,
           class: [`x-${modelName}s-list-item`],
           slotName: modelName

--- a/packages/x-components/src/components/items-list.vue
+++ b/packages/x-components/src/components/items-list.vue
@@ -4,18 +4,18 @@
     v-if="items.length"
     tag="ul"
     class="x-search-items-list"
-    data-test="search-items-list"
+    data-test="items-list"
   >
     <li
       v-for="item in computedItems"
       :key="item.id"
-      class="x-search-items-list__item"
+      class="x-items-list__item"
       :class="item.class"
       :data-test="item.dataTest"
     >
       <!--
         @slot Customized Search items list search item.
-          @binding {SearchItem} item - Search item data.
+          @binding {ListItem} item - Item data.
       -->
       <slot :item="item" :name="item.slotName">{{ item.id }}</slot>
     </li>
@@ -53,7 +53,7 @@
     protected items!: ListItem[];
 
     /**
-     * The list of the search items with additional properties.
+     * The list of the items with additional properties.
      *
      * @returns A list of search items with `dataTest`, `class` and the `slotName` for each item.
      *

--- a/packages/x-components/src/components/search-items-injection.mixin.ts
+++ b/packages/x-components/src/components/search-items-injection.mixin.ts
@@ -1,11 +1,17 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { SearchItem } from '../../../utils/types';
-import { XInject, XProvide } from '../../../components/decorators/injection.decorators';
-import { SEARCH_ITEMS_KEY } from '../../../components/decorators/injection.consts';
+import { SearchItem } from '../utils/types';
+import { XInject, XProvide } from './decorators/injection.decorators';
+import { SEARCH_ITEMS_KEY } from './decorators/injection.consts';
 
+/**
+ * Mixin to facilitate providing and injecting a list of search items. Injected list is
+ * available at `injectedSearchItems`, and the provided list should be stored in `items`.
+ *
+ * @public
+ */
 @Component
-export default class SearchItemsInjectionMixin extends Vue {
+export class SearchItemsInjectionMixin extends Vue {
   /**
    * The search items of the entity that uses the mixin from the state.
    *

--- a/packages/x-components/src/components/search-items-list.vue
+++ b/packages/x-components/src/components/search-items-list.vue
@@ -25,8 +25,8 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { SearchItem } from '../../../utils/types';
-  import { toKebabCase } from '../../../utils/string';
+  import { SearchItem } from '../utils/types';
+  import { toKebabCase } from '../utils/string';
 
   /**
    * It renders a list of {@link SearchItem} providing a slot for each `slotName` which depends on
@@ -35,7 +35,7 @@
    * @public
    */
   @Component
-  export default class SearchItemList extends Vue {
+  export default class SearchItemsList extends Vue {
     /**
      * Animation component that will be used to animate the list.
      *

--- a/packages/x-components/src/utils/array.ts
+++ b/packages/x-components/src/utils/array.ts
@@ -86,10 +86,10 @@ export function arrayToObject<ArrayType, KeyType extends string | number>(
  */
 export function groupItemsBy<ArrayType, ReturnType extends string | number>(
   array: ArrayType[],
-  groupBy: (item: ArrayType) => ReturnType
+  groupBy: (item: ArrayType, index: number) => ReturnType
 ): Record<ReturnType, ArrayType[]> {
-  return array.reduce<Record<ReturnType, ArrayType[]>>((accumulator, current) => {
-    const keyValue = groupBy(current);
+  return array.reduce<Record<ReturnType, ArrayType[]>>((accumulator, current, index) => {
+    const keyValue = groupBy(current, index);
     if (!accumulator[keyValue]) {
       accumulator[keyValue] = [];
     }

--- a/packages/x-components/src/utils/types.ts
+++ b/packages/x-components/src/utils/types.ts
@@ -161,7 +161,7 @@ export type EventsForDirectionLimit = {
  *
  * @public
  */
-export type SearchItem = Identifiable & NamedModel;
+export type ListItem = Identifiable & NamedModel;
 
 /**
  * The type returned by the {@link debounce} function. Basically is the function the

--- a/packages/x-components/src/views/FullApp.vue
+++ b/packages/x-components/src/views/FullApp.vue
@@ -378,7 +378,7 @@
   import BaseResultLink from '../components/result/base-result-link.vue';
   import BaseResultImage from '../components/result/base-result-image.vue';
   import SimpleFilter from '../x-modules/facets/components/filters/simple-filter.vue';
-  import { Dictionary, SearchItem } from '../utils/types';
+  import { Dictionary, ListItem } from '../utils/types';
   import ClearFilters from '../x-modules/facets/components/clear-filters.vue';
   import SelectedFiltersList from '../x-modules/facets/components/lists/selected-filters-list.vue';
   import SortedFilters from '../x-modules/facets/components/lists/sorted-filters.vue';
@@ -507,7 +507,7 @@
     @State('recommendations', 'recommendations')
     public recommendations!: Result[];
 
-    protected get gridItems(): SearchItem[] {
+    protected get gridItems(): ListItem[] {
       return [...getBannersStub(), ...getPromotedsStub(), ...this.results];
     }
 

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -219,9 +219,19 @@
                     </template>
 
                     <template #NextQueriesGroup="{ item: { nextQueries } }">
-                      <BaseSuggestions #default="{ suggestion }" :suggestions="nextQueries">
-                        <NextQuery :suggestion="suggestion" />
-                      </BaseSuggestions>
+                      <div class="x-list x-list--gap-03">
+                        <h1 class="x-title2">What's next?</h1>
+                        <BaseSuggestions
+                          #default="{ suggestion }"
+                          :suggestions="nextQueries"
+                          class="x-list--gap-03"
+                        >
+                          <NextQuery #default="{ suggestion: nextQuery }" :suggestion="suggestion">
+                            <Nq1 />
+                            {{ nextQuery.query }}
+                          </NextQuery>
+                        </BaseSuggestions>
+                      </div>
                     </template>
                   </BaseVariableColumnGrid>
                 </NextQueriesList>
@@ -245,7 +255,7 @@
   import { Facet, SimpleFilter as SimpleFilterModel } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
-  import { BaseIdTogglePanelButton } from '../components';
+  import { BaseIdTogglePanelButton, BaseSuggestions } from '../components';
   import StaggeredFadeAndSlide from '../components/animations/staggered-fade-and-slide.vue';
   import BaseGrid from '../components/base-grid.vue';
   import BaseVariableColumnGrid from '../components/base-variable-column-grid.vue';
@@ -259,6 +269,7 @@
   import CrossIcon from '../components/icons/cross.vue';
   import Grid1Col from '../components/icons/grid-1-col.vue';
   import Grid2Col from '../components/icons/grid-2-col.vue';
+  import Nq1 from '../components/icons/nq-1.vue';
   import SearchIcon from '../components/icons/search.vue';
   import Layout from '../components/layouts/layout.vue';
   import BaseIdModalClose from '../components/modals/base-id-modal-close.vue';
@@ -270,22 +281,23 @@
   import SlidingPanel from '../components/sliding-panel.vue';
   import { infiniteScroll } from '../directives/infinite-scroll/infinite-scroll';
   import { XInstaller } from '../x-installer/x-installer';
+  import ClearFilters from '../x-modules/facets/components/clear-filters.vue';
   import FacetsProvider from '../x-modules/facets/components/facets/facets-provider.vue';
   import Facets from '../x-modules/facets/components/facets/facets.vue';
   import HierarchicalFilter from '../x-modules/facets/components/filters/hierarchical-filter.vue';
   import SimpleFilter from '../x-modules/facets/components/filters/simple-filter.vue';
+  // eslint-disable-next-line max-len
+  import ExcludeFiltersWithNoResults from '../x-modules/facets/components/lists/exclude-filters-with-no-results.vue';
   import FiltersList from '../x-modules/facets/components/lists/filters-list.vue';
   import FiltersSearch from '../x-modules/facets/components/lists/filters-search.vue';
   // eslint-disable-next-line max-len
   import SelectedFiltersList from '../x-modules/facets/components/lists/selected-filters-list.vue';
   import SlicedFilters from '../x-modules/facets/components/lists/sliced-filters.vue';
-  // eslint-disable-next-line max-len
-  import ExcludeFiltersWithNoResults from '../x-modules/facets/components/lists/exclude-filters-with-no-results.vue';
   import SortedFilters from '../x-modules/facets/components/lists/sorted-filters.vue';
-  import ClearFilters from '../x-modules/facets/components/clear-filters.vue';
   import { FilterEntityFactory } from '../x-modules/facets/entities/filter-entity.factory';
   import { SingleSelectModifier } from '../x-modules/facets/entities/single-select.modifier';
   import HistoryQueries from '../x-modules/history-queries/components/history-queries.vue';
+  import { NextQuery } from '../x-modules/next-queries';
   import NextQueriesList from '../x-modules/next-queries/components/next-queries-list.vue';
   import NextQueries from '../x-modules/next-queries/components/next-queries.vue';
   import PopularSearches from '../x-modules/popular-searches/components/popular-searches.vue';
@@ -320,56 +332,59 @@
       infiniteScroll
     },
     components: {
-      NextQueriesList,
-      HierarchicalFilter,
-      ClearFilters,
-      SortedFilters,
-      ExcludeFiltersWithNoResults,
-      FiltersSearch,
-      SlicedFilters,
-      SelectedFiltersList,
-      FiltersList,
-      ChevronUp,
-      Promoted,
-      PromotedsList,
+      Nq1,
       Banner,
       BannersList,
-      BaseIdTogglePanelButton,
-      BaseScrollToTop,
-      ChevronDown,
-      ChevronRight,
-      ChevronLeft,
-      ChevronTinyRight,
-      ChevronTinyLeft,
-      Facets,
-      FacetsProvider,
-      Grid2Col,
-      Grid1Col,
-      CrossIcon,
-      SearchIcon,
-      NextQueries,
-      QuerySuggestions,
-      HistoryQueries,
-      RelatedTags,
-      SlidingPanel,
-      Recommendations,
-      BaseResultImage,
-      BaseVariableColumnGrid,
-      BaseGrid,
-      ResultsList,
-      SortList,
       BaseColumnPickerList,
-      SortDropdown,
-      SimpleFilter,
+      BaseGrid,
       BaseHeaderTogglePanel,
-      SearchButton,
-      ClearSearchInput,
+      BaseIdModal,
       BaseIdModalClose,
       BaseIdModalOpen,
-      BaseIdModal,
-      SearchInput,
+      BaseIdTogglePanelButton,
+      BaseResultImage,
+      BaseScrollToTop,
+      BaseSuggestions,
+      BaseVariableColumnGrid,
+      ChevronDown,
+      ChevronLeft,
+      ChevronRight,
+      ChevronTinyLeft,
+      ChevronTinyRight,
+      ChevronUp,
+      ClearFilters,
+      ClearSearchInput,
+      CrossIcon,
+      ExcludeFiltersWithNoResults,
+      Facets,
+      FacetsProvider,
+      FiltersList,
+      FiltersSearch,
+      Grid1Col,
+      Grid2Col,
+      HierarchicalFilter,
+      HistoryQueries,
+      Layout,
+      NextQueries,
+      NextQueriesList,
+      NextQuery,
       PopularSearches,
-      Layout
+      Promoted,
+      PromotedsList,
+      QuerySuggestions,
+      Recommendations,
+      RelatedTags,
+      ResultsList,
+      SearchButton,
+      SearchIcon,
+      SearchInput,
+      SelectedFiltersList,
+      SimpleFilter,
+      SlicedFilters,
+      SlidingPanel,
+      SortDropdown,
+      SortList,
+      SortedFilters
     }
   })
   export default class App extends Vue {

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -194,29 +194,31 @@
           <ResultsList v-infinite-scroll:body-scroll>
             <BannersList>
               <PromotedsList>
-                <BaseVariableColumnGrid :animation="resultsAnimation">
-                  <template #Result="{ item: result }">
-                    <article class="result" style="max-width: 300px">
-                      <BaseResultImage :result="result" class="x-picture--colored">
-                        <template #placeholder>
-                          <div style="padding-top: 100%; background-color: lightgray"></div>
-                        </template>
-                        <template #fallback>
-                          <div style="padding-top: 100%; background-color: lightsalmon"></div>
-                        </template>
-                      </BaseResultImage>
-                      <h1 class="x-title3">{{ result.name }}</h1>
-                    </article>
-                  </template>
+                <NextQueriesList>
+                  <BaseVariableColumnGrid :animation="resultsAnimation">
+                    <template #Result="{ item: result }">
+                      <article class="result" style="max-width: 300px">
+                        <BaseResultImage :result="result" class="x-picture--colored">
+                          <template #placeholder>
+                            <div style="padding-top: 100%; background-color: lightgray"></div>
+                          </template>
+                          <template #fallback>
+                            <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                          </template>
+                        </BaseResultImage>
+                        <h1 class="x-title3">{{ result.name }}</h1>
+                      </article>
+                    </template>
 
-                  <template #Banner="{ item: banner }">
-                    <Banner :banner="banner" />
-                  </template>
+                    <template #Banner="{ item: banner }">
+                      <Banner :banner="banner" />
+                    </template>
 
-                  <template #Promoted="{ item: promoted }">
-                    <Promoted :promoted="promoted" />
-                  </template>
-                </BaseVariableColumnGrid>
+                    <template #Promoted="{ item: promoted }">
+                      <Promoted :promoted="promoted" />
+                    </template>
+                  </BaseVariableColumnGrid>
+                </NextQueriesList>
               </PromotedsList>
             </BannersList>
           </ResultsList>
@@ -278,6 +280,7 @@
   import { FilterEntityFactory } from '../x-modules/facets/entities/filter-entity.factory';
   import { SingleSelectModifier } from '../x-modules/facets/entities/single-select.modifier';
   import HistoryQueries from '../x-modules/history-queries/components/history-queries.vue';
+  import NextQueriesList from '../x-modules/next-queries/components/next-queries-list.vue';
   import NextQueries from '../x-modules/next-queries/components/next-queries.vue';
   import PopularSearches from '../x-modules/popular-searches/components/popular-searches.vue';
   import QuerySuggestions from '../x-modules/query-suggestions/components/query-suggestions.vue';
@@ -311,6 +314,7 @@
       infiniteScroll
     },
     components: {
+      NextQueriesList,
       HierarchicalFilter,
       ClearFilters,
       SortedFilters,

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -217,6 +217,12 @@
                     <template #Promoted="{ item: promoted }">
                       <Promoted :promoted="promoted" />
                     </template>
+
+                    <template #NextQueriesGroup="{ item: { nextQueries } }">
+                      <BaseSuggestions #default="{ suggestion }" :suggestions="nextQueries">
+                        <NextQuery :suggestion="suggestion" />
+                      </BaseSuggestions>
+                    </template>
                   </BaseVariableColumnGrid>
                 </NextQueriesList>
               </PromotedsList>

--- a/packages/x-components/src/views/sort.vue
+++ b/packages/x-components/src/views/sort.vue
@@ -52,7 +52,7 @@
   import { CheckIcon, ChevronDownIcon, ChevronUpIcon, SearchIcon } from '../components/icons/index';
   import BaseResultLink from '../components/result/base-result-link.vue';
   import BaseResultImage from '../components/result/base-result-image.vue';
-  import { SearchItem } from '../utils/types';
+  import { ListItem } from '../utils/types';
   import SortDropdown from '../x-modules/search/components/sort-dropdown.vue';
   import SortList from '../x-modules/search/components/sort-list.vue';
   import ClearSearchInput from '../x-modules/search-box/components/clear-search-input.vue';
@@ -95,7 +95,7 @@
     @State('search', 'results')
     public results!: Result[];
 
-    protected get gridItems(): SearchItem[] {
+    protected get gridItems(): ListItem[] {
       return [...getBannersStub(), ...getPromotedsStub(), ...this.results];
     }
 

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
@@ -1,0 +1,300 @@
+import { NextQuery } from '@empathyco/x-types';
+import { createLocalVue, mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import Vue, { ComponentOptions, VueConstructor } from 'vue';
+import Vuex, { Store } from 'vuex';
+import { createNextQueryStub } from '../../../../__stubs__/next-queries-stubs.factory';
+import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
+import { SearchItemsInjectionMixin } from '../../../../components/search-items-injection.mixin';
+import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
+import { RootXStoreState } from '../../../../store/store.types';
+import { DeepPartial, Dictionary, SearchItem } from '../../../../utils/types';
+import { nextQueriesXModule } from '../../x-module';
+import NextQueriesList from '../next-queries-list.vue';
+import { resetXNextQueriesStateWith } from './utils';
+
+/**
+ * Renders the `NextQueriesList` component, exposing a basic API for testing.
+ *
+ * @param options - The options to render the component with.
+ * @returns The API for testing the `NextQueriesList` component.
+ */
+function renderNextQueriesList({
+  template = `
+    <NextQueriesList v-bind="$attrs">
+     <template #next-queries-group="{ searchItem }">
+        <ul class="next-queries-group">
+          <li v-for="nextQuery in searchItem.nextQueries" class="next-query">{{
+           nextQuery.query
+          }}</li>
+        </ul>
+      </template>
+    </NextQueriesList>`,
+  nextQueries = [],
+  components,
+  extraItems,
+  ...props
+}: RenderNextQueriesListOptions = {}): RenderNextQueriesListAPI {
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const store = new Store<DeepPartial<RootXStoreState>>({});
+  installNewXPlugin({ store, initialXModules: [nextQueriesXModule] }, localVue);
+  resetXNextQueriesStateWith(store, { nextQueries });
+
+  const wrapper = mount(
+    {
+      template,
+      components: {
+        NextQueriesList,
+        ...components
+      },
+      mixins: [SearchItemsInjectionMixin],
+      computed: {
+        items() {
+          return extraItems;
+        }
+      }
+    },
+    {
+      localVue,
+      store,
+      propsData: props
+    }
+  );
+
+  const nextQueriesListWrapper = wrapper.findComponent(NextQueriesList);
+
+  function getSearchItemWrappers(): WrapperArray<Vue> {
+    return nextQueriesListWrapper.findAll(
+      `${getDataTestSelector('next-queries-groups-list-item')}, ${getDataTestSelector(
+        'extra-items-list-item'
+      )}`
+    );
+  }
+
+  return {
+    wrapper: nextQueriesListWrapper,
+    getSearchItemWrappers,
+    getNextQueryGroupWrappers() {
+      return nextQueriesListWrapper.findAll('.next-queries-group');
+    },
+    getNextQueryWrappers(root = nextQueriesListWrapper) {
+      return root.findAll('.next-query');
+    },
+    getSearchItemsRenderedText() {
+      return getSearchItemWrappers().wrappers.map(wrapper => wrapper.text());
+    }
+  };
+}
+
+/**
+ * Creates a list of {@link SearchItem} of the given length.
+ *
+ * @param length - The length of the list to create.
+ * @returns A list of simple {@link SearchItem}s.
+ */
+function createExtraItems(length: number): SearchItem[] {
+  return Array.from({ length }, (_, index) => ({
+    id: `Extra ${index}`,
+    modelName: `ExtraItem`
+  }));
+}
+
+/**
+ * Creates a list of {@link NextQuery|NextQueries} the given list of queries.
+ *
+ * @param queries - The queries from whom create the next queries objects.
+ * @returns A list of {@link NextQuery|NextQueries}.
+ */
+function createNextQueries(...queries: string[]): NextQuery[] {
+  return queries.map(query => createNextQueryStub(query));
+}
+
+describe('testing NextQueriesList component', () => {
+  it('is an XComponent', () => {
+    const { wrapper } = renderNextQueriesList();
+    expect(isXComponent(wrapper.vm)).toEqual(true);
+  });
+
+  it('has Search as XModule', () => {
+    const { wrapper } = renderNextQueriesList();
+    expect(getXComponentXModuleName(wrapper.vm)).toEqual('nextQueries');
+  });
+
+  it('renders no group if no search items are injected', () => {
+    const nextQueries = createNextQueries('milk', 'sugar', 'beer');
+    const { getNextQueryGroupWrappers, getSearchItemWrappers } = renderNextQueriesList({
+      nextQueries,
+      maxNextQueriesPerGroup: 2,
+      extraItems: []
+    });
+
+    expect(getSearchItemWrappers()).toHaveLength(0);
+    expect(getNextQueryGroupWrappers()).toHaveLength(0);
+  });
+
+  it('inserts next queries groups in the appropriate order', () => {
+    const nextQueries = createNextQueries(
+      'steak',
+      'tomahawk',
+      't-bone',
+      'porterhouse',
+      'rib-eye',
+      'ribs',
+      'picanha',
+      'short-ribs',
+      'flank steak' // This one should be ignored as there is no room for it.
+    );
+    const extraItems = createExtraItems(11);
+    const { getSearchItemsRenderedText } = renderNextQueriesList({
+      nextQueries,
+      extraItems,
+      maxNextQueriesPerGroup: 2,
+      frequency: 3,
+      offset: 4
+    });
+
+    // 11 extra items + 4 groups of NQs at index 4, 7, 10, 13
+    expect(getSearchItemsRenderedText()).toEqual([
+      extraItems[0].id,
+      extraItems[1].id,
+      extraItems[2].id,
+      extraItems[3].id,
+      ['steak', 'tomahawk'].join(''),
+      extraItems[4].id,
+      extraItems[5].id,
+      ['t-bone', 'porterhouse'].join(''),
+      extraItems[6].id,
+      extraItems[7].id,
+      ['rib-eye', 'ribs'].join(''),
+      extraItems[8].id,
+      extraItems[9].id,
+      ['picanha', 'short-ribs'].join(''),
+      extraItems[10].id
+    ]);
+  });
+
+  it('does not render more than the specified groups', () => {
+    const nextQueries = createNextQueries(
+      'tequila',
+      'mezcal',
+      'absinthe',
+      'vodka',
+      'rum', // Should be ignored because maxGroups: 2
+      'dark-rum' // Should be ignored because maxGroups: 2
+    );
+    const extraItems = createExtraItems(10);
+    const { getSearchItemsRenderedText } = renderNextQueriesList({
+      nextQueries,
+      extraItems,
+      maxNextQueriesPerGroup: 2,
+      frequency: 3,
+      offset: 4,
+      maxGroups: 2
+    });
+
+    // 10 extra items + 2 groups of NQs at index 4, 7
+    expect(getSearchItemsRenderedText()).toEqual([
+      extraItems[0].id,
+      extraItems[1].id,
+      extraItems[2].id,
+      extraItems[3].id,
+      ['tequila', 'mezcal'].join(''),
+      extraItems[4].id,
+      extraItems[5].id,
+      ['absinthe', 'vodka'].join(''),
+      extraItems[6].id,
+      extraItems[7].id,
+      extraItems[8].id,
+      extraItems[9].id
+    ]);
+  });
+
+  it('renders a group even if it has not enough next queries', () => {
+    const nextQueries = createNextQueries('piña colada');
+    const extraItems = createExtraItems(4);
+    const { getSearchItemsRenderedText } = renderNextQueriesList({
+      nextQueries,
+      extraItems,
+      maxNextQueriesPerGroup: 4,
+      offset: 2
+    });
+
+    // 4 extra items + 1 groups of NQs at index 2
+    expect(getSearchItemsRenderedText()).toEqual([
+      extraItems[0].id,
+      extraItems[1].id,
+      'piña colada',
+      extraItems[2].id,
+      extraItems[3].id
+    ]);
+  });
+
+  it('provides the modified list of search items', () => {
+    const CustomList: ComponentOptions<Vue> = {
+      mixins: [SearchItemsInjectionMixin],
+      template: `
+        <ul>
+        <li class="search-item" v-for="item in injectedSearchItems">{{ item.id }}</li>
+        </ul>`
+    };
+    const nextQueries = createNextQueries('rib chop', 'shoulder steak');
+    const extraItems = createExtraItems(4);
+    const { wrapper } = renderNextQueriesList({
+      template: `
+        <NextQueriesList v-bind="$attrs">
+        <CustomList/>
+        </NextQueriesList>`,
+      components: { CustomList },
+      nextQueries,
+      extraItems,
+      maxNextQueriesPerGroup: 1,
+      frequency: 3,
+      offset: 2
+    });
+
+    const customSearchItemsRenderedText = wrapper
+      .findAll('.search-item')
+      .wrappers.map(wrapper => wrapper.text());
+
+    expect(customSearchItemsRenderedText).toEqual([
+      extraItems[0].id,
+      extraItems[1].id,
+      'rib chop',
+      extraItems[2].id,
+      extraItems[3].id,
+      'shoulder steak'
+    ]);
+  });
+});
+
+interface RenderNextQueriesListOptions {
+  /** Extra components to be registered and rendered. */
+  components?: Dictionary<VueConstructor | ComponentOptions<Vue>>;
+  /** Extra items to be rendered. */
+  extraItems?: SearchItem[];
+  /** Indicates the cycle size to insert next queries group at. */
+  frequency?: number;
+  /** The maximum number of groups to add to the search items list. */
+  maxGroups?: number;
+  /** The maximum number of next queries to insert in a group. */
+  maxNextQueriesPerGroup?: number;
+  /** The `nextQueries` used to be rendered. */
+  nextQueries?: NextQuery[];
+  /** The first list index that a next queries group should appear in. */
+  offset?: number;
+  /** The template to be rendered. */
+  template?: string;
+}
+
+interface RenderNextQueriesListAPI {
+  /** Retrieves the wrappers of the next queries group. */
+  getNextQueryGroupWrappers: () => WrapperArray<Vue>;
+  /** Retrieves the wrappers of the individual next queries. */
+  getNextQueryWrappers: (root?: Wrapper<Vue>) => WrapperArray<Vue>;
+  /** Retrieves the wrappers of the search items. */
+  getSearchItemWrappers: () => WrapperArray<Vue>;
+  /** Retrieves rendered text for each DOM search item. */
+  getSearchItemsRenderedText: () => string[];
+  /** The `wrapper` wrapper component. */
+  wrapper: Wrapper<Vue>;
+}

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
@@ -120,7 +120,7 @@ describe('testing NextQueriesList component', () => {
     expect(getXComponentXModuleName(wrapper.vm)).toEqual('nextQueries');
   });
 
-  it('renders no group if no search items are injected', () => {
+  it('renders no group if no list items are injected', () => {
     const nextQueries = createNextQueries('milk', 'sugar', 'beer');
     const { getNextQueryGroupWrappers, getSearchItemWrappers } = renderNextQueriesList({
       nextQueries,
@@ -229,7 +229,7 @@ describe('testing NextQueriesList component', () => {
     ]);
   });
 
-  it('provides the modified list of search items', () => {
+  it('provides the modified list of list items', () => {
     const CustomList: ComponentOptions<Vue> = {
       mixins: [ItemsListInjectionMixin],
       template: `
@@ -274,7 +274,7 @@ interface RenderNextQueriesListOptions {
   extraItems?: ListItem[];
   /** Indicates the cycle size to insert next queries group at. */
   frequency?: number;
-  /** The maximum number of groups to add to the search items list. */
+  /** The maximum number of groups to add to the list items list. */
   maxGroups?: number;
   /** The maximum number of next queries to insert in a group. */
   maxNextQueriesPerGroup?: number;
@@ -291,7 +291,7 @@ interface RenderNextQueriesListAPI {
   getNextQueryGroupWrappers: () => WrapperArray<Vue>;
   /** Retrieves the wrappers of the individual next queries. */
   getNextQueryWrappers: (root?: Wrapper<Vue>) => WrapperArray<Vue>;
-  /** Retrieves the wrappers of the search items. */
+  /** Retrieves the wrappers of the list items. */
   getSearchItemWrappers: () => WrapperArray<Vue>;
   /** Retrieves rendered text for each DOM search item. */
   getItemsRenderedText: () => string[];

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
@@ -293,7 +293,7 @@ interface RenderNextQueriesListAPI {
   getNextQueryWrappers: (root?: Wrapper<Vue>) => WrapperArray<Vue>;
   /** Retrieves the wrappers of the list items. */
   getSearchItemWrappers: () => WrapperArray<Vue>;
-  /** Retrieves rendered text for each DOM search item. */
+  /** Retrieves rendered text for each DOM list item. */
   getItemsRenderedText: () => string[];
   /** The `wrapper` wrapper component. */
   wrapper: Wrapper<Vue>;

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
@@ -4,10 +4,10 @@ import Vue, { ComponentOptions, VueConstructor } from 'vue';
 import Vuex, { Store } from 'vuex';
 import { createNextQueryStub } from '../../../../__stubs__/next-queries-stubs.factory';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
-import { SearchItemsInjectionMixin } from '../../../../components/search-items-injection.mixin';
+import { ItemsListInjectionMixin } from '../../../../components/items-list-injection.mixin';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import { RootXStoreState } from '../../../../store/store.types';
-import { DeepPartial, Dictionary, SearchItem } from '../../../../utils/types';
+import { DeepPartial, Dictionary, ListItem } from '../../../../utils/types';
 import { nextQueriesXModule } from '../../x-module';
 import NextQueriesList from '../next-queries-list.vue';
 import { resetXNextQueriesStateWith } from './utils';
@@ -21,9 +21,9 @@ import { resetXNextQueriesStateWith } from './utils';
 function renderNextQueriesList({
   template = `
     <NextQueriesList v-bind="$attrs">
-     <template #next-queries-group="{ searchItem }">
+     <template #next-queries-group="{ item }">
         <ul class="next-queries-group">
-          <li v-for="nextQuery in searchItem.nextQueries" class="next-query">{{
+          <li v-for="nextQuery in item.nextQueries" class="next-query">{{
            nextQuery.query
           }}</li>
         </ul>
@@ -47,7 +47,7 @@ function renderNextQueriesList({
         NextQueriesList,
         ...components
       },
-      mixins: [SearchItemsInjectionMixin],
+      mixins: [ItemsListInjectionMixin],
       computed: {
         items() {
           return extraItems;
@@ -80,19 +80,19 @@ function renderNextQueriesList({
     getNextQueryWrappers(root = nextQueriesListWrapper) {
       return root.findAll('.next-query');
     },
-    getSearchItemsRenderedText() {
+    getItemsRenderedText() {
       return getSearchItemWrappers().wrappers.map(wrapper => wrapper.text());
     }
   };
 }
 
 /**
- * Creates a list of {@link SearchItem} of the given length.
+ * Creates a list of {@link ListItem} of the given length.
  *
  * @param length - The length of the list to create.
- * @returns A list of simple {@link SearchItem}s.
+ * @returns A list of simple {@link ListItem}s.
  */
-function createExtraItems(length: number): SearchItem[] {
+function createExtraItems(length: number): ListItem[] {
   return Array.from({ length }, (_, index) => ({
     id: `Extra ${index}`,
     modelName: `ExtraItem`
@@ -145,7 +145,7 @@ describe('testing NextQueriesList component', () => {
       'flank steak' // This one should be ignored as there is no room for it.
     );
     const extraItems = createExtraItems(11);
-    const { getSearchItemsRenderedText } = renderNextQueriesList({
+    const { getItemsRenderedText } = renderNextQueriesList({
       nextQueries,
       extraItems,
       maxNextQueriesPerGroup: 2,
@@ -154,7 +154,7 @@ describe('testing NextQueriesList component', () => {
     });
 
     // 11 extra items + 4 groups of NQs at index 4, 7, 10, 13
-    expect(getSearchItemsRenderedText()).toEqual([
+    expect(getItemsRenderedText()).toEqual([
       extraItems[0].id,
       extraItems[1].id,
       extraItems[2].id,
@@ -183,7 +183,7 @@ describe('testing NextQueriesList component', () => {
       'dark-rum' // Should be ignored because maxGroups: 2
     );
     const extraItems = createExtraItems(10);
-    const { getSearchItemsRenderedText } = renderNextQueriesList({
+    const { getItemsRenderedText } = renderNextQueriesList({
       nextQueries,
       extraItems,
       maxNextQueriesPerGroup: 2,
@@ -193,7 +193,7 @@ describe('testing NextQueriesList component', () => {
     });
 
     // 10 extra items + 2 groups of NQs at index 4, 7
-    expect(getSearchItemsRenderedText()).toEqual([
+    expect(getItemsRenderedText()).toEqual([
       extraItems[0].id,
       extraItems[1].id,
       extraItems[2].id,
@@ -212,7 +212,7 @@ describe('testing NextQueriesList component', () => {
   it('renders a group even if it has not enough next queries', () => {
     const nextQueries = createNextQueries('piña colada');
     const extraItems = createExtraItems(4);
-    const { getSearchItemsRenderedText } = renderNextQueriesList({
+    const { getItemsRenderedText } = renderNextQueriesList({
       nextQueries,
       extraItems,
       maxNextQueriesPerGroup: 4,
@@ -220,7 +220,7 @@ describe('testing NextQueriesList component', () => {
     });
 
     // 4 extra items + 1 groups of NQs at index 2
-    expect(getSearchItemsRenderedText()).toEqual([
+    expect(getItemsRenderedText()).toEqual([
       extraItems[0].id,
       extraItems[1].id,
       'piña colada',
@@ -231,10 +231,10 @@ describe('testing NextQueriesList component', () => {
 
   it('provides the modified list of search items', () => {
     const CustomList: ComponentOptions<Vue> = {
-      mixins: [SearchItemsInjectionMixin],
+      mixins: [ItemsListInjectionMixin],
       template: `
         <ul>
-        <li class="search-item" v-for="item in injectedSearchItems">{{ item.id }}</li>
+        <li class="search-item" v-for="item in injectedListItems">{{ item.id }}</li>
         </ul>`
     };
     const nextQueries = createNextQueries('rib chop', 'shoulder steak');
@@ -252,11 +252,11 @@ describe('testing NextQueriesList component', () => {
       offset: 2
     });
 
-    const customSearchItemsRenderedText = wrapper
+    const customItemsRenderedText = wrapper
       .findAll('.search-item')
       .wrappers.map(wrapper => wrapper.text());
 
-    expect(customSearchItemsRenderedText).toEqual([
+    expect(customItemsRenderedText).toEqual([
       extraItems[0].id,
       extraItems[1].id,
       'rib chop',
@@ -271,7 +271,7 @@ interface RenderNextQueriesListOptions {
   /** Extra components to be registered and rendered. */
   components?: Dictionary<VueConstructor | ComponentOptions<Vue>>;
   /** Extra items to be rendered. */
-  extraItems?: SearchItem[];
+  extraItems?: ListItem[];
   /** Indicates the cycle size to insert next queries group at. */
   frequency?: number;
   /** The maximum number of groups to add to the search items list. */
@@ -294,7 +294,7 @@ interface RenderNextQueriesListAPI {
   /** Retrieves the wrappers of the search items. */
   getSearchItemWrappers: () => WrapperArray<Vue>;
   /** Retrieves rendered text for each DOM search item. */
-  getSearchItemsRenderedText: () => string[];
+  getItemsRenderedText: () => string[];
   /** The `wrapper` wrapper component. */
   wrapper: Wrapper<Vue>;
 }

--- a/packages/x-components/src/x-modules/next-queries/components/index.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/index.ts
@@ -1,2 +1,3 @@
 export { default as NextQueries } from './next-queries.vue';
 export { default as NextQuery } from './next-query.vue';
+export { default as NextQueriesList } from './next-queries-list.vue';

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -166,7 +166,7 @@ results list.
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList>
       <NextQueriesList />
     </ResultsList>
@@ -201,7 +201,7 @@ more groups will be inserted. Each one of this groups will have up to `6` next q
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList>
       <NextQueriesList :offset="48" :frequency="72" :maxNextQueriesPerGroup="6" :maxGroups="3" />
     </ResultsList>
@@ -233,7 +233,7 @@ component, for example the `BaseGrid`. To do so, you can use the `default` slot
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList>
       <NextQueriesList
         :offset="48"

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -2,7 +2,7 @@
   <NoElement>
     <!--
       @slot Next queries list layout.
-        @binding {SearchItem[]} items - Next queries groups plus the injected search items to
+        @binding {SearchItem[]} items - Next queries groups plus the injected list items to
         render.
         @binding {Vue | string} animation - Animation to animate the elements.
     -->
@@ -85,7 +85,7 @@
     public maxNextQueriesPerGroup!: number;
 
     /**
-     * The maximum number of groups to insert into the injected search items list.
+     * The maximum number of groups to insert into the injected list items list.
      *
      * @public
      */
@@ -196,7 +196,7 @@ example, the first group of next queries will be inserted at the index `48` (`of
 second group will be inserted at index `120` because of the `frequency` prop configured to `72`.
 Finally, a third group will be inserted at index `192`. Because `maxGroups` is configured to `3`, no
 more groups will be inserted. Each one of this groups will have up to `6` next queries
-(`maxGroups`).
+(`maxNextQueriesPerGroup`).
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -1,0 +1,278 @@
+<template>
+  <NoElement>
+    <!--
+      @slot Next queries list layout.
+        @binding {SearchItem[]} items - Next queries groups plus the injected search items to
+        render.
+        @binding {Vue | string} animation - Animation to animate the elements.
+    -->
+    <slot v-bind="{ items, animation }">
+      <SearchItemsList :animation="animation" :searchItems="items">
+        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ searchItem }">
+          <slot :name="slotName" :searchItem="searchItem" />
+        </template>
+      </SearchItemsList>
+    </slot>
+  </NoElement>
+</template>
+
+<script lang="ts">
+  import { NextQuery } from '@empathyco/x-types';
+  import { mixins } from 'vue-class-component';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { Getter } from '../../../components/decorators/store.decorators';
+  import { NoElement } from '../../../components/no-element';
+  import { SearchItemsInjectionMixin } from '../../../components/search-items-injection.mixin';
+  import SearchItemsList from '../../../components/search-items-list.vue';
+  import { xComponentMixin } from '../../../components/x-component.mixin';
+  import { groupItemsBy, SearchItem } from '../../../utils';
+  import ResultsList from '../../search/components/results-list.vue';
+  import { nextQueriesXModule } from '../x-module';
+
+  /**
+   * A list of next queries.
+   */
+  interface NextQueriesGroup extends SearchItem {
+    modelName: 'NextQueriesGroup';
+    nextQueries: NextQuery[];
+  }
+
+  /**
+   * Component that inserts groups of next queries in different positions of the injected search
+   * items list, based on the provided configuration.
+   *
+   * @public
+   */
+  @Component({
+    components: {
+      ResultsList,
+      NoElement,
+      SearchItemsList
+    },
+    mixins: [xComponentMixin(nextQueriesXModule)]
+  })
+  export default class NextQueriesList extends mixins(SearchItemsInjectionMixin) {
+    /**
+     * Animation component that will be used to animate the next queries groups.
+     *
+     * @public
+     */
+    @Prop()
+    protected animation?: Vue | string;
+
+    /**
+     * The first index to insert a group of next queries at.
+     *
+     * @public
+     */
+    @Prop({ default: 24 })
+    public offset!: number;
+
+    /**
+     * The items cycle size to keep inserting next queries groups at.
+     *
+     * @public
+     */
+    @Prop({ default: 24 })
+    public frequency!: number;
+
+    /**
+     * The maximum amount of next queries to add in a single group.
+     *
+     * @public
+     */
+    @Prop({ default: 4 })
+    public maxNextQueriesPerGroup!: number;
+
+    /**
+     * The maximum number of groups to insert into the injected search items list.
+     *
+     * @public
+     */
+    @Prop()
+    public maxGroups!: number;
+
+    /**
+     * The state next queries.
+     *
+     * @internal
+     */
+    @Getter('nextQueries', 'nextQueries')
+    public nextQueries!: NextQuery[];
+
+    /**
+     * The grouped next queries based on the given config.
+     *
+     * @returns A list of next queries groups.
+     * @internal
+     */
+    protected get nextQueriesGroups(): NextQueriesGroup[] {
+      return Object.values(
+        groupItemsBy(this.nextQueries, (_, index) =>
+          Math.floor(index / this.maxNextQueriesPerGroup)
+        )
+      )
+        .slice(0, this.maxGroups)
+        .map(nextQueries => ({
+          modelName: 'NextQueriesGroup' as const,
+          id: nextQueries.map(nextQuery => nextQuery.query).join(','),
+          nextQueries
+        }));
+    }
+
+    /**
+     * New list of {@link SearchItem}s to render.
+     *
+     * @returns The new list of {@link SearchItem}s with the next queries groups inserted.
+     * @internal
+     */
+    public override get items(): SearchItem[] {
+      if (!this.injectedSearchItems) {
+        return this.nextQueriesGroups;
+      }
+
+      return this.nextQueriesGroups.reduce(
+        (searchItems, nextQueriesGroup, index) => {
+          const targetIndex = this.offset + this.frequency * index;
+          if (targetIndex <= searchItems.length) {
+            searchItems.splice(targetIndex, 0, nextQueriesGroup);
+          }
+          return searchItems;
+        },
+        [...this.injectedSearchItems]
+      );
+    }
+  }
+</script>
+
+<docs lang="mdx">
+## Events
+
+This component emits no events.
+
+## See it in action
+
+<!-- prettier-ignore-start -->
+:::warning Backend microservice required
+To use this component, the <b>QuerySignals</b> microservice must be
+implemented.
+:::
+<!-- prettier-ignore-end -->
+
+Usually, this component is going to be used together with the `ResultsList` one. Next queries groups
+will be inserted between the results, guiding users to discover new searches directly from the
+results list.
+
+```vue
+<template>
+  <div>
+    <SearchInput :instant="true" />
+    <ResultsList>
+      <NextQueriesList />
+    </ResultsList>
+  </div>
+</template>
+
+<script>
+  import { NextQueriesList } from '@empathyco/x-components/next-queries';
+  import { ResultsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+
+  export default {
+    name: 'NextQueriesListDemo',
+    components: {
+      NextQueriesList,
+      ResultsList,
+      SearchInput
+    }
+  };
+</script>
+```
+
+### Play with the index that next queries groups are inserted at
+
+The component allows to customise where are the next queries groups inserted. In the following
+example, the first group of next queries will be inserted at the index `48` (`offset`), and then a
+second group will be inserted at index `120` because of the `frequency` prop configured to `72`.
+Finally, a third group will be inserted at index `192`. Because `maxGroups` is configured to `3`, no
+more groups will be inserted. Each one of this groups will have up to `6` next queries
+(`maxGroups`).
+
+```vue
+<template>
+  <div>
+    <SearchInput :instant="true" />
+    <ResultsList>
+      <NextQueriesList :offset="48" :frequency="72" :maxNextQueriesPerGroup="6" :maxGroups="3" />
+    </ResultsList>
+  </div>
+</template>
+
+<script>
+  import { NextQueriesList } from '@empathyco/x-components/next-queries';
+  import { ResultsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+
+  export default {
+    name: 'NextQueriesListDemo',
+    components: {
+      NextQueriesList,
+      ResultsList,
+      SearchInput
+    }
+  };
+</script>
+```
+
+### Customise the layout of the component
+
+This component will render by default the `id` of each search item, both the injected, and for the
+groups of next queries generated, but the common case is to integrate it with another layout
+component, for example the `BaseGrid`. To do so, you can use the `default` slot
+
+```vue
+<template>
+  <div>
+    <SearchInput :instant="true" />
+    <ResultsList>
+      <NextQueriesList
+        :offset="48"
+        :frequency="72"
+        :maxNextQueriesPerGroup="6"
+        :maxGroups="3"
+        #default="{ items }"
+      >
+        <BaseGrid :items="items" :animation="animation">
+          <template #NextQueriesGroup="{ item }">
+            <span>NextQueriesGroup: {{ item.queries.join(', ') }}</span>
+          </template>
+          <template #Result="{ item }">
+            <span>Result: {{ item.name }}</span>
+          </template>
+          <template #default="{ item }">
+            <span>Default: {{ item }}</span>
+          </template>
+        </BaseGrid>
+      </NextQueriesList>
+    </ResultsList>
+  </div>
+</template>
+
+<script>
+  import { NextQueriesList } from '@empathyco/x-components/next-queries';
+  import { ResultsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { BaseGrid } from '@empathyco/x-components';
+
+  export default {
+    name: 'NextQueriesListDemo',
+    components: {
+      NextQueriesList,
+      ResultsList,
+      BaseGrid,
+      SearchInput
+    }
+  };
+</script>
+```
+</docs>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -7,11 +7,11 @@
         @binding {Vue | string} animation - Animation to animate the elements.
     -->
     <slot v-bind="{ items, animation }">
-      <SearchItemsList :animation="animation" :searchItems="items">
-        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ searchItem }">
-          <slot :name="slotName" :searchItem="searchItem" />
+      <ItemsList :animation="animation" :items="items">
+        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ item }">
+          <slot :name="slotName" :item="item" />
         </template>
-      </SearchItemsList>
+      </ItemsList>
     </slot>
   </NoElement>
 </template>
@@ -22,17 +22,17 @@
   import { Component, Prop } from 'vue-property-decorator';
   import { Getter } from '../../../components/decorators/store.decorators';
   import { NoElement } from '../../../components/no-element';
-  import { SearchItemsInjectionMixin } from '../../../components/search-items-injection.mixin';
-  import SearchItemsList from '../../../components/search-items-list.vue';
+  import { ItemsListInjectionMixin } from '../../../components/items-list-injection.mixin';
+  import ItemsList from '../../../components/items-list.vue';
   import { xComponentMixin } from '../../../components/x-component.mixin';
-  import { groupItemsBy, SearchItem } from '../../../utils';
+  import { groupItemsBy, ListItem } from '../../../utils';
   import ResultsList from '../../search/components/results-list.vue';
   import { nextQueriesXModule } from '../x-module';
 
   /**
    * A list of next queries.
    */
-  interface NextQueriesGroup extends SearchItem {
+  interface NextQueriesGroup extends ListItem {
     modelName: 'NextQueriesGroup';
     nextQueries: NextQuery[];
   }
@@ -47,11 +47,11 @@
     components: {
       ResultsList,
       NoElement,
-      SearchItemsList
+      ItemsList
     },
     mixins: [xComponentMixin(nextQueriesXModule)]
   })
-  export default class NextQueriesList extends mixins(SearchItemsInjectionMixin) {
+  export default class NextQueriesList extends mixins(ItemsListInjectionMixin) {
     /**
      * Animation component that will be used to animate the next queries groups.
      *
@@ -121,25 +121,25 @@
     }
 
     /**
-     * New list of {@link SearchItem}s to render.
+     * New list of {@link ListItem}s to render.
      *
-     * @returns The new list of {@link SearchItem}s with the next queries groups inserted.
+     * @returns The new list of {@link ListItem}s with the next queries groups inserted.
      * @internal
      */
-    public override get items(): SearchItem[] {
-      if (!this.injectedSearchItems) {
+    public override get items(): ListItem[] {
+      if (!this.injectedListItems) {
         return this.nextQueriesGroups;
       }
 
       return this.nextQueriesGroups.reduce(
-        (searchItems, nextQueriesGroup, index) => {
+        (items, nextQueriesGroup, index) => {
           const targetIndex = this.offset + this.frequency * index;
-          if (targetIndex <= searchItems.length) {
-            searchItems.splice(targetIndex, 0, nextQueriesGroup);
+          if (targetIndex <= items.length) {
+            items.splice(targetIndex, 0, nextQueriesGroup);
           }
-          return searchItems;
+          return items;
         },
-        [...this.injectedSearchItems]
+        [...this.injectedListItems]
       );
     }
   }

--- a/packages/x-components/src/x-modules/search/components/__tests__/banners-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/banners-list.spec.ts
@@ -7,11 +7,11 @@ import BaseGrid from '../../../../components/base-grid.vue';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import { XPlugin } from '../../../../plugins/x-plugin';
 import { RootXStoreState } from '../../../../store/store.types';
-import { DeepPartial, Dictionary, SearchItem } from '../../../../utils/types';
+import { DeepPartial, Dictionary, ListItem } from '../../../../utils/types';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
 import { getBannersStub } from '../../../../__stubs__/banners-stubs.factory';
 import BannersList from '../banners-list.vue';
-import { SEARCH_ITEMS_KEY } from '../../../../components/decorators/injection.consts';
+import { LIST_ITEMS_KEY } from '../../../../components/decorators/injection.consts';
 import { getResultsStub } from '../../../../__stubs__/results-stubs.factory';
 import { XInject, XProvide } from '../../../../components/decorators/injection.decorators';
 import { resetXSearchStateWith } from './utils';
@@ -88,8 +88,8 @@ describe('testing BannersList component', () => {
     const { wrapper, getBanners } = renderBannersList({
       template: `
         <BannersList>
-          <template #banner="{ searchItem }">
-            <p data-test="banner-slot-overridden">Custom banner: {{ searchItem.title }}</p>
+          <template #banner="{ item }">
+            <p data-test="banner-slot-overridden">Custom banner: {{ item.title }}</p>
           </template>
         </BannersList>`
     });
@@ -130,8 +130,8 @@ describe('testing BannersList component', () => {
       template: `<div><slot/></div>`
     })
     class Provider extends Vue {
-      @XProvide(SEARCH_ITEMS_KEY)
-      public providedStub: SearchItem[] = resultStub;
+      @XProvide(LIST_ITEMS_KEY)
+      public providedStub: ListItem[] = resultStub;
     }
 
     /*
@@ -140,15 +140,15 @@ describe('testing BannersList component', () => {
      */
     @Component({
       template: `
-        <p>{{ injectedItemsString }}</p>
+        <p>{{ injectedListItemsString }}</p>
       `
     })
     class Child extends Vue {
-      @XInject(SEARCH_ITEMS_KEY)
-      public injectedItems: SearchItem[] | undefined;
+      @XInject(LIST_ITEMS_KEY)
+      public injectedListItems: ListItem[] | undefined;
 
-      protected get injectedItemsString(): string {
-        return this.injectedItems?.map(item => item.id).join(',') ?? '';
+      protected get injectedListItemsString(): string {
+        return this.injectedListItems?.map(item => item.id).join(',') ?? '';
       }
     }
 

--- a/packages/x-components/src/x-modules/search/components/__tests__/banners-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/banners-list.spec.ts
@@ -94,7 +94,7 @@ describe('testing BannersList component', () => {
         </BannersList>`
     });
 
-    expect(wrapper.classes('x-search-items-list')).toBe(true);
+    expect(wrapper.classes('x-items-list')).toBe(true);
     expect(wrapper.find(getDataTestSelector('banners-list-item')).exists()).toBe(true);
     expect(wrapper.find(getDataTestSelector('banner-slot-overridden')).text()).toBe(
       `Custom banner: ${getBanners()[0].title}`

--- a/packages/x-components/src/x-modules/search/components/__tests__/promoteds-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/promoteds-list.spec.ts
@@ -94,7 +94,7 @@ describe('testing PromotedsList component', () => {
         </PromotedsList>`
     });
 
-    expect(wrapper.classes('x-search-items-list')).toBe(true);
+    expect(wrapper.classes('x-items-list')).toBe(true);
     expect(wrapper.find(getDataTestSelector('promoteds-list-item')).exists()).toBe(true);
     expect(wrapper.find(getDataTestSelector('promoted-slot-overridden')).text()).toBe(
       `Custom promoted: ${getPromoteds()[0].title}`

--- a/packages/x-components/src/x-modules/search/components/__tests__/promoteds-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/promoteds-list.spec.ts
@@ -7,13 +7,13 @@ import BaseGrid from '../../../../components/base-grid.vue';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import { XPlugin } from '../../../../plugins/x-plugin';
 import { RootXStoreState } from '../../../../store/store.types';
-import { DeepPartial, Dictionary, SearchItem } from '../../../../utils/types';
+import { DeepPartial, Dictionary, ListItem } from '../../../../utils/types';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
 import PromotedsList from '../promoteds-list.vue';
 import { getPromotedsStub } from '../../../../__stubs__/promoteds-stubs.factory';
 import { getResultsStub } from '../../../../__stubs__/results-stubs.factory';
 import { XInject, XProvide } from '../../../../components/decorators/injection.decorators';
-import { SEARCH_ITEMS_KEY } from '../../../../components/decorators/injection.consts';
+import { LIST_ITEMS_KEY } from '../../../../components/decorators/injection.consts';
 import { resetXSearchStateWith } from './utils';
 
 /**
@@ -88,8 +88,8 @@ describe('testing PromotedsList component', () => {
     const { wrapper, getPromoteds } = renderPromotedsList({
       template: `
         <PromotedsList>
-          <template #promoted="{ searchItem }">
-            <p data-test="promoted-slot-overridden">Custom promoted: {{ searchItem.title }}</p>
+          <template #promoted="{ item }">
+            <p data-test="promoted-slot-overridden">Custom promoted: {{ item.title }}</p>
           </template>
         </PromotedsList>`
     });
@@ -130,8 +130,8 @@ describe('testing PromotedsList component', () => {
       template: `<div><slot/></div>`
     })
     class Provider extends Vue {
-      @XProvide(SEARCH_ITEMS_KEY)
-      public providedStub: SearchItem[] = resultStub;
+      @XProvide(LIST_ITEMS_KEY)
+      public providedStub: ListItem[] = resultStub;
     }
 
     /*
@@ -140,15 +140,15 @@ describe('testing PromotedsList component', () => {
      */
     @Component({
       template: `
-        <p>{{ injectedItemsString }}</p>
+        <p>{{ injectedListItemsString }}</p>
       `
     })
     class Child extends Vue {
-      @XInject(SEARCH_ITEMS_KEY)
-      public injectedItems: SearchItem[] | undefined;
+      @XInject(LIST_ITEMS_KEY)
+      public injectedListItems: ListItem[] | undefined;
 
-      protected get injectedItemsString(): string {
-        return this.injectedItems?.map(item => item.id).join(',') ?? '';
+      protected get injectedListItemsString(): string {
+        return this.injectedListItems?.map(item => item.id).join(',') ?? '';
       }
     }
 

--- a/packages/x-components/src/x-modules/search/components/__tests__/results-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/results-list.spec.ts
@@ -8,12 +8,12 @@ import BaseGrid from '../../../../components/base-grid.vue';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import { XPlugin } from '../../../../plugins/x-plugin';
 import { RootXStoreState } from '../../../../store/store.types';
-import { DeepPartial, Dictionary, SearchItem } from '../../../../utils/types';
+import { DeepPartial, Dictionary, ListItem } from '../../../../utils/types';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
 import ResultsList from '../results-list.vue';
 import { InfiniteScroll } from '../../../../directives/infinite-scroll/infinite-scroll.types';
 import { XInject } from '../../../../components/decorators/injection.decorators';
-import { SEARCH_ITEMS_KEY } from '../../../../components/decorators/injection.consts';
+import { LIST_ITEMS_KEY } from '../../../../components/decorators/injection.consts';
 import { resetXSearchStateWith } from './utils';
 
 /**
@@ -88,8 +88,8 @@ describe('testing Results list component', () => {
     const { wrapper, getResults } = renderResultsList({
       template: `
         <ResultsList>
-          <template #result="{ searchItem }">
-            <p data-test="result-slot-overridden">Custom result: {{ searchItem.name }}</p>
+          <template #result="{ item }">
+            <p data-test="result-slot-overridden">Custom result: {{ item.name }}</p>
           </template>
         </ResultsList>`
     });
@@ -127,15 +127,15 @@ describe('testing Results list component', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  it('provides the results from state with the key `searchItem`', () => {
+  it('provides the results from state with the key `item`', () => {
     @Component({
       template: `
         <div>{{ items[0].id }}</div>
       `
     })
     class Child extends Vue {
-      @XInject(SEARCH_ITEMS_KEY)
-      public items!: SearchItem[];
+      @XInject(LIST_ITEMS_KEY)
+      public items!: ListItem[];
     }
 
     const { wrapper, getResults } = renderResultsList({

--- a/packages/x-components/src/x-modules/search/components/__tests__/results-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/results-list.spec.ts
@@ -94,7 +94,7 @@ describe('testing Results list component', () => {
         </ResultsList>`
     });
 
-    expect(wrapper.classes('x-search-items-list')).toBe(true);
+    expect(wrapper.classes('x-items-list')).toBe(true);
     expect(wrapper.find(getDataTestSelector('results-list-item')).exists()).toBe(true);
     expect(wrapper.find(getDataTestSelector('result-slot-overridden')).text()).toBe(
       `Custom result: ${getResults()[0].name}`

--- a/packages/x-components/src/x-modules/search/components/banners-list.vue
+++ b/packages/x-components/src/x-modules/search/components/banners-list.vue
@@ -101,7 +101,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <BannersList />
   </div>
 </template>
@@ -125,7 +125,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <BannersList :animation="fadeAndSlide" />
   </div>
 </template>
@@ -155,7 +155,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <BannersList #default="{ items, animation }">
       <BaseGrid :items="items" :animation="animation">
         <template #Banner="{ item }">
@@ -188,7 +188,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <BannersList #banner="{ item }">
       <span class="banner">
         {{ item.title }}
@@ -225,7 +225,7 @@ value.
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList>
       <BannersList>
         <template #banner="{ item }">Banner: {{ item.id }}</template>

--- a/packages/x-components/src/x-modules/search/components/banners-list.vue
+++ b/packages/x-components/src/x-modules/search/components/banners-list.vue
@@ -6,11 +6,11 @@
         @binding {Vue | string} animation - Animation to animate the elements.
     -->
     <slot v-bind="{ items, animation }">
-      <SearchItemsList :animation="animation" :searchItems="items">
-        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ searchItem }">
-          <slot :name="slotName" :searchItem="searchItem" />
+      <ItemsList :animation="animation" :items="items">
+        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ item }">
+          <slot :name="slotName" :item="item" />
         </template>
-      </SearchItemsList>
+      </ItemsList>
     </slot>
   </NoElement>
 </template>
@@ -21,15 +21,15 @@
   import { Component, Prop } from 'vue-property-decorator';
   import { State } from '../../../components/decorators/store.decorators';
   import { NoElement } from '../../../components/no-element';
-  import { SearchItemsInjectionMixin } from '../../../components/search-items-injection.mixin';
-  import SearchItemsList from '../../../components/search-items-list.vue';
+  import { ItemsListInjectionMixin } from '../../../components/items-list-injection.mixin';
+  import ItemsList from '../../../components/items-list.vue';
   import { xComponentMixin } from '../../../components/x-component.mixin';
-  import { SearchItem } from '../../../utils/types';
+  import { ListItem } from '../../../utils/types';
   import { searchXModule } from '../x-module';
 
   /**
-   * It renders a {@link SearchItemsList} list of banners from {@link SearchState.banners} by
-   * default using the `SearchItemsInjectionMixin`.
+   * It renders a {@link ItemsList} list of banners from {@link SearchState.banners} by
+   * default using the `ItemsInjectionMixin`.
    *
    * The component provides a default slot which wraps the whole component with the `banners`
    * plus the `searchInjectedItems` which also contains the injected search items from
@@ -41,12 +41,12 @@
    */
   @Component({
     components: {
-      SearchItemsList,
+      ItemsList,
       NoElement
     },
     mixins: [xComponentMixin(searchXModule)]
   })
-  export default class BannersList extends SearchItemsInjectionMixin {
+  export default class BannersList extends ItemsListInjectionMixin {
     /**
      * The banners to render from the state.
      *
@@ -64,18 +64,18 @@
     protected animation!: Vue | string;
 
     /**
-     * The `stateItems` concatenated with the `injectedSearchItems` if there are.
+     * The `stateItems` concatenated with the `injectedListItems` if there are.
      *
      * @remarks This computed defines the merging strategy of the `stateItems` and the
-     * `injectedSearchItems`.
+     * `injectedListItems`.
      *
-     * @returns List of {@link SearchItem}.
+     * @returns List of {@link ListItem}.
      *
      * @internal
      */
-    public override get items(): SearchItem[] {
-      return this.injectedSearchItems
-        ? [...this.stateItems, ...this.injectedSearchItems]
+    public override get items(): ListItem[] {
+      return this.injectedListItems
+        ? [...this.stateItems, ...this.injectedListItems]
         : this.stateItems;
     }
   }
@@ -189,9 +189,9 @@ _Type any term in the input field to try it out!_
 <template>
   <div>
     <SearchInput :instant="true" />
-    <BannersList #banner="{ banner }">
+    <BannersList #banner="{ item }">
       <span class="banner">
-        {{ banner.title }}
+        {{ item.title }}
       </span>
     </BannersList>
   </div>
@@ -219,7 +219,7 @@ banners in order to be injected by the `BaseGrid` (or components that extend it)
 ### Data injection
 
 Starting with the `ResultsList` component as root element, you can concat the list of search items
-using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `searchItems`
+using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `listItems`
 value.
 
 ```vue
@@ -228,8 +228,8 @@ value.
     <SearchInput :instant="true" />
     <ResultsList>
       <BannersList>
-        <template #banner="{ searchItem }">Banner: {{ searchItem.id }}</template>
-        <template #result="{ searchItem }">Result: {{ searchItem.id }}</template>
+        <template #banner="{ item }">Banner: {{ item.id }}</template>
+        <template #result="{ item }">Result: {{ item.id }}</template>
       </BannersList>
     </ResultsList>
   </div>

--- a/packages/x-components/src/x-modules/search/components/banners-list.vue
+++ b/packages/x-components/src/x-modules/search/components/banners-list.vue
@@ -2,7 +2,7 @@
   <NoElement>
     <!--
       @slot Customized BannersList layout.
-        @binding {Banner[]} items - Banners plus the injected search items to render.
+        @binding {Banner[]} items - Banners plus the injected list items to render.
         @binding {Vue | string} animation - Animation to animate the elements.
     -->
     <slot v-bind="{ items, animation }">
@@ -32,7 +32,7 @@
    * default using the `ItemsInjectionMixin`.
    *
    * The component provides a default slot which wraps the whole component with the `banners`
-   * plus the `searchInjectedItems` which also contains the injected search items from
+   * plus the `searchInjectedItems` which also contains the injected list items from
    * the ancestor.
    *
    * It also provides the parent slots to customize the items.
@@ -218,7 +218,7 @@ banners in order to be injected by the `BaseGrid` (or components that extend it)
 
 ### Data injection
 
-Starting with the `ResultsList` component as root element, you can concat the list of search items
+Starting with the `ResultsList` component as root element, you can concat the list of list items
 using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `listItems`
 value.
 

--- a/packages/x-components/src/x-modules/search/components/banners-list.vue
+++ b/packages/x-components/src/x-modules/search/components/banners-list.vue
@@ -21,11 +21,11 @@
   import { Component, Prop } from 'vue-property-decorator';
   import { State } from '../../../components/decorators/store.decorators';
   import { NoElement } from '../../../components/no-element';
+  import { SearchItemsInjectionMixin } from '../../../components/search-items-injection.mixin';
+  import SearchItemsList from '../../../components/search-items-list.vue';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { SearchItem } from '../../../utils/types';
   import { searchXModule } from '../x-module';
-  import SearchItemsInjectionMixin from './search-items-injection.mixin';
-  import SearchItemsList from './search-items-list.vue';
 
   /**
    * It renders a {@link SearchItemsList} list of banners from {@link SearchState.banners} by
@@ -101,13 +101,14 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <BannersList />
   </div>
 </template>
 
 <script>
-  import { SearchInput, BannersList } from '@empathyco/x-components/search';
+  import { BannersList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'BannersListDemo',
@@ -124,13 +125,14 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <BannersList :animation="fadeAndSlide" />
   </div>
 </template>
 
 <script>
-  import { SearchInput, BannersList } from '@empathyco/x-components/search';
+  import { BannersList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
   import { FadeAndSlide } from '@empathyco/x-components/animations';
 
   export default {
@@ -153,7 +155,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <BannersList #default="{ items, animation }">
       <BaseGrid :items="items" :animation="animation">
         <template #Banner="{ item }">
@@ -168,7 +170,8 @@ _Type any term in the input field to try it out!_
 </template>
 
 <script>
-  import { SearchInput, BannersList } from '@empathyco/x-components/search';
+  import { BannersList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'BannersListDemo',
@@ -185,7 +188,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <BannersList #banner="{ banner }">
       <span class="banner">
         {{ banner.title }}
@@ -195,7 +198,8 @@ _Type any term in the input field to try it out!_
 </template>
 
 <script>
-  import { SearchInput, BannersList } from '@empathyco/x-components/search';
+  import { BannersList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'BannersListDemo',
@@ -221,7 +225,7 @@ value.
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <ResultsList>
       <BannersList>
         <template #banner="{ searchItem }">Banner: {{ searchItem.id }}</template>
@@ -232,7 +236,8 @@ value.
 </template>
 
 <script>
-  import { SearchInput, ResultsList, BannersList } from '@empathyco/x-components/search';
+  import { ResultsList, BannersList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'BannersListDemo',

--- a/packages/x-components/src/x-modules/search/components/index.ts
+++ b/packages/x-components/src/x-modules/search/components/index.ts
@@ -5,7 +5,6 @@ export { default as PartialResultsList } from './partial-results-list.vue';
 export { default as Promoted } from './promoted.vue';
 export { default as PromotedsList } from './promoteds-list.vue';
 export { default as ResultsList } from './results-list.vue';
-export { default as SearchItemsList } from './search-items-list.vue';
 export { default as SortDropdown } from './sort-dropdown.vue';
 export { default as SortList } from './sort-list.vue';
 export { default as SortMixin } from './sort.mixin';

--- a/packages/x-components/src/x-modules/search/components/promoteds-list.vue
+++ b/packages/x-components/src/x-modules/search/components/promoteds-list.vue
@@ -101,7 +101,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
 
     <PromotedsList />
   </div>
@@ -126,7 +126,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <PromotedsList :animation="fadeAndSlide" />
   </div>
 </template>
@@ -156,7 +156,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <PromotedsList #default="{ items, animation }">
       <BaseGrid :items="items" :animation="animation">
         <template #Promoted="{ item }">
@@ -191,7 +191,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <PromotedsList #promoted="{ item }">
       <span class="promoted">
         {{ item.title }}
@@ -223,7 +223,7 @@ value.
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList>
       <PromotedsList>
         <template #promoted="{ item }">Promoted: {{ item.id }}</template>

--- a/packages/x-components/src/x-modules/search/components/promoteds-list.vue
+++ b/packages/x-components/src/x-modules/search/components/promoteds-list.vue
@@ -21,11 +21,11 @@
   import { Component, Prop } from 'vue-property-decorator';
   import { State } from '../../../components/decorators/store.decorators';
   import { NoElement } from '../../../components/no-element';
+  import { SearchItemsInjectionMixin } from '../../../components/search-items-injection.mixin';
+  import SearchItemsList from '../../../components/search-items-list.vue';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { SearchItem } from '../../../utils/types';
   import { searchXModule } from '../x-module';
-  import SearchItemsInjectionMixin from './search-items-injection.mixin';
-  import SearchItemsList from './search-items-list.vue';
 
   /**
    * It renders a {@link SearchItemsList} of promoteds from {@link SearchState.promoteds} by default
@@ -101,13 +101,15 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
+
     <PromotedsList />
   </div>
 </template>
 
 <script>
-  import { SearchInput, PromotedsList } from '@empathyco/x-components/search';
+  import { PromotedsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'PromotedsListDemo',
@@ -124,14 +126,15 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <PromotedsList :animation="fadeAndSlide" />
   </div>
 </template>
 
 <script>
-  import { SearchInput, PromotedsList } from '@empathyco/x-components/search';
+  import { PromotedsList } from '@empathyco/x-components/search';
   import { FadeAndSlide } from '@empathyco/x-components/animations';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'PromotedsListDemo',
@@ -153,7 +156,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <PromotedsList #default="{ items, animation }">
       <BaseGrid :items="items" :animation="animation">
         <template #Promoted="{ item }">
@@ -168,13 +171,16 @@ _Type any term in the input field to try it out!_
 </template>
 
 <script>
-  import { SearchInput, PromotedsList } from '@empathyco/x-components/search';
+  import { PromotedsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { BaseGrid } from '@empathyco/x-components';
 
   export default {
     name: 'PromotedsListDemo',
     components: {
       SearchInput,
-      PromotedsList
+      PromotedsList,
+      BaseGrid
     }
   };
 </script>
@@ -185,7 +191,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <PromotedsList #promoted="{ promoted }">
       <span class="promoted">
         {{ promoted.title }}
@@ -195,7 +201,8 @@ _Type any term in the input field to try it out!_
 </template>
 
 <script>
-  import { SearchInput, PromotedsList } from '@empathyco/x-components/search';
+  import { PromotedsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'PromotedsListDemo',
@@ -216,7 +223,7 @@ value.
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <ResultsList>
       <PromotedsList>
         <template #promoted="{ searchItem }">Promoted: {{ searchItem.id }}</template>
@@ -227,7 +234,8 @@ value.
 </template>
 
 <script>
-  import { SearchInput, ResultsList, PromotedsList } from '@empathyco/x-components/search';
+  import { ResultsList, PromotedsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'PromotedsListDemo',

--- a/packages/x-components/src/x-modules/search/components/promoteds-list.vue
+++ b/packages/x-components/src/x-modules/search/components/promoteds-list.vue
@@ -6,11 +6,11 @@
         @binding {Vue | string} animation - Animation to animate the elements.
     -->
     <slot v-bind="{ items, animation }">
-      <SearchItemsList :animation="animation" :searchItems="items">
-        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ searchItem }">
-          <slot :name="slotName" :searchItem="searchItem" />
+      <ItemsList :animation="animation" :items="items">
+        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ item }">
+          <slot :name="slotName" :item="item" />
         </template>
-      </SearchItemsList>
+      </ItemsList>
     </slot>
   </NoElement>
 </template>
@@ -21,15 +21,15 @@
   import { Component, Prop } from 'vue-property-decorator';
   import { State } from '../../../components/decorators/store.decorators';
   import { NoElement } from '../../../components/no-element';
-  import { SearchItemsInjectionMixin } from '../../../components/search-items-injection.mixin';
-  import SearchItemsList from '../../../components/search-items-list.vue';
+  import { ItemsListInjectionMixin } from '../../../components/items-list-injection.mixin';
+  import ItemsList from '../../../components/items-list.vue';
   import { xComponentMixin } from '../../../components/x-component.mixin';
-  import { SearchItem } from '../../../utils/types';
+  import { ListItem } from '../../../utils/types';
   import { searchXModule } from '../x-module';
 
   /**
-   * It renders a {@link SearchItemsList} of promoteds from {@link SearchState.promoteds} by default
-   * using the `SearchItemsInjectionMixin`.
+   * It renders a {@link ItemsList} of promoteds from {@link SearchState.promoteds} by default
+   * using the `ItemsInjectionMixin`.
    *
    * The component provides a default slot which wraps the whole component with the `promoteds`
    * plus the `searchInjectedItems` which also contains the injected search items from
@@ -42,11 +42,11 @@
   @Component({
     components: {
       NoElement,
-      SearchItemsList
+      ItemsList
     },
     mixins: [xComponentMixin(searchXModule)]
   })
-  export default class PromotedsList extends SearchItemsInjectionMixin {
+  export default class PromotedsList extends ItemsListInjectionMixin {
     /**
      * The promoteds to render from the state.
      *
@@ -64,18 +64,18 @@
     protected animation!: Vue | string;
 
     /**
-     * The `stateItems` concatenated with the `injectedSearchItems` if there are.
+     * The `stateItems` concatenated with the `injectedListItems` if there are.
      *
      * @remarks This computed defines the merging strategy of the `stateItems` and the
-     * `injectedSearchItems`.
+     * `injectedListItems`.
      *
-     * @returns List of {@link SearchItem}.
+     * @returns List of {@link ListItem}.
      *
      * @internal
      */
-    public override get items(): SearchItem[] {
-      return this.injectedSearchItems
-        ? [...this.stateItems, ...this.injectedSearchItems]
+    public override get items(): ListItem[] {
+      return this.injectedListItems
+        ? [...this.stateItems, ...this.injectedListItems]
         : this.stateItems;
     }
   }
@@ -192,9 +192,9 @@ _Type any term in the input field to try it out!_
 <template>
   <div>
     <SearchInput :instant="true" />
-    <PromotedsList #promoted="{ promoted }">
+    <PromotedsList #promoted="{ item }">
       <span class="promoted">
-        {{ promoted.title }}
+        {{ item.title }}
       </span>
     </PromotedsList>
   </div>
@@ -217,7 +217,7 @@ _Type any term in the input field to try it out!_
 ### Data injection
 
 Starting with the `ResultsList` component as root element, you can concat the list of search items
-using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `searchItems`
+using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `listItems`
 value.
 
 ```vue
@@ -226,8 +226,8 @@ value.
     <SearchInput :instant="true" />
     <ResultsList>
       <PromotedsList>
-        <template #promoted="{ searchItem }">Promoted: {{ searchItem.id }}</template>
-        <template #result="{ searchItem }">Result: {{ searchItem.id }}</template>
+        <template #promoted="{ item }">Promoted: {{ item.id }}</template>
+        <template #result="{ item }">Result: {{ item.id }}</template>
       </PromotedsList>
     </ResultsList>
   </div>

--- a/packages/x-components/src/x-modules/search/components/promoteds-list.vue
+++ b/packages/x-components/src/x-modules/search/components/promoteds-list.vue
@@ -2,7 +2,7 @@
   <NoElement>
     <!--
       @slot Customized Promoteds List layout.
-        @binding {Promoted[]} items - Promoteds plus the injected search items to render.
+        @binding {Promoted[]} items - Promoteds plus the injected list items to render.
         @binding {Vue | string} animation - Animation to animate the elements.
     -->
     <slot v-bind="{ items, animation }">
@@ -32,7 +32,7 @@
    * using the `ItemsInjectionMixin`.
    *
    * The component provides a default slot which wraps the whole component with the `promoteds`
-   * plus the `searchInjectedItems` which also contains the injected search items from
+   * plus the `searchInjectedItems` which also contains the injected list items from
    * the ancestor.
    *
    * It also provides the parent slots to customize the items.
@@ -216,7 +216,7 @@ _Type any term in the input field to try it out!_
 
 ### Data injection
 
-Starting with the `ResultsList` component as root element, you can concat the list of search items
+Starting with the `ResultsList` component as root element, you can concat the list of list items
 using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `listItems`
 value.
 

--- a/packages/x-components/src/x-modules/search/components/results-list.vue
+++ b/packages/x-components/src/x-modules/search/components/results-list.vue
@@ -99,7 +99,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList />
   </div>
 </template>
@@ -123,7 +123,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList :animation="fadeAndSlide" />
   </div>
 </template>
@@ -153,7 +153,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList #default="{ items, animation }">
       <BaseGrid :items="items" :animation="animation">
         <template #Result="{ item }">
@@ -188,7 +188,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList #result="{ item }">
       <span class="result">
         {{ item.name }}
@@ -219,7 +219,7 @@ value.
 ```vue
 <template>
   <div>
-    <SearchInput :instant="true" />
+    <SearchInput />
     <ResultsList>
       <BannersList>
         <PromotedsList>

--- a/packages/x-components/src/x-modules/search/components/results-list.vue
+++ b/packages/x-components/src/x-modules/search/components/results-list.vue
@@ -51,7 +51,7 @@
      * The results to render from the state.
      *
      * @remarks The results list are provided with `items` key. It can be
-     * concatenated with search items from components such as `BannersList`, `PromotedsList`,
+     * concatenated with list items from components such as `BannersList`, `PromotedsList`,
      * `BaseGrid` or any component that injects the list.
      *
      * @public
@@ -212,7 +212,7 @@ _Type any term in the input field to try it out!_
 
 ### Data injection
 
-Starting with the `ResultsList` component as root element, you can concat the list of search items
+Starting with the `ResultsList` component as root element, you can concat the list of list items
 using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `listItems`
 value.
 

--- a/packages/x-components/src/x-modules/search/components/results-list.vue
+++ b/packages/x-components/src/x-modules/search/components/results-list.vue
@@ -19,14 +19,14 @@
   import { Result } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { State } from '../../../components/decorators/store.decorators';
-  import { NoElement } from '../../../components/no-element';
-  import { xComponentMixin } from '../../../components/x-component.mixin';
-  import { searchXModule } from '../x-module';
-  import { InfiniteScroll } from '../../../directives/infinite-scroll/infinite-scroll.types';
   import { SEARCH_ITEMS_KEY } from '../../../components/decorators/injection.consts';
   import { XProvide } from '../../../components/decorators/injection.decorators';
-  import SearchItemsList from './search-items-list.vue';
+  import { State } from '../../../components/decorators/store.decorators';
+  import { NoElement } from '../../../components/no-element';
+  import SearchItemsList from '../../../components/search-items-list.vue';
+  import { xComponentMixin } from '../../../components/x-component.mixin';
+  import { InfiniteScroll } from '../../../directives/infinite-scroll/infinite-scroll.types';
+  import { searchXModule } from '../x-module';
 
   /**
    * It renders a {@link SearchItemsList} list with the results from {@link SearchState.results} by
@@ -99,13 +99,14 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <ResultsList />
   </div>
 </template>
 
 <script>
-  import { SearchInput, ResultsList } from '@empathyco/x-components/search';
+  import { ResultsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'ResultsListDemo',
@@ -122,13 +123,14 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <ResultsList :animation="fadeAndSlide" />
   </div>
 </template>
 
 <script>
-  import { SearchInput, ResultsList } from '@empathyco/x-components/search';
+  import { ResultsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
   import { FadeAndSlide } from '@empathyco/x-components/animations';
 
   export default {
@@ -151,7 +153,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <ResultsList #default="{ items, animation }">
       <BaseGrid :items="items" :animation="animation">
         <template #Result="{ item }">
@@ -166,13 +168,16 @@ _Type any term in the input field to try it out!_
 </template>
 
 <script>
-  import { SearchInput, ResultsList } from '@empathyco/x-components/search';
+  import { ResultsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { BaseGrid } from '@empathyco/x-components';
 
   export default {
     name: 'ResultsListDemo',
     components: {
       SearchInput,
-      ResultsList
+      ResultsList,
+      BaseGrid
     }
   };
 </script>
@@ -183,7 +188,7 @@ _Type any term in the input field to try it out!_
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <ResultsList #result="{ result }">
       <span class="result">
         {{ result.name }}
@@ -214,7 +219,7 @@ value.
 ```vue
 <template>
   <div>
-    <SearchInput />
+    <SearchInput :instant="true" />
     <ResultsList>
       <BannersList>
         <PromotedsList>
@@ -228,12 +233,8 @@ value.
 </template>
 
 <script>
-  import {
-    SearchInput,
-    ResultsList,
-    BannersList,
-    PromotedsList
-  } from '@empathyco/x-components/search';
+  import { ResultsList, BannersList, PromotedsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'ResultsListDemo',

--- a/packages/x-components/src/x-modules/search/components/results-list.vue
+++ b/packages/x-components/src/x-modules/search/components/results-list.vue
@@ -6,11 +6,11 @@
         @binding {Vue | string} animation - Animation to animate the elements.
     -->
     <slot v-bind="{ items, animation }">
-      <SearchItemsList :animation="animation" :searchItems="items">
-        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ searchItem }">
-          <slot :name="slotName" :searchItem="searchItem" />
+      <ItemsList :animation="animation" :items="items">
+        <template v-for="(_, slotName) in $scopedSlots" v-slot:[slotName]="{ item }">
+          <slot :name="slotName" :item="item" />
         </template>
-      </SearchItemsList>
+      </ItemsList>
     </slot>
   </NoElement>
 </template>
@@ -19,17 +19,17 @@
   import { Result } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { SEARCH_ITEMS_KEY } from '../../../components/decorators/injection.consts';
+  import { LIST_ITEMS_KEY } from '../../../components/decorators/injection.consts';
   import { XProvide } from '../../../components/decorators/injection.decorators';
   import { State } from '../../../components/decorators/store.decorators';
   import { NoElement } from '../../../components/no-element';
-  import SearchItemsList from '../../../components/search-items-list.vue';
+  import ItemsList from '../../../components/items-list.vue';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { InfiniteScroll } from '../../../directives/infinite-scroll/infinite-scroll.types';
   import { searchXModule } from '../x-module';
 
   /**
-   * It renders a {@link SearchItemsList} list with the results from {@link SearchState.results} by
+   * It renders a {@link ItemsList} list with the results from {@link SearchState.results} by
    * default.
    *
    * The component provides a default slot which wraps the whole component with the `results` bound.
@@ -42,7 +42,7 @@
   @Component({
     components: {
       NoElement,
-      SearchItemsList
+      ItemsList
     },
     mixins: [xComponentMixin(searchXModule)]
   })
@@ -50,13 +50,13 @@
     /**
      * The results to render from the state.
      *
-     * @remarks The results list are provided with `searchItems` key. It can be
+     * @remarks The results list are provided with `items` key. It can be
      * concatenated with search items from components such as `BannersList`, `PromotedsList`,
      * `BaseGrid` or any component that injects the list.
      *
      * @public
      */
-    @XProvide(SEARCH_ITEMS_KEY)
+    @XProvide(LIST_ITEMS_KEY)
     @State('search', 'results')
     public items!: Result[];
 
@@ -189,9 +189,9 @@ _Type any term in the input field to try it out!_
 <template>
   <div>
     <SearchInput :instant="true" />
-    <ResultsList #result="{ result }">
+    <ResultsList #result="{ item }">
       <span class="result">
-        {{ result.name }}
+        {{ item.name }}
       </span>
     </ResultsList>
   </div>
@@ -213,7 +213,7 @@ _Type any term in the input field to try it out!_
 ### Data injection
 
 Starting with the `ResultsList` component as root element, you can concat the list of search items
-using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `searchItems`
+using `BannersList`, `PromotedsList`, `BaseGrid` or any component that injects the `listItems`
 value.
 
 ```vue
@@ -223,9 +223,9 @@ value.
     <ResultsList>
       <BannersList>
         <PromotedsList>
-          <template #result="{ searchItem }">Result: {{ searchItem.id }}</template>
-          <template #banner="{ searchItem }">Banner: {{ searchItem.id }}</template>
-          <template #promoted="{ searchItem }">Promoted: {{ searchItem.id }}</template>
+          <template #result="{ item }">Result: {{ item.id }}</template>
+          <template #banner="{ item }">Banner: {{ item.id }}</template>
+          <template #promoted="{ item }">Promoted: {{ item.id }}</template>
         </PromotedsList>
       </BannersList>
     </ResultsList>


### PR DESCRIPTION
# Description

Adds the new `NextQueriesList` component. This component allows to insert next queries in an injected list of `SearchItems`. How this component inserts the next queries can be configured using the props.

# Context

This is needed to support an awesome grid of search items.

# Test

Check use cases, documentation, that the components are properly exported...
