### PR TITLE
feat(search): save `Redirection`'s entities.

### DIFF
--- a/packages/search-adapter/src/empathy/mappers/response/empathy-redirection.mapper.ts
+++ b/packages/search-adapter/src/empathy/mappers/response/empathy-redirection.mapper.ts
@@ -22,6 +22,7 @@ export class EmpathyRedirectionMapper implements ResponseMapper<EmpathyDirect, R
 
   map(rawDirect: EmpathyDirect, redirection: Redirection, context: ResponseMapperContext): Redirection {
     return Object.assign(redirection, {
+      modelName: 'Redirection',
       id: rawDirect.id,
       title: rawDirect.title,
       url: rawDirect.url,

--- a/packages/search-adapter/src/empathy/mappers/response/empathy-redirection.mapper.ts
+++ b/packages/search-adapter/src/empathy/mappers/response/empathy-redirection.mapper.ts
@@ -21,10 +21,9 @@ export class EmpathyRedirectionMapper implements ResponseMapper<EmpathyDirect, R
   }
 
   map(rawDirect: EmpathyDirect, redirection: Redirection, context: ResponseMapperContext): Redirection {
-    return Object.assign(redirection, {
+    return Object.assign<Redirection, Partial<Redirection>>(redirection, {
       modelName: 'Redirection',
       id: rawDirect.id,
-      title: rawDirect.title,
       url: rawDirect.url,
       tagging: {
         click: this.mapTagging(rawDirect.trackable_url, {} as Tagging, context)

--- a/packages/search-adapter/src/empathy/models/entities/empathy-direct.model.ts
+++ b/packages/search-adapter/src/empathy/models/entities/empathy-direct.model.ts
@@ -5,7 +5,6 @@
  */
 export interface EmpathyDirect {
   id: string;
-  title: string;
   trackable_url: string;
   url: string;
 }

--- a/packages/search-types/src/named-model.model.ts
+++ b/packages/search-types/src/named-model.model.ts
@@ -13,6 +13,7 @@ export type ModelNameType =
   | 'HistoryQuery'
   | 'Banner'
   | 'Promoted'
+  | 'Redirection'
   | FilterModelName
   | FacetModelName
   | string;

--- a/packages/search-types/src/redirection.model.ts
+++ b/packages/search-types/src/redirection.model.ts
@@ -1,4 +1,5 @@
 import { Identifiable } from './identifiable.model';
+import { NamedModel } from './named-model.model';
 import { Tagging } from './tagging.model';
 
 /**
@@ -9,7 +10,7 @@ import { Tagging } from './tagging.model';
  *
  * @public
  */
-export interface Redirection extends Identifiable {
+export interface Redirection extends NamedModel<'Redirection'>, Identifiable {
   /** Redirect title. */
   title: string;
   /** URL to redirect. */

--- a/packages/search-types/src/redirection.model.ts
+++ b/packages/search-types/src/redirection.model.ts
@@ -11,8 +11,6 @@ import { Tagging } from './tagging.model';
  * @public
  */
 export interface Redirection extends NamedModel<'Redirection'>, Identifiable {
-  /** Redirect title. */
-  title: string;
   /** URL to redirect. */
   url: string;
   /** Redirect tagging. */

--- a/packages/search-types/src/schemas/redirection.schema.ts
+++ b/packages/search-types/src/schemas/redirection.schema.ts
@@ -9,6 +9,7 @@ import { TaggingSchema } from './tagging.schema';
  */
 export const RedirectionSchema: Redirection = {
   ...IdentifiableSchema,
+  modelName: 'Redirection',
   title: expect.any(String),
   url: expect.any(String),
   tagging: {

--- a/packages/search-types/src/schemas/redirection.schema.ts
+++ b/packages/search-types/src/schemas/redirection.schema.ts
@@ -10,7 +10,6 @@ import { TaggingSchema } from './tagging.schema';
 export const RedirectionSchema: Redirection = {
   ...IdentifiableSchema,
   modelName: 'Redirection',
-  title: expect.any(String),
   url: expect.any(String),
   tagging: {
     click: TaggingSchema

--- a/packages/x-components/src/__stubs__/banners-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/banners-stubs.factory.ts
@@ -1,7 +1,7 @@
 import { Banner } from '@empathyco/x-types';
 
 /**
- * Creates {@link @empathyco/x-types#Banner | banners} stub.
+ * Creates a {@link @empathyco/x-types#Banner | banners} stub.
  *
  * @returns Array of banners stub.
  *

--- a/packages/x-components/src/__stubs__/facets-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/facets-stubs.factory.ts
@@ -21,7 +21,7 @@ import {
 } from './filters-stubs.factory';
 
 /**
- * Creates {@link @empathyco/x-types#SimpleFacet | SimpleFacet} stub.
+ * Creates a {@link @empathyco/x-types#SimpleFacet | SimpleFacet} stub.
  *
  * @returns A SimpleFacet.
  *
@@ -230,7 +230,7 @@ export function getSimpleFacetStub(): SimpleFacet {
 }
 
 /**
- * Creates {@link @empathyco/x-types#HierarchicalFacet | HierarchicalFacet} stub.
+ * Creates a {@link @empathyco/x-types#HierarchicalFacet | HierarchicalFacet} stub.
  *
  * @returns A HierarchicalFacet.
  *
@@ -370,7 +370,7 @@ export function getHierarchicalFacetStub(): HierarchicalFacet {
 }
 
 /**
- * Creates {@link @empathyco/x-types#NumberRangeFacet | NumberRangeFacet} stub.
+ * Creates a {@link @empathyco/x-types#NumberRangeFacet | NumberRangeFacet} stub.
  *
  * @returns A NumberRangeFacet.
  *
@@ -459,7 +459,7 @@ export function getNumberRangeFacetStub(): NumberRangeFacet {
 }
 
 /**
- * Creates {@link @empathyco/x-types#Facet | facets} stub.
+ * Creates a {@link @empathyco/x-types#Facet | facets} stub.
  *
  * @returns Array of facets stub.
  *
@@ -470,7 +470,7 @@ export function getFacetsStub(): Facet[] {
 }
 
 /**
- * Creates {@link @empathyco/x-types#Facet | facets} stub.
+ * Creates a {@link @empathyco/x-types#Facet | facets} stub.
  *
  * @returns Dictionary of facets stub.
  *

--- a/packages/x-components/src/__stubs__/filters-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/filters-stubs.factory.ts
@@ -8,7 +8,7 @@ import {
 } from '@empathyco/x-types';
 
 /**
- * Creates {@link @empathyco/x-types#SimpleFilter | SimpleFilter} stub.
+ * Creates a {@link @empathyco/x-types#SimpleFilter | SimpleFilter} stub.
  *
  * @param filter - A partial filter to override certain properties. Useful for testing.
  * @returns A Simple filter.
@@ -30,7 +30,7 @@ export function getSimpleFilterStub(filter: Partial<SimpleFilter> = {}): SimpleF
 }
 
 /**
- * Creates {@link @empathyco/x-types#NumberRangeFilter | NumberRangeFilter} stub.
+ * Creates a {@link @empathyco/x-types#NumberRangeFilter | NumberRangeFilter} stub.
  *
  * @param filter - A partial filter to override certain properties. Useful for testing.
  * @returns A Number range filter.
@@ -58,7 +58,7 @@ export function getNumberRangeFilterStub(
 }
 
 /**
- * Creates {@link @empathyco/x-types#HierarchicalFilter | HierarchicalFilter} stub.
+ * Creates a {@link @empathyco/x-types#HierarchicalFilter | HierarchicalFilter} stub.
  *
  * @param filter - A partial filter to override certain properties. Useful for testing.
  * @returns A Hierarchical filter.

--- a/packages/x-components/src/__stubs__/next-queries-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/next-queries-stubs.factory.ts
@@ -1,7 +1,7 @@
 import { NextQuery } from '@empathyco/x-types';
 
 /**
- * Creates {@link @empathyco/x-types#NextQuery | next queries} stub.
+ * Creates a {@link @empathyco/x-types#NextQuery | next queries} stub.
  *
  * @param amount - Number of stubbed next queries to create.
  *

--- a/packages/x-components/src/__stubs__/promoteds-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/promoteds-stubs.factory.ts
@@ -1,7 +1,7 @@
 import { Promoted } from '@empathyco/x-types';
 
 /**
- * Creates {@link @empathyco/x-types#Promoted | Promoted} stub.
+ * Creates a {@link @empathyco/x-types#Promoted | Promoted} stub.
  *
  * @returns Array of Promoted stub.
  *

--- a/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
@@ -14,17 +14,16 @@ export function getRedirectionsStub(): Redirection[] {
 /**
  * Creates a redirection with a unique identifier.
  *
- * @param title - The redirection title.
+ * @param id - The redirection identifier.
  *
  * @returns A redirection.
  *
  * @internal
  */
-export function createRedirectionStub(title: string): Redirection {
+export function createRedirectionStub(id: string): Redirection {
   return {
-    id: `xr-${title}`,
-    title,
-    url: `https://picsum.photos/seed/${title}/500`,
+    id: `xr-${id}`,
+    url: `https://picsum.photos/seed/${id}/500`,
     tagging: {
       click: {
         params: {},

--- a/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
@@ -24,7 +24,7 @@ export function createRedirectionStub(title: string): Redirection {
   return {
     id: `xr-${title}`,
     title,
-    url: `https://shop.empathy.co/${title}`,
+    url: `https://picsum.photos/seed/${title}/500`,
     tagging: {
       click: {
         params: {},

--- a/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
@@ -1,7 +1,7 @@
 import { Redirection } from '@empathyco/x-types';
 
 /**
- * Creates {@link @empathyco/x-types#Redirection | redirections} stub.
+ * Creates a {@link @empathyco/x-types#Redirection | redirections} stub.
  *
  * @returns A list of redirections.
  *

--- a/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
@@ -1,0 +1,36 @@
+import { Redirection } from '@empathyco/x-types';
+
+/**
+ * Creates {@link @empathyco/x-types#Redirection | redirections} stub.
+ *
+ * @returns A list of redirections.
+ *
+ * @internal
+ */
+export function getRedirectionsStub(): Redirection[] {
+  return [createRedirectionStub('help')];
+}
+
+/**
+ * Creates a redirection with a unique identifier.
+ *
+ * @param title - The redirection title.
+ *
+ * @returns A redirection.
+ *
+ * @internal
+ */
+export function createRedirectionStub(title: string): Redirection {
+  return {
+    id: `xr-${title}`,
+    title,
+    url: `https://shop.empathy.co/${title}`,
+    tagging: {
+      click: {
+        params: {},
+        url: ''
+      }
+    },
+    modelName: 'Redirection'
+  };
+}

--- a/packages/x-components/src/__stubs__/related-tags-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/related-tags-stubs.factory.ts
@@ -1,7 +1,7 @@
 import { RelatedTag } from '@empathyco/x-types';
 
 /**
- * Creates {@link @empathyco/x-types#RelatedTag | related tags} stub.
+ * Creates a {@link @empathyco/x-types#RelatedTag | related tags} stub.
  *
  * @param amount - Number of stubbed related tags to create.
  *

--- a/packages/x-components/src/__stubs__/results-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/results-stubs.factory.ts
@@ -2,7 +2,7 @@ import { Result, ResultTagging, Tagging } from '@empathyco/x-types';
 import { toKebabCase } from '../utils/string';
 
 /**
- * Creates {@link @empathyco/x-types#Result | results} stub.
+ * Creates a {@link @empathyco/x-types#Result | results} stub.
  *
  * @param amount - Number of stubbed results to create.
  *

--- a/packages/x-components/src/__stubs__/search-response-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/search-response-stubs.factory.ts
@@ -6,7 +6,7 @@ import { getRedirectionsStub } from './redirections-stubs.factory';
 import { getResultsStub } from './results-stubs.factory';
 
 /**
- * Creates {@link @empathyco/x-adapter#SearchResponse | search response} stub.
+ * Creates a {@link @empathyco/x-adapter#SearchResponse | search response} stub.
  *
  * @returns Object of search response stub.
  *

--- a/packages/x-components/src/__stubs__/search-response-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/search-response-stubs.factory.ts
@@ -2,6 +2,7 @@ import { SearchResponse } from '@empathyco/x-adapter';
 import { getBannersStub } from './banners-stubs.factory';
 import { getFacetsStub } from './facets-stubs.factory';
 import { getPromotedsStub } from './promoteds-stubs.factory';
+import { getRedirectionsStub } from './redirections-stubs.factory';
 import { getResultsStub } from './results-stubs.factory';
 
 /**
@@ -21,9 +22,9 @@ export function getSearchResponseStub(): SearchResponse {
       params: {},
       url: ''
     },
-    redirections: [],
+    redirections: getRedirectionsStub(),
     results: getResultsStub(),
     spellcheck: '',
-    totalResults: 0
+    totalResults: 100
   };
 }

--- a/packages/x-components/src/adapter/util.ts
+++ b/packages/x-components/src/adapter/util.ts
@@ -20,7 +20,7 @@ export function configureAdapterWithJuguettos(
       return result;
     }, 'results')
     .setFeatureConfig('search', {
-      endpoint: 'https://api.empathybroker.com/search/v1/query/juguettos/searchv2'
+      endpoint: 'https://api{env}.empathybroker.com/search/v1/query/juguettos/searchv2'
     })
     .setFacetConfig(
       {

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -3,6 +3,7 @@ import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 import { getBannersStub } from '../../../../__stubs__/banners-stubs.factory';
 import { getPromotedsStub } from '../../../../__stubs__/promoteds-stubs.factory';
+import { getRedirectionsStub } from '../../../../__stubs__/redirections-stubs.factory';
 import { map } from '../../../../utils';
 import { getFacetsStub } from '../../../../__stubs__/facets-stubs.factory';
 import { getResultsStub } from '../../../../__stubs__/results-stubs.factory';
@@ -17,6 +18,7 @@ describe('testing search module actions', () => {
   const facetsStub = getFacetsStub();
   const bannersStub = getBannersStub();
   const promotedsStub = getPromotedsStub();
+  const redirectionsStub = getRedirectionsStub();
   const searchResponseStub = getSearchResponseStub();
 
   const mockedEmptySearchResponse: SearchResponse = {
@@ -65,7 +67,8 @@ describe('testing search module actions', () => {
   });
 
   describe(`${actionKeys.fetchAndSaveSearchResponse}`, () => {
-    it('should request and store results, facets, banners and promoteds in the state', async () => {
+    // eslint-disable-next-line max-len
+    it('should request and store results, facets, banners, promoteds and redirections in the state', async () => {
       resetSearchStateWith(store, {
         query: 'lego'
       });
@@ -77,6 +80,7 @@ describe('testing search module actions', () => {
       expect(store.state.facets).toEqual(facetsStub);
       expect(store.state.banners).toEqual(bannersStub);
       expect(store.state.promoteds).toEqual(promotedsStub);
+      expect(store.state.redirections).toEqual(redirectionsStub);
       expect(store.state.page).toEqual(1);
       expect(store.state.config.pageSize).toEqual(24);
       expect(store.state.status).toEqual('success');
@@ -155,7 +159,8 @@ describe('testing search module actions', () => {
         results: initialResults,
         facets: initialFacets,
         banners: initialBanners,
-        promoteds: initialPromoteds
+        promoteds: initialPromoteds,
+        redirections: initialRedirections
       } = store.state;
       adapter.search.mockResolvedValueOnce({
         ...mockedEmptySearchResponse,
@@ -172,12 +177,15 @@ describe('testing search module actions', () => {
       expect(store.state.facets).toBe(initialFacets);
       expect(store.state.banners).toEqual(initialBanners);
       expect(store.state.promoteds).toEqual(initialPromoteds);
+      expect(store.state.promoteds).toEqual(initialPromoteds);
+      expect(store.state.redirections).toEqual(initialRedirections);
       await secondRequest;
       expect(store.state.status).toEqual('success');
       expect(store.state.results).toEqual(resultsStub);
       expect(store.state.facets).toEqual(facetsStub);
       expect(store.state.banners).toEqual(bannersStub);
       expect(store.state.promoteds).toEqual(promotedsStub);
+      expect(store.state.redirections).toEqual(redirectionsStub);
     });
 
     it('should set the status to error when it fails', async () => {

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -12,7 +12,7 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveAction<
   },
   onSuccess(
     { commit, state },
-    { results, partialResults, facets, banners, promoteds, totalResults, spellcheck }
+    { results, partialResults, facets, banners, promoteds, totalResults, spellcheck, redirections }
   ) {
     if (state.isAppendResults) {
       commit('appendResults', results);
@@ -21,6 +21,7 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveAction<
       commit('setResults', results);
       commit('setBanners', banners);
       commit('setPromoteds', promoteds);
+      commit('setRedirections', redirections);
     }
 
     commit('setPartialResults', partialResults ?? []);

--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -35,7 +35,8 @@ export const searchXStoreModule: SearchXStoreModule = {
     sort: '',
     page: 1,
     origin: null,
-    isAppendResults: false
+    isAppendResults: false,
+    redirections: []
   }),
   getters: {
     request
@@ -94,6 +95,9 @@ export const searchXStoreModule: SearchXStoreModule = {
     },
     setOrigin(state, origin) {
       state.origin = origin ?? null;
+    },
+    setRedirections(state, redirections) {
+      state.redirections = redirections;
     }
   },
   actions: {

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -5,6 +5,7 @@ import {
   Filter,
   PartialResult,
   Promoted,
+  Redirection,
   RelatedTag,
   Result,
   Sort
@@ -29,14 +30,20 @@ export interface SearchState extends StatusState {
   facets: Facet[];
   /** A flag to indicate if new results are append to the current instead of replacing them. */
   isAppendResults: boolean;
+  /** The origin property of the request. */
+  origin: QueryOrigin | null;
   /** The current page of the request. */
   page: number;
+  /** The extra params property of the state. */
+  params: Dictionary<unknown>;
   /** The list of the partial results, related to the `query` property of the state. */
   partialResults: PartialResult[];
   /** The list of the promoted, related to the `query` property of the state. */
   promoteds: Promoted[];
   /** The internal query of the module. Used to request the search results. */
   query: string;
+  /** The redirections associated to the `query`. */
+  redirections: Redirection[];
   /** The list of the related tags, related to the `query` property of the state. */
   relatedTags: RelatedTag[];
   /** The list of the results, related to the `query` property of the state. */
@@ -50,10 +57,6 @@ export interface SearchState extends StatusState {
   spellcheckedQuery: string;
   /** The total number of results, related to the `query` property of the state. */
   totalResults: number;
-  /** The extra params property of the state. */
-  params: Dictionary<unknown>;
-  /** The origin property of the request. */
-  origin: QueryOrigin | null;
 }
 
 /**
@@ -98,6 +101,12 @@ export interface SearchMutations extends StatusMutations {
    */
   setIsAppendResults(isAppendResults: boolean): void;
   /**
+   * Sets the origin of the module.
+   *
+   * @param origin - The new origin.
+   */
+  setOrigin(origin: QueryOrigin | undefined): void;
+  /**
    * Sets the page of the module.
    *
    * @param page - The new page.
@@ -109,6 +118,12 @@ export interface SearchMutations extends StatusMutations {
    * @param pageSize - The new page size.
    */
   setPageSize(pageSize: number): void;
+  /**
+   * Sets the extra params of the module.
+   *
+   * @param params - The new extra params.
+   */
+  setParams(params: Dictionary<unknown>): void;
   /**
    * Sets the partial results of the module.
    *
@@ -127,6 +142,12 @@ export interface SearchMutations extends StatusMutations {
    * @param newQuery - The new query to save to the state.
    */
   setQuery(newQuery: string): void;
+  /**
+   * Sets the redirection of the module.
+   *
+   * @param redirections - The redirections to store.
+   */
+  setRedirections(redirections: Redirection[]): void;
   /**
    * Sets the related tags of the module.
    *
@@ -163,18 +184,6 @@ export interface SearchMutations extends StatusMutations {
    * @param totalResults - The new total results to save to the state.
    */
   setTotalResults(totalResults: number): void;
-  /**
-   * Sets the extra params of the module.
-   *
-   * @param params - The new extra params.
-   */
-  setParams(params: Dictionary<unknown>): void;
-  /**
-   * Sets the origin of the module.
-   *
-   * @param origin - The new origin.
-   */
-  setOrigin(origin: QueryOrigin | undefined): void;
 }
 
 /**

--- a/packages/x-components/tests/e2e/cucumber/no-suggestions.feature
+++ b/packages/x-components/tests/e2e/cucumber/no-suggestions.feature
@@ -18,5 +18,5 @@ Feature: No Suggestions component
 
     Examples:
       | queryWithoutSuggestions | queryWithSuggestions |
-      | asdfg                   | puzzle               |
+      | asdfg                   | lego                 |
 


### PR DESCRIPTION
BREAKING-CHANGE: `Redirection` now has a compulsory `modelName` property.

EX-4730

# Description

Just saves the redirections to the search state. This does not add the logic or the component, only saves the redirections.
