### PR TITLE
fix: Fix recommendations `setParams` wire. Export `LIST_ITEMS_KEY`.

### DIFF
--- a/packages/x-components/src/components/index.ts
+++ b/packages/x-components/src/components/index.ts
@@ -26,6 +26,7 @@ export { default as SingleColumnLayout } from './layouts/single-column-layout.vu
 // Utils
 export * from './decorators/bus.decorators';
 export * from './decorators/debounce.decorators';
+export * from './decorators/injection.consts';
 export * from './decorators/injection.decorators';
 export * from './decorators/store.decorators';
 export * from './items-list-injection.mixin';

--- a/packages/x-components/src/x-modules/recommendations/wiring.ts
+++ b/packages/x-components/src/x-modules/recommendations/wiring.ts
@@ -1,5 +1,7 @@
-import { namespacedWireDispatchWithoutPayload } from '../../wiring/namespaced-wires.factory';
-import { wireCommit } from '../../wiring/wires.factory';
+import {
+  namespacedWireCommit,
+  namespacedWireDispatchWithoutPayload
+} from '../../wiring/namespaced-wires.factory';
 import { createWiring } from '../../wiring/wiring.utils';
 
 /**
@@ -14,6 +16,12 @@ const moduleName = 'recommendations';
  * @internal
  */
 const wireDispatchWithoutPayload = namespacedWireDispatchWithoutPayload(moduleName);
+/**
+ * WireCommit for {@link RecommendationsXModule}.
+ *
+ * @internal
+ */
+const wireCommit = namespacedWireCommit(moduleName);
 
 /**
  * Requests and stores the recommendations.


### PR DESCRIPTION
# Description

Just to minor fixes. One is fixing the recommendations wiring, which was using a global wire instead of a namespaced one. The other is just exporting a missing injection constant.