### PR TITLE
feat(scroll): add empty `XModule`

### DIFF
--- a/packages/x-components/src/components/scroll/base-scroll-to-top.vue
+++ b/packages/x-components/src/components/scroll/base-scroll-to-top.vue
@@ -134,7 +134,7 @@
     /**
      * Validates when the target scroll component has almost reached the end of the scroll.
      *
-     * @param _payload - {@link XEventsTypes.UserAlmostReachedScrollEnd}.
+     * @param _payload - {@link ScrollXEvents.UserAlmostReachedScrollEnd}.
      * @param metadata - Associated data of the event, including the id.
      * @internal
      */
@@ -148,7 +148,7 @@
     /**
      * Updates the scroll direction of the target scroll component.
      *
-     * @param scrollDirection - The last direction {@link XEventsTypes.UserChangedScrollDirection}.
+     * @param scrollDirection - The last direction {@link ScrollXEvents.UserChangedScrollDirection}.
      * @param metadata - Associated data of the event, including the id.
      * @internal
      */
@@ -163,7 +163,7 @@
      * Updates the scrollTop property with the value of the target scroll component.
      *
      * @param scrollPosition - The number of pixels that the target has been scrolled
-     * {@link XEventsTypes.UserScrolled}.
+     * {@link ScrollXEvents.UserScrolled}.
      * @param metadata - Associated data of the event, including the id.
      * @internal
      */

--- a/packages/x-components/src/index.ts
+++ b/packages/x-components/src/index.ts
@@ -26,6 +26,7 @@ export * from './x-modules/popular-searches';
 export * from './x-modules/query-suggestions';
 export * from './x-modules/recommendations';
 export * from './x-modules/related-tags';
+export * from './x-modules/scroll';
 export * from './x-modules/search';
 export * from './x-modules/search-box';
 export * from './x-modules/tagging';

--- a/packages/x-components/src/store/x.module.ts
+++ b/packages/x-components/src/store/x.module.ts
@@ -20,19 +20,20 @@ export const RootXStoreModule: Module<XModuleState, any> = {
   state: () => ({
     device: null,
     empathize: null,
+    extraParams: null,
+    facets: null,
+    historyQueries: null,
+    identifierResults: null,
     nextQueries: null,
     popularSearches: null,
-    searchBox: null,
     querySuggestions: null,
-    historyQueries: null,
     recommendations: null,
     relatedTags: null,
-    identifierResults: null,
+    scroll: null,
     search: null,
-    facets: null,
+    searchBox: null,
     tagging: null,
-    url: null,
-    extraParams: null
+    url: null
   }),
   namespaced: true
 };

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -34,14 +34,16 @@ import { UrlXEvents } from '../x-modules/url/events.types';
  * * {@link QuerySuggestionsXEvents},
  * * {@link RecommendationsXEvents}
  * * {@link RelatedTagsXEvents}
- * * {@link SearchXEvents},
+ * * {@link ScrollXEvents},
  * * {@link SearchBoxXEvents}
+ * * {@link SearchXEvents}
  * * {@link UrlXEvents}
  *
  * @public
  */
 export interface XEventsTypes
-  extends EmpathizeXEvents,
+  extends DeviceXEvents,
+    EmpathizeXEvents,
     ExtraParamsXEvents,
     FacetsXEvents,
     HistoryQueriesXEvents,
@@ -54,8 +56,7 @@ export interface XEventsTypes
     ScrollXEvents,
     SearchBoxXEvents,
     SearchXEvents,
-    UrlXEvents,
-    DeviceXEvents {
+    UrlXEvents {
   /**
    * The search adapter configuration has changed
    * * Payload: The new search adapter configuration.

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -1,5 +1,4 @@
 import { Result, Suggestion } from '@empathyco/x-types';
-import { ScrollDirection } from '../components/scroll/scroll.types';
 import { ArrowKey, PropsWithType } from '../utils';
 import { DeviceXEvents } from '../x-modules/device';
 import { EmpathizeXEvents } from '../x-modules/empathize/events.types';
@@ -12,6 +11,7 @@ import { PopularSearchesXEvents } from '../x-modules/popular-searches/events.typ
 import { QuerySuggestionsXEvents } from '../x-modules/query-suggestions/events.types';
 import { RecommendationsXEvents } from '../x-modules/recommendations/events.types';
 import { RelatedTagsXEvents } from '../x-modules/related-tags/events.types';
+import { ScrollXEvents } from '../x-modules/scroll/events.types';
 import { SearchBoxXEvents } from '../x-modules/search-box/events.types';
 import { SearchXEvents } from '../x-modules/search/events.types';
 import { UrlXEvents } from '../x-modules/url/events.types';
@@ -41,8 +41,7 @@ import { UrlXEvents } from '../x-modules/url/events.types';
  * @public
  */
 export interface XEventsTypes
-  extends DeviceXEvents,
-    EmpathizeXEvents,
+  extends EmpathizeXEvents,
     ExtraParamsXEvents,
     FacetsXEvents,
     HistoryQueriesXEvents,
@@ -52,9 +51,11 @@ export interface XEventsTypes
     QuerySuggestionsXEvents,
     RecommendationsXEvents,
     RelatedTagsXEvents,
-    SearchXEvents,
+    ScrollXEvents,
     SearchBoxXEvents,
-    UrlXEvents {
+    SearchXEvents,
+    UrlXEvents,
+    DeviceXEvents {
   /**
    * The search adapter configuration has changed
    * * Payload: The new search adapter configuration.
@@ -86,55 +87,45 @@ export interface XEventsTypes
    */
   UserAcceptedSpellcheckQuery: string;
   /**
-   * The user has almost reached the scroll end.
-   * * Payload: The distance missing to end position position.
-   */
-  UserAlmostReachedScrollEnd: number;
-  /**
-   * The user has changed the direction of scroll.
-   * * Payload: The new {@link ScrollDirection} when user changes scroll direction.
-   */
-  UserChangedScrollDirection: ScrollDirection;
-  /**
    * The user has clicked on a result.
    * * Payload: The {@link @empathyco/x-types#Result | result} that the user clicked.
    */
   UserClickedAResult: Result;
-  /**
-   * The user clicked the button to close a modal.
-   * * Payload: the id of the modal to close.
-   */
-  UserClickedCloseModal: string;
   /**
    * The user clicked the button to close the events modal.
    * * Payload: none.
    */
   UserClickedCloseEventsModal: void;
   /**
+   * The user clicked the button to close a modal.
+   * * Payload: the id of the modal to close.
+   */
+  UserClickedCloseModal: string;
+  /**
    * The user clicked the button to select the number of columns.
    * * Payload: the column number.
    */
   UserClickedColumnPicker: number;
-  /**
-   * The user clicked the button to open a modal.
-   * * Payload: the id of the modal to open.
-   */
-  UserClickedOpenModal: string;
   /**
    * The user clicked the button to open the events modal.
    * * Payload: none.
    */
   UserClickedOpenEventsModal: void;
   /**
-   * The user clicked out of a modal while it was opened.
-   * * Payload: the id of the modal.
+   * The user clicked the button to open a modal.
+   * * Payload: the id of the modal to open.
    */
-  UserClickedOutOfModal: string;
+  UserClickedOpenModal: string;
   /**
    * The user clicked out of the events modal while it is opened.
    * * Payload: none.
    */
   UserClickedOutOfEventsModal: void;
+  /**
+   * The user clicked out of a modal while it was opened.
+   * * Payload: the id of the modal.
+   */
+  UserClickedOutOfModal: string;
   /**
    * The user clicked the button to toggle a panel.
    * * Payload: the id of the panel to toggle.
@@ -166,25 +157,10 @@ export interface XEventsTypes
    */
   UserReachedEmpathizeTop: void;
   /**
-   * The user has reached the scroll end.
-   * * Payload: none.
-   */
-  UserReachedScrollEnd: void;
-  /**
-   * The user has reached the scroll start.
-   * * Payload: none.
-   */
-  UserReachedScrollStart: void;
-  /**
    * The user has right clicked on a result.
    * * Payload: The {@link @empathyco/x-types#Result | result} that the user right clicked.
    */
   UserRightClickedAResult: Result;
-  /**
-   * The user has scrolled.
-   * * Payload: The new position of scroll.
-   */
-  UserScrolled: number;
   /**
    * User selected any kind of suggestion (query-suggestion, popular-search...)
    * * Payload: The {@link @empathyco/x-types#Suggestion | suggestion} that the user selected.

--- a/packages/x-components/src/x-modules/scroll/events.types.ts
+++ b/packages/x-components/src/x-modules/scroll/events.types.ts
@@ -1,0 +1,45 @@
+import { ScrollDirection } from '../../components/scroll/scroll.types';
+
+/**
+ * Dictionary of the events of Scroll XModule, where each key is the event name, and the value is
+ * the event payload type or `void` if it has no payload.
+ *
+ * @public
+ */
+export interface ScrollXEvents {
+  /**
+   * The scroll position has been restored successfully.
+   * * Payload: none.
+   */
+  ScrollRestoreSucceeded: void;
+  /**
+   * The scroll position has failed to be restored.
+   * * Payload: none.
+   */
+  ScrollRestoreFailed: void;
+  /**
+   * The user has almost reached the scroll end.
+   * * Payload: The distance missing to end position position.
+   */
+  UserAlmostReachedScrollEnd: number;
+  /**
+   * The user has changed the direction of scroll.
+   * * Payload: The new {@link ScrollDirection} when user changes scroll direction.
+   */
+  UserChangedScrollDirection: ScrollDirection;
+  /**
+   * The user has reached the scroll end.
+   * * Payload: none.
+   */
+  UserReachedScrollEnd: void;
+  /**
+   * The user has reached the scroll start.
+   * * Payload: none.
+   */
+  UserReachedScrollStart: void;
+  /**
+   * The user has scrolled.
+   * * Payload: The new position of scroll.
+   */
+  UserScrolled: number;
+}

--- a/packages/x-components/src/x-modules/scroll/index.ts
+++ b/packages/x-components/src/x-modules/scroll/index.ts
@@ -1,0 +1,4 @@
+export * from './events.types';
+export * from './store';
+export * from './wiring';
+export * from './x-module';

--- a/packages/x-components/src/x-modules/scroll/store/emitters.ts
+++ b/packages/x-components/src/x-modules/scroll/store/emitters.ts
@@ -1,0 +1,9 @@
+import { createStoreEmitters } from '../../../store';
+import { scrollXStoreModule } from './module';
+
+/**
+ * {@link StoreEmitters} For the scroll module.
+ *
+ * @internal
+ */
+export const scrollEmitters = createStoreEmitters(scrollXStoreModule, {});

--- a/packages/x-components/src/x-modules/scroll/store/index.ts
+++ b/packages/x-components/src/x-modules/scroll/store/index.ts
@@ -1,4 +1,4 @@
 export * from './emitters';
 export * from './module';
 export * from './types';
-export { initScrollComponentState } from './utils';
+export * from './utils';

--- a/packages/x-components/src/x-modules/scroll/store/index.ts
+++ b/packages/x-components/src/x-modules/scroll/store/index.ts
@@ -1,0 +1,4 @@
+export * from './emitters';
+export * from './module';
+export * from './types';
+export { initScrollComponentState } from './utils';

--- a/packages/x-components/src/x-modules/scroll/store/module.ts
+++ b/packages/x-components/src/x-modules/scroll/store/module.ts
@@ -1,0 +1,37 @@
+import { ScrollXStoreModule } from './types';
+import { initScrollComponentState } from './utils';
+
+/**
+ * {@link XStoreModule} For the scroll module.
+ *
+ * @internal
+ */
+export const scrollXStoreModule: ScrollXStoreModule = {
+  state: () => ({
+    data: {},
+    pendingScrollTo: ''
+  }),
+  getters: {},
+  mutations: {
+    setScrollPosition(state, { id, position }) {
+      initScrollComponentState(state.data, id);
+      state.data[id].position = position;
+    },
+    setScrollDirection(state, { id, direction }) {
+      initScrollComponentState(state.data, id);
+      state.data[id].direction = direction;
+    },
+    setScrollHasReachedEnd(state, { id, value }) {
+      initScrollComponentState(state.data, id);
+      state.data[id].hasReachedEnd = value;
+    },
+    setScrollHasReachedStart(state, { id, value }) {
+      initScrollComponentState(state.data, id);
+      state.data[id].hasReachedStart = value;
+    },
+    setPendingScrollTo(state, pendingScrollTo) {
+      state.pendingScrollTo = pendingScrollTo;
+    }
+  },
+  actions: {}
+};

--- a/packages/x-components/src/x-modules/scroll/store/types.ts
+++ b/packages/x-components/src/x-modules/scroll/store/types.ts
@@ -55,10 +55,38 @@ export interface ScrollGetters {}
  * @public
  */
 export interface ScrollMutations {
+  /**
+   * Sets the identifier of the element that is pending to be scrolled into the view.
+   *
+   * @param pendingScrollTo - The identifier of the element that should be scrolled into view
+   * whenever it is loaded.
+   */
   setPendingScrollTo(pendingScrollTo: string): void;
+  /**
+   * Sets the scroll position of a certain panel.
+   *
+   * @param position - The new scroll position and the identifier of the panel it belongs.
+   */
   setScrollPosition(position: ScrollPositionPayload): void;
+  /**
+   * Sets the scroll direction of a certain panel.
+   *
+   * @param direction - The new scroll direction and the identifier of the panel it belongs.
+   */
   setScrollDirection(direction: ScrollDirectionPayload): void;
+  /**
+   * Sets if the scroll has reached the start position of a panel.
+   *
+   * @param hasReachedStart - An object containing if the scroll position is at the start and
+   * the identifier of this panel.
+   */
   setScrollHasReachedStart(hasReachedStart: ScrollPositionReachedPayload): void;
+  /**
+   * Sets if the scroll has reached the end position of a panel.
+   *
+   * @param hasReachedEnd - An object containing if the scroll position is at the end and
+   * the identifier of this panel.
+   */
   setScrollHasReachedEnd(hasReachedEnd: ScrollPositionReachedPayload): void;
 }
 

--- a/packages/x-components/src/x-modules/scroll/store/types.ts
+++ b/packages/x-components/src/x-modules/scroll/store/types.ts
@@ -1,0 +1,131 @@
+import { ScrollDirection } from '../../../components/scroll/scroll.types';
+import { XStoreModule } from '../../../store';
+import { Dictionary } from '../../../utils/types';
+
+/**
+ * Scroll store state.
+ *
+ * @public
+ */
+export interface ScrollState {
+  /**
+   * State data of the scroll components.
+   */
+  data: Dictionary<ScrollComponentState>;
+  /**
+   * The `[data-scroll]` value of the pending to restore scroll.
+   */
+  pendingScrollTo: string;
+}
+
+/**
+ * Contains all the state of a scroll component.
+ *
+ * @public
+ */
+export interface ScrollComponentState {
+  /**
+   * The position in pixels the user has scrolled down.
+   */
+  position: number;
+  /**
+   * The direction the user is scrolling.
+   */
+  direction: ScrollDirection;
+  /**
+   * True if the user has already reached the end of the scroll panel.
+   */
+  hasReachedEnd: boolean;
+  /**
+   * True if the scroll position is 0.
+   */
+  hasReachedStart: boolean;
+}
+
+/**
+ * Scroll store getters.
+ *
+ * @public
+ */
+export interface ScrollGetters {}
+
+/**
+ * Scroll store mutations.
+ *
+ * @public
+ */
+export interface ScrollMutations {
+  setPendingScrollTo(pendingScrollTo: string): void;
+  setScrollPosition(position: ScrollPositionPayload): void;
+  setScrollDirection(direction: ScrollDirectionPayload): void;
+  setScrollHasReachedStart(hasReachedStart: ScrollPositionReachedPayload): void;
+  setScrollHasReachedEnd(hasReachedEnd: ScrollPositionReachedPayload): void;
+}
+
+/**
+ * Payload object containing the identifier of the scroll and its position.
+ *
+ * @public
+ */
+export interface ScrollPositionPayload {
+  /**
+   * The amount of pixels scrolled.
+   */
+  position: number;
+  /**
+   * The identifier of the scroll element.
+   */
+  id: string;
+}
+
+/**
+ * Payload object containing the identifier of the scroll and its direction.
+ *
+ * @public
+ */
+export interface ScrollDirectionPayload {
+  /**
+   * The current direction of the scroll.
+   */
+  direction: ScrollDirection;
+  /**
+   * The identifier of the scroll element.
+   */
+  id: string;
+}
+
+/**
+ * Payload object containing the identifier of the scroll and a boolean indicating if
+ * it has reached certain position.
+ *
+ * @public
+ */
+export interface ScrollPositionReachedPayload {
+  /**
+   * True if it has reached certain position. False otherwise.
+   */
+  value: boolean;
+  /**
+   * The identifier of the scroll element.
+   */
+  id: string;
+}
+
+/**
+ * Scroll store actions.
+ *
+ * @public
+ */
+export interface ScrollActions {}
+
+/**
+ * Scroll type safe store module.
+ *
+ * @public
+ */
+export type ScrollXStoreModule = XStoreModule<
+  ScrollState,
+  ScrollGetters,
+  ScrollMutations,
+  ScrollActions
+>;

--- a/packages/x-components/src/x-modules/scroll/store/types.ts
+++ b/packages/x-components/src/x-modules/scroll/store/types.ts
@@ -1,3 +1,4 @@
+import { Identifiable } from '@empathyco/x-types';
 import { ScrollDirection } from '../../../components/scroll/scroll.types';
 import { XStoreModule } from '../../../store';
 import { Dictionary } from '../../../utils/types';
@@ -95,15 +96,11 @@ export interface ScrollMutations {
  *
  * @public
  */
-export interface ScrollPositionPayload {
+export interface ScrollPositionPayload extends Identifiable<string> {
   /**
    * The amount of pixels scrolled.
    */
   position: number;
-  /**
-   * The identifier of the scroll element.
-   */
-  id: string;
 }
 
 /**
@@ -111,15 +108,11 @@ export interface ScrollPositionPayload {
  *
  * @public
  */
-export interface ScrollDirectionPayload {
+export interface ScrollDirectionPayload extends Identifiable<string> {
   /**
    * The current direction of the scroll.
    */
   direction: ScrollDirection;
-  /**
-   * The identifier of the scroll element.
-   */
-  id: string;
 }
 
 /**
@@ -128,15 +121,11 @@ export interface ScrollDirectionPayload {
  *
  * @public
  */
-export interface ScrollPositionReachedPayload {
+export interface ScrollPositionReachedPayload extends Identifiable<string> {
   /**
    * True if it has reached certain position. False otherwise.
    */
   value: boolean;
-  /**
-   * The identifier of the scroll element.
-   */
-  id: string;
 }
 
 /**

--- a/packages/x-components/src/x-modules/scroll/store/utils.ts
+++ b/packages/x-components/src/x-modules/scroll/store/utils.ts
@@ -1,0 +1,25 @@
+import Vue from 'vue';
+import { Dictionary } from '../../../utils/types';
+import { ScrollComponentState } from './types';
+
+/**
+ * Initialises an {@link ScrollComponentState} object if it has not already been created.
+ *
+ * @param state - The state shere the new data should be added.
+ * @param id - The identifier for the {@link ScrollComponentState}.
+ *
+ * @internal
+ */
+export function initScrollComponentState(
+  state: Dictionary<ScrollComponentState>,
+  id: string
+): void {
+  if (!state[id]) {
+    Vue.set<ScrollComponentState>(state, id, {
+      hasReachedStart: false,
+      hasReachedEnd: false,
+      position: 0,
+      direction: 'UP'
+    });
+  }
+}

--- a/packages/x-components/src/x-modules/scroll/store/utils.ts
+++ b/packages/x-components/src/x-modules/scroll/store/utils.ts
@@ -5,17 +5,17 @@ import { ScrollComponentState } from './types';
 /**
  * Initialises an {@link ScrollComponentState} object if it has not already been created.
  *
- * @param state - The state shere the new data should be added.
+ * @param componentsState - The state where the new data should be added.
  * @param id - The identifier for the {@link ScrollComponentState}.
  *
  * @internal
  */
 export function initScrollComponentState(
-  state: Dictionary<ScrollComponentState>,
+  componentsState: Dictionary<ScrollComponentState>,
   id: string
 ): void {
-  if (!state[id]) {
-    Vue.set<ScrollComponentState>(state, id, {
+  if (!componentsState[id]) {
+    Vue.set<ScrollComponentState>(componentsState, id, {
       hasReachedStart: false,
       hasReachedEnd: false,
       position: 0,

--- a/packages/x-components/src/x-modules/scroll/wiring.ts
+++ b/packages/x-components/src/x-modules/scroll/wiring.ts
@@ -38,7 +38,7 @@ export const setScrollDirectionWire = wireCommit(
  *
  * @public
  */
-export const setScrollReachedEndWire = wireCommit(
+export const setScrollHasReachedEndWire = wireCommit(
   'setScrollHasReachedEnd',
   ({ metadata, eventPayload }: WirePayload<boolean>) => ({
     value: eventPayload,
@@ -92,7 +92,7 @@ export const scrollWiring = createWiring({
     setScrollHasReachedStartWire
   },
   UserReachedScrollEnd: {
-    setScrollReachedEndWire
+    setScrollHasReachedEndWire
   },
   ParamsLoadedFromUrl: {
     setPendingScrollToWire

--- a/packages/x-components/src/x-modules/scroll/wiring.ts
+++ b/packages/x-components/src/x-modules/scroll/wiring.ts
@@ -1,0 +1,106 @@
+import { ScrollDirection } from '../../components/scroll/scroll.types';
+import { namespacedWireCommit } from '../../wiring/namespaced-wires.factory';
+import { WirePayload } from '../../wiring/wiring.types';
+import { createWiring } from '../../wiring/wiring.utils';
+
+const moduleName = 'scroll';
+
+const wireCommit = namespacedWireCommit(moduleName);
+
+/**
+ * Saves the scroll position of a container to the store.
+ *
+ * @public
+ */
+export const setScrollPositionWire = wireCommit(
+  'setScrollPosition',
+  ({ metadata, eventPayload }: WirePayload<number>) => ({
+    position: eventPayload,
+    id: metadata.id as string
+  })
+);
+
+/**
+ * Saves the scroll direction of a container to the store.
+ *
+ * @public
+ */
+export const setScrollDirectionWire = wireCommit(
+  'setScrollDirection',
+  ({ metadata, eventPayload }: WirePayload<ScrollDirection>) => ({
+    direction: eventPayload,
+    id: metadata.id as string
+  })
+);
+
+/**
+ * Saves a boolean indicating if the scroll has reached the end of a container to the store.
+ *
+ * @public
+ */
+export const setScrollReachedEndWire = wireCommit(
+  'setScrollHasReachedEnd',
+  ({ metadata, eventPayload }: WirePayload<boolean>) => ({
+    value: eventPayload,
+    id: metadata.id as string
+  })
+);
+
+/**
+ * Saves a boolean indicating if the scroll has reached the start of a container to the store.
+ *
+ * @public
+ */
+export const setScrollHasReachedStartWire = wireCommit(
+  'setScrollHasReachedStart',
+  ({ metadata, eventPayload }: WirePayload<boolean>) => ({
+    value: eventPayload,
+    id: metadata.id as string
+  })
+);
+
+/**
+ * Saves the selector of the item that should be scrolled into the view.
+ *
+ * @public
+ */
+export const setPendingScrollToWire = wireCommit(
+  'setPendingScrollTo',
+  ({ eventPayload: { scroll } }) => scroll
+);
+
+/**
+ * Resets the selector of the scroll that is pending to restore.
+ *
+ * @public
+ */
+export const clearPendingScrollToWire = wireCommit('setPendingScrollTo', '');
+
+/**
+ * Wiring configuration for the {@link ScrollXModule | scroll module}.
+ *
+ * @internal
+ */
+export const scrollWiring = createWiring({
+  UserScrolled: {
+    setScrollPositionWire
+  },
+  UserChangedScrollDirection: {
+    setScrollDirectionWire
+  },
+  UserReachedScrollStart: {
+    setScrollHasReachedStartWire
+  },
+  UserReachedScrollEnd: {
+    setScrollReachedEndWire
+  },
+  ParamsLoadedFromUrl: {
+    setPendingScrollToWire
+  },
+  ScrollRestoreSucceeded: {
+    clearPendingScrollToWire
+  },
+  ScrollRestoreFailed: {
+    clearPendingScrollToWire
+  }
+});

--- a/packages/x-components/src/x-modules/scroll/x-module.ts
+++ b/packages/x-components/src/x-modules/scroll/x-module.ts
@@ -1,0 +1,25 @@
+import { XModule } from '../x-modules.types';
+import { scrollEmitters } from './store/emitters';
+import { scrollXStoreModule } from './store/module';
+import { ScrollXStoreModule } from './store/types';
+import { scrollWiring } from './wiring';
+
+/**
+ * Scroll {@link XModule} alias.
+ *
+ * @public
+ */
+export type ScrollXModule = XModule<ScrollXStoreModule>;
+
+/**
+ * Scroll {@link XModule} implementation. This module is auto-registered as soon as you
+ * import any component from the `empathize` entry point.
+ *
+ * @public
+ */
+export const scrollXModule: ScrollXModule = {
+  name: 'scroll',
+  storeModule: scrollXStoreModule,
+  storeEmitters: scrollEmitters,
+  wiring: scrollWiring
+};

--- a/packages/x-components/src/x-modules/x-modules.types.ts
+++ b/packages/x-components/src/x-modules/x-modules.types.ts
@@ -12,6 +12,7 @@ import { PopularSearchesXModule } from './popular-searches/x-module';
 import { QuerySuggestionsXModule } from './query-suggestions/x-module';
 import { RecommendationsXModule } from './recommendations/x-module';
 import { RelatedTagsXModule } from './related-tags/x-module';
+import { ScrollXModule } from './scroll/x-module';
 import { SearchBoxXModule } from './search-box/x-module';
 import { SearchXModule } from './search/x-module';
 import { TaggingXModule } from './tagging';
@@ -25,6 +26,7 @@ import { UrlXModule } from './url';
 export interface XModulesTree {
   device: DeviceXModule;
   empathize: EmpathizeXModule;
+  extraParams: ExtraParamsXModule;
   facets: FacetsXModule;
   historyQueries: HistoryQueriesXModule;
   identifierResults: IdentifierResultsXModule;
@@ -33,11 +35,11 @@ export interface XModulesTree {
   querySuggestions: QuerySuggestionsXModule;
   recommendations: RecommendationsXModule;
   relatedTags: RelatedTagsXModule;
+  scroll: ScrollXModule;
   search: SearchXModule;
   searchBox: SearchBoxXModule;
   tagging: TaggingXModule;
   url: UrlXModule;
-  extraParams: ExtraParamsXModule;
 }
 
 /**


### PR DESCRIPTION
# Description

Adds a basic scroll x module. The scroll module is needed to solve the problems derived from using observables to keep the state.

Adding a scroll module will also help storing the scroll position in the URL. This is the 1st one of 3 expected PRs.