### PR TITLE
feat(scroll): ignore first visible element when it is also the first one observed

### DIFF
--- a/packages/x-components/src/views/infinite-scroll-body.vue
+++ b/packages/x-components/src/views/infinite-scroll-body.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <WindowScroll tag="body" />
+    <WindowScroll scrollableElement="body" />
     <UrlHandler />
     <h1>Infinite Scroll Body</h1>
     <header class="header">

--- a/packages/x-components/src/x-modules/scroll/components/__tests__/window-scroll.spec.ts
+++ b/packages/x-components/src/x-modules/scroll/components/__tests__/window-scroll.spec.ts
@@ -5,12 +5,12 @@ import { scrollXModule } from '../../x-module';
 import WindowScroll from '../window-scroll.vue';
 
 async function renderWindowScroll({
-  template = `<WindowScroll :throttleMs="throttleMs" :tag="tag"/>`,
+  template = `<WindowScroll :throttleMs="throttleMs" :scrollableElement="scrollableElement"/>`,
   throttleMs = 200,
   scrollHeight = 800,
   clientHeight = 200,
   distanceToBottom = 100,
-  tag,
+  scrollableElement,
   showComponent
 }: RenderWindowScrollOptions = {}): Promise<RenderWindowScrollAPI> {
   const [, localVue] = installNewXPlugin({ initialXModules: [scrollXModule] });
@@ -29,7 +29,7 @@ async function renderWindowScroll({
 
   const wrapperContainer = mount(
     {
-      props: ['throttleMs', 'distanceToBottom', 'tag'],
+      props: ['throttleMs', 'distanceToBottom', 'scrollableElement'],
       components: {
         WindowScroll
       },
@@ -42,7 +42,7 @@ async function renderWindowScroll({
       propsData: {
         throttleMs,
         distanceToBottom,
-        tag
+        scrollableElement
       },
       localVue
     }
@@ -90,7 +90,7 @@ describe('testing Main Scroll Component', () => {
     it('throttles the scroll event', async () => {
       const { wrapper, scrollHtml } = await renderWindowScroll({
         throttleMs: 200,
-        tag: 'html'
+        scrollableElement: 'html'
       });
 
       const listenerScrolled = jest.fn();
@@ -128,7 +128,7 @@ describe('testing Main Scroll Component', () => {
     it('emits the `UserChangedScrollDirection` event when the user changes scrolling direction', async () => {
       const { wrapper, scrollHtml } = await renderWindowScroll({
         throttleMs: 200,
-        tag: 'html'
+        scrollableElement: 'html'
       });
 
       const listenerChangeDirection = jest.fn();
@@ -178,7 +178,7 @@ describe('testing Main Scroll Component', () => {
     it('emits the `UserReachedScrollStart` event when the user scrolls back to the top', async () => {
       const { wrapper, scrollHtml } = await renderWindowScroll({
         throttleMs: 200,
-        tag: 'html'
+        scrollableElement: 'html'
       });
 
       const listenerScrollStart = jest.fn();
@@ -221,7 +221,7 @@ describe('testing Main Scroll Component', () => {
         scrollHeight: 800,
         clientHeight: 200,
         distanceToBottom: 300,
-        tag: 'html'
+        scrollableElement: 'html'
       });
 
       const listenerAlmostReachedScrollEnd = jest.fn();
@@ -323,11 +323,11 @@ describe('testing Main Scroll Component', () => {
     it('does not trigger event when scrolling in body or other element', async () => {
       const { wrapper, scrollBody, scrollContent } = await renderWindowScroll({
         template: `<div>
-                    <WindowScroll :throttleMs="throttleMs" :tag="tag"/>
+                    <WindowScroll :throttleMs="throttleMs" :scrollableElement="scrollableElement"/>
                     <div data-test="content"></div>
                   </div>`,
         throttleMs: 200,
-        tag: 'html'
+        scrollableElement: 'html'
       });
 
       const listenerScrolled = jest.fn();
@@ -349,9 +349,14 @@ describe('testing Main Scroll Component', () => {
 
     it('does not emit event if component is not rendered or is destroyed', async () => {
       const { scrollHtml, setShowComponent } = await renderWindowScroll({
-        template: `<WindowScroll v-if="showComponent" :throttleMs="throttleMs" :tag="tag"/>`,
+        template: `
+          <WindowScroll
+            v-if="showComponent"
+            :throttleMs="throttleMs"
+            :scrollableElement="scrollableElement"
+          />`,
         throttleMs: 200,
-        tag: 'html',
+        scrollableElement: 'html',
         showComponent: false
       });
 
@@ -415,7 +420,7 @@ describe('testing Main Scroll Component', () => {
     it('throttles the scroll event', async () => {
       const { wrapper, scrollBody } = await renderWindowScroll({
         throttleMs: 200,
-        tag: 'body'
+        scrollableElement: 'body'
       });
 
       const listenerScrolled = jest.fn();
@@ -453,7 +458,7 @@ describe('testing Main Scroll Component', () => {
     it('emits the `UserChangedScrollDirection` event when the user changes scrolling direction', async () => {
       const { wrapper, scrollBody } = await renderWindowScroll({
         throttleMs: 200,
-        tag: 'body'
+        scrollableElement: 'body'
       });
 
       const listenerChangeDirection = jest.fn();
@@ -503,7 +508,7 @@ describe('testing Main Scroll Component', () => {
     it('emits the `UserReachedScrollStart` event when the user scrolls back to the top', async () => {
       const { wrapper, scrollBody } = await renderWindowScroll({
         throttleMs: 200,
-        tag: 'body'
+        scrollableElement: 'body'
       });
 
       const listenerScrollStart = jest.fn();
@@ -546,7 +551,7 @@ describe('testing Main Scroll Component', () => {
         scrollHeight: 800,
         clientHeight: 200,
         distanceToBottom: 300,
-        tag: 'body'
+        scrollableElement: 'body'
       });
 
       const listenerAlmostReachedScrollEnd = jest.fn();
@@ -648,11 +653,11 @@ describe('testing Main Scroll Component', () => {
     it('does not trigger event when scrolling in document or other element', async () => {
       const { wrapper, scrollHtml, scrollContent } = await renderWindowScroll({
         template: `<div>
-                    <WindowScroll :throttleMs="throttleMs" :tag="tag"/>
+                    <WindowScroll :throttleMs="throttleMs" :scrollableElement="scrollableElement"/>
                     <div data-test="content"></div>
                   </div>`,
         throttleMs: 200,
-        tag: 'body'
+        scrollableElement: 'body'
       });
 
       const listenerScrolled = jest.fn();
@@ -674,9 +679,14 @@ describe('testing Main Scroll Component', () => {
 
     it('does not emit event if component is not rendered or is destroyed', async () => {
       const { scrollBody, setShowComponent } = await renderWindowScroll({
-        template: `<WindowScroll v-if="showComponent" :throttleMs="throttleMs" :tag="tag"/>`,
+        template: `
+          <WindowScroll
+            v-if="showComponent"
+            :throttleMs="throttleMs"
+            :scrollableElement="scrollableElement"
+          />`,
         throttleMs: 200,
-        tag: 'body',
+        scrollableElement: 'body',
         showComponent: false
       });
 
@@ -748,8 +758,8 @@ interface RenderWindowScrollOptions {
   clientHeight?: number;
   /** Distance to the end of the main scroll. */
   distanceToBottom?: number;
-  /** Tag where apply the scroll. */
-  tag?: 'html' | 'body';
+  /** ScrollableElement where apply the scroll. */
+  scrollableElement?: 'html' | 'body';
   /** If it will show the WindowScroll or not. */
   showComponent?: boolean;
 }

--- a/packages/x-components/src/x-modules/scroll/components/scroll-to-top.vue
+++ b/packages/x-components/src/x-modules/scroll/components/scroll-to-top.vue
@@ -23,6 +23,7 @@
   import { XEventsTypes } from '../../../wiring';
   import { ScrollComponentState } from '../store';
   import { scrollXModule } from '../x-module';
+  import { MainScrollId } from './scroll.const';
 
   /**
    * The `ScrollToTop` component is a button that the user can click to make a container scroll
@@ -56,8 +57,8 @@
      *
      * @public
      */
-    @Prop()
-    public scrollId?: string;
+    @Prop({ default: MainScrollId })
+    public scrollId!: string;
 
     /**
      * State of all the scroll components in this module.

--- a/packages/x-components/src/x-modules/scroll/components/scroll.const.ts
+++ b/packages/x-components/src/x-modules/scroll/components/scroll.const.ts
@@ -7,3 +7,4 @@ import { ScrollVisibilityObserver } from './scroll.types';
  * @internal
  */
 export const ScrollObserverKey: XInjectKey<ScrollVisibilityObserver | null> = 'ScrollObserverKey';
+export const MainScrollId = 'main-scroll';

--- a/packages/x-components/src/x-modules/scroll/components/scroll.const.ts
+++ b/packages/x-components/src/x-modules/scroll/components/scroll.const.ts
@@ -7,4 +7,9 @@ import { ScrollVisibilityObserver } from './scroll.types';
  * @internal
  */
 export const ScrollObserverKey: XInjectKey<ScrollVisibilityObserver | null> = 'ScrollObserverKey';
+/**
+ * The default scroll id for all the scroll components.
+ *
+ * @internal
+ */
 export const MainScrollId = 'main-scroll';

--- a/packages/x-components/src/x-modules/scroll/components/scroll.vue
+++ b/packages/x-components/src/x-modules/scroll/components/scroll.vue
@@ -23,6 +23,7 @@
   import BaseScroll from '../../../components/scroll/base-scroll.vue';
   import { ScrollDirection } from '../../../components/scroll/scroll.types';
   import { scrollXModule } from '../x-module';
+  import { MainScrollId } from './scroll.const';
 
   /**
    * Base scroll component that depending on base scroll component and the user interaction emits
@@ -59,7 +60,7 @@
      *
      * @public
      */
-    @Prop({ default: 'scrollId' })
+    @Prop({ default: MainScrollId })
     public id!: string;
 
     /**

--- a/packages/x-components/src/x-modules/scroll/components/window-scroll.vue
+++ b/packages/x-components/src/x-modules/scroll/components/window-scroll.vue
@@ -4,6 +4,7 @@
   import { ScrollDirection, ScrollMixin, xComponentMixin } from '../../../components';
   import { WireMetadata } from '../../../wiring';
   import { scrollXModule } from '../x-module';
+  import { MainScrollId } from './scroll.const';
 
   type ScrollableTag = 'html' | 'body';
 
@@ -30,7 +31,7 @@
      *
      * @public
      */
-    @Prop({ default: 'main-scroll' })
+    @Prop({ default: MainScrollId })
     protected id!: string;
 
     mounted(): void {
@@ -64,7 +65,7 @@
     protected initAndListenElement(): void {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
-      this.$el = this.tag === 'html' ? document.documentElement : document.body;
+      this.$el = this.tag === 'body' ? document.body : document.documentElement;
       this.$el.addEventListener('scroll', this.throttledStoreScrollData);
     }
 

--- a/packages/x-components/src/x-modules/scroll/components/window-scroll.vue
+++ b/packages/x-components/src/x-modules/scroll/components/window-scroll.vue
@@ -6,7 +6,7 @@
   import { scrollXModule } from '../x-module';
   import { MainScrollId } from './scroll.const';
 
-  type ScrollableTag = 'html' | 'body';
+  type ScrollableElement = 'html' | 'body';
 
   /**
    * The `WindowScroll` component listens to either the `html` or `body` DOM scroll events, and
@@ -25,7 +25,7 @@
      * @public
      */
     @Prop({ default: 'html' })
-    protected tag!: ScrollableTag;
+    protected scrollableElement!: ScrollableElement;
     /**
      * Id to identify the component.
      *
@@ -58,14 +58,15 @@
     }
 
     /**
-     * Sets the HTML element depending on {@link WindowScroll.tag}, and initialises its events.
+     * Sets the HTML element depending on {@link WindowScroll.scrollableElement}, and initialises
+     * its events.
      *
      * @internal
      */
     protected initAndListenElement(): void {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
-      this.$el = this.tag === 'body' ? document.body : document.documentElement;
+      this.$el = this.scrollableElement === 'body' ? document.body : document.documentElement;
       this.$el.addEventListener('scroll', this.throttledStoreScrollData);
     }
 
@@ -114,7 +115,7 @@ this state changes, it emits the appropiate X Event to the rest of the applicati
     id="example-main-scroll"
     throttleMs="100"
     distanceToBottom="300"
-    tag="document"
+    scrollableElement="body"
   />
 </template>
 
@@ -157,7 +158,12 @@ similar styles the corresponding style for tag body like in the next example.
 
 ```vue
 <template>
-  <WindowScroll id="example-main-scroll" throttleMs="100" distanceToBottom="300" tag="body" />
+  <WindowScroll
+    id="example-main-scroll"
+    throttleMs="100"
+    distanceToBottom="300"
+    scrollableElement="body"
+  />
 </template>
 
 <script>

--- a/packages/x-components/tests/unit/main-scroll.spec.ts
+++ b/packages/x-components/tests/unit/main-scroll.spec.ts
@@ -139,11 +139,8 @@ describe('testing MainScroll component', () => {
         userScrolledToElementSpy().should('have.been.calledWith', 'item-5');
       });
 
-      it.only('ignores the first element of scroll', () => {
-        const { scrollToItem, userScrolledToElementSpy } = renderMainScroll({
-          ...defaultParameters,
-          itemHeight: '50px'
-        });
+      it('ignores the first element of scroll', () => {
+        const { scrollToItem, userScrolledToElementSpy } = renderMainScroll(defaultParameters);
         scrollToItem(1);
         userScrolledToElementSpy().should('have.been.calledWith', 'item-1');
         userScrolledToElementSpy().should('not.have.been.calledWith', 'item-0');

--- a/packages/x-components/tests/unit/main-scroll.spec.ts
+++ b/packages/x-components/tests/unit/main-scroll.spec.ts
@@ -20,7 +20,6 @@ function renderMainScroll({
   itemHeight = '50px',
   threshold,
   margin,
-  minScrollTrigger,
   useWindow,
   windowScrollingElement
 }: RenderMainScrollOptions = {}): RenderMainScrollAPI {
@@ -44,7 +43,7 @@ function renderMainScroll({
         MainScrollItem
       },
       template: `
-        <MainScroll v-bind="{ threshold, margin, useWindow, minScrollTrigger }">
+        <MainScroll v-bind="{ threshold, margin, useWindow }">
           <div class="container" ${!useWindow ? `data-test="scroll"` : ''}>
             <MainScrollItem
               v-for="item in items"
@@ -62,8 +61,7 @@ function renderMainScroll({
           items: Array.from({ length: itemsCount }, (_, index) => ({ id: `item-${index}` })),
           threshold,
           margin,
-          useWindow,
-          minScrollTrigger
+          useWindow
         };
       },
       beforeCreate() {
@@ -141,18 +139,17 @@ describe('testing MainScroll component', () => {
         userScrolledToElementSpy().should('have.been.calledWith', 'item-5');
       });
 
-      it('ignores the first pixels of scroll', () => {
+      it.only('ignores the first element of scroll', () => {
         const { scrollToItem, userScrolledToElementSpy } = renderMainScroll({
           ...defaultParameters,
-          minScrollTrigger: 75,
           itemHeight: '50px'
         });
         scrollToItem(1);
+        userScrolledToElementSpy().should('have.been.calledWith', 'item-1');
         userScrolledToElementSpy().should('not.have.been.calledWith', 'item-0');
-        userScrolledToElementSpy().should('not.have.been.calledWith', 'item-1');
 
-        scrollToItem(2);
-        userScrolledToElementSpy().should('have.been.calledWith', 'item-2');
+        scrollToItem(0);
+        userScrolledToElementSpy().should('not.have.been.calledWith', 'item-0');
       });
 
       it('restores the scroll', () => {
@@ -226,8 +223,6 @@ interface RenderMainScrollOptions {
   threshold?: number;
   /** The height of each one of the items. */
   itemHeight?: string;
-  /** The scroll amount in pixels to ignore the first visible element. */
-  minScrollTrigger?: number;
   /** Enables listening to the global scroll instead of the wrapping element scroll. */
   useWindow?: boolean;
   /** When `useWindow=true`, the element that should be scrollable. */


### PR DESCRIPTION
EX-5041

This checks the element is not the first node matching the `[data-scroll]` selector, so when the scroll is at the top we don't have the first visible element stored in the URL.

It also uses a constant for the default main scroll, so the scroll to top button works by default with both components, and the scroll id is only needed to be passed if there are more scroll component instances.