### PR TITLE
docs: Fix components documentation export

### DIFF
--- a/packages/x-components/build/docgen/utils.js
+++ b/packages/x-components/build/docgen/utils.js
@@ -52,7 +52,6 @@ function generateDestination(folder, regex, file) {
   const match = regex.exec(file);
   if (match) {
     const { path, componentName } = match.groups;
-    console.log(join(folder, path, `x-components.${componentName}.md`));
     return join(folder, path, `x-components.${componentName}.md`);
   } else {
     return '';


### PR DESCRIPTION
Exports the documentation of the components under `src/components`, that were not in a nested folder. To reproduce the issue, just trigger a build from the `main` branch, and see how components like the `src/components/base-dropdown` have no exported documentation.

The regular expressions used for the components have been tweaked, a little bit to ensure that they match these missing components. Additionally, named capture groups have been used, but just to provide better readability of the code.