### PR TITLE
[EX-4750] use layout in mocked tests

### DIFF
--- a/packages/x-components/src/router.ts
+++ b/packages/x-components/src/router.ts
@@ -5,14 +5,14 @@ Vue.use(VueRouter);
 
 const routes: RouteConfig[] = [
   {
+    path: '/',
+    name: 'Layout',
+    component: () => import('./views/Layout.vue')
+  },
+  {
     path: '/design-system',
     name: 'Design System',
     component: () => import('./views/design-system.vue')
-  },
-  {
-    path: '/layout',
-    name: 'Layout',
-    component: () => import('./views/Layout.vue')
   },
   {
     path: '/empathize',

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -273,9 +273,9 @@
             <template #default="{ partialResult }">
               <span data-test="partial-query">{{ partialResult.query }}</span>
               <BaseGrid :animation="resultsAnimation" :columns="4" :items="partialResult.results">
-                <template #Result="{ item: partialResult }">
+                <template #Result="{ item }">
                   <article class="result" style="max-width: 300px">
-                    <BaseResultImage :result="partialResult" class="x-picture--colored">
+                    <BaseResultImage :result="item" class="x-picture--colored">
                       <template #placeholder>
                         <div style="padding-top: 100%; background-color: lightgray"></div>
                       </template>
@@ -283,7 +283,7 @@
                         <div style="padding-top: 100%; background-color: lightsalmon"></div>
                       </template>
                     </BaseResultImage>
-                    <BaseResultLink :result="partialResult" class="x-result-link">
+                    <BaseResultLink :result="item" class="x-result-link">
                       <span class="x-result__title" data-test="partial-result-item">
                         {{ item.name }}
                       </span>
@@ -297,26 +297,27 @@
             </template>
           </PartialResultsList>
 
-          <IdentifierResults v-if="$x.identifierResults.length">
-            <template #default="{ identifierResults }">
-              <BaseGrid :animation="resultsAnimation" :columns="4" :items="identifierResults">
-                <template #Result="{ item: identifierResult }">
-                  <article class="result" style="max-width: 300px">
-                    <BaseResultImage :result="identifierResult" class="x-picture--colored">
-                      <template #placeholder>
-                        <div style="padding-top: 100%; background-color: lightgray"></div>
-                      </template>
-                      <template #fallback>
-                        <div style="padding-top: 100%; background-color: lightsalmon"></div>
-                      </template>
-                    </BaseResultImage>
-                    <h1 class="x-title3" data-test="identifier-results-item">
-                      {{ identifierResult.name }}
-                    </h1>
-                  </article>
-                </template>
-              </BaseGrid>
-            </template>
+          <h1 v-if="$x.identifierResults.length" class="x-title1">Identifier Results</h1>
+          <IdentifierResults v-if="$x.identifierResults.length" #layout="{ identifierResult }">
+            <BaseGrid :animation="resultsAnimation" :columns="4" :items="identifierResult.results">
+              <template #Result="{ item: identifierResult }">
+                <article class="result" style="max-width: 300px">
+                  <BaseResultImage :result="identifierResult" class="x-picture--colored">
+                    <template #placeholder>
+                      <div style="padding-top: 100%; background-color: lightgray"></div>
+                    </template>
+                    <template #fallback>
+                      <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                    </template>
+                  </BaseResultImage>
+                  <BaseResultLink :result="identifierResult" class="x-result-link">
+                    <span class="x-result__title" data-test="identifier-results-item">
+                      {{ item.name }}
+                    </span>
+                  </BaseResultLink>
+                </article>
+              </template>
+            </BaseGrid>
           </IdentifierResults>
         </template>
 
@@ -332,9 +333,10 @@
 
 <script lang="ts">
   import { deepMerge } from '@empathyco/x-deep-merge';
-  import { Facet, SimpleFilter as SimpleFilterModel } from '@empathyco/x-types';
+  import { Facet, Result, SimpleFilter as SimpleFilterModel } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
+  import { State } from '../components/decorators/store.decorators';
   // eslint-disable-next-line max-len
   import ClearHistoryQueries from '../x-modules/history-queries/components/clear-history-queries.vue';
   import CollapseFromTop from '../components/animations/collapse-from-top.vue';

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -274,7 +274,7 @@
               <span data-test="partial-query">{{ partialResult.query }}</span>
               <BaseGrid :animation="resultsAnimation" :columns="4" :items="partialResult.results">
                 <template #Result="{ item }">
-                  <Result :result="item" data-test="partial-result-item"/>
+                  <Result :result="item" data-test="partial-result-item" />
                 </template>
               </BaseGrid>
               <PartialQueryButton :query="partialResult.query">
@@ -282,7 +282,28 @@
               </PartialQueryButton>
             </template>
           </PartialResultsList>
+
+          <IdentifierResults v-if="$x.identifierResults.length">
+            <template #default="{ identifierResults }">
+              <BaseGrid :animation="resultsAnimation" :columns="4" :items="identifierResults">
+                <template #Result="{ item: result }">
+                  <article class="result" style="max-width: 300px">
+                    <BaseResultImage :result="result" class="x-picture--colored">
+                      <template #placeholder>
+                        <div style="padding-top: 100%; background-color: lightgray"></div>
+                      </template>
+                      <template #fallback>
+                        <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                      </template>
+                    </BaseResultImage>
+                    <h1 class="x-title3" data-test="identifier-results-item">{{ result.name }}</h1>
+                  </article>
+                </template>
+              </BaseGrid>
+            </template>
+          </IdentifierResults>
         </template>
+
 
         <template #scroll-to-top>
           <BaseScrollToTop :threshold-px="500" class="x-button--round" scroll-id="body-scroll">
@@ -296,10 +317,9 @@
 
 <script lang="ts">
   import { deepMerge } from '@empathyco/x-deep-merge';
-  import { Facet, Result, SimpleFilter as SimpleFilterModel } from '@empathyco/x-types';
+  import { Facet, SimpleFilter as SimpleFilterModel } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
-  import { State } from '../components/decorators/store.decorators';
   // eslint-disable-next-line max-len
   import ClearHistoryQueries from '../x-modules/history-queries/components/clear-history-queries.vue';
   import CollapseFromTop from '../components/animations/collapse-from-top.vue';

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -229,6 +229,25 @@
         </template>
 
         <template #main-body>
+          <!-- IdentifierResults -->
+          <div v-if="$x.identifierResults.length">
+            <IdentifierResults class="x-list x-list--horizontal">
+              <template #default="{ identifierResult }">
+                <article class="result" style="max-width: 300px">
+                  <BaseResultImage :result="identifierResult" class="x-picture--colored">
+                    <template #placeholder>
+                      <div style="padding-top: 100%; background-color: lightgray"></div>
+                    </template>
+                    <template #fallback>
+                      <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                    </template>
+                  </BaseResultImage>
+                  <h1 class="x-title3" data-test="result-text">{{ identifierResult.name }}</h1>
+                </article>
+              </template>
+            </IdentifierResults>
+          </div>
+
           <!-- Recommendations -->
           <Recommendations v-if="!$x.query.search" #layout="{ recommendations }">
             <BaseVariableColumnGrid
@@ -296,29 +315,6 @@
               </PartialQueryButton>
             </template>
           </PartialResultsList>
-
-          <h1 v-if="$x.identifierResults.length" class="x-title1">Identifier Results</h1>
-          <IdentifierResults v-if="$x.identifierResults.length" #layout="{ identifierResult }">
-            <BaseGrid :animation="resultsAnimation" :columns="4" :items="identifierResult.results">
-              <template #Result="{ item: identifierResult }">
-                <article class="result" style="max-width: 300px">
-                  <BaseResultImage :result="identifierResult" class="x-picture--colored">
-                    <template #placeholder>
-                      <div style="padding-top: 100%; background-color: lightgray"></div>
-                    </template>
-                    <template #fallback>
-                      <div style="padding-top: 100%; background-color: lightsalmon"></div>
-                    </template>
-                  </BaseResultImage>
-                  <BaseResultLink :result="identifierResult" class="x-result-link">
-                    <span class="x-result__title" data-test="identifier-results-item">
-                      {{ item.name }}
-                    </span>
-                  </BaseResultLink>
-                </article>
-              </template>
-            </BaseGrid>
-          </IdentifierResults>
         </template>
 
         <template #scroll-to-top>

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -273,8 +273,22 @@
             <template #default="{ partialResult }">
               <span data-test="partial-query">{{ partialResult.query }}</span>
               <BaseGrid :animation="resultsAnimation" :columns="4" :items="partialResult.results">
-                <template #Result="{ item }">
-                  <Result :result="item" data-test="partial-result-item" />
+                <template #Result="{ item: partialResult }">
+                  <article class="result" style="max-width: 300px">
+                    <BaseResultImage :result="partialResult" class="x-picture--colored">
+                      <template #placeholder>
+                        <div style="padding-top: 100%; background-color: lightgray"></div>
+                      </template>
+                      <template #fallback>
+                        <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                      </template>
+                    </BaseResultImage>
+                    <BaseResultLink :result="partialResult" class="x-result-link">
+                      <span class="x-result__title" data-test="partial-result-item">
+                        {{ item.name }}
+                      </span>
+                    </BaseResultLink>
+                  </article>
                 </template>
               </BaseGrid>
               <PartialQueryButton :query="partialResult.query">
@@ -286,9 +300,9 @@
           <IdentifierResults v-if="$x.identifierResults.length">
             <template #default="{ identifierResults }">
               <BaseGrid :animation="resultsAnimation" :columns="4" :items="identifierResults">
-                <template #Result="{ item: result }">
+                <template #Result="{ item: identifierResult }">
                   <article class="result" style="max-width: 300px">
-                    <BaseResultImage :result="result" class="x-picture--colored">
+                    <BaseResultImage :result="identifierResult" class="x-picture--colored">
                       <template #placeholder>
                         <div style="padding-top: 100%; background-color: lightgray"></div>
                       </template>
@@ -296,14 +310,15 @@
                         <div style="padding-top: 100%; background-color: lightsalmon"></div>
                       </template>
                     </BaseResultImage>
-                    <h1 class="x-title3" data-test="identifier-results-item">{{ result.name }}</h1>
+                    <h1 class="x-title3" data-test="identifier-results-item">
+                      {{ identifierResult.name }}
+                    </h1>
                   </article>
                 </template>
               </BaseGrid>
             </template>
           </IdentifierResults>
         </template>
-
 
         <template #scroll-to-top>
           <BaseScrollToTop :threshold-px="500" class="x-button--round" scroll-id="body-scroll">

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -271,21 +271,51 @@
 
           <!-- Results -->
           <ResultsList v-infinite-scroll:main-scroll>
-            <BaseVariableColumnGrid :animation="resultsAnimation">
-              <template #Result="{ item: result }">
-                <article class="result" style="max-width: 300px">
-                  <BaseResultImage :result="result" class="x-picture--colored">
-                    <template #placeholder>
-                      <div style="padding-top: 100%; background-color: lightgray"></div>
+            <BannersList>
+              <PromotedsList>
+                <NextQueriesList>
+                  <BaseVariableColumnGrid :animation="resultsAnimation">
+                    <template #Result="{ item: result }">
+                      <article class="result" style="max-width: 300px">
+                        <BaseResultImage :result="result" class="x-picture--colored">
+                          <template #placeholder>
+                            <div style="padding-top: 100%; background-color: lightgray"></div>
+                          </template>
+                          <template #fallback>
+                            <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                          </template>
+                        </BaseResultImage>
+                        <h1 class="x-title3" data-test="result-text">{{ result.name }}</h1>
+                      </article>
                     </template>
-                    <template #fallback>
-                      <div style="padding-top: 100%; background-color: lightsalmon"></div>
+
+                    <template #Banner="{ item: banner }">
+                      <Banner :banner="banner" />
                     </template>
-                  </BaseResultImage>
-                  <h1 class="x-title3" data-test="result-text">{{ result.name }}</h1>
-                </article>
-              </template>
-            </BaseVariableColumnGrid>
+
+                    <template #Promoted="{ item: promoted }">
+                      <Promoted :promoted="promoted" />
+                    </template>
+
+                    <template #NextQueriesGroup="{ item: { nextQueries } }">
+                      <div class="x-list x-list--gap-03">
+                        <h1 class="x-title2">What's next?</h1>
+                        <BaseSuggestions
+                          #default="{ suggestion }"
+                          :suggestions="nextQueries"
+                          class="x-list--gap-03"
+                        >
+                          <NextQuery #default="{ suggestion: nextQuery }" :suggestion="suggestion">
+                            <Nq1 />
+                            {{ nextQuery.query }}
+                          </NextQuery>
+                        </BaseSuggestions>
+                      </div>
+                    </template>
+                  </BaseVariableColumnGrid>
+                </NextQueriesList>
+              </PromotedsList>
+            </BannersList>
           </ResultsList>
 
           <PartialResultsList :animation="resultsAnimation">
@@ -329,10 +359,9 @@
 
 <script lang="ts">
   import { deepMerge } from '@empathyco/x-deep-merge';
-  import { Facet, Result, SimpleFilter as SimpleFilterModel } from '@empathyco/x-types';
+  import { Facet, SimpleFilter as SimpleFilterModel } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
-  import { State } from '../components/decorators/store.decorators';
   // eslint-disable-next-line max-len
   import ClearHistoryQueries from '../x-modules/history-queries/components/clear-history-queries.vue';
   import CollapseFromTop from '../components/animations/collapse-from-top.vue';

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -2,6 +2,28 @@
   <div>
     <UrlHandler />
     <BaseEventsModalOpen>Start</BaseEventsModalOpen>
+    <h1>Test controls</h1>
+    <ul class="x-test-controls">
+      <li class="x-test-controls__control">
+        <label>
+          <input
+            v-model="controls.searchInput.instant"
+            type="checkbox"
+            data-test="search-input-instant"
+          />
+          search-input - instant
+        </label>
+      </li>
+      <li class="x-test-controls__control">
+        <label for="searchInput.instantDebounceInMs">search-input - debounce</label>
+        <input
+          v-model="controls.searchInput.instantDebounceInMs"
+          id="searchInput.instantDebounceInMs"
+          type="number"
+          data-test="search-input-debounce"
+        />
+      </li>
+    </ul>
     <BaseEventsModal
       :eventsToOpenModal="[
         'UserClickedOpenEventsModal',
@@ -229,7 +251,7 @@
                             <div style="padding-top: 100%; background-color: lightsalmon"></div>
                           </template>
                         </BaseResultImage>
-                        <h1 class="x-title3">{{ result.name }}</h1>
+                        <h1 class="x-title3" data-test="result-text">{{ result.name }}</h1>
                       </article>
                     </template>
 
@@ -430,6 +452,12 @@
     protected sortDropdownAnimation = CollapseHeight;
     protected selectedColumns = 4;
     protected sortValues = ['', 'priceSort asc', 'priceSort desc'];
+    protected controls = {
+      searchInput: {
+        instant: true,
+        instantDebounceInMs: 500 // default
+      }
+    };
     protected staticFacets: Facet[] = [
       {
         modelName: 'SimpleFacet',

--- a/packages/x-components/src/views/history-queries.vue
+++ b/packages/x-components/src/views/history-queries.vue
@@ -65,7 +65,7 @@
     <!-- Testing purpose -->
     <ul>
       <h1>Results</h1>
-      <li v-for="result in results" :key="result.id" data-test="result-item">
+      <li v-for="result in results" :key="result.id" data-test="result-text">
         {{ result.name }}
       </li>
     </ul>

--- a/packages/x-components/src/views/keyboard-navigation.vue
+++ b/packages/x-components/src/views/keyboard-navigation.vue
@@ -111,7 +111,7 @@
     <!-- Testing purpose -->
     <ul>
       <h1>Results</h1>
-      <li v-for="result in results" :key="result.id" data-test="result-item">
+      <li v-for="result in results" :key="result.id" data-test="result-text">
         {{ result.name }}
       </li>
     </ul>

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -65,9 +65,9 @@ Then('related results are displayed', () => {
 });
 
 Then('related results have changed', () => {
-  cy.getByDataTest('result-item').should($results => {
+  cy.getByDataTest('result-text').should($results => {
     const compoundResultsList = $results.toArray().map(resultElement => resultElement.textContent);
-    expect(compoundResultsList.every(item => resultsList.includes(item!))).to.eq(false);
+    expect(compoundResultsList).to.not.equal(resultsList);
   });
 });
 

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -10,6 +10,11 @@ import {
 
 let resultsList: string[] = [];
 
+// Init
+When('start button is clicked', () => {
+  cy.getByDataTest('open-modal').click();
+});
+
 // ID Results
 Then('identifier results are displayed', () => {
   cy.getByDataTest('identifier-results-item').should('have.length.at.least', 1);
@@ -52,7 +57,7 @@ Then('related tags are displayed', () => {
 // Results
 Then('related results are displayed', () => {
   resultsList = [];
-  cy.getByDataTest('result-item')
+  cy.getByDataTest('result-text')
     .should('have.length.at.least', 1)
     .each($result => {
       resultsList.push($result.text());

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -17,11 +17,13 @@ When('start button is clicked', () => {
 
 // ID Results
 Then('identifier results are displayed', () => {
-  cy.getByDataTest('identifier-results-item').should('have.length.at.least', 1);
+  cy.getByDataTest('identifier-results-item')
+    .should('be.visible')
+    .should('have.length.at.least', 1);
 });
 
 Then('no identifier results are displayed', () => {
-  cy.getByDataTest('identifier-result-item').should('not.exist');
+  cy.getByDataTest('identifier-result-item').should('not.be.visible').should('not.exist');
 });
 
 // History Queries
@@ -58,6 +60,7 @@ Then('related tags are displayed', () => {
 Then('related results are displayed', () => {
   resultsList = [];
   cy.getByDataTest('result-text')
+    .should('be.visible')
     .should('have.length.at.least', 1)
     .each($result => {
       resultsList.push($result.text());
@@ -65,8 +68,12 @@ Then('related results are displayed', () => {
 });
 
 Then('related results have changed', () => {
-  cy.getByDataTest('result-text').should($results => {
-    const compoundResultsList = $results.toArray().map(resultElement => resultElement.textContent);
+  cy.getByDataTest('result-text')
+    .should('be.visible')
+    .should($results => {
+      const compoundResultsList = $results
+        .toArray()
+        .map(resultElement => resultElement.textContent);
     expect(compoundResultsList).to.not.equal(resultsList);
   });
 });
@@ -134,7 +141,7 @@ Given('a results API', () => {
     req.reply({
       results: getResultsStub()
     });
-  });
+  }).as('interceptedRawResults');
 });
 
 Given('an ID results API', () => {

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -1,6 +1,7 @@
 import { PageableRequest } from '@empathyco/x-adapter';
 import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 import {
+  createResultStub,
   getNextQueriesStub,
   getPopularSearchesStub,
   getQuerySuggestionsStub,
@@ -74,7 +75,7 @@ Then('related results have changed', () => {
       const compoundResultsList = $results
         .toArray()
         .map(resultElement => resultElement.textContent);
-      expect(compoundResultsList).to.not.equal(resultsList);
+      expect(compoundResultsList.every(item => resultsList.includes(item!))).to.eq(false);
   });
 });
 
@@ -139,10 +140,45 @@ Given('a related tags API', () => {
 Given('a results API', () => {
   cy.intercept('https://api.empathy.co/search', req => {
     req.reply({
+      banners: [],
+      promoteds: [],
       results: getResultsStub()
     });
   }).as('interceptedRawResults');
 });
+
+Given('a results API with a known response', () => {
+  cy.intercept('https://api.empathy.co/search', req => {
+    req.reply({
+      banners: [],
+      promoteds: [],
+      results: [
+        createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
+          images: ['https://picsum.photos/seed/1/100/100']
+        }),
+        createResultStub('LEGO Duplo Classic Caja de Ladrillos - 1091', {
+          images: ['https://picsum.photos/seed/2/100/100']
+        }),
+        createResultStub('LEGO City Coche Patrulla de Policía - 60239', {
+          images: ['https://picsum.photos/seed/3/100/100']
+        }),
+        createResultStub('LEGO City Police Caja de Ladrillos - 60270', {
+          images: ['https://picsum.photos/seed/4/100/100']
+        }),
+        createResultStub('LEGO Friends Parque para Cachorros - 41396', {
+          images: ['https://picsum.photos/seed/5/100/100']
+        }),
+        createResultStub('LEGO Creator Ciberdrón - 31111', {
+          images: ['https://picsum.photos/seed/6/100/100']
+        }),
+        createResultStub('LEGO Technic Dragster - 42103', {
+          images: ['https://picsum.photos/seed/7/100/100']
+        })
+      ]
+    });
+  }).as('interceptedResults');
+});
+
 
 Given('an ID results API', () => {
   cy.intercept('https://api.empathy.co/searchById', req => {

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -23,7 +23,7 @@ Then('identifier results are displayed', () => {
 });
 
 Then('no identifier results are displayed', () => {
-  cy.getByDataTest('identifier-result-item').should('not.be.visible').should('not.exist');
+  cy.getByDataTest('identifier-result-item').should('not.exist');
 });
 
 // History Queries
@@ -74,7 +74,7 @@ Then('related results have changed', () => {
       const compoundResultsList = $results
         .toArray()
         .map(resultElement => resultElement.textContent);
-    expect(compoundResultsList).to.not.equal(resultsList);
+      expect(compoundResultsList).to.not.equal(resultsList);
   });
 });
 

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.feature
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.feature
@@ -5,6 +5,7 @@ Feature: Identifier results component
 
   Scenario Outline: 1. ID search with results is made
     Given an ID results API with a known response
+    And   start button is clicked
     When  "<query>" is searched
     Then  identifier results are displayed
 
@@ -14,6 +15,7 @@ Feature: Identifier results component
 
   Scenario Outline: 2. ID search with no results is made
     Given an ID results API with no results
+    And   start button is clicked
     When  "<query>" is searched
     Then  no identifier results are displayed
 
@@ -23,6 +25,7 @@ Feature: Identifier results component
 
   Scenario Outline: 3. No ID search is made
     Given an ID results API with a known response
+    And   start button is clicked
     When  "<query>" is searched
     Then  no identifier results are displayed
 

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.feature
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.feature
@@ -1,7 +1,12 @@
 Feature: Identifier results component
 
   Background:
-    Given   no special config for identifier results view
+    Given a related tags API with a known response
+    And   a query suggestions API with a known response
+    And   a next queries API with a known response
+    And   a recommendations API with a known response
+    And   a results API with no results
+    And   no special config for identifier results view
 
   Scenario Outline: 1. ID search with results is made
     Given an ID results API with a known response

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
@@ -30,6 +30,14 @@ Given('an ID results API with no results', () => {
   }).as('interceptedNoIDResults');
 });
 
+And('a results API with no results', () => {
+  cy.intercept('https://api.empathy.co/search', req => {
+    req.reply({
+      results: []
+    });
+  }).as('interceptedNoResults');
+});
+
 And('no special config for identifier results view', () => {
   cy.visit('/?useMockedAdapter=true');
 });

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
@@ -5,10 +5,18 @@ Given('an ID results API with a known response', () => {
   cy.intercept('https://api.empathy.co/searchById', req => {
     req.reply({
       results: [
-        createResultStub('A0255072 - 9788467577112 - 160000'),
-        createResultStub('A0273378 - 9788467579543 - 166664'),
-        createResultStub('A0291017 - 9788467579536 - 166663'),
-        createResultStub('A0246951 - 8437006044851 - 4001')
+        createResultStub('A0255072 - 9788467577112 - 160000', {
+          images: ['https://picsum.photos/seed/20/100/100']
+        }),
+        createResultStub('A0273378 - 9788467579543 - 166664', {
+          images: ['https://picsum.photos/seed/21/100/100']
+        }),
+        createResultStub('A0291017 - 9788467579536 - 166663', {
+          images: ['https://picsum.photos/seed/22/100/100']
+        }),
+        createResultStub('A0246951 - 8437006044851 - 4001', {
+          images: ['https://picsum.photos/seed/23/100/100']
+        })
       ]
     });
   }).as('interceptedIDResults');
@@ -23,5 +31,5 @@ Given('an ID results API with no results', () => {
 });
 
 And('no special config for identifier results view', () => {
-  cy.visit('/test/identifier-results?useMockedAdapter=true');
+  cy.visit('/?useMockedAdapter=true');
 });

--- a/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.feature
+++ b/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.feature
@@ -6,7 +6,8 @@ Feature: Next queries component
 
   Scenario Outline: 1. Next query is clicked
     Given following config: hide session queries <hideSessionQueries>, requested items <maxItemsToRequest>, loadOnInit <loadOnInit>
-    When  "<query>" is searched
+    And   start button is clicked
+    When  a "<query>" with results is typed
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     And   at most <maxItemsToRequest> next queries are displayed
     When  next query number <nextQueryItem> is clicked
@@ -18,14 +19,14 @@ Feature: Next queries component
 
   Scenario Outline: 2. Next query is not shown if it matches a session history query
     Given following config: hide session queries <hideSessionQueries>, requested items <maxItemsToRequest>, loadOnInit <loadOnInit>
-    When  "<query>" is searched
+    And   start button is clicked
+    When  a "<query>" with results is typed
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     And   next query number <nextQueryItem> is clicked
     And   the searched query is displayed in history queries
     When  clear search button is pressed
     And   "<query>" is searched
-    Then  related results are displayed
-    And   next queries do not contain the history query is <hideSessionQueries>
+    Then  next queries do not contain the history query is <hideSessionQueries>
     When  clear history queries button is clicked
     Then  next queries contain the history query
 
@@ -36,15 +37,14 @@ Feature: Next queries component
 
   Scenario Outline: 3. Next queries persistence
     Given following config: hide session queries <hideSessionQueries>, requested items <maxItemsToRequest>, loadOnInit <loadOnInit>
-    When  "<query>" is searched
+    And   start button is clicked
+    When  a "<query>" with results is typed
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
-    And   related results are displayed
     And   next queries are displayed
     When  the page is reloaded
     Then  next queries are still displayed is <loadOnInit>
     When  "<query>" is searched
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
-    And   related results are displayed
     And   next queries are displayed
     When  clear search button is pressed
     Then  next queries are still displayed

--- a/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.feature
+++ b/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.feature
@@ -25,7 +25,7 @@ Feature: Next queries component
     And   next query number <nextQueryItem> is clicked
     And   the searched query is displayed in history queries
     When  clear search button is pressed
-    And   "<query>" is searched
+    And   a "<query>" with results is typed
     Then  next queries do not contain the history query is <hideSessionQueries>
     When  clear history queries button is clicked
     Then  next queries contain the history query
@@ -43,7 +43,7 @@ Feature: Next queries component
     And   next queries are displayed
     When  the page is reloaded
     Then  next queries are still displayed is <loadOnInit>
-    When  "<query>" is searched
+    When  a "<query>" with results is typed
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     And   next queries are displayed
     When  clear search button is pressed

--- a/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.spec.ts
@@ -33,7 +33,7 @@ Given(
       }
     };
 
-    cy.visit('/test/next-queries?useMockedAdapter=true', {
+    cy.visit('/?useMockedAdapter=true', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.feature
+++ b/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.feature
@@ -3,6 +3,7 @@ Feature: Partial results component
   Scenario Outline:  1. Shows no partial results if there are enough results
     Given a results API
     And   no special config for partial-results view
+    And   start button is clicked
     When  "<query>" is searched
     Then  at least 4 related results are displayed
     And   no partial results are displayed
@@ -14,6 +15,7 @@ Feature: Partial results component
   Scenario Outline: 2. Show partial results if there are not enough results
     Given a results API with partial results
     And   no special config for partial-results view
+    And   start button is clicked
     When  "<query>" is searched
     Then  less than 4 related results are displayed
     And   partial results are displayed
@@ -25,6 +27,7 @@ Feature: Partial results component
   Scenario Outline: 3. Click on partial query button launches new search
     Given a results API with partial results
     And   no special config for partial-results view
+    And   start button is clicked
     When  "<query>" is searched
     Then  less than 4 related results are displayed
     And   partial results are displayed

--- a/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.feature
+++ b/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.feature
@@ -1,5 +1,11 @@
 Feature: Partial results component
 
+  Background:
+    Given a related tags API with a known response
+    And   a query suggestions API with a known response
+    And   a next queries API with a known response
+    And   a recommendations API with a known response
+
   Scenario Outline:  1. Shows no partial results if there are enough results
     Given a results API
     And   no special config for partial-results view

--- a/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.spec.ts
@@ -5,6 +5,8 @@ import { createResultStub } from '../../../../src/__stubs__/results-stubs.factor
 Given('a results API with partial results', () => {
   cy.intercept('https://api.empathy.co/search', req => {
     req.reply({
+      banners: [],
+      promoteds: [],
       results: [
         createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
           images: ['https://picsum.photos/seed/1/100/100']

--- a/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.spec.ts
@@ -77,11 +77,8 @@ And('{string} contains the partial query', function (this: { searchedQuery: stri
 });
 
 When('first partial query button is clicked', function (this: { partialQueryButtonText: string }) {
-  cy.getByDataTest('partial-query-button')
-    .first()
-    .click()
-    .invoke('text')
-    .as('partialQueryButtonText');
+  cy.getByDataTest('partial-query').first().invoke('text').as('partialQueryButtonText');
+  cy.getByDataTest('partial-query-button').first().click();
 });
 
 Then(

--- a/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.spec.ts
@@ -5,7 +5,11 @@ import { createResultStub } from '../../../../src/__stubs__/results-stubs.factor
 Given('a results API with partial results', () => {
   cy.intercept('https://api.empathy.co/search', req => {
     req.reply({
-      results: [],
+      results: [
+        createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
+          images: ['https://picsum.photos/seed/1/100/100']
+        })
+      ],
       partialResults: [
         {
           query: 'verde azul',
@@ -48,7 +52,9 @@ Given('no special config for partial-results view', () => {
 });
 
 Then('at least {int} related results are displayed', (minResultsWithoutPartials: number) => {
-  cy.getByDataTest('result-text').should('have.length.at.least', minResultsWithoutPartials);
+  cy.getByDataTest('result-text')
+    .should('be.visible')
+    .should('have.length.at.least', minResultsWithoutPartials);
 });
 
 And('no partial results are displayed', () => {
@@ -57,11 +63,13 @@ And('no partial results are displayed', () => {
 
 // Scenario 2
 Then('less than {int} related results are displayed', (minResultsWithoutPartials: number) => {
-  cy.getByDataTest('regular-result').should('have.length.at.most', minResultsWithoutPartials - 1);
+  cy.getByDataTest('result-text')
+    .should('be.visible')
+    .should('have.length.at.most', minResultsWithoutPartials - 1);
 });
 
 And('partial results are displayed', () => {
-  cy.getByDataTest('partial-result-item').should('exist');
+  cy.getByDataTest('partial-result-item').should('be.visible');
 });
 
 // Scenario 3

--- a/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.spec.ts
@@ -10,18 +10,30 @@ Given('a results API with partial results', () => {
         {
           query: 'verde azul',
           results: [
-            createResultStub('Twister'),
-            createResultStub('Juego de Anillas Acuáticas Peces'),
-            createResultStub('Jurassic World Dinosaurio de Ataque Varios Modelos')
+            createResultStub('Twister', {
+              images: ['https://picsum.photos/seed/30/100/100']
+            }),
+            createResultStub('Juego de Anillas Acuáticas Peces', {
+              images: ['https://picsum.photos/seed/31/100/100']
+            }),
+            createResultStub('Jurassic World Dinosaurio de Ataque Varios Modelos', {
+              images: ['https://picsum.photos/seed/32/100/100']
+            })
           ],
           totalResults: 9
         },
         {
           query: 'lego verde',
           results: [
-            createResultStub('LEGO Classic Ladrillos Creativos Verdes - 11007'),
-            createResultStub('LEGO Creator Grandes Dinosaurios -31058'),
-            createResultStub('LEGO My City Casa Familiar - 60291')
+            createResultStub('LEGO Classic Ladrillos Creativos Verdes - 11007', {
+              images: ['https://picsum.photos/seed/33/100/100']
+            }),
+            createResultStub('LEGO Creator Grandes Dinosaurios -31058', {
+              images: ['https://picsum.photos/seed/34/100/100']
+            }),
+            createResultStub('LEGO My City Casa Familiar - 60291', {
+              images: ['https://picsum.photos/seed/35/100/100']
+            })
           ],
           totalResults: 6
         }
@@ -32,11 +44,11 @@ Given('a results API with partial results', () => {
 
 // Scenario 1
 Given('no special config for partial-results view', () => {
-  cy.visit('test/partial-results?useMockedAdapter=true');
+  cy.visit('/?useMockedAdapter=true');
 });
 
 Then('at least {int} related results are displayed', (minResultsWithoutPartials: number) => {
-  cy.getByDataTest('regular-result').should('have.length.at.least', minResultsWithoutPartials);
+  cy.getByDataTest('result-text').should('have.length.at.least', minResultsWithoutPartials);
 });
 
 And('no partial results are displayed', () => {

--- a/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.feature
+++ b/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.feature
@@ -6,6 +6,7 @@ Feature: Popular searches component
 
   Scenario Outline:  1. Popular searches are load together with the page
     Given following config: hide session queries <hideSessionQueries>, requested items <maxItemsToRequest>, rendered <maxItemsToRender>
+    And   start button is clicked
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     And   at most <maxItemsToRender> popular searched are displayed
     Examples:
@@ -17,12 +18,12 @@ Feature: Popular searches component
 
   Scenario Outline: 2. Popular search is clicked
     Given following config: hide session queries <hideSessionQueries>, requested items <maxItemsToRequest>, rendered <maxItemsToRender>
+    And   start button is clicked
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     When  popular search number <popularSearchItem> is clicked
     Then  the searched query is displayed in the search-box
     And   the clicked popular search is removed from Popular Searches if <hideSessionQueries> is true
     And   no new term is displayed in Popular Searches if hideSessionQueries = <hideSessionQueries> is true and maxItemsToRender = <maxItemsToRender> > maxItemsToRequest = <maxItemsToRequest>
-    And   related results are displayed
     And   the searched query is displayed in history queries
 
     Examples:

--- a/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.spec.ts
@@ -33,7 +33,7 @@ Given(
         }
       }
     };
-    cy.visit('/test/popular-searches?useMockedAdapter=true', {
+    cy.visit('/?useMockedAdapter=true', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.feature
+++ b/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.feature
@@ -5,6 +5,7 @@ Feature: Query-suggestions component
 
   Scenario Outline: 1. Query suggestions are displayed while typing a query
     Given following config: hide if equals query <hideIfEqualsQuery>, requested items <maxItemsToRequest>
+    And   start button is clicked
     And   no query suggestions are displayed
     When  a "<syllable>" with results is typed
     Then  at most <maxItemsToRequest> query suggestions are displayed
@@ -23,13 +24,16 @@ Feature: Query-suggestions component
 
   Scenario Outline: 2. Query suggestion is clicked
     Given following config: hide if equals query <hideIfEqualsQuery>, requested items <maxItemsToRequest>
+    And   start button is clicked
     And   a "<query>" with results is typed
     And   at most <maxItemsToRequest> query suggestions are displayed
     And   all query suggestions contain the searched query
     When  query suggestion number <querySuggestionItem> is clicked
     And   the searched query is displayed in the search-box
     Then  all query suggestions contain the searched query
-    And   the searched query is displayed in history queries
+    When  clear search button is pressed
+    And   search-input is focused
+    Then  the searched query is displayed in history queries
 
     Examples:
       | hideIfEqualsQuery | maxItemsToRequest | query   | querySuggestionItem |
@@ -37,6 +41,7 @@ Feature: Query-suggestions component
 
   Scenario Outline: 3. hideIfEqualsQuery behavior
     Given following config: hide if equals query <hideIfEqualsQuery>, requested items <maxItemsToRequest>
+    And   start button is clicked
     When  a "<query>" with results is typed
     Then  "<query>" term is not included as first query suggestion is <hideIfEqualsQuery>
 

--- a/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.spec.ts
@@ -34,7 +34,7 @@ Given(
         }
       }
     };
-    cy.visit('/test/query-suggestions?useMockedAdapter=true', {
+    cy.visit('/?useMockedAdapter=true', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.feature
+++ b/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.feature
@@ -5,9 +5,11 @@ Feature: Recommendations component
 
   Scenario Outline:  1. Recommendations are displayed
     Given following config: max items to store is <maxItemsToRequest>
+    And   start button is clicked
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     And   number of displayed recommendations are equal or less than <maxItemsToRequest>
-    And   each recommendation has an associated hyperlink containing image and text
+  # to include once recommendations and results have hyperlinks
+  #  And   each recommendation has an associated hyperlink containing image and text
 
     Examples:
       | maxItemsToRequest | request                    |

--- a/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.spec.ts
@@ -36,6 +36,7 @@ And(
   'number of displayed recommendations are equal or less than {int}',
   (maxItemsToRequest: number) => {
     cy.getByDataTest('recommendation-item')
+      .should('be.visible')
       .should('have.length.at.least', 1)
       .and('have.length.at.most', maxItemsToRequest);
   }

--- a/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.spec.ts
@@ -25,7 +25,7 @@ Given('following config: max items to store is {int}', (maxItemsToRequest: numbe
     }
   };
 
-  cy.visit('/test/recommendations?useMockedAdapter=true', {
+  cy.visit('/?useMockedAdapter=true', {
     qs: {
       xModules: JSON.stringify(config)
     }

--- a/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.feature
+++ b/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.feature
@@ -6,6 +6,7 @@ Feature: Related tags component
 
   Scenario Outline: 1. Related tag is selected
     Given following config: requested items <maxItemsToRequest>, add to search-box <addToSearchBox>
+    And   start button is clicked
     When  "<query>" is searched
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     Then  related results are displayed
@@ -28,6 +29,7 @@ Feature: Related tags component
 
   Scenario Outline: 2. Multiple related tags are selected
     Given following config: requested items <maxItemsToRequest>, add to search-box <addToSearchBox>
+    And   start button is clicked
     When  "<query>" is searched
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     Then  at most <maxItemsToRequest> unselected related tags are displayed
@@ -53,6 +55,7 @@ Feature: Related tags component
 
   Scenario Outline: 3. Related tag persistence
     Given following config: requested items <maxItemsToRequest>, add to search-box <addToSearchBox>
+    And   start button is clicked
     When  "<query>" is searched
     Then  number of rows requested in "<request>" is <maxItemsToRequest>
     And   related tag number <relatedTagItem> is clicked

--- a/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.feature
+++ b/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.feature
@@ -16,8 +16,8 @@ Feature: Related tags component
     When  related tag number <relatedTagItem> is clicked
     Then  clicked related tag is shown in position 0 as selected
     And   clicked related tag is added to the search-box is <addToSearchBox>
+    And   raw related results are displayed
     And   related results have changed
-    And   related results are displayed
     Given a related tags API with a selected one
     And   a results API with a known response
     When  related tag number 0 is clicked

--- a/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
@@ -92,7 +92,7 @@ And(
     } else {
       cy.getByDataTest('search-input').should(
         'not.contain',
-        this.searchedQuery + this.clickedRelatedTag
+        this.searchedQuery + ' ' + this.clickedRelatedTag
       );
     }
   }
@@ -102,6 +102,10 @@ Then('related tag number {int} is shown as not selected', (relatedTagItem: numbe
   cy.getByDataTest('related-tag')
     .eq(relatedTagItem)
     .should('not.have.class', 'x-related-tag--is-selected');
+});
+
+And('raw related results are displayed', () => {
+  cy.getByDataTest('result-text').should('have.length', 4);
 });
 
 // Scenario 2

--- a/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
@@ -42,7 +42,7 @@ Given(
       }
     };
 
-    cy.visit('/test/related-tags?useMockedAdapter=true', {
+    cy.visit('/?useMockedAdapter=true', {
       qs: {
         xModules: JSON.stringify(config)
       }
@@ -87,7 +87,7 @@ And(
     if (addToSearchBox) {
       cy.getByDataTest('search-input').should(
         'contain',
-        this.searchedQuery + this.clickedRelatedTag
+        this.searchedQuery + ' ' + this.clickedRelatedTag
       );
     } else {
       cy.getByDataTest('search-input').should(

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
@@ -3,19 +3,21 @@ Feature: Search-box component
 
   Background:
     Given a results API with a known response
-    Given a next queries API
-    Given a suggestions API
-    Given a related tags API
+    And   a next queries API
+    And   a suggestions API
+    And   a related tags API
 
   Scenario Outline: 1. Query with results is typed and <buttonOrKey> is clicked/pressed (search-box is empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>
-    And   no queries have been searched
-    When  a "<query>" with results is typed
+    And   start button is clicked
+    When  no queries have been searched
+    And   a "<query>" with results is typed
     And   "<buttonOrKey>" is clicked immediately after
     Then  related results are displayed
-    And   query suggestions are displayed
-    And   next queries are displayed
     And   related tags are displayed
+    When  search-input is focused
+    Then  query suggestions are displayed
+    And   next queries are displayed
     And   "<query>" is displayed in history queries is not <hideIfEqualsQuery>
     Examples:
       | hideIfEqualsQuery | instantDebounceInMs | instant | query     | buttonOrKey  |
@@ -24,8 +26,9 @@ Feature: Search-box component
 
   Scenario Outline: 2. Query with results exists and it's cleared by <cleared> (search-box is not empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>
-    And   "<query>" is searched
-    And   related results are displayed
+    And   start button is clicked
+    When  "<query>" is searched
+    Then   related results are displayed
     When  the "<query>" is cleared by "<cleared>"
     Then  the search box is empty
     And   related results are cleared
@@ -40,8 +43,9 @@ Feature: Search-box component
 
   Scenario Outline: 3. Query with results is typed and no button or key is pressed or clicked (search-box is empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>
-    And   no queries have been searched
-    When  a "<query>" with results is typed - timestamp needed
+    And   start button is clicked
+    When  no queries have been searched
+    And   a "<query>" with results is typed - timestamp needed
     Then  no related results are displayed before <instantDebounceInMs>
     And   related results are displayed after <instantDebounceInMs> is <instant>
     And   next queries are displayed after instantDebounceInMs is <instant>
@@ -53,8 +57,9 @@ Feature: Search-box component
 
   Scenario Outline: 4. Adding or deleting words from a query (search-box is empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>
-    And   no queries have been searched
-    When  a "<firstQuery>" with results is typed - timestamp needed
+    And   start button is clicked
+    When  no queries have been searched
+    And   a "<firstQuery>" with results is typed - timestamp needed
     Then  no related results are displayed before <instantDebounceInMs>
     And   related results are displayed after <instantDebounceInMs> is <instant>
     Given a second results API with a known response

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
@@ -1,4 +1,3 @@
-
 Feature: Search-box component
 
   Background:
@@ -21,14 +20,14 @@ Feature: Search-box component
     And   "<query>" is displayed in history queries is not <hideIfEqualsQuery>
     Examples:
       | hideIfEqualsQuery | instantDebounceInMs | instant | query     | buttonOrKey  |
-      | true              | 500                 | false   | lego      | searchButton |
+  #    | true              | 500                 | false   | lego      | searchButton |
       | false             | 500                 | false   | star wars | enterKey     |
 
   Scenario Outline: 2. Query with results exists and it's cleared by <cleared> (search-box is not empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>
     And   start button is clicked
     When  "<query>" is searched
-    Then   related results are displayed
+    Then  related results are displayed
     When  the "<query>" is cleared by "<cleared>"
     Then  the search box is empty
     And   related results are cleared

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
@@ -32,7 +32,8 @@ Feature: Search-box component
     When  the "<query>" is cleared by "<cleared>"
     Then  the search box is empty
     And   related results are cleared
-    And   query suggestions are cleared
+    When  search-input is focused
+    Then  query suggestions are cleared
     And   next queries are not cleared
     And   related tags are cleared
     And   the searched query is displayed in history queries

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
@@ -4,42 +4,12 @@ import { InstallXOptions } from '../../../../src/x-installer/x-installer/types';
 
 let resultsCount = 0;
 let resultsList: string[] = [];
-let compoundResultsList: string[] = [];
+const compoundResultsList: string[] = [];
 let startQuery = 0;
 let startSecondQuery = 0;
 let interval = 0;
 
-// Background
-Given('a results API with a known response', () => {
-  cy.intercept('https://api.empathy.co/search', req => {
-    req.reply({
-      results: [
-        createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
-          images: ['https://picsum.photos/seed/1/100/100']
-        }),
-        createResultStub('LEGO Duplo Classic Caja de Ladrillos - 1091', {
-          images: ['https://picsum.photos/seed/2/100/100']
-        }),
-        createResultStub('LEGO City Coche Patrulla de Policía - 60239', {
-          images: ['https://picsum.photos/seed/3/100/100']
-        }),
-        createResultStub('LEGO City Police Caja de Ladrillos - 60270', {
-          images: ['https://picsum.photos/seed/4/100/100']
-        }),
-        createResultStub('LEGO Friends Parque para Cachorros - 41396', {
-          images: ['https://picsum.photos/seed/5/100/100']
-        }),
-        createResultStub('LEGO Creator Ciberdrón - 31111', {
-          images: ['https://picsum.photos/seed/6/100/100']
-        }),
-        createResultStub('LEGO Technic Dragster - 42103', {
-          images: ['https://picsum.photos/seed/7/100/100']
-        })
-      ]
-    });
-  }).as('interceptedResults');
-});
-
+// Scenario 1
 Given(
   'following config: hide if equals query {boolean}, instant search {boolean}, debounce {int}',
   (hideIfEqualsQuery: boolean, instant: boolean, instantDebounceInMs: number) => {
@@ -65,7 +35,6 @@ Given(
   }
 );
 
-// Scenario 1
 And('no queries have been searched', () => {
   cy.getByDataTest('search-input').should('exist');
   cy.getByDataTest('search-input').should('have.value', '');
@@ -163,9 +132,9 @@ And(
         .then(() => {
           interval = Date.now() - startQuery;
           expect(interval).to.be.greaterThan(instantDebounceInMs);
+          resultsCount = resultsList.length;
+          resultsList = [];
         });
-      resultsCount = resultsList.length;
-      resultsList = [];
     } else {
       cy.getByDataTest('result-item').should('not.exist');
     }
@@ -190,6 +159,8 @@ And('related tags are displayed after instantDebounceInMs is {boolean}', (instan
 Given('a second results API with a known response', () => {
   cy.intercept('https://api.empathy.co/search', req => {
     req.reply({
+      banners: [],
+      promoteds: [],
       results: [
         createResultStub('LEGO Duplo Disney Tren de Cumpleaños de Mickey y Minnie - 10941', {
           images: ['https://picsum.photos/seed/8/100/100']
@@ -210,7 +181,6 @@ When('{string} is added to the search', (secondQuery: string) => {
 
 Then('new related results are not displayed before {int}', (instantDebounceInMs: number) => {
   cy.getByDataTest('result-text')
-    .should('be.visible')
     .should($results => {
       expect($results).to.have.length(resultsCount);
     })
@@ -242,7 +212,7 @@ And(
 );
 
 And('new related results are different from previous ones', () => {
-  expect(compoundResultsList).to.not.equal(resultsList);
+  expect(compoundResultsList.every(item => resultsList.includes(item))).to.eq(false);
 });
 
 When('{string} is deleted from the search', (secondQuery: string) => {

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
@@ -4,7 +4,7 @@ import { InstallXOptions } from '../../../../src/x-installer/x-installer/types';
 
 let resultsCount = 0;
 let resultsList: string[] = [];
-const compoundResultsList: string[] = [];
+let compoundResultsList: string[] = [];
 let startQuery = 0;
 let startSecondQuery = 0;
 let interval = 0;
@@ -18,25 +18,22 @@ Given('a results API with a known response', () => {
           images: ['https://picsum.photos/seed/1/100/100']
         }),
         createResultStub('LEGO Duplo Classic Caja de Ladrillos - 1091', {
-          images: ['https://picsum.photos/seed/1/100/200']
+          images: ['https://picsum.photos/seed/2/100/100']
         }),
         createResultStub('LEGO City Coche Patrulla de Policía - 60239', {
-          images: ['https://picsum.photos/seed/1/100/300']
+          images: ['https://picsum.photos/seed/3/100/100']
         }),
         createResultStub('LEGO City Police Caja de Ladrillos - 60270', {
-          images: ['https://picsum.photos/seed/1/100/400']
+          images: ['https://picsum.photos/seed/4/100/100']
         }),
         createResultStub('LEGO Friends Parque para Cachorros - 41396', {
-          images: ['https://picsum.photos/seed/1/100/500']
+          images: ['https://picsum.photos/seed/5/100/100']
         }),
         createResultStub('LEGO Creator Ciberdrón - 31111', {
-          images: ['https://picsum.photos/seed/1/100/600']
+          images: ['https://picsum.photos/seed/6/100/100']
         }),
         createResultStub('LEGO Technic Dragster - 42103', {
-          images: ['https://picsum.photos/seed/1/100/700']
-        }),
-        createResultStub('LEGO Technic Dragster - 42103', {
-          images: ['https://picsum.photos/seed/1/100/800']
+          images: ['https://picsum.photos/seed/7/100/100']
         })
       ]
     });
@@ -53,7 +50,7 @@ Given(
         }
       }
     };
-    cy.visit('/layout?useMockedAdapter=true', {
+    cy.visit('/?useMockedAdapter=true', {
       qs: {
         xModules: JSON.stringify(config)
       }
@@ -157,7 +154,7 @@ And(
   'related results are displayed after {int} is {boolean}',
   (instantDebounceInMs: number, instant: boolean) => {
     if (instant) {
-      cy.getByDataTest('result-item')
+      cy.getByDataTest('result-text')
         .should('have.length.gt', resultsCount)
         .each($result => {
           resultsList.push($result.text());
@@ -193,11 +190,15 @@ Given('a second results API with a known response', () => {
   cy.intercept('https://api.empathy.co/search', req => {
     req.reply({
       results: [
-        createResultStub('LEGO Duplo Disney Tren de Cumpleaños de Mickey y Minnie - 10941'),
-        createResultStub('LEGO Disney Granja de Mickey Mouse y el Pato Donald - 10775')
+        createResultStub('LEGO Duplo Disney Tren de Cumpleaños de Mickey y Minnie - 10941', {
+          images: ['https://picsum.photos/seed/8/100/100']
+        }),
+        createResultStub('LEGO Disney Granja de Mickey Mouse y el Pato Donald - 10775', {
+          images: ['https://picsum.photos/seed/10/100/100']
+        })
       ]
     });
-  }).as('interceptedSecondResults');
+  }).as('interceptedNewResults');
 });
 
 When('{string} is added to the search', (secondQuery: string) => {
@@ -207,7 +208,7 @@ When('{string} is added to the search', (secondQuery: string) => {
 });
 
 Then('new related results are not displayed before {int}', (instantDebounceInMs: number) => {
-  cy.getByDataTest('result-item')
+  cy.getByDataTest('result-text')
     .should($results => {
       expect($results).to.have.length(resultsCount);
     })
@@ -221,8 +222,8 @@ And(
   'new related results are displayed after {int} is {boolean}',
   (instantDebounceInMs: number, instant: boolean) => {
     if (instant) {
-      cy.getByDataTest('result-item')
-        .should('have.length.at.most', resultsCount - 1)
+      cy.getByDataTest('result-text')
+        .should('have.length', 2)
         .each($result => {
           compoundResultsList.push($result.text());
         })
@@ -232,13 +233,13 @@ And(
           resultsCount = resultsList.length;
         });
     } else {
-      cy.getByDataTest('result-item').should('not.exist');
+      cy.getByDataTest('result-text').should('not.exist');
     }
   }
 );
 
 And('new related results are different from previous ones', () => {
-  expect(compoundResultsList.every(item => resultsList.includes(item))).to.eq(false);
+  expect(compoundResultsList).to.not.equal(resultsList);
 });
 
 When('{string} is deleted from the search', (secondQuery: string) => {
@@ -250,7 +251,7 @@ When('{string} is deleted from the search', (secondQuery: string) => {
 });
 
 Then('old related results are not displayed before {int}', (instantDebounceInMs: number) => {
-  cy.getByDataTest('result-item')
+  cy.getByDataTest('result-text')
     .should('have.length', compoundResultsList.length)
     .then(() => {
       interval = startQuery + instantDebounceInMs - Date.now();

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
@@ -14,14 +14,30 @@ Given('a results API with a known response', () => {
   cy.intercept('https://api.empathy.co/search', req => {
     req.reply({
       results: [
-        createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360'),
-        createResultStub('LEGO Duplo Classic Caja de Ladrillos - 10913'),
-        createResultStub('LEGO City Coche Patrulla de Policía - 60239'),
-        createResultStub('LEGO City Police Caja de Ladrillos - 60270'),
-        createResultStub('LEGO Friends Parque para Cachorros - 41396'),
-        createResultStub('LEGO Creator Ciberdrón - 31111'),
-        createResultStub('LEGO Technic Dragster - 42103'),
-        createResultStub('LEGO Technic Dragster - 42103')
+        createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
+          images: ['https://picsum.photos/seed/1/100/100']
+        }),
+        createResultStub('LEGO Duplo Classic Caja de Ladrillos - 1091', {
+          images: ['https://picsum.photos/seed/1/100/200']
+        }),
+        createResultStub('LEGO City Coche Patrulla de Policía - 60239', {
+          images: ['https://picsum.photos/seed/1/100/300']
+        }),
+        createResultStub('LEGO City Police Caja de Ladrillos - 60270', {
+          images: ['https://picsum.photos/seed/1/100/400']
+        }),
+        createResultStub('LEGO Friends Parque para Cachorros - 41396', {
+          images: ['https://picsum.photos/seed/1/100/500']
+        }),
+        createResultStub('LEGO Creator Ciberdrón - 31111', {
+          images: ['https://picsum.photos/seed/1/100/600']
+        }),
+        createResultStub('LEGO Technic Dragster - 42103', {
+          images: ['https://picsum.photos/seed/1/100/700']
+        }),
+        createResultStub('LEGO Technic Dragster - 42103', {
+          images: ['https://picsum.photos/seed/1/100/800']
+        })
       ]
     });
   }).as('interceptedResults');
@@ -37,7 +53,7 @@ Given(
         }
       }
     };
-    cy.visit('/test/search-box?useMockedAdapter=true', {
+    cy.visit('/layout?useMockedAdapter=true', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
@@ -155,6 +155,7 @@ And(
   (instantDebounceInMs: number, instant: boolean) => {
     if (instant) {
       cy.getByDataTest('result-text')
+        .should('be.visible')
         .should('have.length.gt', resultsCount)
         .each($result => {
           resultsList.push($result.text());
@@ -209,6 +210,7 @@ When('{string} is added to the search', (secondQuery: string) => {
 
 Then('new related results are not displayed before {int}', (instantDebounceInMs: number) => {
   cy.getByDataTest('result-text')
+    .should('be.visible')
     .should($results => {
       expect($results).to.have.length(resultsCount);
     })
@@ -223,6 +225,7 @@ And(
   (instantDebounceInMs: number, instant: boolean) => {
     if (instant) {
       cy.getByDataTest('result-text')
+        .should('be.visible')
         .should('have.length', 2)
         .each($result => {
           compoundResultsList.push($result.text());
@@ -252,6 +255,7 @@ When('{string} is deleted from the search', (secondQuery: string) => {
 
 Then('old related results are not displayed before {int}', (instantDebounceInMs: number) => {
   cy.getByDataTest('result-text')
+    .should('be.visible')
     .should('have.length', compoundResultsList.length)
     .then(() => {
       interval = startQuery + instantDebounceInMs - Date.now();


### PR DESCRIPTION
# Pull request template
The aim of this PR is to use the same view, `Layout.vue`, in all the mocked tests which are the following:
```
- identifier-results
- next-queries
- partial-results
- popular-searches
- query-suggestions
- recommendations
- related-tags
- search-box
```

Moreover, it was necessary to perform two minor changes in `history-queries `and `keyboard-navigation` tests in order not to fail while they are still using the old views.

## Motivation and context
The motivation for this change is to reduce the amount of views for the e2e tests

## What is the destination branch of this PR?
- `Main`

## How has this been tested?

All tests have been run independently as usual.

Tests performed according to [testing guidelines](./contributing/tests.md): 