### PR TITLE
feat(search): add `SearchTaggingChanged`  emitter and save coming `queryTagging` from the search response

### DIFF
--- a/packages/x-components/src/__stubs__/empty-search-response-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/empty-search-response-stubs.factory.ts
@@ -1,0 +1,25 @@
+import { SearchResponse } from '../../../search-adapter/types/types/response.types';
+
+/**
+ * Creates an empty {@link @empathyco/x-adapter#SearchResponse | search response} stub.
+ *
+ * @returns Object of an empty search response stub.
+ *
+ * @internal
+ */
+export function getEmptySearchResponseStub(): SearchResponse {
+  return {
+    banners: [],
+    facets: [],
+    partialResults: [],
+    promoteds: [],
+    queryTagging: {
+      params: {},
+      url: ''
+    },
+    redirections: [],
+    results: [],
+    spellcheck: '',
+    totalResults: 0
+  };
+}

--- a/packages/x-components/src/__stubs__/index.ts
+++ b/packages/x-components/src/__stubs__/index.ts
@@ -1,4 +1,5 @@
 export * from './banners-stubs.factory';
+export * from './empty-search-response-stubs.factory';
 export * from './facets-stubs.factory';
 export * from './filters-stubs.factory';
 export * from './history-queries-stubs.factory';

--- a/packages/x-components/src/__stubs__/search-response-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/search-response-stubs.factory.ts
@@ -19,8 +19,13 @@ export function getSearchResponseStub(): SearchResponse {
     partialResults: [],
     promoteds: getPromotedsStub(),
     queryTagging: {
-      params: {},
-      url: ''
+      params: {
+        q: 'lego',
+        totalHits: '789',
+        lang: 'es',
+        follow: false
+      },
+      url: 'https://api.empathybroker.com/tagging/v1/track/query'
     },
     redirections: getRedirectionsStub(),
     results: getResultsStub(),

--- a/packages/x-components/src/x-modules/search/events.types.ts
+++ b/packages/x-components/src/x-modules/search/events.types.ts
@@ -1,5 +1,5 @@
 import { SearchRequest } from '@empathyco/x-adapter';
-import { Facet, Result, Sort, Redirection } from '@empathyco/x-types';
+import { Facet, Result, Sort, Redirection, TaggingInfo } from '@empathyco/x-types';
 
 /**
  * Dictionary of the events of Search XModule, where each key is the event name, and the value is
@@ -29,6 +29,11 @@ export interface SearchXEvents {
    * to conform a valid request.
    */
   SearchRequestChanged: SearchRequest | null;
+  /**
+   * Query tagging has been changed.
+   * * Payload: The new query tagging object.
+   */
+  SearchTaggingChanged: TaggingInfo;
   /**
    * Sort has been changed.
    * * Payload: The new sort string.

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -70,7 +70,7 @@ describe('testing search module actions', () => {
 
   describe('fetchAndSaveSearchResponse', () => {
     // eslint-disable-next-line max-len
-    it('should request and store results, facets, banners, promoteds and redirections in the state', async () => {
+    it('should request and store results, facets, banners, promoteds, redirections and query tagging in the state', async () => {
       resetSearchStateWith(store, {
         query: 'lego'
       });
@@ -86,25 +86,32 @@ describe('testing search module actions', () => {
       expect(store.state.page).toEqual(1);
       expect(store.state.config.pageSize).toEqual(24);
       expect(store.state.status).toEqual('success');
+      expect(store.state.queryTagging).toEqual(searchResponseStub.queryTagging);
     });
 
     // eslint-disable-next-line max-len
-    it('should clear results, facets, banners and promoteds in the state if the query is empty', async () => {
+    it('should clear results, facets, banners, promoteds, redirections and query tagging in the state if the query is empty', async () => {
       resetSearchStateWith(store, {
         results: resultsStub,
         facets: facetsStub,
         banners: bannersStub,
-        promoteds: promotedsStub
+        promoteds: promotedsStub,
+        redirections: redirectionsStub,
+        queryTagging: searchResponseStub.queryTagging
       });
       expect(store.state.results).toEqual(resultsStub);
       expect(store.state.facets).toEqual(facetsStub);
       expect(store.state.banners).toEqual(bannersStub);
       expect(store.state.promoteds).toEqual(promotedsStub);
+      expect(store.state.redirections).toEqual(redirectionsStub);
+      expect(store.state.queryTagging).toEqual(searchResponseStub.queryTagging);
       await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
       expect(store.state.results).toEqual([]);
       expect(store.state.facets).toEqual([]);
       expect(store.state.banners).toEqual([]);
       expect(store.state.promoteds).toEqual([]);
+      expect(store.state.redirections).toEqual([]);
+      expect(store.state.queryTagging).toEqual({ url: '', params: {} });
     });
 
     it('should request and store total results in the state', async () => {

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -1,7 +1,8 @@
-import { SearchResponse } from '@empathyco/x-adapter';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 import { getBannersStub } from '../../../../__stubs__/banners-stubs.factory';
+//eslint-disable-next-line max-len
+import { getEmptySearchResponseStub } from '../../../../__stubs__/empty-search-response-stubs.factory';
 import { getFacetsStub } from '../../../../__stubs__/facets-stubs.factory';
 import { getPromotedsStub } from '../../../../__stubs__/promoteds-stubs.factory';
 import { getRedirectionsStub } from '../../../../__stubs__/redirections-stubs.factory';
@@ -21,21 +22,7 @@ describe('testing search module actions', () => {
   const promotedsStub = getPromotedsStub();
   const redirectionsStub = getRedirectionsStub();
   const searchResponseStub = getSearchResponseStub();
-
-  const mockedEmptySearchResponse: SearchResponse = {
-    banners: [],
-    facets: [],
-    partialResults: [],
-    promoteds: [],
-    queryTagging: {
-      params: {},
-      url: ''
-    },
-    redirections: [],
-    results: [],
-    spellcheck: '',
-    totalResults: 0
-  };
+  const emptySearchResponseStub = getEmptySearchResponseStub();
 
   const adapter = getMockedAdapter({ search: searchResponseStub });
 
@@ -64,7 +51,7 @@ describe('testing search module actions', () => {
 
     it('should return empty search response if there is not request', async () => {
       const searchResponse = await store.dispatch('fetchSearchResponse', store.getters.request);
-      expect(searchResponse).toEqual(mockedEmptySearchResponse);
+      expect(searchResponse).toEqual(emptySearchResponseStub);
     });
   });
 
@@ -120,7 +107,7 @@ describe('testing search module actions', () => {
       });
 
       adapter.search.mockResolvedValueOnce({
-        ...mockedEmptySearchResponse,
+        ...emptySearchResponseStub,
         totalResults: 116
       });
 
@@ -144,7 +131,7 @@ describe('testing search module actions', () => {
       });
 
       adapter.search.mockResolvedValueOnce({
-        ...mockedEmptySearchResponse,
+        ...emptySearchResponseStub,
         spellcheck: 'coche'
       });
 
@@ -172,7 +159,7 @@ describe('testing search module actions', () => {
         redirections: initialRedirections
       } = store.state;
       adapter.search.mockResolvedValueOnce({
-        ...mockedEmptySearchResponse,
+        ...emptySearchResponseStub,
         results: resultsStub.slice(0, 1),
         facets: facetsStub.slice(0, 1)
       });
@@ -263,7 +250,7 @@ describe('testing search module actions', () => {
       });
 
       adapter.search.mockResolvedValueOnce({
-        ...mockedEmptySearchResponse,
+        ...emptySearchResponseStub,
         results: resultsStub.slice(1, 2),
         banners: bannersStub.slice(0, 1),
         promoteds: promotedsStub.slice(1, 2)
@@ -287,7 +274,7 @@ describe('testing search module actions', () => {
       });
 
       adapter.search.mockResolvedValueOnce({
-        ...mockedEmptySearchResponse,
+        ...emptySearchResponseStub,
         results: resultsStub.slice(1, 2),
         banners: bannersStub.slice(1, 2),
         promoteds: promotedsStub.slice(1, 2)

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -12,7 +12,17 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   },
   onSuccess(
     { commit, state },
-    { results, partialResults, facets, banners, promoteds, totalResults, spellcheck, redirections }
+    {
+      results,
+      partialResults,
+      facets,
+      banners,
+      promoteds,
+      totalResults,
+      spellcheck,
+      redirections,
+      queryTagging
+    }
   ) {
     if (state.isAppendResults) {
       commit('appendResults', results);
@@ -29,6 +39,7 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
       commit('setFacets', facets);
     }
 
+    commit('setQueryTagging', queryTagging);
     commit('setTotalResults', totalResults);
     commit('setSpellcheck', spellcheck ?? '');
   }

--- a/packages/x-components/src/x-modules/search/store/emitters.ts
+++ b/packages/x-components/src/x-modules/search/store/emitters.ts
@@ -16,6 +16,7 @@ export const searchEmitters = createStoreEmitters(searchXStoreModule, {
   PageChanged: state => state.page,
   ResultsChanged: state => state.results,
   SearchRequestChanged: (_, getters) => getters.request,
+  SearchTaggingChanged: state => state.queryTagging,
   SpellcheckChanged: state => state.spellcheckedQuery,
   SortChanged: state => state.sort
 });

--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -38,7 +38,11 @@ export const searchXStoreModule: SearchXStoreModule = {
     page: 1,
     origin: null,
     isAppendResults: false,
-    redirections: []
+    redirections: [],
+    queryTagging: {
+      url: '',
+      params: {}
+    }
   }),
   getters: {
     request
@@ -103,6 +107,9 @@ export const searchXStoreModule: SearchXStoreModule = {
     },
     setRedirections(state, redirections) {
       state.redirections = redirections;
+    },
+    setQueryTagging(state, queryTagging) {
+      state.queryTagging = queryTagging;
     }
   },
   actions: {

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -8,7 +8,8 @@ import {
   Redirection,
   RelatedTag,
   Result,
-  Sort
+  Sort,
+  TaggingInfo
 } from '@empathyco/x-types';
 import { XActionContext, XStoreModule } from '../../../store';
 import { StatusMutations, StatusState } from '../../../store/utils/status-store.utils';
@@ -43,6 +44,8 @@ export interface SearchState extends StatusState {
   promoteds: Promoted[];
   /** The internal query of the module. Used to request the search results. */
   query: string;
+  /** The query tagging used to track the search events. */
+  queryTagging: TaggingInfo;
   /** The redirections associated to the `query`. */
   redirections: Redirection[];
   /** The list of the related tags, related to the `query` property of the state. */
@@ -143,6 +146,12 @@ export interface SearchMutations extends StatusMutations {
    * @param newQuery - The new query to save to the state.
    */
   setQuery(newQuery: string): void;
+  /**
+   * Sets the query tagging of the module, which is used to track the query.
+   *
+   * @param queryTagging - The new query tagging object to save to the state.
+   */
+  setQueryTagging(queryTagging: TaggingInfo): void;
   /**
    * Sets the redirection of the module.
    *


### PR DESCRIPTION
Make a request and check the store state in the search module, you will see there the tagging object stored.

EX-3525