### PR TITLE
fix(identifier-results): provide resultClickExtraEvents so BaseResultLink emits them when clicked

### DIFF
--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
@@ -22,10 +22,12 @@
 
 <script lang="ts">
   import { Result } from '@empathyco/x-types';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { Component, Prop, Provide } from 'vue-property-decorator';
   import Vue from 'vue';
   import { State } from '../../../components/decorators/store.decorators';
   import { xComponentMixin } from '../../../components/x-component.mixin';
+  import { PropsWithType } from '../../../utils/types';
+  import { XEventsTypes } from '../../../wiring/events.types';
   import { identifierResultsXModule } from '../x-module';
 
   /**
@@ -54,6 +56,16 @@
      */
     @State('identifierResults', 'identifierResults')
     public identifierResults!: Result[];
+
+    /**
+     * The additional events to be emitted by the mandatory {@link BaseResultLink} component.
+     *
+     * @public
+     */
+    @Provide()
+    protected resultClickExtraEvents: PropsWithType<XEventsTypes, Result>[] = [
+      'UserClickedAIdentifierResult'
+    ];
   }
 </script>
 


### PR DESCRIPTION
[EX-4980](https://searchbroker.atlassian.net/browse/EX-4980)

Add missing provider in `identifier-results` so extra events (`UserClickedAIdentifierResult`) are emitted when clicking an identifier result.
