### PR TITLE
test(e2e): fix invalid `IdentifierResults` `data-test` selector

### DIFF
--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -63,7 +63,7 @@ Then('identifier results are displayed', () => {
 });
 
 Then('no identifier results are displayed', () => {
-  cy.getByDataTest('identifier-result-item').should('not.exist');
+  cy.getByDataTest('identifier-results-item').should('not.exist');
 });
 
 // Facets


### PR DESCRIPTION
The identifier results data-test is not ok, luckily to us the step that uses this selector was trying to not find the element :trollface: 

```javascript
Then('no identifier results are displayed', () => {
  cy.getByDataTest('identifier-result-item').should('not.exist');
});
```