### PR TITLE
ci: Remove private token from `build` step.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ jobs:
     container: cypress/browsers:node14.17.0-chrome91-ff89
     steps:
       - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.SUPPORT_TOKEN }}
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages


### PR DESCRIPTION
This just removes an organization privately token from the build action. This way public forks should be allowed to run this action without any issue.