### PR TITLE
[EX-4902] Set keyboard navigation in header and Empathize

### DIFF
--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -54,15 +54,15 @@
         />
       </li>
     </ul>
-    <BaseKeyboardNavigation>
-      <BaseEventsModal :eventsToOpenModal="eventsToOpenModal">
-        <MultiColumnMaxWidthLayout class="x-background--neutral-100">
-          <template #header-middle>
-            <div
-              class="
-                x-list x-list--vertical x-list--gap-05 x-list--align-stretch x-list__item--expand
-              "
-            >
+    <BaseEventsModal :eventsToOpenModal="eventsToOpenModal">
+      <MultiColumnMaxWidthLayout class="x-background--neutral-100">
+        <template #header-middle>
+          <div
+            class="
+              x-list x-list--vertical x-list--gap-05 x-list--align-stretch x-list__item--expand
+            "
+          >
+            <BaseKeyboardNavigation>
               <div class="x-input-group x-input-group--card">
                 <SearchInput
                   aria-label="Search for products"
@@ -75,34 +75,36 @@
                   <SearchIcon />
                 </SearchButton>
               </div>
+            </BaseKeyboardNavigation>
 
-              <!-- Spellcheck -->
-              <Spellcheck>
-                <template #default="{ query }">
-                  No results found for '{{ query }}'. We show you results for
-                  <SpellcheckButton />
-                </template>
-              </Spellcheck>
+            <!-- Spellcheck -->
+            <Spellcheck>
+              <template #default="{ query }">
+                No results found for '{{ query }}'. We show you results for
+                <SpellcheckButton />
+              </template>
+            </Spellcheck>
 
-              <SlidingPanel v-if="$x.relatedTags.length">
-                <template #sliding-panel-left-button>
-                  <ChevronLeft />
-                </template>
-                <RelatedTags class="x-tag--card x-list--gap-03" />
-                <template #sliding-panel-right-button>
-                  <ChevronRight />
-                </template>
-              </SlidingPanel>
-            </div>
-          </template>
+            <SlidingPanel v-if="$x.relatedTags.length">
+              <template #sliding-panel-left-button>
+                <ChevronLeft />
+              </template>
+              <RelatedTags class="x-tag--card x-list--gap-03" />
+              <template #sliding-panel-right-button>
+                <ChevronRight />
+              </template>
+            </SlidingPanel>
+          </div>
+        </template>
 
-          <template #header-end>
-            <BaseEventsModalClose lass="x-button--ghost">
-              <CrossIcon />
-            </BaseEventsModalClose>
-          </template>
+        <template #header-end>
+          <BaseEventsModalClose lass="x-button--ghost">
+            <CrossIcon />
+          </BaseEventsModalClose>
+        </template>
 
-          <template #sub-header>
+        <template #sub-header>
+          <BaseKeyboardNavigation>
             <Empathize
               :animation="empathizeAnimation"
               class="
@@ -118,374 +120,365 @@
               <QuerySuggestions max-items-to-render="10" />
               <NextQueries max-items-to-render="10" />
             </Empathize>
-          </template>
+          </BaseKeyboardNavigation>
+        </template>
 
-          <template #toolbar-aside>
-            <BaseIdTogglePanelButton
-              v-if="$x.totalResults > 0"
-              class="x-button x-button--ghost"
-              panelId="aside-panel"
+        <template #toolbar-aside>
+          <BaseIdTogglePanelButton
+            v-if="$x.totalResults > 0"
+            class="x-button x-button--ghost"
+            panelId="aside-panel"
+          >
+            Toggle Aside
+          </BaseIdTogglePanelButton>
+        </template>
+
+        <template #toolbar-body>
+          <div
+            v-if="$x.totalResults > 0"
+            class="x-list x-list--horizontal x-list--align-center x-list--gap-04"
+          >
+            <span>{{ $x.totalResults }} Results</span>
+            <BaseColumnPickerList
+              #default="{ column }"
+              v-model="selectedColumns"
+              :columns="columnPickerValues"
             >
-              Toggle Aside
-            </BaseIdTogglePanelButton>
-          </template>
-
-          <template #toolbar-body>
-            <div
-              v-if="$x.totalResults > 0"
-              class="x-list x-list--horizontal x-list--align-center x-list--gap-04"
+              <template v-if="column === 0">
+                <ChevronTinyRight />
+                <Grid1Col />
+                <ChevronTinyLeft />
+              </template>
+              <Grid1Col v-else-if="column === 4" />
+              <Grid2Col v-else-if="column === 6" />
+            </BaseColumnPickerList>
+            <SortDropdown
+              :items="sortValues"
+              class="x-dropdown--round x-dropdown--right x-dropdown--l"
+              :animation="sortDropdownAnimation"
             >
-              <span>{{ $x.totalResults }} Results</span>
-              <BaseColumnPickerList
-                #default="{ column }"
-                v-model="selectedColumns"
-                :columns="columnPickerValues"
-              >
-                <template v-if="column === 0">
-                  <ChevronTinyRight />
-                  <Grid1Col />
-                  <ChevronTinyLeft />
-                </template>
-                <Grid1Col v-else-if="column === 4" />
-                <Grid2Col v-else-if="column === 6" />
-              </BaseColumnPickerList>
-              <SortDropdown
-                :items="sortValues"
-                class="x-dropdown--round x-dropdown--right x-dropdown--l"
-                :animation="sortDropdownAnimation"
-              >
-                <template #toggle="{ item }">
-                  <span data-test="sort-dropdown-toggle">{{ item || 'default' }}</span>
-                  <ChevronTinyDown />
-                </template>
-                <template #item="{ item, isSelected }">
-                  <ChevronTinyRight />
-                  <span>{{ item || 'default' }}</span>
-                  <CheckTiny v-if="isSelected" />
-                </template>
-              </SortDropdown>
+              <template #toggle="{ item }">
+                <span data-test="sort-dropdown-toggle">{{ item || 'default' }}</span>
+                <ChevronTinyDown />
+              </template>
+              <template #item="{ item, isSelected }">
+                <ChevronTinyRight />
+                <span>{{ item || 'default' }}</span>
+                <CheckTiny v-if="isSelected" />
+              </template>
+            </SortDropdown>
 
-              <RenderlessExtraParams #default="{ value, updateValue }" name="store">
-                <BaseDropdown
-                  @change="updateValue"
-                  class="x-dropdown x-dropdown--round x-dropdown--right x-dropdown--l"
-                  :value="value"
-                  :items="stores"
-                />
-              </RenderlessExtraParams>
-            </div>
-          </template>
+            <RenderlessExtraParams #default="{ value, updateValue }" name="store">
+              <BaseDropdown
+                @change="updateValue"
+                class="x-dropdown x-dropdown--round x-dropdown--right x-dropdown--l"
+                :value="value"
+                :items="stores"
+              />
+            </RenderlessExtraParams>
+          </div>
+        </template>
 
-          <template #main-aside>
-            <div
-              v-if="$x.totalResults > 0"
-              class="
-                x-list
-                x-list--padding-05
-                x-list--padding-top
-                x-list--gap-06
-                x-list--border
-                x-list--border-top
-              "
-            >
-              <FacetsProvider :facets="staticFacets" />
-              <ClearFilters />
-              <SelectedFiltersList>
-                <template #default="{ filter }">
-                  <SimpleFilter :filter="filter" class="x-tag" />
-                </template>
-              </SelectedFiltersList>
+        <template #main-aside>
+          <div
+            v-if="$x.totalResults > 0"
+            class="
+              x-list
+              x-list--padding-05
+              x-list--padding-top
+              x-list--gap-06
+              x-list--border
+              x-list--border-top
+            "
+          >
+            <FacetsProvider :facets="staticFacets" />
+            <ClearFilters />
+            <SelectedFiltersList>
+              <template #default="{ filter }">
+                <SimpleFilter :filter="filter" class="x-tag" />
+              </template>
+            </SelectedFiltersList>
 
-              <!-- Facets -->
-              <Facets class="x-list--gap-06" renderable-facets="!rootCategories_facet">
-                <!--  Hierarchical Facet    -->
-                <template #hierarchical-category="{ facet }">
-                  <BaseHeaderTogglePanel class="x-facet">
-                    <template #header-content>
-                      <span class="x-ellipsis">{{ facet.label }}</span>
-                      <ChevronDown />
-                    </template>
-                    <!-- Filters -->
-                    <SlicedFilters max="4" :filters="facet.filters">
-                      <FiltersList v-slot="{ filter }">
-                        <HierarchicalFilter :filter="filter" :data-test="`${facet.label}-filter`" />
-                      </FiltersList>
-                    </SlicedFilters>
-                  </BaseHeaderTogglePanel>
-                </template>
+            <!-- Facets -->
+            <Facets class="x-list--gap-06" renderable-facets="!rootCategories_facet">
+              <!--  Hierarchical Facet    -->
+              <template #hierarchical-category="{ facet }">
+                <BaseHeaderTogglePanel class="x-facet">
+                  <template #header-content>
+                    <span class="x-ellipsis">{{ facet.label }}</span>
+                    <ChevronDown />
+                  </template>
+                  <!-- Filters -->
+                  <SlicedFilters max="4" :filters="facet.filters">
+                    <FiltersList v-slot="{ filter }">
+                      <HierarchicalFilter :filter="filter" :data-test="`${facet.label}-filter`" />
+                    </FiltersList>
+                  </SlicedFilters>
+                </BaseHeaderTogglePanel>
+              </template>
 
-                <!--  Brand Facet    -->
-                <template #brand-facet="{ facet }">
-                  <BaseHeaderTogglePanel class="x-facet">
-                    <template #header-content>
-                      <span :data-test="facet.label" class="x-ellipsis">{{ facet.label }}</span>
-                      <span data-test="total-filters">{{ facet.filters.length }}</span>
-                      <ChevronDown />
-                    </template>
+              <!--  Brand Facet    -->
+              <template #brand-facet="{ facet }">
+                <BaseHeaderTogglePanel class="x-facet">
+                  <template #header-content>
+                    <span :data-test="facet.label" class="x-ellipsis">{{ facet.label }}</span>
+                    <span data-test="total-filters">{{ facet.filters.length }}</span>
+                    <ChevronDown />
+                  </template>
 
-                    <!-- Filters -->
-                    <ExcludeFiltersWithNoResults :filters="facet.filters">
-                      <SortedFilters>
-                        <FiltersSearch>
-                          <SlicedFilters
-                            :max="controls.slicedFilters.max"
-                            :data-test="`${facet.label}-sliced-filters`"
-                          >
-                            <FiltersList
-                              v-slot="{
-                                // eslint-disable-next-line vue/no-unused-vars
-                                filter
-                              }"
-                            >
-                              <SimpleFilter
-                                #label="{ filter }"
-                                :filter="filter"
-                                :data-test="`${facet.label}-filter`"
-                              >
-                                {{ filter.label }}
-                                <span data-test="brand-filter-total-results">
-                                  {{ filter.totalResults }}
-                                </span>
-                              </SimpleFilter>
-                            </FiltersList>
-                          </SlicedFilters>
-                        </FiltersSearch>
-                      </SortedFilters>
-                    </ExcludeFiltersWithNoResults>
-                  </BaseHeaderTogglePanel>
-                </template>
-
-                <!--  Default Facet    -->
-                <template #default="{ facet }">
-                  <BaseHeaderTogglePanel class="x-facet">
-                    <template #header-content>
-                      <span :data-test="facet.label" class="x-ellipsis">{{ facet.label }}</span>
-                      <ChevronDown />
-                    </template>
-
-                    <!-- Filters -->
-                    <ExcludeFiltersWithNoResults :filters="facet.filters">
-                      <SortedFilters>
+                  <!-- Filters -->
+                  <ExcludeFiltersWithNoResults :filters="facet.filters">
+                    <SortedFilters>
+                      <FiltersSearch>
                         <SlicedFilters
                           :max="controls.slicedFilters.max"
                           :data-test="`${facet.label}-sliced-filters`"
                         >
-                          <SelectedFilters #default="{ selectedFilters }" :facetId="facet.id">
-                            <span :data-test="`${facet.label}-selected-filters`">
-                              {{ selectedFilters.length }}
-                            </span>
-                          </SelectedFilters>
-                          <FiltersList v-slot="{ filter }">
+                          <FiltersList
+                            v-slot="{
+                              // eslint-disable-next-line vue/no-unused-vars
+                              filter
+                            }"
+                          >
                             <SimpleFilter
-                              #label
+                              #label="{ filter }"
                               :filter="filter"
                               :data-test="`${facet.label}-filter`"
                             >
-                              <BasePriceFilterLabel
-                                v-if="facet.id === 'price'"
-                                :filter="filter"
-                                class="x-filter__label"
-                                format="ii.dd €"
-                                lessThan="Less than {max}"
-                                fromTo="From {min} to {max}"
-                                from="More than {min}"
-                              />
+                              {{ filter.label }}
+                              <span data-test="brand-filter-total-results">
+                                {{ filter.totalResults }}
+                              </span>
                             </SimpleFilter>
                           </FiltersList>
                         </SlicedFilters>
-                      </SortedFilters>
-                    </ExcludeFiltersWithNoResults>
-                  </BaseHeaderTogglePanel>
-                </template>
-              </Facets>
-            </div>
-          </template>
+                      </FiltersSearch>
+                    </SortedFilters>
+                  </ExcludeFiltersWithNoResults>
+                </BaseHeaderTogglePanel>
+              </template>
 
-          <template #main-body>
-            <!--  Redirection  -->
-            <Redirection
-              #default="{ redirection, redirect, abortRedirect, isRedirecting, delayInSeconds }"
-              class="x-margin--top-03 x-margin--bottom-03"
-              delayInSeconds="5"
-            >
-              <p>
-                Your search matches a special place in our website, to visit it, your are being
-                redirected
-              </p>
-              <a @click="redirect" :href="redirection.url">{{ redirection.url }}</a>
-              <div class="x-list x-list--horizontal x-list--gap-07">
-                <button
-                  @click="abortRedirect"
-                  class="x-button x-button--ghost x-font-color--neutral-70"
-                >
-                  No, I'll stay here
-                </button>
-                <button @click="redirect" class="x-button x-button--ghost x-font-color--neutral-10">
-                  Yes, redirect me
-                </button>
-              </div>
-              <AutoProgressBar :isLoading="isRedirecting" :durationInSeconds="delayInSeconds" />
-            </Redirection>
+              <!--  Default Facet    -->
+              <template #default="{ facet }">
+                <BaseHeaderTogglePanel class="x-facet">
+                  <template #header-content>
+                    <span :data-test="facet.label" class="x-ellipsis">{{ facet.label }}</span>
+                    <ChevronDown />
+                  </template>
 
-            <template v-if="!$x.redirections.length">
-              <!-- IdentifierResults -->
-              <IdentifierResults class="x-list x-list--horizontal">
-                <template #default="{ identifierResult }">
-                  <article class="result">
-                    <BaseResultImage :result="identifierResult" class="x-picture--colored">
-                      <template #placeholder>
-                        <div style="padding-top: 100%; background-color: lightgray"></div>
-                      </template>
-                      <template #fallback>
-                        <div style="padding-top: 100%; background-color: lightsalmon"></div>
-                      </template>
-                    </BaseResultImage>
-                    <h1 class="x-title3" data-test="result-text">{{ identifierResult.name }}</h1>
-                  </article>
-                </template>
-              </IdentifierResults>
+                  <!-- Filters -->
+                  <ExcludeFiltersWithNoResults :filters="facet.filters">
+                    <SortedFilters>
+                      <SlicedFilters
+                        :max="controls.slicedFilters.max"
+                        :data-test="`${facet.label}-sliced-filters`"
+                      >
+                        <SelectedFilters #default="{ selectedFilters }" :facetId="facet.id">
+                          <span :data-test="`${facet.label}-selected-filters`">
+                            {{ selectedFilters.length }}
+                          </span>
+                        </SelectedFilters>
+                        <FiltersList v-slot="{ filter }">
+                          <SimpleFilter
+                            #label
+                            :filter="filter"
+                            :data-test="`${facet.label}-filter`"
+                          >
+                            <BasePriceFilterLabel
+                              v-if="facet.id === 'price'"
+                              :filter="filter"
+                              class="x-filter__label"
+                              format="ii.dd €"
+                              lessThan="Less than {max}"
+                              fromTo="From {min} to {max}"
+                              from="More than {min}"
+                            />
+                          </SimpleFilter>
+                        </FiltersList>
+                      </SlicedFilters>
+                    </SortedFilters>
+                  </ExcludeFiltersWithNoResults>
+                </BaseHeaderTogglePanel>
+              </template>
+            </Facets>
+          </div>
+        </template>
 
-              <!--  No Results Message  -->
-              <div v-if="$x.noResults" class="x-message x-margin--top-03 x-margin--bottom-03">
-                <p>
-                  There are no results for
-                  <span class="x-font-weight--bold">{{ $x.query.search }}</span>
-                </p>
-                <p>You may be interested in these:</p>
-              </div>
-
-              <!-- Results -->
-              <ResultsList v-infinite-scroll:main-scroll>
-                <BannersList>
-                  <PromotedsList>
-                    <NextQueriesList>
-                      <BaseVariableColumnGrid :animation="resultsAnimation">
-                        <template #result="{ item: result }">
-                          <MainScrollItem :item="result">
-                            <article class="result" style="max-width: 300px">
-                              <BaseResultLink :result="result">
-                                <BaseResultImage :result="result" class="x-picture--colored">
-                                  <template #placeholder>
-                                    <div
-                                      style="padding-top: 100%; background-color: lightgray"
-                                    ></div>
-                                  </template>
-                                  <template #fallback>
-                                    <div
-                                      data-test="result-picture-fallback"
-                                      style="padding-top: 100%; background-color: lightsalmon"
-                                    ></div>
-                                  </template>
-                                </BaseResultImage>
-                                <h1 class="x-title3" data-test="result-text">{{ result.name }}</h1>
-                              </BaseResultLink>
-                            </article>
-                          </MainScrollItem>
-                        </template>
-
-                        <template #banner="{ item: banner }">
-                          <Banner :banner="banner" />
-                        </template>
-
-                        <template #promoted="{ item: promoted }">
-                          <Promoted :promoted="promoted" />
-                        </template>
-
-                        <template #next-queries-group="{ item: { nextQueries } }">
-                          <div class="x-list x-list--gap-03">
-                            <h1 class="x-title2">What's next?</h1>
-                            <BaseSuggestions
-                              #default="{ suggestion }"
-                              :suggestions="nextQueries"
-                              class="x-list--gap-03"
-                            >
-                              <NextQuery
-                                #default="{ suggestion: nextQuery }"
-                                :suggestion="suggestion"
-                              >
-                                <Nq1 />
-                                {{ nextQuery.query }}
-                              </NextQuery>
-                            </BaseSuggestions>
-                          </div>
-                        </template>
-                      </BaseVariableColumnGrid>
-                    </NextQueriesList>
-                  </PromotedsList>
-                </BannersList>
-              </ResultsList>
-
-              <!-- Partials -->
-              <PartialResultsList :animation="resultsAnimation">
-                <template #default="{ partialResult }">
-                  <span data-test="partial-query">{{ partialResult.query }}</span>
-                  <BaseGrid
-                    :animation="resultsAnimation"
-                    :columns="4"
-                    :items="partialResult.results"
-                  >
-                    <template #result="{ item }">
-                      <article class="result" style="max-width: 300px">
-                        <BaseResultImage :result="item" class="x-picture--colored">
-                          <template #placeholder>
-                            <div style="padding-top: 100%; background-color: lightgray"></div>
-                          </template>
-                          <template #fallback>
-                            <div
-                              data-test="result-picture-fallback"
-                              style="padding-top: 100%; background-color: lightsalmon"
-                            ></div>
-                          </template>
-                        </BaseResultImage>
-                        <span class="x-result__title" data-test="partial-result-item">
-                          {{ item.name }}
-                        </span>
-                      </article>
-                    </template>
-                  </BaseGrid>
-                  <PartialQueryButton :query="partialResult.query">
-                    <template #default="{ query }">Ver todos {{ query }}</template>
-                  </PartialQueryButton>
-                </template>
-              </PartialResultsList>
-
-              <!-- Recommendations -->
-              <Recommendations
-                v-if="!$x.query.search || $x.noResults"
-                #layout="{ recommendations }"
+        <template #main-body>
+          <!--  Redirection  -->
+          <Redirection
+            #default="{ redirection, redirect, abortRedirect, isRedirecting, delayInSeconds }"
+            class="x-margin--top-03 x-margin--bottom-03"
+            delayInSeconds="5"
+          >
+            <p>
+              Your search matches a special place in our website, to visit it, your are being
+              redirected
+            </p>
+            <a @click="redirect" :href="redirection.url">{{ redirection.url }}</a>
+            <div class="x-list x-list--horizontal x-list--gap-07">
+              <button
+                @click="abortRedirect"
+                class="x-button x-button--ghost x-font-color--neutral-70"
               >
-                <BaseVariableColumnGrid
-                  #default="{ item: result }"
-                  :animation="resultsAnimation"
-                  :items="recommendations"
-                >
-                  <article class="result" style="max-width: 300px">
-                    <BaseResultImage :result="result" class="x-picture--colored">
-                      <template #placeholder>
-                        <div style="padding-top: 100%; background-color: lightgray"></div>
-                      </template>
-                      <template #fallback>
-                        <div
-                          data-test="result-picture-fallback"
-                          style="padding-top: 100%; background-color: lightsalmon"
-                        ></div>
-                      </template>
-                    </BaseResultImage>
-                    <h1 class="x-title3" data-test="recommendation-item">{{ result.name }}</h1>
-                  </article>
-                </BaseVariableColumnGrid>
-              </Recommendations>
-            </template>
-          </template>
+                No, I'll stay here
+              </button>
+              <button @click="redirect" class="x-button x-button--ghost x-font-color--neutral-10">
+                Yes, redirect me
+              </button>
+            </div>
+            <AutoProgressBar :isLoading="isRedirecting" :durationInSeconds="delayInSeconds" />
+          </Redirection>
 
-          <template #scroll-to-top>
-            <ScrollToTop :threshold-px="500" class="x-button--round" scroll-id="main-scroll">
-              <ChevronUp />
-            </ScrollToTop>
+          <template v-if="!$x.redirections.length">
+            <!-- IdentifierResults -->
+            <IdentifierResults class="x-list x-list--horizontal">
+              <template #default="{ identifierResult }">
+                <article class="result">
+                  <BaseResultImage :result="identifierResult" class="x-picture--colored">
+                    <template #placeholder>
+                      <div style="padding-top: 100%; background-color: lightgray"></div>
+                    </template>
+                    <template #fallback>
+                      <div style="padding-top: 100%; background-color: lightsalmon"></div>
+                    </template>
+                  </BaseResultImage>
+                  <h1 class="x-title3" data-test="result-text">{{ identifierResult.name }}</h1>
+                </article>
+              </template>
+            </IdentifierResults>
+
+            <!--  No Results Message  -->
+            <div v-if="$x.noResults" class="x-message x-margin--top-03 x-margin--bottom-03">
+              <p>
+                There are no results for
+                <span class="x-font-weight--bold">{{ $x.query.search }}</span>
+              </p>
+              <p>You may be interested in these:</p>
+            </div>
+
+            <!-- Results -->
+            <ResultsList v-infinite-scroll:main-scroll>
+              <BannersList>
+                <PromotedsList>
+                  <NextQueriesList>
+                    <BaseVariableColumnGrid :animation="resultsAnimation">
+                      <template #result="{ item: result }">
+                        <MainScrollItem :item="result">
+                          <article class="result" style="max-width: 300px">
+                            <BaseResultLink :result="result">
+                              <BaseResultImage :result="result" class="x-picture--colored">
+                                <template #placeholder>
+                                  <div style="padding-top: 100%; background-color: lightgray"></div>
+                                </template>
+                                <template #fallback>
+                                  <div
+                                    data-test="result-picture-fallback"
+                                    style="padding-top: 100%; background-color: lightsalmon"
+                                  ></div>
+                                </template>
+                              </BaseResultImage>
+                              <h1 class="x-title3" data-test="result-text">{{ result.name }}</h1>
+                            </BaseResultLink>
+                          </article>
+                        </MainScrollItem>
+                      </template>
+
+                      <template #banner="{ item: banner }">
+                        <Banner :banner="banner" />
+                      </template>
+
+                      <template #promoted="{ item: promoted }">
+                        <Promoted :promoted="promoted" />
+                      </template>
+
+                      <template #next-queries-group="{ item: { nextQueries } }">
+                        <div class="x-list x-list--gap-03">
+                          <h1 class="x-title2">What's next?</h1>
+                          <BaseSuggestions
+                            #default="{ suggestion }"
+                            :suggestions="nextQueries"
+                            class="x-list--gap-03"
+                          >
+                            <NextQuery
+                              #default="{ suggestion: nextQuery }"
+                              :suggestion="suggestion"
+                            >
+                              <Nq1 />
+                              {{ nextQuery.query }}
+                            </NextQuery>
+                          </BaseSuggestions>
+                        </div>
+                      </template>
+                    </BaseVariableColumnGrid>
+                  </NextQueriesList>
+                </PromotedsList>
+              </BannersList>
+            </ResultsList>
+
+            <!-- Partials -->
+            <PartialResultsList :animation="resultsAnimation">
+              <template #default="{ partialResult }">
+                <span data-test="partial-query">{{ partialResult.query }}</span>
+                <BaseGrid :animation="resultsAnimation" :columns="4" :items="partialResult.results">
+                  <template #result="{ item }">
+                    <article class="result" style="max-width: 300px">
+                      <BaseResultImage :result="item" class="x-picture--colored">
+                        <template #placeholder>
+                          <div style="padding-top: 100%; background-color: lightgray"></div>
+                        </template>
+                        <template #fallback>
+                          <div
+                            data-test="result-picture-fallback"
+                            style="padding-top: 100%; background-color: lightsalmon"
+                          ></div>
+                        </template>
+                      </BaseResultImage>
+                      <span class="x-result__title" data-test="partial-result-item">
+                        {{ item.name }}
+                      </span>
+                    </article>
+                  </template>
+                </BaseGrid>
+                <PartialQueryButton :query="partialResult.query">
+                  <template #default="{ query }">Ver todos {{ query }}</template>
+                </PartialQueryButton>
+              </template>
+            </PartialResultsList>
+
+            <!-- Recommendations -->
+            <Recommendations v-if="!$x.query.search || $x.noResults" #layout="{ recommendations }">
+              <BaseVariableColumnGrid
+                #default="{ item: result }"
+                :animation="resultsAnimation"
+                :items="recommendations"
+              >
+                <article class="result" style="max-width: 300px">
+                  <BaseResultImage :result="result" class="x-picture--colored">
+                    <template #placeholder>
+                      <div style="padding-top: 100%; background-color: lightgray"></div>
+                    </template>
+                    <template #fallback>
+                      <div
+                        data-test="result-picture-fallback"
+                        style="padding-top: 100%; background-color: lightsalmon"
+                      ></div>
+                    </template>
+                  </BaseResultImage>
+                  <h1 class="x-title3" data-test="recommendation-item">{{ result.name }}</h1>
+                </article>
+              </BaseVariableColumnGrid>
+            </Recommendations>
           </template>
-        </MultiColumnMaxWidthLayout>
-      </BaseEventsModal>
-    </BaseKeyboardNavigation>
+        </template>
+
+        <template #scroll-to-top>
+          <ScrollToTop :threshold-px="500" class="x-button--round" scroll-id="main-scroll">
+            <ChevronUp />
+          </ScrollToTop>
+        </template>
+      </MultiColumnMaxWidthLayout>
+    </BaseEventsModal>
   </div>
 </template>
 

--- a/packages/x-components/tests/e2e/cucumber/keyboard-navigation.feature
+++ b/packages/x-components/tests/e2e/cucumber/keyboard-navigation.feature
@@ -15,14 +15,16 @@ Feature: Keyboard navigation component
     And   "<focusableElement>" element position is stored
     And   "right" arrow is pressed 1 times
     Then  next element position is "on the right"
-    When  "down" arrow is pressed 2 times
-    Then  next element position is "below"
-    When  "left" arrow is pressed 3 times
+    When  "left" arrow is pressed 1 times
     Then  next element position is "on the left"
+    When  "down" arrow is pressed 1 times
+    Then  next element position is "below"
+    When  "left" arrow is pressed 1 times
+    Then  next element position is "on the left"
+    When  "right" arrow is pressed 3 times
+    Then  next element position is "on the right"
     When  "up" arrow is pressed 1 times
     Then  next element position is "above"
-    When  "right" arrow is pressed 1 times
-    Then  next element position is "on the right"
 
     Examples:
       | query | focusableElement |

--- a/packages/x-components/tests/e2e/cucumber/keyboard-navigation.feature
+++ b/packages/x-components/tests/e2e/cucumber/keyboard-navigation.feature
@@ -6,13 +6,12 @@ Feature: Keyboard navigation component
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   no special config for layout view
+    And   start button is clicked
+    And   "lego" is searched
 
   Scenario Outline: 1. Navigating with arrow keys
-    Given no special config for layout view
-    And   start button is clicked
-    When  "<query>" is searched
-    And   related results are displayed
-    And   "<focusableElement>" element position is stored
+    When  "<focusableElement>" element position is stored
     And   "right" arrow is pressed 1 times
     Then  next element position is "on the right"
     When  "left" arrow is pressed 1 times
@@ -27,20 +26,18 @@ Feature: Keyboard navigation component
     Then  next element position is "above"
 
     Examples:
-      | query | focusableElement |
-      | lego  | search-input     |
+      | focusableElement |
+      | search-input     |
 
   Scenario Outline: 2. Not navigating out of bounds
-    Given no special config for layout view
-    And   start button is clicked
-    When  "<query>" is searched
-    And   related results are displayed
-    And   "<focusableElement>" element position is stored
+    When  "<focusableElement>" element position is stored
     Then  top out of bounds is reached
+    When  "<focusableElement2>" element position is stored
+    Then  bottom out of bounds is reached
 
     Examples:
-      | query | focusableElement |
-      | lego  | search-input     |
+      | focusableElement | focusableElement2 |
+      | search-input     | next-query        |
 
 
 

--- a/packages/x-components/tests/e2e/cucumber/keyboard-navigation.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/keyboard-navigation.spec.ts
@@ -11,7 +11,9 @@ type Direction = 'above' | 'below' | 'on the left' | 'on the right';
 
 // Scenario 1
 And('{string} element position is stored', (focusableElement: string) => {
-  cy.getByDataTest(focusableElement).focus().as('originalElement');
+  return focusableElement === 'search-input'
+    ? cy.getByDataTest(focusableElement).focus().as('originalElement')
+    : cy.getByDataTest(focusableElement).last().focus().as('originalElement');
 });
 
 Then('next element position is "{direction}"', (expectedPosition: Direction) => {

--- a/packages/x-components/tests/e2e/cucumber/keyboard-navigation.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/keyboard-navigation.spec.ts
@@ -8,12 +8,11 @@ defineParameterType({
   }
 });
 type Direction = 'above' | 'below' | 'on the left' | 'on the right';
+type Move = 'up' | 'right' | 'bottom' | 'left';
 
 // Scenario 1
 And('{string} element position is stored', (focusableElement: string) => {
-  return focusableElement === 'search-input'
-    ? cy.getByDataTest(focusableElement).focus().as('originalElement')
-    : cy.getByDataTest(focusableElement).last().focus().as('originalElement');
+  return cy.getByDataTest(focusableElement).last().focus().as('originalElement');
 });
 
 Then('next element position is "{direction}"', (expectedPosition: Direction) => {
@@ -38,14 +37,11 @@ Then('next element position is "{direction}"', (expectedPosition: Direction) => 
   cy.focused().as('originalElement');
 });
 
-When(
-  '{string} arrow is pressed {int} times',
-  (direction: 'up' | 'right' | 'bottom' | 'right', pressedTimes: number) => {
-    for (let i = 0; i < pressedTimes; i++) {
-      cy.focused().type(`{${direction}arrow}`);
-    }
-  }
-);
+When('{string} arrow is pressed {int} times', (direction: Move, pressedTimes: number) => {
+  Array.from({ length: pressedTimes }).forEach(() => {
+    cy.focused().type(`{${direction}arrow}`);
+  });
+});
 
 // Scenario 2
 Then('top out of bounds is reached', () => {


### PR DESCRIPTION
## Motivation and context
Although the first idea was to include keyboard-navigation in all the layout including the grid, the approach changed to make it only work in the Empathize. For consistency, it has been added as well in part of the header (`SearchInput`, `ClearSearchInput `and `SearchButton`). It was not possible to added it to the RTs, though. However, that's not essential (although it is desirable) since it's not mandatory for RTs to be placed just below the `search-box`

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

As usual, change `cypress.json` file in order to run tests independently. 

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
