### PR TITLE
fix(design-system): fix issues with components height and layout

### DIFF
--- a/packages/x-components/src/design-system/components/button/default.scss
+++ b/packages/x-components/src/design-system/components/button/default.scss
@@ -11,8 +11,7 @@
   // spacing
   gap: var(--x-size-gap-button-default);
   @include safari-gap(var(--x-size-gap-button-default));
-  padding-block-start: var(--x-size-padding-top-button-default);
-  padding-block-end: var(--x-size-padding-bottom-button-default);
+  min-height: var(--x-size-height-button-default);
   padding-inline-end: var(--x-size-padding-right-button-default);
   padding-inline-start: var(--x-size-padding-left-button-default);
 

--- a/packages/x-components/src/design-system/components/button/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/button/default.tokens.scss
@@ -18,9 +18,8 @@
   --x-size-border-width-left-button-default: var(--x-size-border-width-button-default);
 
   // spacing
-  --x-size-padding-top-button-default: var(--x-size-base-04);
+  --x-size-height-button-default: var(--x-size-base-08);
   --x-size-padding-right-button-default: var(--x-size-base-05);
-  --x-size-padding-bottom-button-default: var(--x-size-base-04);
   --x-size-padding-left-button-default: var(--x-size-base-05);
   --x-size-gap-button-default: var(--x-size-base-03);
 

--- a/packages/x-components/src/design-system/components/button/round.scss
+++ b/packages/x-components/src/design-system/components/button/round.scss
@@ -14,13 +14,7 @@
   );
 
   // size
-  --x-size-padding-top-button-default: var(--x-size-padding-top-button-round);
-  --x-size-padding-right-button-default: var(--x-size-padding-right-button-round);
-  --x-size-padding-bottom-button-default: var(--x-size-padding-bottom-button-round);
-  --x-size-padding-left-button-default: var(--x-size-padding-left-button-round);
-
-  // sizing
-  min-width: var(--x-size-width-icon);
-  min-height: var(--x-size-height-icon);
-  box-sizing: content-box;
+  min-width: var(--x-size-height-button-default);
+  --x-size-padding-left-button-default: 0;
+  --x-size-padding-right-button-default: 0;
 }

--- a/packages/x-components/src/design-system/components/button/round.tokens.scss
+++ b/packages/x-components/src/design-system/components/button/round.tokens.scss
@@ -5,11 +5,4 @@
   --x-size-border-radius-top-right-button-round: var(--x-size-border-radius-button-round);
   --x-size-border-radius-bottom-right-button-round: var(--x-size-border-radius-button-round);
   --x-size-border-radius-bottom-left-button-round: var(--x-size-border-radius-button-round);
-
-  // spacing
-  --x-space-padding-button-round: var(--x-size-base-04);
-  --x-size-padding-left-button-round: var(--x-space-padding-button-round);
-  --x-size-padding-bottom-button-round: var(--x-space-padding-button-round);
-  --x-size-padding-right-button-round: var(--x-space-padding-button-round);
-  --x-size-padding-top-button-round: var(--x-space-padding-button-round);
 }

--- a/packages/x-components/src/design-system/components/grid/default.scss
+++ b/packages/x-components/src/design-system/components/grid/default.scss
@@ -7,7 +7,7 @@
   padding: var(--x-size-padding-grid);
   gap: var(--x-size-gap-grid);
 
-  &__item {
+  &--cols-auto.x-grid__item {
     // layout
     min-width: var(--x-size-min-width-grid-item);
   }

--- a/packages/x-components/src/design-system/components/grid/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/grid/default.tokens.scss
@@ -1,6 +1,6 @@
 :root {
   // layout
   --x-size-padding-grid: 0;
-  --x-size-gap-grid: 0;
+  --x-size-gap-grid: var(--x-size-base-03);
   --x-size-min-width-grid-item: 150px;
 }

--- a/packages/x-components/src/design-system/components/input-group/default.scss
+++ b/packages/x-components/src/design-system/components/input-group/default.scss
@@ -7,10 +7,12 @@
   align-content: center;
   align-items: center;
   box-sizing: border-box;
+  min-width: 0;
 
   // size
   gap: var(--x-size-gap-input-group-default);
   @include safari-gap(var(--x-size-gap-input-group-default));
+  height: var(--x-size-height-input-group-default);
 
   // color
   background-color: var(--x-color-background-input-group-default);
@@ -55,8 +57,6 @@
     border: none;
 
     // size
-    padding-block-start: var(--x-size-padding-top-input-group-default);
-    padding-block-end: var(--x-size-padding-bottom-input-group-default);
     padding-inline-start: 0;
     padding-inline-end: 0;
 
@@ -73,10 +73,7 @@
     //layout
     flex: 1 1 100%;
     min-width: 0;
-    @include safari {
-      margin-block-start: calc(var(--x-size-font-input-group-default) * -0.13) !important;
-      margin-block-end: calc(var(--x-size-font-input-group-default) * -0.13) !important;
-    }
+    border: none;
 
     &::placeholder {
       // typography
@@ -88,39 +85,35 @@
     }
   }
 
+  > .x-button {
+    height: var(--x-size-height-input-group-default);
+    min-height: var(--x-size-height-input-group-default);
+    // need negative margin equals to the border width to make
+    // the child border to overlap the parent border.
+    margin: calc(#{var(--x-size-border-width-input-group-default)} * -1);
+    &:first-child {
+      margin-inline-end: 0;
+    }
+    &:last-child {
+      margin-inline-start: 0;
+    }
+  }
+
   > .x-button:not(.x-input-group__action) {
     // typography
     font-weight: var(--x-number-font-weight-input-group-default-button);
   }
 
   > .x-input-group__action {
-    //layout
-    align-self: stretch;
-
     // size
-    padding: var(--x-size-padding-input-group-default-action);
+    box-sizing: border-box;
+    padding: 0 calc(#{var(--x-size-padding-input-group-default-action)} - 1px);
+    min-width: var(--x-size-height-input-group-default);
 
     // border
     border-radius: var(--x-size-border-radius-top-left-input-group-default)
       var(--x-size-border-radius-top-right-input-group-default)
       var(--x-size-border-radius-bottom-right-input-group-default)
       var(--x-size-border-radius-bottom-left-input-group-default);
-
-    // need negative margin equals to the border width to make
-    // the child border to overlap the parent border.
-    margin-block-start: calc(#{var(--x-size-border-width-top-input-group-default)} * -1) !important;
-    margin-block-end: calc(
-      #{var(--x-size-border-width-bottom-input-group-default)} * -1
-    ) !important;
-    &:first-child {
-      margin-inline-start: calc(
-        #{var(--x-size-border-width-left-input-group-default)} * -1
-      ) !important;
-    }
-    &:last-child {
-      margin-inline-end: calc(
-        #{var(--x-size-border-width-right-input-group-default)} * -1
-      ) !important;
-    }
   }
 }

--- a/packages/x-components/src/design-system/components/input-group/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/input-group/default.tokens.scss
@@ -7,12 +7,11 @@
   --x-color-text-input-group-placeholder-default: var(--x-color-text-input-placeholder-default);
 
   // size
+  --x-size-height-input-group-default: var(--x-size-height-input-default);
   --x-size-gap-input-group-default: var(--x-size-base-03);
-  --x-size-padding-top-input-group-default: var(--x-size-base-03);
-  --x-size-padding-bottom-input-group-default: var(--x-size-padding-top-input-group-default);
   --x-size-padding-left-input-group-default: var(--x-size-base-06);
   --x-size-padding-right-input-group-default: var(--x-size-padding-left-input-group-default);
-  --x-size-padding-input-group-default-action: var(--x-size-padding-top-input-group-default);
+  --x-size-padding-input-group-default-action: var(--x-size-base-03);
 
   // border
   --x-size-border-width-input-group-default: var(--x-size-border-width-input-default);

--- a/packages/x-components/src/design-system/components/input-group/line.scss
+++ b/packages/x-components/src/design-system/components/input-group/line.scss
@@ -2,9 +2,7 @@
 .x-input-group--line.x-input-group {
   // size
   > *:not(.x-input-group__action) {
-    --x-size-padding-top-input-group-default: var(--x-size-padding-top-input-group-line);
     --x-size-padding-right-input-group-default: var(--x-size-padding-right-input-group-line);
-    --x-size-padding-bottom-input-group-default: var(--x-size-padding-bottom-input-group-line);
     --x-size-padding-left-input-group-default: var(--x-size-padding-left-input-group-line);
   }
 
@@ -19,9 +17,11 @@
   --x-size-border-width-left-input-group-default: var(--x-size-border-width-left-input-group-line);
 
   > .x-input-group__action {
-    // size
-    margin-top: 0;
-    margin-left: 0;
-    margin-right: 0;
+    margin-block-start: calc(#{var(--x-size-border-width-top-input-group-line)} * -1) !important;
+    margin-inline-end: calc(#{var(--x-size-border-width-right-input-group-line)} * -1) !important;
+    margin-block-end: calc(#{var(--x-size-border-width-bottom-input-group-line)} * -1) !important;
+    margin-inline-start: calc(
+      #{var(--x-size-border-width-inline-input-group-line)} * -1
+    ) !important;
   }
 }

--- a/packages/x-components/src/design-system/components/input-group/line.tokens.scss
+++ b/packages/x-components/src/design-system/components/input-group/line.tokens.scss
@@ -1,9 +1,7 @@
 :root {
   // size
-  --x-size-padding-top-input-group-line: var(--x-size-base-03);
-  --x-size-padding-bottom-input-group-line: var(--x-size-padding-top-input-group-line);
   --x-size-padding-left-input-group-line: 0;
-  --x-size-padding-right-input-group-line: var(--x-size-padding-left-input-group-line);
+  --x-size-padding-right-input-group-line: 0;
 
   // border
   --x-size-border-width-input-group-line: var(--x-size-border-width-input-group-default);

--- a/packages/x-components/src/design-system/components/input/default.scss
+++ b/packages/x-components/src/design-system/components/input/default.scss
@@ -4,13 +4,15 @@
   // layout
   box-sizing: border-box;
   margin: 0;
+  min-width: 0;
   @include safari {
     -webkit-appearance: none;
   }
 
   // size
-  padding-block-start: var(--x-size-padding-top-input-default);
-  padding-block-end: var(--x-size-padding-bottom-input-default);
+  height: var(--x-size-height-input-default);
+  padding-block-start: 0;
+  padding-block-end: 0;
   padding-inline-start: var(--x-size-padding-left-input-default);
   padding-inline-end: var(--x-size-padding-right-input-default);
 

--- a/packages/x-components/src/design-system/components/input/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/input/default.tokens.scss
@@ -20,9 +20,8 @@
   --x-size-border-radius-bottom-left-input-default: var(--x-size-border-radius-input-default);
 
   // size
-  --x-size-padding-top-input-default: var(--x-size-base-03);
+  --x-size-height-input-default: var(--x-size-base-07);
   --x-size-padding-right-input-default: var(--x-size-base-04);
-  --x-size-padding-bottom-input-default: var(--x-size-base-03);
   --x-size-padding-left-input-default: var(--x-size-base-04);
 
   // typography

--- a/packages/x-components/src/design-system/components/list/default.scss
+++ b/packages/x-components/src/design-system/components/list/default.scss
@@ -3,7 +3,7 @@
 .x-list {
   // layout
   display: flex;
-  flex-flow: var(--x-size-flow-list);
+  flex-flow: var(--x-string-flow-list);
   list-style: none;
 
   // size
@@ -32,10 +32,7 @@
   font-weight: var(--x-number-font-weight-text);
   line-height: var(--x-size-line-height-text);
 
-  > * {
-    min-width: 0;
-    min-height: 0;
-  }
+  min-width: 0;
 }
 
 .x-list--vertical.x-list {
@@ -89,6 +86,18 @@
 .x-list {
   .x-list__item--expand {
     flex: 1 1 auto;
+  }
+
+  &.x-list--horizontal {
+    .x-list__item--expand {
+      min-width: 0;
+    }
+  }
+
+  &:not(.x-list--horizontal) {
+    .x-list__item--expand {
+      min-height: 0;
+    }
   }
 
   .x-list__item--stretch {

--- a/packages/x-components/src/design-system/components/list/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/list/default.tokens.scss
@@ -1,6 +1,6 @@
 :root {
   // layout
-  --x-size-flow-list: column nowrap;
+  --x-string-flow-list: column nowrap;
 
   // size
   --x-size-padding-list: 0;

--- a/packages/x-components/src/design-system/components/scroll/default.scss
+++ b/packages/x-components/src/design-system/components/scroll/default.scss
@@ -1,4 +1,4 @@
-.x-scroll {
+.x-scroll:not(.x-scroll--no-scroll-bar) {
   overflow-y: var(--x-string-overflow-scroll);
 
   &::-webkit-scrollbar {

--- a/packages/x-components/src/design-system/components/sliding-panel/default.scss
+++ b/packages/x-components/src/design-system/components/sliding-panel/default.scss
@@ -111,11 +111,11 @@
 
   &__scroll {
     > * {
-      min-width: auto;
+      flex: 0 0 auto;
     }
 
     > .x-list {
-      --x-size-flow-list: row nowrap;
+      --x-string-flow-list: row nowrap;
     }
   }
 }

--- a/packages/x-components/src/design-system/components/suggestion-group/default.scss
+++ b/packages/x-components/src/design-system/components/suggestion-group/default.scss
@@ -42,9 +42,8 @@
     --x-color-text-button-default: var(--x-color-text-suggestion-group-default);
 
     // size
-    --x-size-padding-top-button-default: 0;
+    --x-size-height-button-default: var(--x-size-line-height-suggestion-group-default);
     --x-size-padding-right-button-default: 0;
-    --x-size-padding-bottom-button-default: 0;
     --x-size-padding-left-button-default: 0;
 
     // border

--- a/packages/x-components/src/design-system/components/tag/default.scss
+++ b/packages/x-components/src/design-system/components/tag/default.scss
@@ -33,8 +33,7 @@
   // size
   gap: var(--x-size-gap-tag-default);
   @include safari-gap(var(--x-size-gap-tag-default));
-  padding-block-start: var(--x-size-padding-top-tag-default);
-  padding-block-end: var(--x-size-padding-bottom-tag-default);
+  min-height: var(--x-size-height-tag-default);
   padding-inline-start: var(--x-size-padding-left-tag-default);
   padding-inline-end: var(--x-size-padding-right-tag-default);
   min-width: calc(3 * var(--x-size-line-height-tag-default));

--- a/packages/x-components/src/design-system/components/tag/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/tag/default.tokens.scss
@@ -21,9 +21,8 @@
   --x-size-border-radius-bottom-left-tag-default: var(--x-size-border-radius-tag-default);
 
   // size
-  --x-size-padding-top-tag-default: var(--x-size-base-03);
+  --x-size-height-tag-default: var(--x-size-base-07);
   --x-size-padding-right-tag-default: var(--x-size-base-04);
-  --x-size-padding-bottom-tag-default: var(--x-size-base-03);
   --x-size-padding-left-tag-default: var(--x-size-base-04);
   --x-size-gap-tag-default: var(--x-size-base-02);
 


### PR DESCRIPTION
EX-4693

This PR fixes some issues with the height of some components. In those components, top and bottom padding were replaced by height in the container. It can not be done in others (suggestions, filters) but we will find out another way to resolve it. At the moment is fine with the changed components.

Also fixes some other issues found in the layout of other components in the design system.