### PR TITLE
fix(popular-searches): fix popular searches and query suggestions canceling requests

### DIFF
--- a/packages/x-components/src/x-modules/popular-searches/store/actions/fetch-suggestions.action.ts
+++ b/packages/x-components/src/x-modules/popular-searches/store/actions/fetch-suggestions.action.ts
@@ -14,5 +14,7 @@ import { PopularSearchesXStoreModule } from '../types';
 export const fetchSuggestions: PopularSearchesXStoreModule['actions']['fetchSuggestions'] = ({
   getters
 }) => {
-  return XPlugin.adapter.getSuggestions(getters.request).then(({ suggestions }) => suggestions);
+  return XPlugin.adapter
+    .getSuggestions(getters.request, { requestId: 'popularSearches' })
+    .then(({ suggestions }) => suggestions);
 };


### PR DESCRIPTION

EX-4697

Since the popular searches and the query suggestions use the same adapter endpoint (suggestions), when a new request is made before the previous one is resolved, this is cancelled. Example:

Open search -> Popular Searches requested
Type a query -> Query Suggestions requested -> Popular Searches Request is cancelled.

To solve this we can pass an identifier to the adapter to distinguish the two different requests to the same endpoint.