### PR TITLE
[EX-5015] E2E tests retries

### DIFF
--- a/packages/x-components/cypress.json
+++ b/packages/x-components/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:8080",
-  "defaultCommandTimeout": 30000,
+  "defaultCommandTimeout": 7000,
   "viewportHeight": 1080,
   "viewportWidth": 1920,
   "screenshotOnRunFailure": false,
@@ -15,5 +15,5 @@
     "componentFolder": "tests/unit",
     "testFiles": "**/*.spec.ts"
   },
-  "retries": 2
+  "retries": 1
 }


### PR DESCRIPTION
## Motivation and context
Right now, the timeout until one test is considered fail is 30s. Moreover, the number of retries in case of failure is 3. This means a total of 30s x 3 = 1m30s waiting in case a test is failing.
The aim of this task is to avoid wasting time by finding the best possible combination between these two.

**### SOLUTION
7s, 1 retry. Build ran successfully 10/10 times.**

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?
Multiple builds will be launched to determine which is the limit the tests start failing

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
