### PR TITLE
feat: replace `BaseEventButton` for an html button

### DIFF
--- a/packages/x-components/src/components/suggestions/__tests__/base-suggestion.spec.ts
+++ b/packages/x-components/src/components/suggestions/__tests__/base-suggestion.spec.ts
@@ -55,7 +55,7 @@ describe('testing Base Suggestion component', () => {
 
   it('emits suggestionSelectedEvent and the default events onclick', async () => {
     const target = { target: component.element };
-    const spyOn = jest.spyOn(component.vm.$children[0].$x, 'emit');
+    const spyOn = jest.spyOn(component.vm.$x, 'emit');
     component.trigger('click');
 
     await localVue.nextTick();

--- a/packages/x-components/src/components/suggestions/__tests__/base-suggestion.spec.ts
+++ b/packages/x-components/src/components/suggestions/__tests__/base-suggestion.spec.ts
@@ -1,9 +1,11 @@
 import { Suggestion } from '@empathyco/x-types';
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
+import { XPlugin } from '../../../plugins/x-plugin';
 import { normalizeString } from '../../../utils/normalize';
 import { XEventsTypes } from '../../../wiring/events.types';
 import { getDataTestSelector, installNewXPlugin } from '../../../__tests__/utils';
+import { WireMetadata } from '../../../wiring/wiring.types';
 import BaseSuggestion from '../base-suggestion.vue';
 
 describe('testing Base Suggestion component', () => {
@@ -54,8 +56,8 @@ describe('testing Base Suggestion component', () => {
   });
 
   it('emits suggestionSelectedEvent and the default events onclick', async () => {
-    const target = { target: component.element };
-    const spyOn = jest.spyOn(component.vm.$x, 'emit');
+    const target = expect.objectContaining<Partial<WireMetadata>>({ target: component.element });
+    const spyOn = jest.spyOn(XPlugin.bus, 'emit');
     component.trigger('click');
 
     await localVue.nextTick();

--- a/packages/x-components/src/components/suggestions/base-suggestion.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestion.vue
@@ -56,8 +56,8 @@
      *
      * @public
      */
-    @Prop({ required: false }) //TODO: set to true when the suggestions components pass it.
-    protected feature!: QueryFeature;
+    @Prop() //TODO: set to true when the suggestions components pass it.
+    protected feature?: QueryFeature;
 
     /**
      * The {@link XEvent | XEvents} that will be emitted when selecting a suggestion.
@@ -92,7 +92,7 @@
      * @public
      */
     protected emitEvents(): void {
-      forEach<Partial<XEventsTypes>>(this.events, (event, payload) => {
+      forEach(this.events, (event, payload) => {
         this.$x.emit(event, payload, {
           target: this.$el as HTMLElement,
           feature: this.feature

--- a/packages/x-components/src/components/suggestions/base-suggestion.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestion.vue
@@ -1,5 +1,5 @@
 <template>
-  <BaseEventButton :events="events" :class="dynamicCSSClasses" class="x-suggestion">
+  <button @click="emitEvents" :class="dynamicCSSClasses" class="x-suggestion">
     <!-- eslint-disable max-len -->
     <!--
       @slot Button content
@@ -10,31 +10,30 @@
     <slot v-bind="{ suggestion, queryHTML }">
       <span v-html="queryHTML" :aria-label="suggestion.query" class="x-suggestion__query" />
     </slot>
-  </BaseEventButton>
+  </button>
 </template>
 
 <script lang="ts">
   import { Suggestion } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
+  import { QueryFeature } from '../../types';
+  import { forEach } from '../../utils';
   import { normalizeString } from '../../utils/normalize';
   import { sanitize } from '../../utils/sanitize';
   import { VueCSSClasses } from '../../utils/types';
   import { XEventsTypes } from '../../wiring/events.types';
-  import BaseEventButton from '../base-event-button.vue';
 
   /**
    * Renders a button with a default slot. It receives a query, which should be the query of the
-   * module using this component, a suggestion and the {@link XEvent | XEvents} that will be emitted
-   * on click.
+   * module using this component, a suggestion, the {@link XEvent | XEvents} that will be emitted
+   * on click with a given feature.
    *
    * The default slot receives the suggestion and the matched query has props.
    *
    * @public
    */
-  @Component({
-    components: { BaseEventButton }
-  })
+  @Component
   export default class BaseSuggestion extends Vue {
     /**
      * The normalized query of the module using this component.
@@ -51,6 +50,14 @@
      */
     @Prop({ required: true })
     protected suggestion!: Suggestion;
+
+    /**
+     * The feature from which the events will be emitted.
+     *
+     * @public
+     */
+    @Prop({ required: false }) //TODO: set to true when the suggestions components pass it.
+    protected feature!: QueryFeature;
 
     /**
      * The {@link XEvent | XEvents} that will be emitted when selecting a suggestion.
@@ -77,6 +84,20 @@
         UserSelectedASuggestion: this.suggestion,
         ...this.suggestionSelectedEvents
       };
+    }
+
+    /**
+     * Emits the events when the button is clicked.
+     *
+     * @public
+     */
+    protected emitEvents(): void {
+      forEach<Partial<XEventsTypes>>(this.events, (event, payload) => {
+        this.$x.emit(event, payload, {
+          target: this.$el as HTMLElement,
+          feature: this.feature
+        });
+      });
     }
 
     /**

--- a/packages/x-components/src/components/suggestions/base-suggestion.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestion.vue
@@ -17,8 +17,8 @@
   import { Suggestion } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { QueryFeature } from '../../types';
-  import { forEach } from '../../utils';
+  import { QueryFeature } from '../../types/origin';
+  import { forEach } from '../../utils/object';
   import { normalizeString } from '../../utils/normalize';
   import { sanitize } from '../../utils/sanitize';
   import { VueCSSClasses } from '../../utils/types';

--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -21,7 +21,6 @@
   import { State } from '../../../components/decorators/store.decorators';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { VueCSSClasses } from '../../../utils/types';
-  import { XEvent } from '../../../wiring';
   import { relatedTagsXModule } from '../x-module';
 
   /**
@@ -56,16 +55,16 @@
      * @public
      */
     protected emitEvents(): void {
-      const selectionEvent: XEvent = this.isSelected
-        ? 'UserDeselectedARelatedTag'
-        : 'UserSelectedARelatedTag';
-
       this.$x.emit('UserPickedARelatedTag', this.relatedTag, {
         target: this.$el as HTMLElement
       });
-      this.$x.emit(selectionEvent, this.relatedTag, {
-        target: this.$el as HTMLElement
-      });
+      this.$x.emit(
+        this.isSelected ? 'UserDeselectedARelatedTag' : 'UserSelectedARelatedTag',
+        this.relatedTag,
+        {
+          target: this.$el as HTMLElement
+        }
+      );
     }
 
     /**

--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -55,9 +55,8 @@
      * @public
      */
     protected emitEvents(): void {
-      this.$x.emit('UserPickedARelatedTag', this.relatedTag, {
-        target: this.$el as HTMLElement
-      });
+      // We have to emit this events first to avoid the UserPickedARelatedTag wires to change the
+      // isSelected value before emiting this selection events.
       this.$x.emit(
         this.isSelected ? 'UserDeselectedARelatedTag' : 'UserSelectedARelatedTag',
         this.relatedTag,
@@ -65,6 +64,9 @@
           target: this.$el as HTMLElement
         }
       );
+      this.$x.emit('UserPickedARelatedTag', this.relatedTag, {
+        target: this.$el as HTMLElement
+      });
     }
 
     /**

--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -1,6 +1,6 @@
 <template>
-  <BaseEventButton
-    :events="events"
+  <button
+    @click="emitEvents"
     class="x-tag x-related-tag"
     data-test="related-tag"
     :class="dynamicClasses"
@@ -11,18 +11,17 @@
       @binding {boolean} isSelected - Related tag status.
       -->
     <slot v-bind="{ relatedTag, isSelected }">{{ relatedTag.tag }}</slot>
-  </BaseEventButton>
+  </button>
 </template>
 
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
   import { RelatedTag as RelatedTagModel } from '@empathyco/x-types';
-  import BaseEventButton from '../../../components/base-event-button.vue';
   import { State } from '../../../components/decorators/store.decorators';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { VueCSSClasses } from '../../../utils/types';
-  import { RelatedTagsXEvents } from '../events.types';
+  import { XEvent } from '../../../wiring';
   import { relatedTagsXModule } from '../x-module';
 
   /**
@@ -33,7 +32,6 @@
    * @public
    */
   @Component({
-    components: { BaseEventButton },
     mixins: [xComponentMixin(relatedTagsXModule)]
   })
   export default class RelatedTag extends Vue {
@@ -53,22 +51,21 @@
     public selectedRelatedTags!: RelatedTagModel[];
 
     /**
-     * Events list which is going to be emitted when a related tag is selected.
+     * Emits events when the button is clicked.
      *
-     * @returns The {@link XEvent | XEvents} to emit.
-     *
-     * @internal
+     * @public
      */
-    protected get events(): Partial<RelatedTagsXEvents> {
-      return this.isSelected
-        ? {
-            UserPickedARelatedTag: this.relatedTag,
-            UserDeselectedARelatedTag: this.relatedTag
-          }
-        : {
-            UserPickedARelatedTag: this.relatedTag,
-            UserSelectedARelatedTag: this.relatedTag
-          };
+    protected emitEvents(): void {
+      const selectionEvent: XEvent = this.isSelected
+        ? 'UserDeselectedARelatedTag'
+        : 'UserSelectedARelatedTag';
+
+      this.$x.emit('UserPickedARelatedTag', this.relatedTag, {
+        target: this.$el as HTMLElement
+      });
+      this.$x.emit(selectionEvent, this.relatedTag, {
+        target: this.$el as HTMLElement
+      });
     }
 
     /**

--- a/packages/x-components/src/x-modules/search-box/components/search-button.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-button.vue
@@ -1,23 +1,21 @@
 <template>
-  <BaseEventButton
-    :events="events"
+  <button
+    @click="emitEvents"
     class="x-button x-search-button"
     :class="dynamicClasses"
     data-test="search-button"
   >
     <!-- @slot _Required_. Button content (text, icon, or both) -->
     <slot><span class="x-icon">⌕</span></slot>
-  </BaseEventButton>
+  </button>
 </template>
 
 <script lang="ts">
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
   import { State } from '../../../components/decorators/store.decorators';
-  import BaseEventButton from '../../../components/base-event-button.vue';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { VueCSSClasses } from '../../../utils/types';
-  import { XEventsTypes } from '../../../wiring/events.types';
   import { searchBoxXModule } from '../x-module';
 
   /**
@@ -31,8 +29,7 @@
    * @public
    */
   @Component({
-    mixins: [xComponentMixin(searchBoxXModule)],
-    components: { BaseEventButton }
+    mixins: [xComponentMixin(searchBoxXModule)]
   })
   export default class SearchButton extends Vue {
     @State('searchBox', 'query')
@@ -42,13 +39,20 @@
       return this.query.length === 0;
     }
 
-    protected get events(): Partial<XEventsTypes> {
-      return !this.isQueryEmpty
-        ? {
-            UserAcceptedAQuery: this.query,
-            UserPressedSearchButton: this.query
-          }
-        : {};
+    /**
+     * Emits events when the button is clicked.
+     *
+     * @public
+     */
+    protected emitEvents(): void {
+      if (!this.isQueryEmpty) {
+        this.$x.emit('UserAcceptedAQuery', this.query, {
+          target: this.$el as HTMLElement
+        });
+        this.$x.emit('UserPressedSearchButton', this.query, {
+          target: this.$el as HTMLElement
+        });
+      }
     }
 
     protected get dynamicClasses(): VueCSSClasses {

--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -11,6 +11,7 @@
     :value="query"
     autocomplete="off"
     class="x-input x-search-input"
+    enterkeyhint="search"
     inputmode="search"
     type="search"
     data-test="search-input"

--- a/packages/x-components/src/x-modules/search/components/__tests__/partial-query-button.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/partial-query-button.spec.ts
@@ -1,7 +1,7 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
-import { BaseEventButton, getXComponentXModuleName, isXComponent } from '../../../../components';
+import { getXComponentXModuleName, isXComponent } from '../../../../components';
 import PartialQueryButton from '../partial-query-button.vue';
 
 function renderPartialQueryButton({
@@ -31,7 +31,7 @@ function renderPartialQueryButton({
   return {
     partialQueryButtonWrapper,
     async clickEventButton() {
-      const eventButton = wrapper.findComponent(BaseEventButton);
+      const eventButton = wrapper.findComponent(PartialQueryButton);
       eventButton.trigger('click');
       await localVue.nextTick();
     }
@@ -60,7 +60,7 @@ describe('testing PartialQueryButton component', () => {
     const { partialQueryButtonWrapper } = renderPartialQueryButton({
       query: 'lego',
       template: `
-      <PartialQueryButton :query="query" >      
+      <PartialQueryButton :query="query" >
         <template #default="{ query }">
           <span data-test="partial-query-button__text" class="x-partial-query-button__text">
             Set this partial query {{ query }} as the new query.

--- a/packages/x-components/src/x-modules/search/components/__tests__/partial-query-button.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/partial-query-button.spec.ts
@@ -30,7 +30,7 @@ function renderPartialQueryButton({
 
   return {
     partialQueryButtonWrapper,
-    async clickEventButton() {
+    async click() {
       await wrapper.trigger('click');
     }
   };
@@ -76,7 +76,7 @@ describe('testing PartialQueryButton component', () => {
     const userAcceptedAQuery = jest.fn();
     const UserClickedPartialQuery = jest.fn();
     const query = 'coche';
-    const { partialQueryButtonWrapper, clickEventButton } = renderPartialQueryButton({
+    const { partialQueryButtonWrapper, click } = renderPartialQueryButton({
       query
     });
     const $x = partialQueryButtonWrapper.vm.$x;
@@ -84,7 +84,7 @@ describe('testing PartialQueryButton component', () => {
     $x.on('UserAcceptedAQuery').subscribe(userAcceptedAQuery);
     $x.on('UserClickedPartialQuery').subscribe(UserClickedPartialQuery);
 
-    clickEventButton();
+    click();
 
     expect(userAcceptedAQuery).toHaveBeenNthCalledWith(1, query);
     expect(UserClickedPartialQuery).toHaveBeenNthCalledWith(1, query);
@@ -102,5 +102,5 @@ interface RenderPartialQueryButtonAPI {
   /** The wrapper of the button element.*/
   partialQueryButtonWrapper: Wrapper<Vue>;
   /** Clicks the event button and waits for the view to update. */
-  clickEventButton: () => Promise<void>;
+  click: () => Promise<void>;
 }

--- a/packages/x-components/src/x-modules/search/components/__tests__/partial-query-button.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/partial-query-button.spec.ts
@@ -101,6 +101,6 @@ interface RenderPartialQueryButtonOptions {
 interface RenderPartialQueryButtonAPI {
   /** The wrapper of the button element.*/
   partialQueryButtonWrapper: Wrapper<Vue>;
-  /** Clicks the event button and waits for the view to update. */
+  /** Clicks the button and waits for the view to update. */
   click: () => Promise<void>;
 }

--- a/packages/x-components/src/x-modules/search/components/__tests__/partial-query-button.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/partial-query-button.spec.ts
@@ -1,7 +1,7 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
-import { getXComponentXModuleName, isXComponent } from '../../../../components';
+import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import PartialQueryButton from '../partial-query-button.vue';
 
 function renderPartialQueryButton({
@@ -31,9 +31,7 @@ function renderPartialQueryButton({
   return {
     partialQueryButtonWrapper,
     async clickEventButton() {
-      const eventButton = wrapper.findComponent(PartialQueryButton);
-      eventButton.trigger('click');
-      await localVue.nextTick();
+      await wrapper.trigger('click');
     }
   };
 }

--- a/packages/x-components/src/x-modules/search/components/__tests__/spellcheck-button.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/spellcheck-button.spec.ts
@@ -34,9 +34,7 @@ function renderSpellcheckButton({
   return {
     wrapper,
     async clickEventButton() {
-      const eventButton = wrapper.findComponent(SpellcheckButton);
-      eventButton.trigger('click');
-      await localVue.nextTick();
+      await wrapper.trigger('click');
     }
   };
 }

--- a/packages/x-components/src/x-modules/search/components/__tests__/spellcheck-button.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/spellcheck-button.spec.ts
@@ -2,7 +2,6 @@ import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
-import { BaseEventButton } from '../../../../components';
 import { RootXStoreState } from '../../../../store';
 import { DeepPartial } from '../../../../utils';
 import SpellcheckButton from '../spellcheck-button.vue';
@@ -35,7 +34,7 @@ function renderSpellcheckButton({
   return {
     wrapper,
     async clickEventButton() {
-      const eventButton = wrapper.findComponent(BaseEventButton);
+      const eventButton = wrapper.findComponent(SpellcheckButton);
       eventButton.trigger('click');
       await localVue.nextTick();
     }

--- a/packages/x-components/src/x-modules/search/components/__tests__/spellcheck-button.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/spellcheck-button.spec.ts
@@ -33,7 +33,7 @@ function renderSpellcheckButton({
 
   return {
     wrapper,
-    async clickEventButton() {
+    async click() {
       await wrapper.trigger('click');
     }
   };
@@ -74,13 +74,13 @@ describe('testing SpellcheckButton component', () => {
     const userAcceptedAQuery = jest.fn();
     const userAcceptSpellcheck = jest.fn();
     const spellcheckedQuery = 'coche';
-    const { wrapper, clickEventButton } = renderSpellcheckButton({ spellcheckedQuery });
+    const { wrapper, click } = renderSpellcheckButton({ spellcheckedQuery });
     const $x = wrapper.vm.$x;
 
     $x.on('UserAcceptedAQuery').subscribe(userAcceptedAQuery);
     $x.on('UserAcceptedSpellcheckQuery').subscribe(userAcceptSpellcheck);
 
-    clickEventButton();
+    click();
 
     expect(userAcceptedAQuery).toHaveBeenNthCalledWith(1, spellcheckedQuery);
     expect(userAcceptSpellcheck).toHaveBeenNthCalledWith(1, spellcheckedQuery);
@@ -98,5 +98,5 @@ interface RenderSpellcheckButtonAPI {
   /** The wrapper of the container element.*/
   wrapper: Wrapper<Vue>;
   /** Clicks the event button and waits for the view to update. */
-  clickEventButton: () => Promise<void>;
+  click: () => Promise<void>;
 }

--- a/packages/x-components/src/x-modules/search/components/__tests__/spellcheck-button.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/spellcheck-button.spec.ts
@@ -97,6 +97,6 @@ interface RenderSpellcheckButtonOptions {
 interface RenderSpellcheckButtonAPI {
   /** The wrapper of the container element.*/
   wrapper: Wrapper<Vue>;
-  /** Clicks the event button and waits for the view to update. */
+  /** Clicks the button and waits for the view to update. */
   click: () => Promise<void>;
 }

--- a/packages/x-components/src/x-modules/search/components/partial-query-button.vue
+++ b/packages/x-components/src/x-modules/search/components/partial-query-button.vue
@@ -1,18 +1,17 @@
 <template>
-  <BaseEventButton
-    :events="events"
+  <button
+    @click="emitEvents"
     class="x-button x-partial-query-button"
     data-test="partial-query-button"
   >
     <slot v-bind="{ query }">{{ query }}</slot>
-  </BaseEventButton>
+  </button>
 </template>
 
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { BaseEventButton, xComponentMixin } from '../../../components';
-  import { XEventsTypes } from '../../../wiring';
+  import { xComponentMixin } from '../../../components';
   import { searchXModule } from '../x-module';
 
   /**
@@ -23,7 +22,6 @@
    * @public
    */
   @Component({
-    components: { BaseEventButton },
     mixins: [xComponentMixin(searchXModule)]
   })
   export default class PartialQueryButton extends Vue {
@@ -36,17 +34,17 @@
     public query!: string;
 
     /**
-     * Events list which are going to be emitted when the button is clicked.
-     *
-     * @returns The {@link XEvent | XEvents} to emit.
+     * Emits events when the button is clicked.
      *
      * @public
      */
-    protected get events(): Partial<XEventsTypes> {
-      return {
-        UserAcceptedAQuery: this.query,
-        UserClickedPartialQuery: this.query
-      };
+    protected emitEvents(): void {
+      this.$x.emit('UserAcceptedAQuery', this.query, {
+        target: this.$el as HTMLElement
+      });
+      this.$x.emit('UserClickedPartialQuery', this.query, {
+        target: this.$el as HTMLElement
+      });
     }
   }
 </script>

--- a/packages/x-components/src/x-modules/search/components/partial-query-button.vue
+++ b/packages/x-components/src/x-modules/search/components/partial-query-button.vue
@@ -11,7 +11,7 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { xComponentMixin } from '../../../components';
+  import { xComponentMixin } from '../../../components/x-component.mixin';
   import { searchXModule } from '../x-module';
 
   /**

--- a/packages/x-components/src/x-modules/search/components/spellcheck-button.vue
+++ b/packages/x-components/src/x-modules/search/components/spellcheck-button.vue
@@ -12,7 +12,8 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
-  import { State, xComponentMixin } from '../../../components';
+  import { State } from '../../../components/decorators/store.decorators';
+  import { xComponentMixin } from '../../../components/x-component.mixin';
   import { searchXModule } from '../x-module';
   /**
    * A button that when pressed emits the {@link XEventsTypes.UserAcceptedAQuery}

--- a/packages/x-components/src/x-modules/search/components/spellcheck-button.vue
+++ b/packages/x-components/src/x-modules/search/components/spellcheck-button.vue
@@ -1,19 +1,18 @@
 <template>
-  <BaseEventButton
+  <button
     v-if="spellcheckedQuery"
-    :events="events"
+    @click="emitEvents"
     class="x-spellcheck-button"
     data-test="set-spellcheck"
   >
     <slot v-bind="{ spellcheckedQuery }">{{ spellcheckedQuery }}</slot>
-  </BaseEventButton>
+  </button>
 </template>
 
 <script lang="ts">
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
-  import { BaseEventButton, State, xComponentMixin } from '../../../components';
-  import { XEventsTypes } from '../../../wiring';
+  import { State, xComponentMixin } from '../../../components';
   import { searchXModule } from '../x-module';
   /**
    * A button that when pressed emits the {@link XEventsTypes.UserAcceptedAQuery}
@@ -23,7 +22,6 @@
    * @public
    */
   @Component({
-    components: { BaseEventButton },
     mixins: [xComponentMixin(searchXModule)]
   })
   export default class SpellcheckButton extends Vue {
@@ -36,17 +34,17 @@
     public spellcheckedQuery!: string;
 
     /**
-     * Events list which are going to be emitted when the button is clicked.
-     *
-     * @returns The {@link XEvent | XEvents} to emit.
+     * Emits events when the button is clicked.
      *
      * @public
      */
-    protected get events(): Partial<XEventsTypes> {
-      return {
-        UserAcceptedAQuery: this.spellcheckedQuery,
-        UserAcceptedSpellcheckQuery: this.spellcheckedQuery
-      };
+    protected emitEvents(): void {
+      this.$x.emit('UserAcceptedAQuery', this.spellcheckedQuery, {
+        target: this.$el as HTMLElement
+      });
+      this.$x.emit('UserAcceptedSpellcheckQuery', this.spellcheckedQuery, {
+        target: this.$el as HTMLElement
+      });
     }
   }
 </script>


### PR DESCRIPTION

# Description

The goal of this PR is to replace the `BaseEventButton` used in some components for an html button. The purpose of this is to ease the process of passing a `feature` property in the metadata for each component that requires it. Recap of the changes:

- `RelatedTag`
- `SpellcheckButton`
- `PartialQueryButton`
- `SearchButton`
- `BaseSuggestion` (used by `QuerySuggestion`, `HistoryQuery`, `PopularSearch` and `NextQuery`)

The case of the `BaseSuggestion` requires to add a prop for the components that use it to decide which `feature` the events should be emitted with.

Tests have been fixed accordingly.

EXTRA: added the `eventkeyhint` attribute to the `SearchInput` component.

## Motivation and context

This is part of the tagging development and is required to be able to pass different `feature` properties in the `metadata` of the events that are emitted by components that require it.

## Test it

Interacting with the changed components in the `Layout` should give hints that the events are being emitted correctly. Behaviour and DOM should remain almost as the same as in main.

