### PR TITLE
Feature/ex 4786 allow inverting highlighting suggestions

### DIFF
--- a/packages/x-components/src/components/suggestions/base-suggestion.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestion.vue
@@ -94,14 +94,14 @@
      * Generates css classes dynamically.
      *
      * @remarks
-     * 'x-suggestion--has-matching-query added when the query should be matched.
+     * 'x-suggestion--matching added when the query should be matched.
      *
      * @returns The {@link VueCSSClasses} classes.
      * @public
      */
     protected get dynamicCSSClasses(): VueCSSClasses {
       return {
-        'x-suggestion--has-matching-query': this.hasMatchingQuery
+        'x-suggestion--matching': this.hasMatchingQuery
       };
     }
 

--- a/packages/x-components/src/design-system/components/suggestion-group/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/suggestion-group/default.tokens.scss
@@ -1,7 +1,7 @@
 :root {
   // color
   --x-color-text-suggestion-group-default: var(--x-color-text-suggestion-default);
-  --x-color-text-suggestion-group-matching-part-default: var(--x-color-text-suggestion-matching-part-default);
+  --x-color-text-suggestion-group-matching-part-default-has-matching-query: var(--x-color-text-suggestion-matching-part-default-has-matching-query);
   --x-color-background-suggestion-group-default: var(--x-color-background-suggestion-default);
 
   // size

--- a/packages/x-components/src/design-system/components/suggestion-group/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/suggestion-group/default.tokens.scss
@@ -1,7 +1,7 @@
 :root {
   // color
   --x-color-text-suggestion-group-default: var(--x-color-text-suggestion-default);
-  --x-color-text-suggestion-group-matching-part-default-has-matching-query: var(--x-color-text-suggestion-matching-part-default-has-matching-query);
+  --x-color-text-suggestion-group-matching-part-default: var(--x-color-text-suggestion-matching-part-default);
   --x-color-background-suggestion-group-default: var(--x-color-background-suggestion-default);
 
   // size

--- a/packages/x-components/src/design-system/components/suggestion/default.scss
+++ b/packages/x-components/src/design-system/components/suggestion/default.scss
@@ -37,28 +37,30 @@
 
   &--has-matching-query {
     // typography
-    --x-font-family-suggestion-default: var(--x-font-family-suggestion-non-matching-part-default);
-    --x-size-font-suggestion-default: var(--x-size-font-suggestion-non-matching-part-default);
+    --x-font-family-suggestion-default: var(--x-font-family-suggestion-default-has-matching-query);
+    --x-size-font-suggestion-default: var(--x-size-font-suggestion-default-has-matching-query);
     --x-size-line-height-suggestion-default: var(
-      --x-size-line-height-suggestion-non-matching-part-default
+      --x-size-line-height-suggestion-default-has-matching-query
     );
     --x-number-font-weight-suggestion-default: var(
-      --x-number-font-weight-suggestion-non-matching-part-default
+      --x-number-font-weight-suggestion-default-has-matching-query
     );
 
     // color
-    --x-color-text-suggestion-default: var(--x-color-text-suggestion-non-matching-part-default);
+    --x-color-text-suggestion-default: var(--x-color-text-suggestion-default-has-matching-query);
 
     .x-suggestion {
       &__matching-part {
         // typography
-        font-family: var(--x-font-family-suggestion-matching-part-default);
-        font-size: var(--x-size-font-suggestion-matching-part-default);
-        line-height: var(--x-size-line-height-suggestion-matching-part-default);
-        font-weight: var(--x-number-font-weight-suggestion-matching-part-default);
+        font-family: var(--x-font-family-suggestion-matching-part-default-has-matching-query);
+        font-size: var(--x-size-font-suggestion-matching-part-default-has-matching-query);
+        line-height: var(--x-size-line-height-suggestion-matching-part-default-has-matching-query);
+        font-weight: var(
+          --x-number-font-weight-suggestion-matching-part-default-has-matching-query
+        );
 
         // color
-        color: var(--x-color-text-suggestion-matching-part-default);
+        color: var(--x-color-text-suggestion-matching-part-default-has-matching-query);
       }
     }
   }

--- a/packages/x-components/src/design-system/components/suggestion/default.scss
+++ b/packages/x-components/src/design-system/components/suggestion/default.scss
@@ -35,33 +35,27 @@
     flex: 1 1 auto;
   }
 
-  &--has-matching-query {
+  &__matching-part {
     // typography
-    --x-font-family-suggestion-default: var(--x-font-family-suggestion-default-has-matching-query);
-    --x-size-font-suggestion-default: var(--x-size-font-suggestion-default-has-matching-query);
-    --x-size-line-height-suggestion-default: var(
-      --x-size-line-height-suggestion-default-has-matching-query
-    );
+    font-family: var(--x-font-family-suggestion-matching-part-default);
+    font-size: var(--x-size-font-suggestion-matching-part-default);
+    line-height: var(--x-size-line-height-suggestion-matching-part-default);
+    font-weight: var(--x-number-font-weight-suggestion-matching-part-default);
+
+    // color
+    color: var(--x-color-text-suggestion-matching-part-default);
+  }
+
+  &--matching {
+    // typography
+    --x-font-family-suggestion-default: var(--x-font-family-suggestion-default-matching);
+    --x-size-font-suggestion-default: var(--x-size-font-suggestion-default-matching);
+    --x-size-line-height-suggestion-default: var(--x-size-line-height-suggestion-default-matching);
     --x-number-font-weight-suggestion-default: var(
-      --x-number-font-weight-suggestion-default-has-matching-query
+      --x-number-font-weight-suggestion-default-matching
     );
 
     // color
-    --x-color-text-suggestion-default: var(--x-color-text-suggestion-default-has-matching-query);
-
-    .x-suggestion {
-      &__matching-part {
-        // typography
-        font-family: var(--x-font-family-suggestion-matching-part-default-has-matching-query);
-        font-size: var(--x-size-font-suggestion-matching-part-default-has-matching-query);
-        line-height: var(--x-size-line-height-suggestion-matching-part-default-has-matching-query);
-        font-weight: var(
-          --x-number-font-weight-suggestion-matching-part-default-has-matching-query
-        );
-
-        // color
-        color: var(--x-color-text-suggestion-matching-part-default-has-matching-query);
-      }
-    }
+    --x-color-text-suggestion-default: var(--x-color-text-suggestion-default-matching);
   }
 }

--- a/packages/x-components/src/design-system/components/suggestion/default.scss
+++ b/packages/x-components/src/design-system/components/suggestion/default.scss
@@ -36,19 +36,20 @@
   }
 
   &--has-matching-query {
-    .x-suggestion {
-      // typography
-      --x-font-family-suggestion-default: var(--x-font-family-suggestion-non-matching-part-default);
-      --x-size-font-suggestion-default: var(--x-size-font-suggestion-non-matching-part-default);
-      --x-size-line-height-suggestion-default: var(
-        --x-size-line-height-suggestion-non-matching-part-default
-      );
-      --x-number-font-weight-suggestion-default: var(
-        --x-number-font-weight-suggestion-non-matching-part-default
-      );
+    // typography
+    --x-font-family-suggestion-default: var(--x-font-family-suggestion-non-matching-part-default);
+    --x-size-font-suggestion-default: var(--x-size-font-suggestion-non-matching-part-default);
+    --x-size-line-height-suggestion-default: var(
+      --x-size-line-height-suggestion-non-matching-part-default
+    );
+    --x-number-font-weight-suggestion-default: var(
+      --x-number-font-weight-suggestion-non-matching-part-default
+    );
 
-      // color
-      color: var(--x-color-text-suggestion-non-matching-part-default);
+    // color
+    --x-color-text-suggestion-default: var(--x-color-text-suggestion-non-matching-part-default);
+
+    .x-suggestion {
       &__matching-part {
         // typography
         font-family: var(--x-font-family-suggestion-matching-part-default);

--- a/packages/x-components/src/design-system/components/suggestion/default.scss
+++ b/packages/x-components/src/design-system/components/suggestion/default.scss
@@ -35,14 +35,30 @@
     flex: 1 1 auto;
   }
 
-  &__matching-part {
-    // typography
-    font-family: var(--x-font-family-suggestion-matching-part-default);
-    font-size: var(--x-size-font-suggestion-matching-part-default);
-    line-height: var(--x-size-line-height-suggestion-matching-part-default);
-    font-weight: var(--x-number-font-weight-suggestion-matching-part-default);
+  &--has-matching-query {
+    .x-suggestion {
+      // typography
+      --x-font-family-suggestion-default: var(--x-font-family-suggestion-non-matching-part-default);
+      --x-size-font-suggestion-default: var(--x-size-font-suggestion-non-matching-part-default);
+      --x-size-line-height-suggestion-default: var(
+        --x-size-line-height-suggestion-non-matching-part-default
+      );
+      --x-number-font-weight-suggestion-default: var(
+        --x-number-font-weight-suggestion-non-matching-part-default
+      );
 
-    // color
-    color: var(--x-color-text-suggestion-matching-part-default);
+      // color
+      color: var(--x-color-text-suggestion-non-matching-part-default);
+      &__matching-part {
+        // typography
+        font-family: var(--x-font-family-suggestion-matching-part-default);
+        font-size: var(--x-size-font-suggestion-matching-part-default);
+        line-height: var(--x-size-line-height-suggestion-matching-part-default);
+        font-weight: var(--x-number-font-weight-suggestion-matching-part-default);
+
+        // color
+        color: var(--x-color-text-suggestion-matching-part-default);
+      }
+    }
   }
 }

--- a/packages/x-components/src/design-system/components/suggestion/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/suggestion/default.tokens.scss
@@ -1,8 +1,8 @@
 :root {
   // color
   --x-color-text-suggestion-default: var(--x-color-text-default);
-  --x-color-text-suggestion-matching-part-default: red;
-  --x-color-text-suggestion-default-matching: blue;
+  --x-color-text-suggestion-matching-part-default: var(--x-color-base-neutral-35);
+  --x-color-text-suggestion-default-matching: var(--x-color-text-suggestion-default);
   --x-color-background-suggestion-default: transparent;
 
   // size
@@ -27,8 +27,8 @@
   );
   --x-font-family-suggestion-default-matching: var(--x-font-family-suggestion-default);
   --x-size-font-suggestion-default-matching: var(--x-size-font-suggestion-default);
-  --x-size-line-height-suggestion-default-matching: var(
-    --x-size-line-height-suggestion-default
+  --x-size-line-height-suggestion-default-matching: var(--x-size-line-height-suggestion-default);
+  --x-number-font-weight-suggestion-default-matching: var(
+    --x-number-font-weight-suggestion-default
   );
-  --x-number-font-weight-suggestion-default-matching: bold;
 }

--- a/packages/x-components/src/design-system/components/suggestion/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/suggestion/default.tokens.scss
@@ -2,6 +2,7 @@
   // color
   --x-color-text-suggestion-default: var(--x-color-text-default);
   --x-color-text-suggestion-matching-part-default: var(--x-color-base-neutral-35);
+  --x-color-text-suggestion-non-matching-part-default: var(--x-color-text-suggestion-default);
   --x-color-background-suggestion-default: transparent;
 
   // size
@@ -18,6 +19,18 @@
   --x-number-font-weight-suggestion-default: var(--x-number-font-weight-text);
   --x-font-family-suggestion-matching-part-default: var(--x-font-family-suggestion-default);
   --x-size-font-suggestion-matching-part-default: var(--x-size-font-suggestion-default);
-  --x-size-line-height-suggestion-matching-part-default: var(--x-size-line-height-suggestion-default);
-  --x-number-font-weight-suggestion-matching-part-default: var(--x-number-font-weight-suggestion-default);
+  --x-size-line-height-suggestion-matching-part-default: var(
+    --x-size-line-height-suggestion-default
+  );
+  --x-number-font-weight-suggestion-matching-part-default: var(
+    --x-number-font-weight-suggestion-default
+  );
+  --x-font-family-suggestion-non-matching-part-default: var(--x-font-family-suggestion-default);
+  --x-size-font-suggestion-non-matching-part-default: var(--x-size-font-suggestion-default);
+  --x-size-line-height-suggestion-non-matching-part-default: var(
+    --x-size-line-height-suggestion-default
+  );
+  --x-number-font-weight-suggestion-non-matching-part-default: var(
+    --x-number-font-weight-suggestion-default
+  );
 }

--- a/packages/x-components/src/design-system/components/suggestion/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/suggestion/default.tokens.scss
@@ -1,8 +1,8 @@
 :root {
   // color
   --x-color-text-suggestion-default: var(--x-color-text-default);
-  --x-color-text-suggestion-matching-part-default: var(--x-color-base-neutral-35);
-  --x-color-text-suggestion-non-matching-part-default: var(--x-color-text-suggestion-default);
+  --x-color-text-suggestion-matching-part-default-has-matching-query: red;
+  --x-color-text-suggestion-default-has-matching-query: blue;
   --x-color-background-suggestion-default: transparent;
 
   // size
@@ -17,20 +17,18 @@
   --x-size-font-suggestion-default: var(--x-size-font-text);
   --x-size-line-height-suggestion-default: var(--x-size-line-height-text);
   --x-number-font-weight-suggestion-default: var(--x-number-font-weight-text);
-  --x-font-family-suggestion-matching-part-default: var(--x-font-family-suggestion-default);
-  --x-size-font-suggestion-matching-part-default: var(--x-size-font-suggestion-default);
-  --x-size-line-height-suggestion-matching-part-default: var(
+  --x-font-family-suggestion-matching-part-default-has-matching-query: var(--x-font-family-suggestion-default);
+  --x-size-font-suggestion-matching-part-default-has-matching-query: var(--x-size-font-suggestion-default);
+  --x-size-line-height-suggestion-matching-part-default-has-matching-query: var(
     --x-size-line-height-suggestion-default
   );
-  --x-number-font-weight-suggestion-matching-part-default: var(
+  --x-number-font-weight-suggestion-matching-part-default-has-matching-query: var(
     --x-number-font-weight-suggestion-default
   );
-  --x-font-family-suggestion-non-matching-part-default: var(--x-font-family-suggestion-default);
-  --x-size-font-suggestion-non-matching-part-default: var(--x-size-font-suggestion-default);
-  --x-size-line-height-suggestion-non-matching-part-default: var(
+  --x-font-family-suggestion-default-has-matching-query: var(--x-font-family-suggestion-default);
+  --x-size-font-suggestion-default-has-matching-query: var(--x-size-font-suggestion-default);
+  --x-size-line-height-suggestion-default-has-matching-query: var(
     --x-size-line-height-suggestion-default
   );
-  --x-number-font-weight-suggestion-non-matching-part-default: var(
-    --x-number-font-weight-suggestion-default
-  );
+  --x-number-font-weight-suggestion-default-has-matching-query: bold;
 }

--- a/packages/x-components/src/design-system/components/suggestion/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/suggestion/default.tokens.scss
@@ -1,8 +1,8 @@
 :root {
   // color
   --x-color-text-suggestion-default: var(--x-color-text-default);
-  --x-color-text-suggestion-matching-part-default-has-matching-query: red;
-  --x-color-text-suggestion-default-has-matching-query: blue;
+  --x-color-text-suggestion-matching-part-default: red;
+  --x-color-text-suggestion-default-matching: blue;
   --x-color-background-suggestion-default: transparent;
 
   // size
@@ -17,18 +17,18 @@
   --x-size-font-suggestion-default: var(--x-size-font-text);
   --x-size-line-height-suggestion-default: var(--x-size-line-height-text);
   --x-number-font-weight-suggestion-default: var(--x-number-font-weight-text);
-  --x-font-family-suggestion-matching-part-default-has-matching-query: var(--x-font-family-suggestion-default);
-  --x-size-font-suggestion-matching-part-default-has-matching-query: var(--x-size-font-suggestion-default);
-  --x-size-line-height-suggestion-matching-part-default-has-matching-query: var(
+  --x-font-family-suggestion-matching-part-default: var(--x-font-family-suggestion-default);
+  --x-size-font-suggestion-matching-part-default: var(--x-size-font-suggestion-default);
+  --x-size-line-height-suggestion-matching-part-default: var(
     --x-size-line-height-suggestion-default
   );
-  --x-number-font-weight-suggestion-matching-part-default-has-matching-query: var(
+  --x-number-font-weight-suggestion-matching-part-default: var(
     --x-number-font-weight-suggestion-default
   );
-  --x-font-family-suggestion-default-has-matching-query: var(--x-font-family-suggestion-default);
-  --x-size-font-suggestion-default-has-matching-query: var(--x-size-font-suggestion-default);
-  --x-size-line-height-suggestion-default-has-matching-query: var(
+  --x-font-family-suggestion-default-matching: var(--x-font-family-suggestion-default);
+  --x-size-font-suggestion-default-matching: var(--x-size-font-suggestion-default);
+  --x-size-line-height-suggestion-default-matching: var(
     --x-size-line-height-suggestion-default
   );
-  --x-number-font-weight-suggestion-default-has-matching-query: bold;
+  --x-number-font-weight-suggestion-default-matching: bold;
 }

--- a/packages/x-components/src/design-system/components/typography/default.scss
+++ b/packages/x-components/src/design-system/components/typography/default.scss
@@ -5,7 +5,7 @@
   font-size: var(--x-size-font-text);
   font-weight: var(--x-number-font-weight-text);
   line-height: var(--x-size-line-height-text);
-  text-decoration: var(--x-font-text-decoration);
+  text-decoration: var(--x-string-text-decoration);
 
   // color
   color: var(--x-color-text-default);

--- a/packages/x-components/src/design-system/components/typography/stroke.scss
+++ b/packages/x-components/src/design-system/components/typography/stroke.scss
@@ -7,7 +7,7 @@
     --x-string-text-decoration-title1: line-through;
   }
   &.x-title2 {
-    --x-string-text-ecoration-title2: line-through;
+    --x-string-text-decoration-title2: line-through;
   }
   &.x-title3 {
     --x-string-text-decoration-title3: line-through;

--- a/packages/x-components/src/design-system/components/typography/stroke.scss
+++ b/packages/x-components/src/design-system/components/typography/stroke.scss
@@ -1,18 +1,18 @@
 // text
 .x-text--stroke {
   &.x-text {
-    --x-font-text-decoration: line-through;
+    --x-string-text-decoration: line-through;
   }
   &.x-title1 {
-    --x-font-decoration-title1: line-through;
+    --x-string-text-decoration-title1: line-through;
   }
   &.x-title2 {
-    --x-font-decoration-title2: line-through;
+    --x-string-text-ecoration-title2: line-through;
   }
   &.x-title3 {
-    --x-font-decoration-title3: line-through;
+    --x-string-text-decoration-title3: line-through;
   }
   &.x-small {
-    --x-font-decoration-small: line-through;
+    --x-string-text-decoration-small: line-through;
   }
 }

--- a/packages/x-components/src/views/design-system.vue
+++ b/packages/x-components/src/views/design-system.vue
@@ -1884,7 +1884,7 @@
       <article class="x-list x-list--wrap x-list--gap-06 x-list--align-start">
         <h2 class="x-title2">Default</h2>
 
-        <div class="x-suggestion x-suggestion--has-matching-query">
+        <div class="x-suggestion">
           <span class="x-suggestion__query">Suggestion</span>
         </div>
 
@@ -1895,7 +1895,7 @@
           </span>
         </div>
 
-        <div class="x-suggestion">
+        <div class="x-suggestion x-suggestion--has-matching-query">
           <SearchIcon />
           <span class="x-suggestion__query">
             Suggestion
@@ -1936,7 +1936,7 @@
         <h2 class="x-title2">Default</h2>
 
         <div class="x-suggestion-group">
-          <div class="x-suggestion x-suggestion--has-matching-query">
+          <div class="x-suggestion">
             <span class="x-suggestion__query">Suggestion</span>
           </div>
           <button class="x-button">

--- a/packages/x-components/src/views/design-system.vue
+++ b/packages/x-components/src/views/design-system.vue
@@ -1884,7 +1884,11 @@
       <article class="x-list x-list--wrap x-list--gap-06 x-list--align-start">
         <h2 class="x-title2">Default</h2>
 
-        <div class="x-suggestion">
+        <div class="x-suggestion x-suggestion--has-matching-query">
+          <span class="x-suggestion__query">Suggestion</span>
+        </div>
+
+        <div class="x-suggestion x-suggestion--has-matching-query">
           <span class="x-suggestion__query">
             Suggestion
             <span class="x-suggestion__matching-part">Query</span>
@@ -1899,7 +1903,7 @@
           </span>
         </div>
 
-        <div class="x-suggestion">
+        <div class="x-suggestion x-suggestion--has-matching-query">
           <span class="x-suggestion__query">
             Suggestion
             <span class="x-suggestion__matching-part">Query</span>
@@ -1907,7 +1911,7 @@
           <SearchIcon />
         </div>
 
-        <div class="x-suggestion">
+        <div class="x-suggestion x-suggestion--has-matching-query">
           <SearchIcon />
           <span class="x-suggestion__query">
             Suggestion extra large name
@@ -1915,7 +1919,7 @@
           </span>
         </div>
 
-        <div class="x-suggestion">
+        <div class="x-suggestion x-suggestion--has-matching-query">
           <span class="x-suggestion__query">
             Suggestion extra large name
             <span class="x-suggestion__matching-part">Query</span>
@@ -1932,7 +1936,16 @@
         <h2 class="x-title2">Default</h2>
 
         <div class="x-suggestion-group">
-          <div class="x-suggestion">
+          <div class="x-suggestion x-suggestion--has-matching-query">
+            <span class="x-suggestion__query">Suggestion</span>
+          </div>
+          <button class="x-button">
+            <CrossIcon />
+          </button>
+        </div>
+
+        <div class="x-suggestion-group">
+          <div class="x-suggestion x-suggestion--has-matching-query">
             <span class="x-suggestion__query">
               Suggestion
               <span class="x-suggestion__matching-part">Query</span>
@@ -1947,7 +1960,7 @@
           <button class="x-button">
             <CrossIcon />
           </button>
-          <div class="x-suggestion">
+          <div class="x-suggestion x-suggestion--has-matching-query">
             <span class="x-suggestion__query">
               Suggestion
               <span class="x-suggestion__matching-part">Query</span>
@@ -1956,7 +1969,7 @@
         </div>
 
         <div class="x-suggestion-group">
-          <div class="x-suggestion">
+          <div class="x-suggestion x-suggestion--has-matching-query">
             <SearchIcon />
             <span class="x-suggestion__query">
               Suggestion
@@ -1972,7 +1985,7 @@
           <button class="x-button">
             <CrossIcon />
           </button>
-          <div class="x-suggestion">
+          <div class="x-suggestion x-suggestion--has-matching-query">
             <span class="x-suggestion__query">
               Suggestion
               <span class="x-suggestion__matching-part">Query</span>
@@ -1985,7 +1998,7 @@
           <button class="x-button">
             <CrossIcon />
           </button>
-          <div class="x-suggestion">
+          <div class="x-suggestion x-suggestion--has-matching-query">
             <span class="x-suggestion__query">
               Suggestion extra large name
               <span class="x-suggestion__matching-part">Query</span>

--- a/packages/x-components/src/views/design-system.vue
+++ b/packages/x-components/src/views/design-system.vue
@@ -1888,14 +1888,14 @@
           <span class="x-suggestion__query">Suggestion</span>
         </div>
 
-        <div class="x-suggestion x-suggestion--has-matching-query">
+        <div class="x-suggestion x-suggestion--matching">
           <span class="x-suggestion__query">
             Suggestion
             <span class="x-suggestion__matching-part">Query</span>
           </span>
         </div>
 
-        <div class="x-suggestion x-suggestion--has-matching-query">
+        <div class="x-suggestion x-suggestion--matching">
           <SearchIcon />
           <span class="x-suggestion__query">
             Suggestion
@@ -1903,7 +1903,7 @@
           </span>
         </div>
 
-        <div class="x-suggestion x-suggestion--has-matching-query">
+        <div class="x-suggestion x-suggestion--matching">
           <span class="x-suggestion__query">
             Suggestion
             <span class="x-suggestion__matching-part">Query</span>
@@ -1911,7 +1911,7 @@
           <SearchIcon />
         </div>
 
-        <div class="x-suggestion x-suggestion--has-matching-query">
+        <div class="x-suggestion x-suggestion--matching">
           <SearchIcon />
           <span class="x-suggestion__query">
             Suggestion extra large name
@@ -1919,7 +1919,7 @@
           </span>
         </div>
 
-        <div class="x-suggestion x-suggestion--has-matching-query">
+        <div class="x-suggestion x-suggestion--matching">
           <span class="x-suggestion__query">
             Suggestion extra large name
             <span class="x-suggestion__matching-part">Query</span>
@@ -1945,7 +1945,7 @@
         </div>
 
         <div class="x-suggestion-group">
-          <div class="x-suggestion x-suggestion--has-matching-query">
+          <div class="x-suggestion x-suggestion--matching">
             <span class="x-suggestion__query">
               Suggestion
               <span class="x-suggestion__matching-part">Query</span>
@@ -1960,7 +1960,7 @@
           <button class="x-button">
             <CrossIcon />
           </button>
-          <div class="x-suggestion x-suggestion--has-matching-query">
+          <div class="x-suggestion x-suggestion--matching">
             <span class="x-suggestion__query">
               Suggestion
               <span class="x-suggestion__matching-part">Query</span>
@@ -1969,7 +1969,7 @@
         </div>
 
         <div class="x-suggestion-group">
-          <div class="x-suggestion x-suggestion--has-matching-query">
+          <div class="x-suggestion x-suggestion--matching">
             <SearchIcon />
             <span class="x-suggestion__query">
               Suggestion
@@ -1985,7 +1985,7 @@
           <button class="x-button">
             <CrossIcon />
           </button>
-          <div class="x-suggestion x-suggestion--has-matching-query">
+          <div class="x-suggestion x-suggestion--matching">
             <span class="x-suggestion__query">
               Suggestion
               <span class="x-suggestion__matching-part">Query</span>
@@ -1998,7 +1998,7 @@
           <button class="x-button">
             <CrossIcon />
           </button>
-          <div class="x-suggestion x-suggestion--has-matching-query">
+          <div class="x-suggestion x-suggestion--matching">
             <span class="x-suggestion__query">
               Suggestion extra large name
               <span class="x-suggestion__matching-part">Query</span>

--- a/packages/x-components/src/x-modules/query-suggestions/components/__tests__/query-suggestion.spec.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/components/__tests__/query-suggestion.spec.ts
@@ -40,7 +40,7 @@ describe('testing query-suggestion component', () => {
 
     await localVue.nextTick();
 
-    expect(component.classes()).toContain('x-suggestion--has-matching-query');
+    expect(component.classes()).toContain('x-suggestion--matching');
   });
 
   it('renders the suggestion received as prop', () => {


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Description

Applies only matching part tokens when the suggestion has the `--matching` modifier. Adds new `non-matching` tokens.