### PR TITLE
fix(x-plugin): Fix no results message flash on load.

### DIFF
--- a/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
@@ -97,7 +97,7 @@ describe('testing plugin alias', () => {
   });
 
   it('updates the status values when the module is registered', () => {
-    const REQUEST_STATUS_REGEX = /success|loading|error/;
+    const REQUEST_STATUS_REGEX = /success|loading|error|/;
 
     XPlugin.registerXModule(identifierResultsXModule);
     XPlugin.registerXModule(popularSearchesXModule);

--- a/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
@@ -97,7 +97,7 @@ describe('testing plugin alias', () => {
   });
 
   it('updates the status values when the module is registered', () => {
-    const REQUEST_STATUS_REGEX = /success|loading|error|/;
+    const REQUEST_STATUS_REGEX = /success|loading|error|initial/;
 
     XPlugin.registerXModule(identifierResultsXModule);
     XPlugin.registerXModule(popularSearchesXModule);

--- a/packages/x-components/src/plugins/x-plugin.alias.ts
+++ b/packages/x-components/src/plugins/x-plugin.alias.ts
@@ -74,7 +74,7 @@ export function getAliasAPI(
       return store.getters[getGetterPath('nextQueries', 'nextQueries')] ?? [];
     },
     get noResults() {
-      return !this.totalResults && !!this.query.search && this.status.search !== 'loading';
+      return !this.totalResults && !!this.query.search && this.status.search === 'success';
     },
     get partialResults() {
       return store.state.x.search?.partialResults ?? [];

--- a/packages/x-components/src/store/utils/status-store.utils.ts
+++ b/packages/x-components/src/store/utils/status-store.utils.ts
@@ -31,7 +31,7 @@ export interface StatusMutations {
  *
  * @public
  */
-export type RequestStatus = 'success' | 'loading' | 'error';
+export type RequestStatus = 'success' | 'loading' | 'error' | '';
 
 /**
  * Sets the request status. Can be used as a mutation.

--- a/packages/x-components/src/store/utils/status-store.utils.ts
+++ b/packages/x-components/src/store/utils/status-store.utils.ts
@@ -31,7 +31,7 @@ export interface StatusMutations {
  *
  * @public
  */
-export type RequestStatus = 'success' | 'loading' | 'error' | '';
+export type RequestStatus = 'success' | 'loading' | 'error' | 'initial';
 
 /**
  * Sets the request status. Can be used as a mutation.

--- a/packages/x-components/src/x-modules/identifier-results/store/module.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/module.ts
@@ -20,7 +20,7 @@ export const identifierResultsXStoreModule: IdentifierResultsXStoreModule = {
   state: () => ({
     query: '',
     identifierResults: [],
-    status: '',
+    status: 'initial',
     config: {
       debounceInMs: 600,
       maxItemsToRequest: 10,

--- a/packages/x-components/src/x-modules/identifier-results/store/module.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/module.ts
@@ -20,7 +20,7 @@ export const identifierResultsXStoreModule: IdentifierResultsXStoreModule = {
   state: () => ({
     query: '',
     identifierResults: [],
-    status: 'success',
+    status: '',
     config: {
       debounceInMs: 600,
       maxItemsToRequest: 10,

--- a/packages/x-components/src/x-modules/next-queries/store/module.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/module.ts
@@ -20,7 +20,7 @@ export const nextQueriesXStoreModule: NextQueriesXStoreModule = {
     query: '',
     nextQueries: [],
     searchedQueries: [],
-    status: 'success',
+    status: '',
     config: {
       maxItemsToRequest: 20,
       hideSessionQueries: true,

--- a/packages/x-components/src/x-modules/next-queries/store/module.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/module.ts
@@ -20,7 +20,7 @@ export const nextQueriesXStoreModule: NextQueriesXStoreModule = {
     query: '',
     nextQueries: [],
     searchedQueries: [],
-    status: '',
+    status: 'initial',
     config: {
       maxItemsToRequest: 20,
       hideSessionQueries: true,

--- a/packages/x-components/src/x-modules/popular-searches/store/module.ts
+++ b/packages/x-components/src/x-modules/popular-searches/store/module.ts
@@ -17,7 +17,7 @@ export const popularSearchesXStoreModule: PopularSearchesXStoreModule = {
   state: () => ({
     popularSearches: [],
     searchedQueries: [],
-    status: '',
+    status: 'initial',
     config: {
       hideSessionQueries: true,
       maxItemsToRequest: 20,

--- a/packages/x-components/src/x-modules/popular-searches/store/module.ts
+++ b/packages/x-components/src/x-modules/popular-searches/store/module.ts
@@ -17,7 +17,7 @@ export const popularSearchesXStoreModule: PopularSearchesXStoreModule = {
   state: () => ({
     popularSearches: [],
     searchedQueries: [],
-    status: 'success',
+    status: '',
     config: {
       hideSessionQueries: true,
       maxItemsToRequest: 20,

--- a/packages/x-components/src/x-modules/query-suggestions/store/module.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/store/module.ts
@@ -19,7 +19,7 @@ export const querySuggestionsXStoreModule: QuerySuggestionsXStoreModule = {
   state: () => ({
     query: '',
     suggestions: [],
-    status: '',
+    status: 'initial',
     config: {
       debounceInMs: 200,
       maxItemsToRequest: 10,

--- a/packages/x-components/src/x-modules/query-suggestions/store/module.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/store/module.ts
@@ -19,7 +19,7 @@ export const querySuggestionsXStoreModule: QuerySuggestionsXStoreModule = {
   state: () => ({
     query: '',
     suggestions: [],
-    status: 'success',
+    status: '',
     config: {
       debounceInMs: 200,
       maxItemsToRequest: 10,

--- a/packages/x-components/src/x-modules/recommendations/store/module.ts
+++ b/packages/x-components/src/x-modules/recommendations/store/module.ts
@@ -19,7 +19,7 @@ export const recommendationsXStoreModule: RecommendationsXStoreModule = {
       maxItemsToRequest: 24
     },
     origin: RECOMMENDATIONS_ORIGIN,
-    status: 'success',
+    status: '',
     recommendations: [],
     params: {}
   }),

--- a/packages/x-components/src/x-modules/recommendations/store/module.ts
+++ b/packages/x-components/src/x-modules/recommendations/store/module.ts
@@ -19,7 +19,7 @@ export const recommendationsXStoreModule: RecommendationsXStoreModule = {
       maxItemsToRequest: 24
     },
     origin: RECOMMENDATIONS_ORIGIN,
-    status: '',
+    status: 'initial',
     recommendations: [],
     params: {}
   }),

--- a/packages/x-components/src/x-modules/related-tags/store/module.ts
+++ b/packages/x-components/src/x-modules/related-tags/store/module.ts
@@ -21,7 +21,7 @@ export const relatedTagsXStoreModule: RelatedTagsXStoreModule = {
     query: '',
     relatedTags: [],
     selectedRelatedTags: [],
-    status: 'success',
+    status: '',
     config: {
       maxItemsToRequest: 10
     },

--- a/packages/x-components/src/x-modules/related-tags/store/module.ts
+++ b/packages/x-components/src/x-modules/related-tags/store/module.ts
@@ -21,7 +21,7 @@ export const relatedTagsXStoreModule: RelatedTagsXStoreModule = {
     query: '',
     relatedTags: [],
     selectedRelatedTags: [],
-    status: '',
+    status: 'initial',
     config: {
       maxItemsToRequest: 10
     },

--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -32,7 +32,7 @@ export const searchXStoreModule: SearchXStoreModule = {
     },
     totalResults: 0,
     spellcheckedQuery: '',
-    status: 'success',
+    status: '',
     sort: '',
     page: 1,
     origin: null,

--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -32,7 +32,7 @@ export const searchXStoreModule: SearchXStoreModule = {
     },
     totalResults: 0,
     spellcheckedQuery: '',
-    status: '',
+    status: 'initial',
     sort: '',
     page: 1,
     origin: null,


### PR DESCRIPTION
EX-4951

This PR fixes the No results message flashes on load.

Steps to reproduce:

1- load with a query in URL multiple times
2- Sometimes you'll see the No Results Message flashes momentaneously 