### PR TITLE
fix(url): Fix URL clear query issue.

### DIFF
--- a/packages/x-components/src/x-modules/url/store/emitters.ts
+++ b/packages/x-components/src/x-modules/url/store/emitters.ts
@@ -20,9 +20,8 @@ export const replaceableParams: UrlParamKey[] = ['scroll', 'page'];
  * @returns True if is pushable change, false otherwise.
  */
 function shouldPushUrl(newParams: UrlParams, oldParams: UrlParams): boolean {
-  return Object.keys(newParams).some(
-    key => !replaceableParams.includes(key) && oldParams[key] !== newParams[key]
-  );
+  const keys = Object.keys(oldParams).concat(Object.keys(newParams));
+  return keys.some(key => !replaceableParams.includes(key) && oldParams[key] !== newParams[key]);
 }
 
 /**
@@ -34,10 +33,10 @@ function shouldPushUrl(newParams: UrlParams, oldParams: UrlParams): boolean {
  * @returns True if is pushable change, false otherwise.
  */
 function shouldReplaceUrl(newParams: UrlParams, oldParams: UrlParams): boolean {
+  const keys = Object.keys(oldParams).concat(Object.keys(newParams));
   return (
-    Object.keys(newParams).some(
-      key => replaceableParams.includes(key) && oldParams[key] !== newParams[key]
-    ) && !shouldPushUrl(newParams, oldParams)
+    keys.some(key => replaceableParams.includes(key) && oldParams[key] !== newParams[key]) &&
+    !shouldPushUrl(newParams, oldParams)
   );
 }
 

--- a/packages/x-components/src/x-modules/url/store/emitters.ts
+++ b/packages/x-components/src/x-modules/url/store/emitters.ts
@@ -19,8 +19,11 @@ export const replaceableParams: UrlParamKey[] = ['scroll', 'page'];
  *
  * @returns True if is pushable change, false otherwise.
  */
-function shouldPushUrl(newParams: UrlParams, oldParams: UrlParams): boolean {
-  const keys = Object.keys(oldParams).concat(Object.keys(newParams));
+function shouldPushUrl(
+  newParams: Partial<UrlParams> = {},
+  oldParams: Partial<UrlParams> = {}
+): boolean {
+  const keys = Object.keys({ ...oldParams, ...newParams });
   return keys.some(key => !replaceableParams.includes(key) && oldParams[key] !== newParams[key]);
 }
 
@@ -32,8 +35,11 @@ function shouldPushUrl(newParams: UrlParams, oldParams: UrlParams): boolean {
  *
  * @returns True if is pushable change, false otherwise.
  */
-function shouldReplaceUrl(newParams: UrlParams, oldParams: UrlParams): boolean {
-  const keys = Object.keys(oldParams).concat(Object.keys(newParams));
+function shouldReplaceUrl(
+  newParams: Partial<UrlParams> = {},
+  oldParams: Partial<UrlParams> = {}
+): boolean {
+  const keys = Object.keys({ ...oldParams, ...newParams });
   return (
     keys.some(key => replaceableParams.includes(key) && oldParams[key] !== newParams[key]) &&
     !shouldPushUrl(newParams, oldParams)


### PR DESCRIPTION
EX-4949


This PR fixes URL clear query parameter bug.

Steps to reproduce:

1- search
2- click in clear query
3- the query parameter is still in URL