### PR TITLE
[EX-5009] Fix sliding panel test

### DIFF
--- a/packages/x-components/src/__stubs__/related-tags-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/related-tags-stubs.factory.ts
@@ -9,7 +9,7 @@ import { RelatedTag } from '@empathyco/x-types';
  *
  * @internal
  */
-export function getRelatedTagsStub(amount = 9): RelatedTag[] {
+export function getRelatedTagsStub(amount = 12): RelatedTag[] {
   return Array.from({ length: amount }, (_, index) =>
     createRelatedTagStub('Related Tag', `Related Tag ${index + 1}`)
   );

--- a/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
@@ -21,7 +21,7 @@ Given('a related tags API with a selected one', () => {
   cy.intercept('https://api.empathy.co/getRelatedTags', req => {
     req.reply({
       relatedTags: [
-        createRelatedTagStub('lego', 'bombero', true),
+        createRelatedTagStub('lego', 'bombero', { selected: true }),
         createRelatedTagStub('lego', 'policia'),
         createRelatedTagStub('lego', 'barbie')
       ]

--- a/packages/x-components/tests/e2e/cucumber/sliding-panel.feature
+++ b/packages/x-components/tests/e2e/cucumber/sliding-panel.feature
@@ -12,17 +12,14 @@ Feature: Sliding panel component
     Then  "right" sliding panel arrow is displayed
     And   only some related tags are visible
     When  "right" sliding panel arrow is clicked
-    And   wait for the movement of the elements inside the sliding panel
     Then  visible related tags have changed
     And   "both" sliding panel arrow is displayed
     And   only some related tags are visible
     When  "right" sliding panel arrow is clicked
-    And   wait for the movement of the elements inside the sliding panel
     Then  visible related tags have changed
     And   "left" sliding panel arrow is displayed
     And   only some related tags are visible
     When  "left" sliding panel arrow is clicked
-    And   wait for the movement of the elements inside the sliding panel
     Then  visible related tags have changed
 
     Examples:

--- a/packages/x-components/tests/e2e/cucumber/sliding-panel.feature
+++ b/packages/x-components/tests/e2e/cucumber/sliding-panel.feature
@@ -11,15 +11,19 @@ Feature: Sliding panel component
     When  "<query>" is searched
     Then  "right" sliding panel arrow is displayed
     And   only some related tags are visible
-    When  right sliding panel arrow is clicked
+    When  "right" sliding panel arrow is clicked
     And   wait for the movement of the elements inside the sliding panel
     Then  visible related tags have changed
     And   "both" sliding panel arrow is displayed
     And   only some related tags are visible
-    When  right sliding panel arrow is clicked
+    When  "right" sliding panel arrow is clicked
     And   wait for the movement of the elements inside the sliding panel
     Then  visible related tags have changed
     And   "left" sliding panel arrow is displayed
+    And   only some related tags are visible
+    When  "left" sliding panel arrow is clicked
+    And   wait for the movement of the elements inside the sliding panel
+    Then  visible related tags have changed
 
     Examples:
       | query |

--- a/packages/x-components/tests/e2e/cucumber/sliding-panel.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/sliding-panel.spec.ts
@@ -1,7 +1,6 @@
 import { Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 let initialRelatedTags: string[] = [];
-let finalRelatedTags: string[] = [];
 
 /**
  * Function to calculate if an element is visible inside a scroll.
@@ -66,14 +65,17 @@ Then('only some related tags are visible', () => {
 });
 
 Then('visible related tags have changed', () => {
-  finalRelatedTags = [];
   cy.getByDataTest('sliding-panel-scroll').then($scroll => {
     cy.getByDataTest('related-tag-item')
       .filter((_index, $element) => isElementVisible($element, $scroll.get(0)))
-      .each($element => finalRelatedTags.push($element.get(0).textContent ?? ''))
-      .then(() => {
-        const expected = initialRelatedTags.some(rt => !finalRelatedTags.includes(rt));
-        expect(expected).to.be.true;
+      .should($newRelatedTags => {
+        const newRelatedTags = $newRelatedTags
+          .map((_index, $relatedTag) => $relatedTag.textContent ?? '')
+          .toArray();
+        const areRelatedTagsDifferent = initialRelatedTags.some(
+          relatedTag => !newRelatedTags.includes(relatedTag)
+        );
+        expect(areRelatedTagsDifferent).to.be.true;
       });
   });
 });

--- a/packages/x-components/tests/e2e/cucumber/sliding-panel.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/sliding-panel.spec.ts
@@ -44,8 +44,8 @@ Then('{string} sliding panel arrow is displayed', (displayedArrows: string) => {
   }
 });
 
-When('right sliding panel arrow is clicked', () => {
-  cy.getByDataTest('sliding-panel-right-button').click();
+When('{string} sliding panel arrow is clicked', (direction: string) => {
+  cy.getByDataTest(`sliding-panel-${direction}-button`).click();
 });
 
 Then('wait for the movement of the elements inside the sliding panel', () => {


### PR DESCRIPTION
- `related-tags-stubs.factory.ts` have been modified in order to generate 12 RTs.
- doesn't seem necessary to modify `cy.wait(100)`
- Took advantage from the bug and added check for `sliding-panel-left-button`

## Motivation and context
Sliding panel e2e test is failing in Jenkins. Reproducible in local if CPU performance is slowdown x4.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

CPU performance have been slowdown x6 and test still passes.

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
