### PR TITLE
feat: Make `Identifiable` type generic

### DIFF
--- a/packages/search-types/src/identifiable.model.ts
+++ b/packages/search-types/src/identifiable.model.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export interface Identifiable {
+export interface Identifiable<ID = string | number> {
   /** A unique ID that identifies the Object. */
-  id: string | number;
+  id: ID;
 }

--- a/packages/search-types/src/schemas/identifiable.schema.ts
+++ b/packages/search-types/src/schemas/identifiable.schema.ts
@@ -6,5 +6,5 @@ import { Identifiable } from '../identifiable.model';
  * @public
  */
 export const IdentifiableSchema: Identifiable = {
-  id: expect.anyOf([String, Number])
+  id: expect.anything()
 };


### PR DESCRIPTION
Just makes the Identifiable type generic so we can use it with another ID types