### PR TITLE
chore(design-system): Fix dropdown toggle icon alignment

### DIFF
--- a/packages/x-components/src/design-system/components/dropdown/default.scss
+++ b/packages/x-components/src/design-system/components/dropdown/default.scss
@@ -49,7 +49,7 @@
     overflow: var(--x-string-overflow-dropdown-toggle-default);
     box-shadow: var(--x-string-box-shadow-dropdown-default);
 
-    .x-icon:last-child {
+    * + .x-icon:last-child {
       margin-inline-start: auto;
     }
   }


### PR DESCRIPTION
EX-4764

# Description

Aligns the last button of the dropdown toggle to the end only if it has a previous sibling.
