### PR TITLE
Bugfix/ex 4878 fix components markdown

### DIFF
--- a/.github/contributing/components.md
+++ b/.github/contributing/components.md
@@ -2,8 +2,9 @@
 
 ## Naming components
 
-Multiple parts of the library use similar patterns to provide components that are highly customizable. These components must have similar names.
-The components defined as classes must be written in `PascalCase`.
+Multiple parts of the library use similar patterns to provide components that are highly
+customizable. These components must have similar names. The components defined as classes must be
+written in `PascalCase`.
 
 ```ts
 // ❌ Wrong
@@ -45,7 +46,9 @@ When a component is used in a template, the tag of the component must be written
 
 ### Base components
 
-The base components have no dependencies with any [X Module](./concepts.md#x-module). They serve as blocks to build more complex components. Base components must be prefixed with `Base` using `PascalCase`.
+The base components have no dependencies with any [X Module](./concepts.md#x-module). They serve as
+blocks to build more complex components. Base components must be prefixed with `Base` using
+`PascalCase`.
 
 ```ts
 // ❌ Wrong
@@ -69,7 +72,9 @@ base-button.vue
 
 ### List components
 
-Lists components are used across all apps. These components render a list of the same type of items. They can have filtering functionality, but do not contain additional logic. Usually, the item component can be replaced using slots. List components must be suffixed with `List`.
+Lists components are used across all apps. These components render a list of the same type of items.
+They can have filtering functionality, but do not contain additional logic. Usually, the item
+component can be replaced using slots. List components must be suffixed with `List`.
 
 ```ts
 // ❌ Wrong
@@ -93,8 +98,11 @@ suggestion-list.vue
 
 ### Button components
 
-These components are perceived by the User as buttons. They are not the same as an HTML `<button>` tag. There are components with `<button>` that are displayed with `link` style, for example. Valid examples include the button used to clear the search input or the button to clear the selected filters. 
-If the button represents an entity, the entity name should be used instead. For example, with different types of suggestions (`NextQuery`, `PopularSearch`, `QuerySuggestion`...). 
+These components are perceived by the User as buttons. They are not the same as an HTML `<button>`
+tag. There are components with `<button>` that are displayed with `link` style, for example. Valid
+examples include the button used to clear the search input or the button to clear the selected
+filters. If the button represents an entity, the entity name should be used instead. For example,
+with different types of suggestions (`NextQuery`, `PopularSearch`, `QuerySuggestion`...).
 
 Button components must be suffixed with `Button`.
 
@@ -120,8 +128,8 @@ clear-button.vue
 
 ### Panel components
 
-These components contain other components. Panel components must be suffixed with `Panel`.
-They must be prefixed with `Base` if they are a [Base Component](#base-components).
+These components contain other components. Panel components must be suffixed with `Panel`. They must
+be prefixed with `Base` if they are a [Base Component](#base-components).
 
 ```ts
 // ❌ Wrong
@@ -167,7 +175,8 @@ export default class BaseFilter extends Vue {}
 
 ## Naming props
 
-Props are used to pass variables and other information around between different components. The name must be written in `camelCase` and must follow the rules written in [Base-naming](base-naming.md).
+Props are used to pass variables and other information around between different components. The name
+must be written in `camelCase` and must follow the rules written in [Base-naming](base-naming.md).
 
 ### `alwaysVisible`
 
@@ -177,15 +186,18 @@ Props are used to pass variables and other information around between different 
 
 ### `<event>:<source>`
 
-If a component can emit multiple types of events, such as clicks depending on the subcomponent clicked, you must name the events according to the `<event>:<source>` convention in `kebab` case. 
-`event` represents the name of the DOM event that triggered the Vue event, and `source` represents the name of the element that triggered the event.
+If a component can emit multiple types of events, such as clicks depending on the subcomponent
+clicked, you must name the events according to the `<event>:<source>` convention in `kebab` case.
+`event` represents the name of the DOM event that triggered the Vue event, and `source` represents
+the name of the element that triggered the event.
 
 - `click:close`, `click:item`, `click:link`, `click:right-button`.
 
 ## Naming getters
 
-Getters belong to [X Module](./concepts.md#x-module). There are two different ways of declaring a getter. It can be a **function** or a **class** with multiple getters. 
-If the getter is a **function**, it should be named using `camelCase`. It should explain what it returns.
+Getters belong to [X Module](./concepts.md#x-module). There are two different ways of declaring a
+getter. It can be a **function** or a **class** with multiple getters. If the getter is a
+**function**, it should be named using `camelCase`. It should explain what it returns.
 
 ```ts
 // ❌ Wrong
@@ -207,7 +219,9 @@ export const request: SearchXStoreModule['getters']['request'] = ({ query }) => 
 };
 ```
 
-If the getter is a **class**, it should follow the [Classes](./base-naming.md#classes) convention, explain what it returns, and be suffixed with `Getter`. Each function inside the class should explain what it does or returns.
+If the getter is a **class**, it should follow the [Classes](./base-naming.md#classes) convention,
+explain what it returns, and be suffixed with `Getter`. Each function inside the class should
+explain what it does or returns.
 
 ```ts
 // ❌ Wrong
@@ -225,8 +239,8 @@ export class HistoryQueriesGetter implements GettersClass<HistoryQueriesXStoreMo
 }
 ```
 
-The file name must be written using `kebab-case` and be suffixed with `.getter`. 
-IMPORTANT: Pay attention to the period before `getter`.
+The file name must be written using `kebab-case` and be suffixed with `.getter`. IMPORTANT: Pay
+attention to the period before `getter`.
 
 ```
 // ❌ Wrong
@@ -238,11 +252,14 @@ selected-filters.getter.ts
 
 ## Documentation
 
-Components are documented using [Markdown](https://daringfireball.net/projects/markdown/basics) and [Vue Styleguidist](https://vue-styleguidist.github.io/docs/GettingStarted.html). The Vue Styleguidist library is used to export the doc to Markdown.
+Components are documented using [Markdown](https://daringfireball.net/projects/markdown/basics) and
+[Vue Styleguidist](https://vue-styleguidist.github.io/docs/GettingStarted.html). The Vue
+Styleguidist library is used to export the doc to Markdown.
 
 ### Links
 
-You must use [jsdoc tag](https://jsdoc.app/tags-inline-link.html) within JS/TS comments wherever you can, including a readable link text.
+You must use [jsdoc tag](https://jsdoc.app/tags-inline-link.html) within JS/TS comments wherever you
+can, including a readable link text.
 
 `{@link namepathOrURL|link text}`
 
@@ -279,7 +296,9 @@ Document slot by explaining what they are used for and if they have any bindings
 
 ### Component
 
-Components must be documented by explaining what they do. You should add some context about how they achieve that. You must end the inline documentation with `@public` to make it available for export using Vue Styleguidist 
+Components must be documented by explaining what they do. You should add some context about how they
+achieve that. You must end the inline documentation with `@public` to make it available for export
+using Vue Styleguidist
 
 ```ts
 // ❌ Wrong
@@ -311,7 +330,9 @@ export default class HistoryQuery extends Vue {}
 
 ### Props
 
-Document props by explaining what they do and add extra information about how they are used. End the inline documentation with `@public` or `@internal`, depending on whether it needs to be exported or not.
+Document props by explaining what they do and add extra information about how they are used. End the
+inline documentation with `@public` or `@internal`, depending on whether it needs to be exported or
+not.
 
 ```ts
 // ❌ Wrong
@@ -341,7 +362,9 @@ class Component {
 
 ### Methods & computed
 
-Document methods and computed by explaining what they do and what they return. Use `@returns` to indicate what is returned, and end the inline documentation with `@public` or `@internal` depending on whether it should be exported or not.
+Document methods and computed by explaining what they do and what they return. Use `@returns` to
+indicate what is returned, and end the inline documentation with `@public` or `@internal` depending
+on whether it should be exported or not.
 
 ```ts
 // ❌ Wrong
@@ -375,21 +398,30 @@ class CurrencyComponent {
 
 ### Component examples
 
-Each component must have a documentation block where you explain how the component is used and the different uses.
+Each component must have a documentation block where you explain how the component is used and the
+different uses.
 
 It must contain examples to show the `default`, `props` and `customized` usages.
 
 ```vue
-<docs>
-  # Example
-  ## Default usage
-  ## Prop 1
-  ## Prop 2
-  ## ...
-  ## Customized usage
-  ## Usage 1
-  ## Usage 2
-  ## ...
+<docs lang="mdx">
+# Example
+
+## Default usage
+
+## Prop 1
+
+## Prop 2
+
+## ...
+
+## Customized usage
+
+## Usage 1
+
+## Usage 2
+
+## ...
 </docs>
 ```
 
@@ -419,29 +451,20 @@ It renders a list of items using the default slot:
 </template>
 ```
 
-
 ### Events
 
-Each component must have an events documentation section that explains which events it emits, and how and when they are emitted.
+Each component must have an events documentation section that explains which events it emits, and
+how and when they are emitted.
 
 Each event must be written according to the format:
- - -`EventName`: the event is emitted when...(something happened). The event payload is ...:
+
+- -`EventName`: the event is emitted when...(something happened). The event payload is ...:
 
 This approach is the same for the Vue events emitted by the component.
+
 ```vue
-// ❌ Wrong
-
-## Events
-
-- The event is `UserClickedColumnPicker` and it is emitted when the user clicks the component. The payload is
-the column number.
-
-// ✅ Good
-
-## Events
-
-- `UserClickedColumnPicker`: the event is emitted after the user clicks an item. The event payload
-is the number of columns that the clicked item represents.
-
+// ❌ Wrong ## Events - The event is `UserClickedColumnPicker` and it is emitted when the user
+clicks the component. The payload is the column number. // ✅ Good ## Events -
+`UserClickedColumnPicker`: the event is emitted after the user clicks an item. The event payload is
+the number of columns that the clicked item represents.
 ```
-

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "prettier": "@empathyco/eslint-plugin-x/prettier-config",
   "lint-staged": {
-    "*.{ts,tsx,md,vue}": [
+    "*.{ts,tsx,vue}": [
       "prettier --write",
       "cross-env NODE_ENV=production eslint --cache --fix"
     ],
-    "*.{js,json}": "prettier --write"
+    "*.{md,js,json}": "prettier --write"
   }
 }

--- a/packages/x-components/contributing/components.md
+++ b/packages/x-components/contributing/components.md
@@ -405,16 +405,24 @@ used, and the different uses that can be given to it.
 It should have examples to show the `default`, `props` and `customized` usages.
 
 ```vue
-<docs>
-  # Example
-  ## Default usage
-  ## Prop 1
-  ## Prop 2
-  ## ...
-  ## Customized usage
-  ## Usage 1
-  ## Usage 2
-  ## ...
+<docs lang="mdx">
+# Example
+
+## Default usage
+
+## Prop 1
+
+## Prop 2
+
+## ...
+
+## Customized usage
+
+## Usage 1
+
+## Usage 2
+
+## ...
 </docs>
 ```
 
@@ -445,29 +453,20 @@ It renders a list of items using the default slot:
 </template>
 ```
 
-
 ### Events
 
-Each component must have an events section where it is explained what, how and when they are emitted.
+Each component must have an events section where it is explained what, how and when they are
+emitted.
 
 Each event must be written following the next template:
- - -`EventName`: the event is emitted when...(something happend). The event payload is ...:
+
+- -`EventName`: the event is emitted when...(something happend). The event payload is ...:
 
 This approach is the same for the Vue events emitted by the component.
+
 ```vue
-// ❌ Wrong
-
-## Events
-
-- The event is `UserClickedColumnPicker` and its emitted when the user clicks the component. The payload is
-the column number.
-
-// ✅ Good
-
-## Events
-
-- `UserClickedColumnPicker`: the event is emitted after the user clicks an item. The event payload
-is the number of columns that the clicked item represents.
-
+// ❌ Wrong ## Events - The event is `UserClickedColumnPicker` and its emitted when the user clicks
+the component. The payload is the column number. // ✅ Good ## Events - `UserClickedColumnPicker`:
+the event is emitted after the user clicks an item. The event payload is the number of columns that
+the clicked item represents.
 ```
-

--- a/packages/x-components/src/components/animations/animate-width.vue
+++ b/packages/x-components/src/components/animations/animate-width.vue
@@ -34,7 +34,7 @@
 </style>
 
 <docs lang="mdx">
-#Example
+# Examples
 
 The AnimateWidth component is intended to be used as a prop in animatable components but also works
 as a transition to animate the width of an element.

--- a/packages/x-components/src/components/animations/collapse-from-top.vue
+++ b/packages/x-components/src/components/animations/collapse-from-top.vue
@@ -76,13 +76,15 @@
   }
 </style>
 
-<docs>
-#Example
-The CollapseTop component is intended to be used as animation to wrap an element with
-v-if or v-show and animate it. The animation consists on scale its vertical size from 0 to 1, and
-after this show the content with an opacity transition
+<docs lang="mdx">
+# Examples
+
+The CollapseTop component is intended to be used as animation to wrap an element with v-if or v-show
+and animate it. The animation consists on scale its vertical size from 0 to 1, and after this show
+the content with an opacity transition
 
 Used wrapping a component:
+
 ```vue
 <CollapseFromTop>
   <ComponentOrElement v-if="open"/>

--- a/packages/x-components/src/components/animations/collapse-height.vue
+++ b/packages/x-components/src/components/animations/collapse-height.vue
@@ -39,13 +39,15 @@
   }
 </style>
 
-<docs>
-#Example
-The CollapseHeight component is intended to be used as animation to wrap an element with
-v-if or v-show and animate it. The animation consists on scale its height size from 0 to auto.
-This transition does not work with components that have vertical margin, padding or border.
+<docs lang="mdx">
+# Examples
+
+The CollapseHeight component is intended to be used as animation to wrap an element with v-if or
+v-show and animate it. The animation consists on scale its height size from 0 to auto. This
+transition does not work with components that have vertical margin, padding or border.
 
 Used wrapping a component:
+
 ```vue
 <CollapseHeight>
   <ComponentOrElement v-if="open"/>

--- a/packages/x-components/src/components/animations/collapse-width.vue
+++ b/packages/x-components/src/components/animations/collapse-width.vue
@@ -39,15 +39,16 @@
   }
 </style>
 
-<docs>
-#Example
-The CollapseWidth component is intended to be used as animation to wrap an element with
-v-if or v-show and animate it. The animation consists on scale its width size from 0 to auto.
-This transition does not work with components that have horizontal margin, padding or border. It
-also is dependant of the width of the child elements and not the root element.
+<docs lang="mdx">
+# Examples
 
+The CollapseWidth component is intended to be used as animation to wrap an element with v-if or
+v-show and animate it. The animation consists on scale its width size from 0 to auto. This
+transition does not work with components that have horizontal margin, padding or border. It also is
+dependant of the width of the child elements and not the root element.
 
 Used wrapping a component:
+
 ```vue
 <CollapseWidth>
   <ComponentOrElement v-if="open"/>

--- a/packages/x-components/src/components/animations/fade-and-slide.vue
+++ b/packages/x-components/src/components/animations/fade-and-slide.vue
@@ -57,23 +57,25 @@
   }
 </style>
 
-<docs>
-  #Example
+<docs lang="mdx">
+# Examples
 
-  The FadeAndSlide component is intended to be used as a prop in animatable components but also
-  works as a wrapper of a transition group that can receive the tag it will render to as a prop.
+The FadeAndSlide component is intended to be used as a prop in animatable components but also works
+as a wrapper of a transition group that can receive the tag it will render to as a prop.
 
-  Used as a prop in an animatable component:
-  ```vue
-  <AnimatableComponent :animation="FadeAndSlide" />
-  ```
+Used as a prop in an animatable component:
 
-  Used as a regular component passing a the tag as prop:
-  ```vue
-  <FadeAndSlide tag="ul">
-    <li>Element to animate</li>
-    <li>Element to animate</li>
-    <li>Element to animate</li>
-  </FadeAndSlide>
-  ```
+```vue
+<AnimatableComponent :animation="FadeAndSlide" />
+```
+
+Used as a regular component passing a the tag as prop:
+
+```vue
+<FadeAndSlide tag="ul">
+  <li>Element to animate</li>
+  <li>Element to animate</li>
+  <li>Element to animate</li>
+</FadeAndSlide>
+```
 </docs>

--- a/packages/x-components/src/components/animations/staggered-fade-and-slide.vue
+++ b/packages/x-components/src/components/animations/staggered-fade-and-slide.vue
@@ -51,23 +51,22 @@
   }
 </style>
 
-<docs>
-
-The Staggered fade and slide components works as the normal fade and slide components, but
-it also adds a configurable delay to each transition.
+<docs lang="mdx">
+The Staggered fade and slide components works as the normal fade and slide components, but it also
+adds a configurable delay to each transition.
 
 ## Example
 
 ### Used with animatable components
 
 ```vue
-<AnimatableComponent :animation="StaggeredFadeAndSlide"/>
+<AnimatableComponent :animation="StaggeredFadeAndSlide" />
 ```
 
 ### Used as a regular component:
 
-This components exposes all the props and events of the Staggering transition group, like the
-`tag` or the `stagger` props:
+This components exposes all the props and events of the Staggering transition group, like the `tag`
+or the `stagger` props:
 
 ```vue
 <StaggeredFadeAndSlide tag="ul" :stagger="50">
@@ -76,5 +75,4 @@ This components exposes all the props and events of the Staggering transition gr
   <li>Element to animate</li>
 </StaggeredFadeAndSlide>
 ```
-
 </docs>

--- a/packages/x-components/src/components/base-event-button.vue
+++ b/packages/x-components/src/components/base-event-button.vue
@@ -38,27 +38,27 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Basic example
+## Basic example
 
-  The event prop is required. It will render a <button></button> that emits the event passed as
-  prop with the value as payload on click:
+The event prop is required. It will render a <button></button> that emits the event passed as prop
+with the value as payload on click:
 
-  ```vue
-  <BaseEventButton :events="{myEvent: payload}"/>
-  ```
+```vue
+<BaseEventButton :events="{ myEvent: payload }" />
+```
 
-  If the event doesn't need payload then `undefined` must be passed:
+If the event doesn't need payload then `undefined` must be passed:
 
-  ```vue
-  <BaseEventButton :events="{myEvent: undefined}"/>
-  ```
+```vue
+<BaseEventButton :events="{ myEvent: undefined }" />
+```
 
-  It can emit multiple events at the same time:
+It can emit multiple events at the same time:
 
-  ```vue
-  <BaseEventButton :events="{myFirstEvent: payload1, mySecondEvent: payload2}"/>
-  ```
+```vue
+<BaseEventButton :events="{ myFirstEvent: payload1, mySecondEvent: payload2 }" />
+```
 </docs>

--- a/packages/x-components/src/components/base-grid.vue
+++ b/packages/x-components/src/components/base-grid.vue
@@ -177,7 +177,7 @@
 </style>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 This component renders a list of elements in different slots depending on their modelName. In order
 to achieve this, it exposes a scopedSlot for each different modelName. In case the items used do not

--- a/packages/x-components/src/components/base-keyboard-navigation.vue
+++ b/packages/x-components/src/components/base-keyboard-navigation.vue
@@ -144,64 +144,68 @@
   }
 </script>
 
-<docs>
-  #Example
+<docs lang="mdx">
+# Examples
 
-  This component has a slot to inject other components inside it. The component expects a required
-  prop, navigationHijacker, which is an array of objects containing: the xEvent to listen to, the
-  moduleName in charge of emitting the event and to which direction it should react to; to take
-  control of the navigation. It has another prop, optional in this case, to emit an xEvent when
-  reaching the navigation limit in any direction.
+This component has a slot to inject other components inside it. The component expects a required
+prop, navigationHijacker, which is an array of objects containing: the xEvent to listen to, the
+moduleName in charge of emitting the event and to which direction it should react to; to take
+control of the navigation. It has another prop, optional in this case, to emit an xEvent when
+reaching the navigation limit in any direction.
 
-  ## Basic Usage
+## Basic Usage
 
-  ```vue
-  <KeyboardNavigation>
-    <QuerySuggestions/>
-  </KeyboardNavigation>
-  ```
+```vue
+<KeyboardNavigation>
+  <QuerySuggestions/>
+</KeyboardNavigation>
+```
 
-  ## Defining multiple conditions to take navigation's control
+## Defining multiple conditions to take navigation's control
 
-  ```vue
-  <KeyboardNavigation
-    :navigationHijacker="[{
+```vue
+<KeyboardNavigation
+  :navigationHijacker="[
+    {
       xEvent: 'UserPressedArrowKey',
       moduleName: 'searchBox',
       direction: 'ArrowDown'
-    }, {
+    },
+    {
       xEvent: 'UserPressedArrowKey',
       moduleName: 'facets',
       direction: 'ArrowRight'
-    }]"
-  >
-    <QuerySuggestions/>
-  </KeyboardNavigation>
-  ```
+    }
+  ]"
+>
+  <QuerySuggestions/>
+</KeyboardNavigation>
+```
 
-  ## Defining events to emit when reaching a navigation limit
+## Defining events to emit when reaching a navigation limit
 
-  ```vue
-  <KeyboardNavigation
-    :navigationHijacker="[{
+```vue
+<KeyboardNavigation
+  :navigationHijacker="[
+    {
       xEvent: 'UserPressedArrowKey',
       moduleName: 'searchBox',
       direction: 'ArrowDown'
-    }]"
-    :eventsForDirectionLimit="{
-      ArrowUp: 'UserReachedEmpathizeTop'
-    }"
-  >
-    <QuerySuggestions/>
-  </KeyboardNavigation>
-  ```
+    }
+  ]"
+  :eventsForDirectionLimit="{
+    ArrowUp: 'UserReachedEmpathizeTop'
+  }"
+>
+  <QuerySuggestions/>
+</KeyboardNavigation>
+```
 
+## Events
 
-  ## Events
+An event that the component will emit:
 
-  An event that the component will emit:
-
-  - `UserReachedEmpathizeTop`: the event emitted by default when the container reaches its top
+- `UserReachedEmpathizeTop`: the event emitted by default when the container reaches its top
   navigation, but more events can be emitted for each direction using the `eventsForDirectionLimit`
   prop.
 </docs>

--- a/packages/x-components/src/components/base-rating.vue
+++ b/packages/x-components/src/components/base-rating.vue
@@ -108,8 +108,8 @@
   }
 </style>
 
-<docs>
-#Examples
+<docs lang="mdx">
+# Examples
 
 This component receives a `value` as prop and renders a set of elements, which will be filled based
 on this value.
@@ -117,7 +117,7 @@ on this value.
 ## Basic usage
 
 ```vue
-<BaseRating :value="5.23"/>
+<BaseRating :value="5.23" />
 ```
 
 ## Customizing its contents
@@ -132,5 +132,4 @@ on this value.
   </template>
 </BaseRating>
 ```
-
 </docs>

--- a/packages/x-components/src/components/column-picker/base-column-picker-list.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-list.vue
@@ -88,7 +88,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 This component renders a list of elements in different slots depending on the columns prop. Each
 element will emit the needed events to sync other instances of columns pickers, or grids with the

--- a/packages/x-components/src/components/modals/base-events-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-close.vue
@@ -37,7 +37,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 The `BaseEventsModalClose` component can be used to close the `BaseEventsModal` component.
 

--- a/packages/x-components/src/components/modals/base-events-modal-open.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-open.vue
@@ -37,7 +37,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 This component serves to open the `BaseEventsModal`.
 

--- a/packages/x-components/src/components/modals/base-events-modal.vue
+++ b/packages/x-components/src/components/modals/base-events-modal.vue
@@ -114,7 +114,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 The `BaseEventsModal` component handles the modal open/close state via the events passed via props.
 Its configured by default to work as a modal for a whole search application, but if the events are

--- a/packages/x-components/src/components/modals/base-id-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-id-modal-close.vue
@@ -36,7 +36,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 Component containing an event button that emits `UserClickedCloseModal` when clicked with the
 modalId as payload. It has a default slot to customize its contents.

--- a/packages/x-components/src/components/modals/base-id-modal-open.vue
+++ b/packages/x-components/src/components/modals/base-id-modal-open.vue
@@ -36,7 +36,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 Component containing an event button that emits `UserClickedOpenModal` when it is clicked with the
 modalId as payload. It has a default slot to customize its contents.

--- a/packages/x-components/src/components/modals/base-id-modal.vue
+++ b/packages/x-components/src/components/modals/base-id-modal.vue
@@ -93,7 +93,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 The `BaseIdModal` component reacts to the `UserClickedOpenModal`, `UserClickedCloseModal` and
 `UserClickedOutOfModal` to handle its open/close state. The component filters out the events which

--- a/packages/x-components/src/components/panels/base-header-toggle-panel.vue
+++ b/packages/x-components/src/components/panels/base-header-toggle-panel.vue
@@ -86,11 +86,11 @@
   }
 </style>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
-Toggle panel which uses the base toggle panel, adds a header and manage the open / close state
-of the panel.
+Toggle panel which uses the base toggle panel, adds a header and manage the open / close state of
+the panel.
 
 ## Basic usage
 

--- a/packages/x-components/src/components/panels/base-id-toggle-panel-button.vue
+++ b/packages/x-components/src/components/panels/base-id-toggle-panel-button.vue
@@ -68,7 +68,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 ## Basic example
 

--- a/packages/x-components/src/components/panels/base-id-toggle-panel.vue
+++ b/packages/x-components/src/components/panels/base-id-toggle-panel.vue
@@ -97,7 +97,7 @@
 </script>
 
 <docs lang="mdx">
-#Example
+# Examples
 
 ## Basic usage
 

--- a/packages/x-components/src/components/panels/base-toggle-panel.vue
+++ b/packages/x-components/src/components/panels/base-toggle-panel.vue
@@ -38,8 +38,8 @@
   }
 </script>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
 Simple panel that receives its open state via prop, which is responsible of rendering default slot
 inside a configurable transition.
@@ -47,6 +47,7 @@ inside a configurable transition.
 ## Basic usage
 
 Using default slot:
+
 ```vue
 <BaseTogglePanel :open="true" :animation="collapseFromTop">
   <Filters :filters="filters">

--- a/packages/x-components/src/components/result/base-result-add-to-cart.vue
+++ b/packages/x-components/src/components/result/base-result-add-to-cart.vue
@@ -47,27 +47,27 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  Renders a button with a default slot. It receives the result with the data and emits an event
-  `UserClickedResultAddToCart` to the bus on click mouse event.
+Renders a button with a default slot. It receives the result with the data and emits an event
+`UserClickedResultAddToCart` to the bus on click mouse event.
 
-  ## Basic example
+## Basic example
 
-  This component is a button to emit `UserClickedResultAddToCart` whe clicked by the user
+This component is a button to emit `UserClickedResultAddToCart` whe clicked by the user
 
-  ```vue
-  <BaseResultAddToCart :result="result">
-    <img src="./add-to-cart.svg" />
-    <span>Add to cart</span>
-  </BaseResultAddToCart>
-  ```
+```vue
+<BaseResultAddToCart :result="result">
+  <img src="./add-to-cart.svg" />
+  <span>Add to cart</span>
+</BaseResultAddToCart>
+```
 
-  ## Events
+## Events
 
-  A list of events that the component will emit:
+A list of events that the component will emit:
 
-  - `UserClickedResultAddToCart`: the event is emitted after the user clicks the button. The event
+- `UserClickedResultAddToCart`: the event is emitted after the user clicks the button. The event
   payload is the result data.
 </docs>

--- a/packages/x-components/src/components/result/base-result-current-price.vue
+++ b/packages/x-components/src/components/result/base-result-current-price.vue
@@ -70,26 +70,23 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Basic example
+## Basic example
 
-  This component shows the current price formatted. You can provide the `format` by property or let
-  the `BaseCurrency` component use an injected one.
+This component shows the current price formatted. You can provide the `format` by property or let
+the `BaseCurrency` component use an injected one.
 
-  ```vue
-  <BaseResultCurrentPrice
-    :value="result"
-    :format="'i.iii,ddd €'"
-  />
-  ```
+```vue
+<BaseResultCurrentPrice :value="result" :format="'i.iii,ddd €'" />
+```
 
-  ## Overriding default slot
+## Overriding default slot
 
-  ```vue
-  <BaseResultCurrentPrice :result="result">
-    <span class="custom-base-result-current-price">{{ result.price.value }}</span>
-  </BaseResultCurrentPrice>
-  ```
+```vue
+<BaseResultCurrentPrice :result="result">
+  <span class="custom-base-result-current-price">{{ result.price.value }}</span>
+</BaseResultCurrentPrice>
+```
 </docs>

--- a/packages/x-components/src/components/result/base-result-link.vue
+++ b/packages/x-components/src/components/result/base-result-link.vue
@@ -106,40 +106,39 @@
   }
 </style>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Basic example
+## Basic example
 
-  This component is a wrapper for the result contents (images, name, price...) It may be part of
-  the search result page, recommendations or other section which needs to include results.
+This component is a wrapper for the result contents (images, name, price...) It may be part of the
+search result page, recommendations or other section which needs to include results.
 
-  This component will emit `UserClickedAResult` when clicked or middle clicked and
-  `UserRightClickedAResult` when right  clicked.
+This component will emit `UserClickedAResult` when clicked or middle clicked and
+`UserRightClickedAResult` when right clicked.
 
-  Additionally, this component may be injected other events to be emitted on click event, so,
-  depending where it's used its father component may provide this events.
+Additionally, this component may be injected other events to be emitted on click event, so,
+depending where it's used its father component may provide this events.
 
-  The result prop is required. It will render a `<a></a>` with the href to the result URL:
+The result prop is required. It will render a `<a></a>` with the href to the result URL:
 
-  ```vue
-  <BaseResultLink :result="result">
-    <template #default="{ result }">
-      <img :src="result.images[0]"/>
-      <span>{{ result.name }}</span>
-    </template>
-  </BaseResultLink>
-  ```
+```vue
+<BaseResultLink :result="result">
+  <template #default="{ result }">
+    <img :src="result.images[0]"/>
+    <span>{{ result.name }}</span>
+  </template>
+</BaseResultLink>
+```
 
-  ## Events
+## Events
 
-  A list of events that the component will emit:
+A list of events that the component will emit:
 
-  - `UserClickedAResult`: the event is emitted after the user clicks the element. The event payload
-  is the result data and the metadata with the target and the origin of the element that emitted
-  it.
-  - `UserRightClickedAResult`: the event is emitted after the user right clicks the element. The
-  event payload is the result data and the metadata with the target and the origin of the element
-  that emitted it.
-  - The component can emit more events on click using the `resultClickExtraEvents` prop.
+- `UserClickedAResult`: the event is emitted after the user clicks the element. The event payload is
+  the result data and the metadata with the target and the origin of the element that emitted it.
+- `UserRightClickedAResult`: the event is emitted after the user right clicks the element. The event
+  payload is the result data and the metadata with the target and the origin of the element that
+  emitted it.
+- The component can emit more events on click using the `resultClickExtraEvents` prop.
 </docs>

--- a/packages/x-components/src/components/result/base-result-previous-price.vue
+++ b/packages/x-components/src/components/result/base-result-previous-price.vue
@@ -59,24 +59,23 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Basic example
+## Basic example
 
-  This component shows the previous price formatted if it has discount. The component has two
-  optional props. `format` to select the currency format to be applied.
+This component shows the previous price formatted if it has discount. The component has two optional
+props. `format` to select the currency format to be applied.
 
-  ```vue
-  <BaseResultPreviousPrice
-    :value="result"
-    :format="'i.iii,ddd €'"
-  />
-  ```
-  ## Overriding default slot
-  ```vue
-  <BaseResultPreviousPrice :result="result">
-    <span class="custom-base-result-previous-price">{{ result.price.originalValue }}</span>
-  </BaseResultPreviousPrice>
-  ```
+```vue
+<BaseResultPreviousPrice :value="result" :format="'i.iii,ddd €'" />
+```
+
+## Overriding default slot
+
+```vue
+<BaseResultPreviousPrice :result="result">
+  <span class="custom-base-result-previous-price">{{ result.price.originalValue }}</span>
+</BaseResultPreviousPrice>
+```
 </docs>

--- a/packages/x-components/src/components/scroll/base-scroll-to-top.vue
+++ b/packages/x-components/src/components/scroll/base-scroll-to-top.vue
@@ -188,7 +188,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 ## Basic example
 

--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -241,15 +241,14 @@
   }
 </style>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
-This component allows for any other component or element inside it to be horizontally navigable.
-It also implements customizable buttons as well as other minor customizations to its
-general behavior.
-The component uses the method `scrollBy` from `Element` to function, and it doesn't work properly
-in all browsers. A polyfill for the `scrollBy` would be needed for the component to behave as
-expected in those browsers.
+This component allows for any other component or element inside it to be horizontally navigable. It
+also implements customizable buttons as well as other minor customizations to its general behavior.
+The component uses the method `scrollBy` from `Element` to function, and it doesn't work properly in
+all browsers. A polyfill for the `scrollBy` would be needed for the component to behave as expected
+in those browsers.
 
 ## Default usage
 
@@ -272,8 +271,8 @@ Edit how much the scroll travels when navigating with the buttons by changing th
 ```
 
 Hide the navigational buttons completely by setting the `showButtons` prop to `false`. This is
-intended to be used when other scrolling options are available, like in mobile, where you can
-scroll just by swiping.
+intended to be used when other scrolling options are available, like in mobile, where you can scroll
+just by swiping.
 
 ```vue
 <SlidingPanel :showButtons="isMobile">

--- a/packages/x-components/src/components/staggering-transition-group.vue
+++ b/packages/x-components/src/components/staggering-transition-group.vue
@@ -467,24 +467,19 @@
   }
 </style>
 
-<docs>
-#Examples
+<docs lang="mdx">
+# Examples
 
 ## Basic example
 
-Apart from all the props and events that the classic transition group has, the staggering
-transition group also exposes a new `stagger` property, which allows to configure the delay for
-each one of the nodes when animating.
+Apart from all the props and events that the classic transition group has, the staggering transition
+group also exposes a new `stagger` property, which allows to configure the delay for each one of the
+nodes when animating.
 
 ```vue
-<staggering-transition-group
-  appear
-  :stagger="50"
-  name="staggered-fade-slide-"
->
+<staggering-transition-group appear :stagger="50" name="staggered-fade-slide-">
   <!-- @slot (Required) Transition-group content -->
   <slot />
 </staggering-transition-group>
 ```
-
 </docs>

--- a/packages/x-components/src/components/suggestions/base-suggestion.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestion.vue
@@ -152,39 +152,40 @@
   }
 </script>
 
-<docs>
-  #Example
+<docs lang="mdx">
+# Examples
 
-  This default suggestion component expects a suggestion to render and pass to its default slot, a
-  normalized query to compare with the suggestion's query and highlight its matching parts and
-  events to emit when the suggestion is selected.
+This default suggestion component expects a suggestion to render and pass to its default slot, a
+normalized query to compare with the suggestion's query and highlight its matching parts and events
+to emit when the suggestion is selected.
 
-  ## Default usage
+## Default usage
 
-  ```vue
-  <BaseSuggestion v-bind="{ query, suggestion, suggestionSelectedEvents }"/>
-  ```
+```vue
+<BaseSuggestion v-bind="{ query, suggestion, suggestionSelectedEvents }" />
+```
 
-  ## Customized usage
+## Customized usage
 
-  ```vue
-  <BaseSuggestion v-bind="{ query, suggestion, suggestionSelectedEvents }">
-    <template #default="{ suggestion, queryHTML }">
-      <span
-        class="my-suggestion"
-        v-html="queryHTML"
-        :aria-label="suggestion.query"
-      />
-    </template>
-  </BaseSuggestion>
-  ```
-  ## Events
+```vue
+<BaseSuggestion v-bind="{ query, suggestion, suggestionSelectedEvents }">
+  <template #default="{ suggestion, queryHTML }">
+    <span
+      class="my-suggestion"
+      v-html="queryHTML"
+      :aria-label="suggestion.query"
+    />
+  </template>
+</BaseSuggestion>
+```
 
-  A list of events that the component will emit:
+## Events
 
-  - `UserAcceptedAQuery`: the event is emitted after the user clicks the button. The event payload
-  is the suggestion query data.
-  - `UserSelectedASuggestion`: the event is emitted after the user clicks the button. The event
+A list of events that the component will emit:
+
+- `UserAcceptedAQuery`: the event is emitted after the user clicks the button. The event payload is
+  the suggestion query data.
+- `UserSelectedASuggestion`: the event is emitted after the user clicks the button. The event
   payload is the suggestion data.
-  - The component can emit more events on click using the `suggestionSelectedEvents` prop.
+- The component can emit more events on click using the `suggestionSelectedEvents` prop.
 </docs>

--- a/packages/x-components/src/components/suggestions/base-suggestions.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestions.vue
@@ -92,38 +92,38 @@
   }
 </script>
 
-<docs>
-  #Example
+<docs lang="mdx">
+# Examples
 
-  For this component to work, you will need to set a list of suggestions as prop, and also to
-  implement the component for single suggestion, which handles the click event. In the following
-  example, the suggestions are retrieved from a property called `suggestions`, and the
-  implementation of the suggestion component is a simple `button`, that calls the
-  `emitSuggestionSelected` method when clicked.
+For this component to work, you will need to set a list of suggestions as prop, and also to
+implement the component for single suggestion, which handles the click event. In the following
+example, the suggestions are retrieved from a property called `suggestions`, and the implementation
+of the suggestion component is a simple `button`, that calls the `emitSuggestionSelected` method
+when clicked.
 
-  ```vue
-  <BaseSuggestions :suggestions="suggestions">
-    <template #default="{ suggestion }">
-      <button @click="emitSuggestionSelected($event, suggestion)">
-        {{ suggestion.query }}
-      </button>
-    </template>
-  </BaseSuggestions>
-  ```
+```vue
+<BaseSuggestions :suggestions="suggestions">
+  <template #default="{ suggestion }">
+    <button @click="emitSuggestionSelected($event, suggestion)">
+      {{ suggestion.query }}
+    </button>
+  </template>
+</BaseSuggestions>
+```
 
-  Following the previous example, the component options object could be something like this:
+Following the previous example, the component options object could be something like this:
 
-  ```js
-    export default {
-      computed: {
-        ...mapGetters(['x', 'querySuggestions'], { suggestions: 'suggestions' })
-      },
-      methods: {
-        emitSuggestionSelected(event, suggestion) {
-          this.$x.emit('UserAcceptedAQuery', suggestion.query, { target: event.target });
-          this.$x.emit('UserSelectedAQuerySuggestion', suggestion, { target: event.target });
-        }
-      }
+```js
+export default {
+  computed: {
+    ...mapGetters(['x', 'querySuggestions'], { suggestions: 'suggestions' })
+  },
+  methods: {
+    emitSuggestionSelected(event, suggestion) {
+      this.$x.emit('UserAcceptedAQuery', suggestion.query, { target: event.target });
+      this.$x.emit('UserSelectedAQuerySuggestion', suggestion, { target: event.target });
     }
-  ```
+  }
+};
+```
 </docs>

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -129,14 +129,16 @@
   }
 </script>
 
-<docs>
-#Examples
+<docs lang="mdx">
+# Examples
 
-This component will listen to the configured events in eventsToOpenEmpathize and
-eventsToCloseEmpathize props and open/close itself accordingly. By default, those props values are:
-```eventsToOpenEmpathize=['UserFocusedSearchBox', 'UserIsTypingAQuery', 'UserClickedSearchBox']```
-and ```eventsToCloseEmpathize=['UserClosedEmpathize', 'UserSelectedASuggestion', 'UserPressedEnter',
-'UserBlurredSearchBox']```
+This component will listen to the configured events in `eventsToOpenEmpathize` and
+`eventsToCloseEmpathize` props and open/close itself accordingly. By default, those props values
+are:
+
+- Open: `UserFocusedSearchBox`, `'`UserIsTypingAQuery`, `'`UserClickedSearchBox` and
+- Close: `UserClosedEmpathize`, `UserSelectedASuggestion`, `UserPressedEnter`,
+  'UserBlurredSearchBox`
 
 ## Basic examples
 
@@ -159,8 +161,9 @@ Defining custom values for the events to open and close the Empathize. For examp
 the search box loses the focus and closing it when the search box receives the focus:
 
 ```vue
-<Empathize :eventsToOpenEmpathize="['UserBlurredSearchBox']"
-           :eventsToCloseEmpathize="['UserFocusedSearchBox']"
+<Empathize
+  :eventsToOpenEmpathize="['UserBlurredSearchBox']"
+  :eventsToCloseEmpathize="['UserFocusedSearchBox']"
 >
   <template #default>
     Please, type a query in the Search Box.
@@ -168,8 +171,8 @@ the search box loses the focus and closing it when the search box receives the f
 </Empathize>
 ```
 
-An animation can be used for the opening and closing using the `animation` prop. The animation,
-must be a Component with a `Transition` with a slot inside:
+An animation can be used for the opening and closing using the `animation` prop. The animation, must
+be a Component with a `Transition` with a slot inside:
 
 ```vue
 <Empathize :animation="collapseFromTop">
@@ -184,9 +187,9 @@ must be a Component with a `Transition` with a slot inside:
 A list of events that the component will emit:
 
 - `EmpathizeOpened`: the event is emitted after receiving an event to change the state `isOpen` to
-`true`. The event payload is undefined and can have a metadata with the module and the element that
-emitted it.
+  `true`. The event payload is undefined and can have a metadata with the module and the element
+  that emitted it.
 - `EmpathizeClosed`: the event is emitted after receiving an event to change the state `isOpen` to
-`false`. The event payload is undefined and can have a metadata with the module and the element that
-emitted it.
+  `false`. The event payload is undefined and can have a metadata with the module and the element
+  that emitted it.
 </docs>

--- a/packages/x-components/src/x-modules/extra-params/components/renderless-extra-param.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/renderless-extra-param.vue
@@ -105,7 +105,7 @@
 </script>
 
 <docs lang="mdx">
-#Example
+# Examples
 
 Renders default slot content. It binds to the default slot the name of the extra parameter and the
 default value of it.

--- a/packages/x-components/src/x-modules/facets/components/clear-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/clear-filters.vue
@@ -131,8 +131,8 @@
   }
 </script>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
 This component renders a button, which on clicked emits the `UserClickedClearAllFilters` or
 `UserClickedClearAllFilters` event.
@@ -148,13 +148,13 @@ This component renders a button, which on clicked emits the `UserClickedClearAll
 In this example, show the custom message in button.
 
 ```vue
-<ClearFilters v-slot="{ selectedFilters }" >
+<ClearFilters v-slot="{ selectedFilters }">
   Delete {{ selectedFilters.length }} selected
 </ClearFilters>
 ```
 
-In this example, show the custom message in button with always visible a true and
-list of facets ids.
+In this example, show the custom message in button with always visible a true and list of facets
+ids.
 
 ```vue
 <ClearFilters v-slot="{ selectedFilters }" :alwaysVisible="true" :facetsIds="facetsIds">
@@ -167,8 +167,7 @@ list of facets ids.
 A list of events that the component will emit:
 
 - `UserClickedClearAllFilters`: the event is emitted after the user clicks the button to clear a
-certain facets filter. The event payload is the id of the facets that are going to be cleared.
+  certain facets filter. The event payload is the id of the facets that are going to be cleared.
 - `UserClickedClearAllFilters`: the event is emitted after the user clicks the button. The event
-payload is undefined.
-
+  payload is undefined.
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/all-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/all-filter.vue
@@ -88,12 +88,12 @@
   }
 </script>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
 This component receives a required `facet` as prop and renders a button, which on clicked emits the
-UserClickedAllFilter event. By default the rendered button displays a message with the
-facet label but this content is customizable through the default slot.
+UserClickedAllFilter event. By default the rendered button displays a message with the facet label
+but this content is customizable through the default slot.
 
 ## Basic usage
 
@@ -136,10 +136,11 @@ facet label but this content is customizable through the default slot.
   </template>
 </Facets>
 ```
+
 ## Events
 
 A list of events that the component will emit:
 
-- `UserClickedAllFilter`: the event is emitted after the user clicks the button. The event
-payload is the id of the facet that this `AllFilter` component corresponds to.
+- `UserClickedAllFilter`: the event is emitted after the user clicks the button. The event payload
+  is the id of the facet that this `AllFilter` component corresponds to.
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/base-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/base-filter.vue
@@ -84,8 +84,8 @@
   }
 </script>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
 This component receives a `filter` as prop and renders a button, which on clicked emits the
 `UserClickedAFilter` event. If more events are needed to be emitted they can be passed using the
@@ -94,7 +94,7 @@ This component receives a `filter` as prop and renders a button, which on clicke
 ## Basic usage
 
 ```vue
-<BaseFilter :filter="filter"/>
+<BaseFilter :filter="filter" />
 ```
 
 ## Customizing its contents
@@ -110,7 +110,7 @@ This component receives a `filter` as prop and renders a button, which on clicke
 
 ```vue
 <template>
-  <BaseFilter :filter="filter" :clickEvents="clickEvents"/>
+  <BaseFilter :filter="filter" :clickEvents="clickEvents" />
 </template>
 
 <script>
@@ -135,6 +135,6 @@ This component receives a `filter` as prop and renders a button, which on clicke
 A list of events that the component will emit:
 
 - `UserClickedAFilter`: the event is emitted after the user clicks the filter. The event payload is
-the filter data.
+  the filter data.
 - Custom events defined in the `clickEvents` prop.
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
@@ -153,8 +153,8 @@
   }
 </script>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
 This component renders a button, which on clicked emits the `UserClickedAFilter` and
 `UserClickedAHierarchicalFilter` events. By default it renders the filter label as the button text.
@@ -199,6 +199,6 @@ In this example, the child filters will also include the label and checkbox.
 
 A list of events that the component will emit:
 
-- `UserClickedAHierarchicalFilter`: the event is emitted after the user clicks the button. The
-event payload is the hierarchical filter.
+- `UserClickedAHierarchicalFilter`: the event is emitted after the user clicks the button. The event
+  payload is the hierarchical filter.
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
@@ -65,8 +65,8 @@
   }
 </script>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
 This component renders a button, which on clicked emits the `UserClickedAFilter` and the
 `UserClickedANumberRangeFilter` events. By default, it renders the filter label as the button text.
@@ -91,5 +91,5 @@ This component renders a button, which on clicked emits the `UserClickedAFilter`
 A list of events that the component will emit:
 
 - `UserClickedANumberRangeFilter`: the event is emitted after the user clicks the button. The event
-payload is the number range filter.
+  payload is the number range filter.
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/renderless-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/renderless-filter.vue
@@ -94,16 +94,16 @@
   }
 </script>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
-Renders default slot content. It binds to the default slot a filter, the events that will
-be emitted when clicking the content, the css classes and if the content should be disabled.
+Renders default slot content. It binds to the default slot a filter, the events that will be emitted
+when clicking the content, the css classes and if the content should be disabled.
 
 ## Basic usage
 
 ```vue
-<RenderlessFilter :filter="filter"/>
+<RenderlessFilter :filter="filter" />
 ```
 
 ## Customizing its contents and adding new events
@@ -113,14 +113,11 @@ be emitted when clicking the content, the css classes and if the content should 
   <RenderlessFilter
     :filter="filter"
     :clickEvents="clickEvents"
-    v-slot="{ filter, clickFilter, cssClasses, isDisabled }">
-      <button
-        @click="clickFilter"
-        :class="cssClasses"
-        :disabled="isDisabled"
-      >
-        {{ filter.label }}
-      </button>
+    v-slot="{ filter, clickFilter, cssClasses, isDisabled }"
+  >
+    <button @click="clickFilter" :class="cssClasses" :disabled="isDisabled">
+      {{ filter.label }}
+    </button>
   </RenderlessFilter>
 </template>
 
@@ -140,5 +137,4 @@ be emitted when clicking the content, the css classes and if the content should 
   };
 </script>
 ```
-
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
@@ -94,7 +94,7 @@
 </script>
 
 <docs lang="mdx">
-#Example
+# Examples
 
 This component renders a button, which on clicked emits the `UserClickedAFilter` and the
 `UserClickedASimpleFilter` events. By default, it renders a `button` with the `filter.label`

--- a/packages/x-components/src/x-modules/facets/components/lists/filters-list.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/filters-list.vue
@@ -91,11 +91,11 @@
   }
 </style>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
-Renders a list with a list item per each filter in the filters prop array.
-Each list item has a scoped slot, passing the filter as slot prop.
+Renders a list with a list item per each filter in the filters prop array. Each list item has a
+scoped slot, passing the filter as slot prop.
 
 ## Important
 
@@ -106,6 +106,7 @@ filters list to their children, it is mandatory to send it as prop.
 ## Basic usage
 
 Using default slot:
+
 ```vue
 <FiltersList :filters="filters">
   <template #default="{ filter }">
@@ -115,6 +116,7 @@ Using default slot:
 ```
 
 Using default slot abbreviated syntax:
+
 ```vue
 <FiltersList :filters="filters" v-slot="{ filter }">
   <p>{{ filter.label }}</p>
@@ -123,8 +125,8 @@ Using default slot abbreviated syntax:
 
 > **Using injection**: It can receive the filters list by injection. It only works if it has a
 > parent component that receives and exposes the filters list. Using the injection, It is not
-> necessary to send the prop to the child components, it has to be send it in the parent component
-> , the rest of components will inject this list.
+> necessary to send the prop to the child components, it has to be send it in the parent component ,
+> the rest of components will inject this list.
 
 ```vue
 <SlicedFilters :filters="filters">

--- a/packages/x-components/src/x-modules/facets/components/lists/filters-search.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/filters-search.vue
@@ -134,7 +134,7 @@
 </style>
 
 <docs lang="mdx">
-#Example
+# Examples
 
 It renders an input and a list of filters passed as prop or being injected. The list of filters can
 be sifted with the query typed in the input. This component has also a debounce prop to set the time

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
@@ -96,7 +96,7 @@
 </script>
 
 <docs lang="mdx">
-#Example
+# Examples
 
 Provides a scoped slot with the selected filters from every facet, or from the facet which facet id
 is passed as property.

--- a/packages/x-components/src/x-modules/facets/components/lists/sliced-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/sliced-filters.vue
@@ -121,74 +121,72 @@
   }
 </script>
 
-<docs>
-  # Example
+<docs lang="mdx">
+# Example
 
-  The sliced filters component, takes a list of filters, and the maximum number of filters to
-  render as prop. Then, it slices the list of filters using the `max` prop, and returns this new
-  filters list using the default scoped slot.
+The sliced filters component, takes a list of filters, and the maximum number of filters to render
+as prop. Then, it slices the list of filters using the `max` prop, and returns this new filters list
+using the default scoped slot.
 
-  The user can click the show more button if he wants to see the full list of filters, or the show
-  less button when he wants to reset the filters. This buttons text or icons can be configured
-  via slot too. They receive a `difference` prop which can be useful for writing friendlier
-  messages.
+The user can click the show more button if he wants to see the full list of filters, or the show
+less button when he wants to reset the filters. This buttons text or icons can be configured via
+slot too. They receive a `difference` prop which can be useful for writing friendlier messages.
 
-  This component is usually integrated with the `Facets` and `Filters` component. It is useful
-  when there are lots of available filters for a single facet, helping to improve the
-  app performance, as less nodes are rendered.
+This component is usually integrated with the `Facets` and `Filters` component. It is useful when
+there are lots of available filters for a single facet, helping to improve the app performance, as
+less nodes are rendered.
 
-  ## Important
+## Important
 
-  The component has two ways of receive the filters list, it can be injected by another component or
-  be send it as a prop. If the component doesnt have a parent component that receive and exposed a
-  filters list to their children, it is mandatory to send it as prop.
+The component has two ways of receive the filters list, it can be injected by another component or
+be send it as a prop. If the component doesnt have a parent component that receive and exposed a
+filters list to their children, it is mandatory to send it as prop.
 
+## Basic usage
 
-  ## Basic usage
-
-  ```vue
-  <template>
-    <Facets v-slot="{ facet }">
-      <SlicedFilters :filters="facet.filters" :max="4">
-        <template #default="{ slicedFilters }">
-          <Filters :items="slicedFilters" v-slot="{ filter }">
-            <SimpleFilter :filter="filter"/>
-          </Filters>
-        </template>
-        <template #show-more="{ difference }">Show {{ difference }} more filters</template>
-        <template #show-less="{ difference }">Show {{ difference }} less filters</template>
-      </SlicedFilters>
-    </Facets>
-  </template>
-  <script>
-    import { BaseShowMoreFilters} from "@empathyco/x-components";
-    import { Facets, SimpleFilter, Filters } from "@empathyco/x-components";
-
-    export default {
-      components: {
-        Facets,
-        BaseShowMoreFilters,
-        Filters,
-        SimpleFilter
-      }
-    }
-  </script>
-  ```
-
-  > **Using injection**: It can receive the filters list by injection. It only works if it has a
-  > parent component that receives and exposes the filters list. Using the injection, It is not
-  > necessary to send the prop to the child components, it has to be send it in the parent component
-  > , the rest of components will inject this list.
-
-  ```vue
+```vue
+<template>
   <Facets v-slot="{ facet }">
     <SlicedFilters :filters="facet.filters" :max="4">
-        <Filters v-slot="{ filter }">
-          <SimpleFilter :filter="filter"/>
+      <template #default="{ slicedFilters }">
+        <Filters :items="slicedFilters" v-slot="{ filter }">
+          <SimpleFilter :filter="filter" />
         </Filters>
+      </template>
       <template #show-more="{ difference }">Show {{ difference }} more filters</template>
       <template #show-less="{ difference }">Show {{ difference }} less filters</template>
     </SlicedFilters>
   </Facets>
-  ```
+</template>
+<script>
+  import { BaseShowMoreFilters } from '@empathyco/x-components';
+  import { Facets, SimpleFilter, Filters } from '@empathyco/x-components';
+
+  export default {
+    components: {
+      Facets,
+      BaseShowMoreFilters,
+      Filters,
+      SimpleFilter
+    }
+  };
+</script>
+```
+
+> **Using injection**: It can receive the filters list by injection. It only works if it has a
+> parent component that receives and exposes the filters list. Using the injection, It is not
+> necessary to send the prop to the child components, it has to be send it in the parent component ,
+> the rest of components will inject this list.
+
+```vue
+<Facets v-slot="{ facet }">
+  <SlicedFilters :filters="facet.filters" :max="4">
+      <Filters v-slot="{ filter }">
+        <SimpleFilter :filter="filter"/>
+      </Filters>
+    <template #show-more="{ difference }">Show {{ difference }} more filters</template>
+    <template #show-less="{ difference }">Show {{ difference }} less filters</template>
+  </SlicedFilters>
+</Facets>
+```
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/lists/sorted-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/sorted-filters.vue
@@ -40,73 +40,73 @@
   }
 </script>
 
-<docs>
-  # Example
+<docs lang="mdx">
+# Example
 
-  The sorted filters component takes a list of filters and returns this new filters list sorted by
-  the `selected` filter property.
+The sorted filters component takes a list of filters and returns this new filters list sorted by the
+`selected` filter property.
 
-  ## Remarks
+## Remarks
 
-  - The component can receive the filters list by property or using the XInjection feature.
-  - It also provides the resultant list bound in the default slot or with the XProvide feature.
+- The component can receive the filters list by property or using the XInjection feature.
+- It also provides the resultant list bound in the default slot or with the XProvide feature.
 
-  Both XInjection and XProvide features are from the extended FiltersInjectionMixin. You don't have
-  to use XInjection and XProvide together, e.g. you can use pass the filters using a prop and then
-  returns the result with XProvide.
+Both XInjection and XProvide features are from the extended FiltersInjectionMixin. You don't have to
+use XInjection and XProvide together, e.g. you can use pass the filters using a prop and then
+returns the result with XProvide.
 
-  ## Basic usage
+## Basic usage
 
-  ### Using props and binding the result
+### Using props and binding the result
 
-  ```vue
-  <template>
-    <Facets v-slot="{ facet }">
-      <SortedFilters :filters="facet.filters" #default="{ sortedFilters }">
-        <Filters :items="sortedFilters" v-slot="{ filter }">
-          <SimpleFilter :filter="filter"/>
-        </Filters>
-      </SortedFilters>
-    </Facets>
-  </template>
-
-  <script>
-    import { Facets, SimpleFilter, Filters } from "@empathyco/x-components";
-
-    export default {
-      components: {
-        Facets,
-        Filters,
-        SimpleFilter
-      }
-    }
-  </script>
-  ```
-
-  ### Using XInject and XProvide
-
-  ```vue
+```vue
+<template>
   <Facets v-slot="{ facet }">
-    <FiltersSearch :filters="facet.filters">
-      <SortedFilters>
-        <Filters v-slot="{ filter }">
-          <SimpleFilter :filter="filter"/>
-        </Filters>
-      </SortedFilters>
-    </FiltersSearch>
+    <SortedFilters :filters="facet.filters" #default="{ sortedFilters }">
+      <Filters :items="sortedFilters" v-slot="{ filter }">
+        <SimpleFilter :filter="filter" />
+      </Filters>
+    </SortedFilters>
   </Facets>
+</template>
 
-  <script>
-    import { Facets, FiltersSearch, SimpleFilter, Filters } from "@empathyco/x-components";
+<script>
+  import { Facets, SimpleFilter, Filters } from '@empathyco/x-components';
 
-    export default {
-      components: {
-        Facets,
-        FiltersSearch,
-        Filters,
-        SimpleFilter
-      }
+  export default {
+    components: {
+      Facets,
+      Filters,
+      SimpleFilter
     }
-  </script>
-  ```
+  };
+</script>
+```
+
+### Using XInject and XProvide
+
+```vue
+<Facets v-slot="{ facet }">
+  <FiltersSearch :filters="facet.filters">
+    <SortedFilters>
+      <Filters v-slot="{ filter }">
+        <SimpleFilter :filter="filter"/>
+      </Filters>
+    </SortedFilters>
+  </FiltersSearch>
+</Facets>
+
+<script>
+  import { Facets, FiltersSearch, SimpleFilter, Filters } from '@empathyco/x-components';
+
+  export default {
+    components: {
+      Facets,
+      FiltersSearch,
+      Filters,
+      SimpleFilter
+    }
+  };
+</script>
+```
 </docs>

--- a/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
@@ -76,22 +76,22 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Basic example
+## Basic example
 
-  The component exposes a single default slot, where you can add icons or text.
+The component exposes a single default slot, where you can add icons or text.
 
-  ```vue
-  <ClearHistoryQueries>
-    <img class="x-history-query__icon" src="./my-icon.svg"/>
-  </ClearHistoryQueries>
-  ```
+```vue
+<ClearHistoryQueries>
+  <img class="x-history-query__icon" src="./my-icon.svg"/>
+</ClearHistoryQueries>
+```
 
-  ## Events
+## Events
 
-  A list of events that the component will emit:
+A list of events that the component will emit:
 
-  - `UserPressedClearHistoryQueries`: the event is emitted after the user clicks the button.
+- `UserPressedClearHistoryQueries`: the event is emitted after the user clicks the button.
 </docs>

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -98,58 +98,57 @@
   }
 </script>
 
-<docs>
-  # Examples
+<docs lang="mdx">
+# Examples
 
-  This component renders a list of suggestions coming from the user queries history
+This component renders a list of suggestions coming from the user queries history
 
-  ## Default usage
+## Default usage
 
-  No props are required for the usage of this component.
+No props are required for the usage of this component.
 
-  ```vue
-  <HistoryQueries/>
-  ```
+```vue
+<HistoryQueries />
+```
 
-  The component has two optional props. `animation` to render the component with an animation and
-  `maxItemToRender` to limit the number of history queries will be rendered (by default it is 5).
+The component has two optional props. `animation` to render the component with an animation and
+`maxItemToRender` to limit the number of history queries will be rendered (by default it is 5).
 
-  ```vue
-  <HistoryQueries :animation="FadeAndSlide" :maxItemsToRender="10"/>
-  ```
+```vue
+<HistoryQueries :animation="FadeAndSlide" :maxItemsToRender="10" />
+```
 
-  ## Overriding Suggestion component
+## Overriding Suggestion component
 
-  The default `HistoryQuery` component that is used in every suggestion can be replaced.
-  To do so, the `suggestion` slot is available, containing the history query data under the
-  `suggestion` property. Remember that if HistoryQuery component wasn't used the
-  `handleHistoryQuerySelection` method needs to be implemented emitting the needed events.
+The default `HistoryQuery` component that is used in every suggestion can be replaced. To do so, the
+`suggestion` slot is available, containing the history query data under the `suggestion` property.
+Remember that if HistoryQuery component wasn't used the `handleHistoryQuerySelection` method needs
+to be implemented emitting the needed events.
 
-  ```vue
-  <HistoryQueries>
-    <template #suggestion="{ suggestion }">
-      <img class="x-history-query__icon" src="./history-query-extra-icon.svg"/>
-      <HistoryQuery :suggestion="suggestion"/>
-    </template>
-  </HistoryQueries>
-  ```
+```vue
+<HistoryQueries>
+  <template #suggestion="{ suggestion }">
+    <img class="x-history-query__icon" src="./history-query-extra-icon.svg"/>
+    <HistoryQuery :suggestion="suggestion"/>
+  </template>
+</HistoryQueries>
+```
 
-  ## Overriding suggestion-content and suggestion-remove-content slot
+## Overriding suggestion-content and suggestion-remove-content slot
 
-  The content of the `HistoryQuery` component can be overridden. For replacing the default
-  suggestion content, the `suggestion-content` slot is available, containing the history query
-  suggestion (in the `suggestion` property), and the matching query part HTML (in the
-  `queryHTML` property).
+The content of the `HistoryQuery` component can be overridden. For replacing the default suggestion
+content, the `suggestion-content` slot is available, containing the history query suggestion (in the
+`suggestion` property), and the matching query part HTML (in the `queryHTML` property).
 
-  ```vue
-  <HistoryQueries>
-    <template #suggestion-content="{ queryHTML }">
-      <img class="x-history-query__history-icon" src="./history-icon.svg"/>
-      <span class="x-history-query__matching-part" v-html="queryHTML"></span>
-    </template>
-    <template #suggestion-remove-content>
-      <img class="x-history-queries__remove" src="./remove-icon.svg"/>
-    </template>
-  </HistoryQueries>
-  ```
+```vue
+<HistoryQueries>
+  <template #suggestion-content="{ queryHTML }">
+    <img class="x-history-query__history-icon" src="./history-icon.svg"/>
+    <span class="x-history-query__matching-part" v-html="queryHTML"></span>
+  </template>
+  <template #suggestion-remove-content>
+    <img class="x-history-queries__remove" src="./remove-icon.svg"/>
+  </template>
+</HistoryQueries>
+```
 </docs>

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -83,45 +83,39 @@
   }
 </script>
 
-<docs>
-  # Examples
+<docs lang="mdx">
+# Examples
 
-  ## Basic usage
+## Basic usage
 
-  This component only requires a prop called `suggestion`
+This component only requires a prop called `suggestion`
 
-  ```vue
-  <HistoryQuery :suggestion="historyQuery"/>
-  ```
+```vue
+<HistoryQuery :suggestion="historyQuery" />
+```
 
-  ## Customizing slots content
+## Customizing slots content
 
-  Suggestion and remove buttons contents can be customized.
+Suggestion and remove buttons contents can be customized.
 
-  The default slot allows you to replace the content of the suggestion button. It has two
-  properties, the suggestion itself, and a `string` of HTML with the matched query.
+The default slot allows you to replace the content of the suggestion button. It has two properties,
+the suggestion itself, and a `string` of HTML with the matched query.
 
-  The other slot is called `remove-button-content`, and allows you to set the content of the
-  button that serves to remove this query from the history. This slot only has one property, the
-  suggestion.
+The other slot is called `remove-button-content`, and allows you to set the content of the button
+that serves to remove this query from the history. This slot only has one property, the suggestion.
 
-  ```vue
-  <HistoryQuery :suggestion="historyQuery">
-    <template #default="{ suggestion, queryHTML }">
-      <img class="x-history-query__history-icon" src="./history-icon.svg"/>
-      <span class="x-history-query__matching-part" v-html="queryHTML"/>
-    </template>
+````vue
+<HistoryQuery :suggestion="historyQuery">
+  <template #default="{ suggestion, queryHTML }">
+    <img class="x-history-query__history-icon" src="./history-icon.svg"/>
+    <span class="x-history-query__matching-part" v-html="queryHTML"/>
+  </template>
 
-    <template #remove-button-content="{ suggestion }">
-      <img class="x-history-query__remove-icon" src="./remove-icon.svg"/>
-    </template>
-  </HistoryQuery>
-    ```
-
-  ## Events
-
-  A list of events that the component will emit:
-
-  - `UserSelectedAHistoryQuery`: the event is emitted after the user clicks the button. The event
-  payload is the history query data.
+  <template #remove-button-content="{ suggestion }">
+    <img class="x-history-query__remove-icon" src="./remove-icon.svg"/>
+  </template>
+</HistoryQuery>
+``` ## Events A list of events that the component will emit: - `UserSelectedAHistoryQuery`: the
+event is emitted after the user clicks the button. The event payload is the history query data.
+````
 </docs>

--- a/packages/x-components/src/x-modules/history-queries/components/remove-history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/remove-history-query.vue
@@ -49,24 +49,23 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Basic Example
+## Basic Example
 
-  You can customize the content that this component renders. To do so, simply use the default
-  slot.
+You can customize the content that this component renders. To do so, simply use the default slot.
 
-  ```vue
-  <RemoveHistoryQuery :historyQuery="historyQuery">
-    <img class="x-history-query__icon" src="./my-awesome-clear-icon.svg"/>
-  </RemoveHistoryQuery>
-  ```
+```vue
+<RemoveHistoryQuery :historyQuery="historyQuery">
+  <img class="x-history-query__icon" src="./my-awesome-clear-icon.svg"/>
+</RemoveHistoryQuery>
+```
 
-  ## Events
+## Events
 
-  A list of events that the component will emit:
+A list of events that the component will emit:
 
-  - `UserPressedRemoveHistoryQuery`: the event is emitted after the user clicks the button. The
-  event payload is the history query data.
+- `UserPressedRemoveHistoryQuery`: the event is emitted after the user clicks the button. The event
+  payload is the history query data.
 </docs>

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
@@ -69,14 +69,15 @@
   }
 </script>
 
-<docs>
-  #Example
+<docs lang="mdx">
+# Examples
 
-  This component renders an identifier result value and highlights its matching part with the query
-  from the state. Receives as prop the result data
+This component renders an identifier result value and highlights its matching part with the query
+from the state. Receives as prop the result data
 
-  ## Basic usage:
-  ```vue
-  <IdentifierResult v-bind="{ result }"/>
-  ```
+## Basic usage:
+
+```vue
+<IdentifierResult v-bind="{ result }" />
+```
 </docs>

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
@@ -57,24 +57,24 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Adding a IdentifierResult component within a BaseResultLink
+## Adding a IdentifierResult component within a BaseResultLink
 
-  A IdentifierResult **must** be used inside the IdentifierResults component. In the example below
-  the BaseResultLink is used as a wrapper and its default slot is filled with the IdentifierResult
-  component.
+A IdentifierResult **must** be used inside the IdentifierResults component. In the example below the
+BaseResultLink is used as a wrapper and its default slot is filled with the IdentifierResult
+component.
 
-  ```vue
-  <IdentifierResults :animation="fadeAndSlide">
-    <template #default="{ identifierResult }">
-      <BaseResultLink :result="identifierResult">
-        <template #default="{ result }">
-          <IdentifierResult :result="result"/>
-        </template>
-      </BaseResultLink>
-    </template>
-  </IdentifierResults>
-  ```
+```vue
+<IdentifierResults :animation="fadeAndSlide">
+  <template #default="{ identifierResult }">
+    <BaseResultLink :result="identifierResult">
+      <template #default="{ result }">
+        <IdentifierResult :result="result"/>
+      </template>
+    </BaseResultLink>
+  </template>
+</IdentifierResults>
+```
 </docs>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -76,57 +76,58 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Basic example
+## Basic example
 
-  You don't need to pass any props, or slots. Simply add the component, and when it has any next
-  queries it will show them
+You don't need to pass any props, or slots. Simply add the component, and when it has any next
+queries it will show them
 
-  ```vue
-  <NextQueries />
-  ```
+```vue
+<NextQueries />
+```
 
-  The component has two optional props. `animation` to render the component with an animation and
-  `maxItemToRender` to limit the number of next queries will be rendered (by default it is 5).
+The component has two optional props. `animation` to render the component with an animation and
+`maxItemToRender` to limit the number of next queries will be rendered (by default it is 5).
 
-  ```vue
-  <NextQueries :animation="FadeAndSlide" :maxItemsToRender="10"/>
-  ```
+```vue
+<NextQueries :animation="FadeAndSlide" :maxItemsToRender="10" />
+```
 
-  ## Overriding Next Queries' Content
+## Overriding Next Queries' Content
 
-  You can use your custom implementation of the Next Query's content.
-  In the example below, instead of using the default Next Query's content, an icon
-  is added, as well as a span with the query of the Next Query suggestion.
+You can use your custom implementation of the Next Query's content. In the example below, instead of
+using the default Next Query's content, an icon is added, as well as a span with the query of the
+Next Query suggestion.
 
-  ```vue
-  <NextQueries>
-    <template #suggestion-content="{suggestion}">
-      <img src="./next-query-icon.svg" class="x-next-query__icon"/>
-      <span class="x-next-query__query">{{ suggestion.query }}</span>
-    </template>
-  </NextQueries>
-  ```
+```vue
+<NextQueries>
+  <template #suggestion-content="{suggestion}">
+    <img src="./next-query-icon.svg" class="x-next-query__icon"/>
+    <span class="x-next-query__query">{{ suggestion.query }}</span>
+  </template>
+</NextQueries>
+```
 
-  ## Adding a custom next query component
+## Adding a custom next query component
 
-  You can use your custom implementation of a next query component. To work correctly, it should
-  use the `emitNextQuerySelected` function when the next query is selected.
-  In the example below, instead of using the default `button` tag for a next query, an icon is
-  added, and the text of the next query is wrapped in a `span`
-  ```vue
-  <NextQueries>
-    <template #suggestion="{suggestion}">
-      <NextQuery :suggestion="suggestion" class="x-next-queries__suggestion">
-        <template #default="{suggestion}">
-          <img src="./next-query-icon.svg" class="x-next-query__icon"/>
-          <span class="x-next-query__query">{{ suggestion.query }}</span>
-        </template>
-      </NextQuery>
-      <button>Custom Behaviour</button>
-    </template>
-  </NextQueries>
-  ```
+You can use your custom implementation of a next query component. To work correctly, it should use
+the `emitNextQuerySelected` function when the next query is selected. In the example below, instead
+of using the default `button` tag for a next query, an icon is added, and the text of the next query
+is wrapped in a `span`
+
+```vue
+<NextQueries>
+  <template #suggestion="{suggestion}">
+    <NextQuery :suggestion="suggestion" class="x-next-queries__suggestion">
+      <template #default="{suggestion}">
+        <img src="./next-query-icon.svg" class="x-next-query__icon"/>
+        <span class="x-next-query__query">{{ suggestion.query }}</span>
+      </template>
+    </NextQuery>
+    <button>Custom Behaviour</button>
+  </template>
+</NextQueries>
+```
 </docs>

--- a/packages/x-components/src/x-modules/next-queries/components/next-query.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-query.vue
@@ -58,36 +58,37 @@
   }
 </script>
 
-<docs>
-  #Example
+<docs lang="mdx">
+# Examples
 
-  This components expects just a suggestion as a prop to be rendered. It has a slot to override
-  the content. By default, it renders the suggestion query of the next query.
+This components expects just a suggestion as a prop to be rendered. It has a slot to override the
+content. By default, it renders the suggestion query of the next query.
 
-  ## Basic Usage
+## Basic Usage
 
-  Using default slot:
-  ```vue
-  <NextQuery :suggestion="suggestion"/>
-  ```
+Using default slot:
 
-  ## Overriding default slot.
+```vue
+<NextQuery :suggestion="suggestion" />
+```
 
-  The default slot allows you to replace the content of the suggestion button.
+## Overriding default slot.
 
-  ```vue
-  <NextQuery :suggestion="suggestion">
-    <template #default="{ suggestion }">
-      <img class="x-next-query__icon" src="./next-query.svg" />
-      <span class="x-next-query__query" :aria-label="suggestion.query">{{ suggestion.query }}</span>
-    </template>
-  </NextQuery>
-  ```
+The default slot allows you to replace the content of the suggestion button.
 
-  ## Events
+```vue
+<NextQuery :suggestion="suggestion">
+  <template #default="{ suggestion }">
+    <img class="x-next-query__icon" src="./next-query.svg" />
+    <span class="x-next-query__query" :aria-label="suggestion.query">{{ suggestion.query }}</span>
+  </template>
+</NextQuery>
+```
 
-  A list of events that the component will emit:
+## Events
 
-  - `UserSelectedANextQuery`: the event is emitted after the user clicks the button. The event
-  payload is the next query data.
+A list of events that the component will emit:
+
+- `UserSelectedANextQuery`: the event is emitted after the user clicks the button. The event payload
+  is the next query data.
 </docs>

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
@@ -58,33 +58,35 @@
   }
 </script>
 
-<docs>
-  #Example
+<docs lang="mdx">
+# Examples
 
-  This components expects just a suggestion as a prop to be rendered. It has a slot to override
-  the content. By default, it renders the suggestion query of the popular search.
+This components expects just a suggestion as a prop to be rendered. It has a slot to override the
+content. By default, it renders the suggestion query of the popular search.
 
-  ## Basic Usage
-  ```vue
-  <PopularSearch :suggestion="suggestion"/>
-  ```
+## Basic Usage
 
-  ## Custom Usage
-  ```vue
-  <PopularSearch :suggestion="suggestion">
-    <template #default="{ suggestion }">
-      <svg height="10" width="10">
-        <circle cx="5" cy="5" r="4" stroke="black" />
-      </svg>
-      <span :aria-label="suggestion.query">{{ suggestion.query }}</span>
-    </template>
-  </PopularSearch>
-  ```
+```vue
+<PopularSearch :suggestion="suggestion" />
+```
 
-  ## Events
+## Custom Usage
 
-  A list of events that the component will emit:
+```vue
+<PopularSearch :suggestion="suggestion">
+  <template #default="{ suggestion }">
+    <svg height="10" width="10">
+      <circle cx="5" cy="5" r="4" stroke="black" />
+    </svg>
+    <span :aria-label="suggestion.query">{{ suggestion.query }}</span>
+  </template>
+</PopularSearch>
+```
 
-  - `UserSelectedAPopularSearch`: the event is emitted after the user clicks the button. The event
+## Events
+
+A list of events that the component will emit:
+
+- `UserSelectedAPopularSearch`: the event is emitted after the user clicks the button. The event
   payload is the popular search data.
 </docs>

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -75,59 +75,59 @@
   }
 </script>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  ## Default Usage
+## Default Usage
 
-  You don't need to pass any props, or slots. Simply add the component, and when it has any
-  popular searches it will show them.
+You don't need to pass any props, or slots. Simply add the component, and when it has any popular
+searches it will show them.
 
-  ```vue
-  <PopularSearches/>
-  ```
+```vue
+<PopularSearches />
+```
 
-  The component has two optional props. `animation` to render the component with an animation and
-  `maxItemToRender` to limit the number of popular searches will be rendered (by default it is 5).
+The component has two optional props. `animation` to render the component with an animation and
+`maxItemToRender` to limit the number of popular searches will be rendered (by default it is 5).
 
-  ```vue
-  <PopularSearches :animation="FadeAndSlide" :maxItemsToRender="10"/>
-  ```
+```vue
+<PopularSearches :animation="FadeAndSlide" :maxItemsToRender="10" />
+```
 
-  ## Overriding Popular Search's Content
+## Overriding Popular Search's Content
 
-  You can use your custom implementation of the Popular Search's content.
-  In the example below, instead of using the default Popular Search's content, an icon
-  is added, as well as a span with the query of the Popular Search's suggestion.
+You can use your custom implementation of the Popular Search's content. In the example below,
+instead of using the default Popular Search's content, an icon is added, as well as a span with the
+query of the Popular Search's suggestion.
 
-  ```vue
-  <PopularSearches>
-    <template #suggestion-content="{ suggestion }">
-      <img class="x-popular-search__icon" src="./popular-search-icon.svg" />
-      <span class="x-popular-search__query">{{ suggestion.query }}</span>
-    </template>
-  </PopularSearches>
-  ```
+```vue
+<PopularSearches>
+  <template #suggestion-content="{ suggestion }">
+    <img class="x-popular-search__icon" src="./popular-search-icon.svg" />
+    <span class="x-popular-search__query">{{ suggestion.query }}</span>
+  </template>
+</PopularSearches>
+```
 
-  ## Adding a Custom Popular Search Item
+## Adding a Custom Popular Search Item
 
-  You can use your custom implementation for the whole Popular Search item.
-  In the example below, we change the default implementation of the Popular Search in Popular
-  Searches. A custom Popular Search implementation is added, it has an image and a span as content
-  (as in the previous example). Also, a button with a user customized behaviour is added at the
-  same hierarchical level as the Popular Search component.
+You can use your custom implementation for the whole Popular Search item. In the example below, we
+change the default implementation of the Popular Search in Popular Searches. A custom Popular Search
+implementation is added, it has an image and a span as content (as in the previous example). Also, a
+button with a user customized behaviour is added at the same hierarchical level as the Popular
+Search component.
 
-  ```vue
-  <PopularSearches>
-    <template #suggestion="{suggestion}">
-      <PopularSearch :suggestion="suggestion">
-        <template #default="{suggestion}">
-          <img class="x-popular-search__icon" src="./popular-search-icon.svg" />
-          <span class="x-popular-search__query">{{ suggestion.query }}</span>
-        </template>
-      </PopularSearch>
-      <button>Custom Behaviour</button>
-    </template>
-  </PopularSearches>
-  ```
+```vue
+<PopularSearches>
+  <template #suggestion="{suggestion}">
+    <PopularSearch :suggestion="suggestion">
+      <template #default="{suggestion}">
+        <img class="x-popular-search__icon" src="./popular-search-icon.svg" />
+        <span class="x-popular-search__query">{{ suggestion.query }}</span>
+      </template>
+    </PopularSearch>
+    <button>Custom Behaviour</button>
+  </template>
+</PopularSearches>
+```
 </docs>

--- a/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
+++ b/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
@@ -91,62 +91,61 @@
   }
 </style>
 
-<docs>
-  #Examples
+<docs lang="mdx">
+# Examples
 
-  It renders a list of recommendations from recommendations state by default. The component
-  provides the slot layout which wraps the whole component with the recommendations bound. It also
-  provides the default slot to customize the item, which is within the layout slot, with the
-  recommendation bound. Each recommendation should be represented by a BaseResultLink component
-  besides any other component.
+It renders a list of recommendations from recommendations state by default. The component provides
+the slot layout which wraps the whole component with the recommendations bound. It also provides the
+default slot to customize the item, which is within the layout slot, with the recommendation bound.
+Each recommendation should be represented by a BaseResultLink component besides any other component.
 
-  ## Basic example
+## Basic example
 
-  ## Adding a custom BaseResultLink component
+## Adding a custom BaseResultLink component
 
-  A BaseResultLink **must** be used inside the Recommendations component. In the example below
-  the BaseResultLink default slot is filled with an image of the result and a span for the title.
-  Besides that, an additional button has been added.
+A BaseResultLink **must** be used inside the Recommendations component. In the example below the
+BaseResultLink default slot is filled with an image of the result and a span for the title. Besides
+that, an additional button has been added.
 
-  ```vue
-  <Recommendations>
-    <template #default="{ recommendation }">
-      <BaseResultLink :result="recommendation" class="x-recommendations__link">
-        <template #default="{ result }">
-          <img :src="result.images[0]" class="x-recommendations__image"/>
-          <span class="x-recommendations__title">{{ result.name }}</span>
-        </template>
-      </BaseResultLink>
-      <button>Custom Behaviour</button>
-    </template>
-  </Recommendations>
-  ```
+```vue
+<Recommendations>
+  <template #default="{ recommendation }">
+    <BaseResultLink :result="recommendation" class="x-recommendations__link">
+      <template #default="{ result }">
+        <img :src="result.images[0]" class="x-recommendations__image"/>
+        <span class="x-recommendations__title">{{ result.name }}</span>
+      </template>
+    </BaseResultLink>
+    <button>Custom Behaviour</button>
+  </template>
+</Recommendations>
+```
 
-  ## Overriding layout content
+## Overriding layout content
 
-  It renders a list of recommendations customizing the layout slot. In the example below,
-  instead of using the default Recommendations content, a BaseGrid component is used to render
-  the recommendations.
+It renders a list of recommendations customizing the layout slot. In the example below, instead of
+using the default Recommendations content, a BaseGrid component is used to render the
+recommendations.
 
-  ```vue
-  <Recommendations :animation="staggeredFadeAndSlide">
-    <template #layout="{ recommendations, animation }">
-      <BaseGrid :items="recommendations" :animation="animation">
-        <template #result="{ item }">
-          <BaseResultLink :result="item">
-            <BaseResultImage :result="item" />
-            <span class="x-result__title">{{ item.name }}</span>
-          </BaseResultLink>
-        </template>
-      </BaseGrid>
-    </template>
-  </Recommendations>
-  ```
+```vue
+<Recommendations :animation="staggeredFadeAndSlide">
+  <template #layout="{ recommendations, animation }">
+    <BaseGrid :items="recommendations" :animation="animation">
+      <template #result="{ item }">
+        <BaseResultLink :result="item">
+          <BaseResultImage :result="item" />
+          <span class="x-result__title">{{ item.name }}</span>
+        </BaseResultLink>
+      </template>
+    </BaseGrid>
+  </template>
+</Recommendations>
+```
 
-  ## Events
+## Events
 
-  A list of events that the component will emit:
+A list of events that the component will emit:
 
-  - `UserClickedARecommendation`: the event is emitted after the user clicks the button.
-  - A list of events emitted by the `BaseResultLink`.
+- `UserClickedARecommendation`: the event is emitted after the user clicks the button.
+- A list of events emitted by the `BaseResultLink`.
 </docs>

--- a/packages/x-components/src/x-modules/search/components/partial-query-button.vue
+++ b/packages/x-components/src/x-modules/search/components/partial-query-button.vue
@@ -52,7 +52,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 ## Basic example
 

--- a/packages/x-components/src/x-modules/search/components/partial-results-list.vue
+++ b/packages/x-components/src/x-modules/search/components/partial-results-list.vue
@@ -81,7 +81,7 @@
 </style>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 This component loops through an array of partials an exposed a slot to use customize each partial.
 

--- a/packages/x-components/src/x-modules/search/components/spellcheck-button.vue
+++ b/packages/x-components/src/x-modules/search/components/spellcheck-button.vue
@@ -52,7 +52,7 @@
 </script>
 
 <docs lang="mdx">
-#Examples
+# Examples
 
 ## Basic example
 

--- a/packages/x-components/src/x-modules/search/components/spellcheck.vue
+++ b/packages/x-components/src/x-modules/search/components/spellcheck.vue
@@ -42,18 +42,17 @@
   }
 </script>
 
-<docs>
-#Example
+<docs lang="mdx">
+# Examples
 
-This default spellcheck component expects a query and a spellcheckedQuery to render
-and pass to its default slot.
+This default spellcheck component expects a query and a spellcheckedQuery to render and pass to its
+default slot.
 
 This two props should be show like a message comparing them.
 
 ## Basic usage
 
 ```vue
-
 <Spellcheck />
 ```
 


### PR DESCRIPTION
Makes all components use `lang="mdx"` in its docs, so prettier can format it. 
Fixes some `#Example` headers in docs, which should be `# Example` (note the space between `#` and the text).
Fixes an issue where eslint was trying to lint `.md` files, which we don't support in our rules.