### PR TITLE
feature: Add SnippetCallbacks component.

### DIFF
--- a/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
+++ b/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
@@ -8,18 +8,12 @@ function renderSnippetCallbacks({
   callbacks = {}
 }: RenderSnippetCallbacksOptions = {}): RenderSnippetCallbacksAPI {
   const [, localVue] = installNewXPlugin();
-  const wrapper = mount(
-    {
-      components: { SnippetCallbacks },
-      template: '<SnippetCallbacks />'
+  const wrapper = mount(SnippetCallbacks, {
+    provide: {
+      snippetConfig: localVue.observable({ ...baseSnippetConfig, callbacks })
     },
-    {
-      provide: {
-        snippetConfig: localVue.observable({ ...baseSnippetConfig, callbacks })
-      },
-      localVue
-    }
-  );
+    localVue
+  });
 
   return {
     wrapper
@@ -81,8 +75,8 @@ describe('testing SnippetCallbacks component', () => {
  * Options to configure how the snippet callbacks component should be rendered.
  */
 interface RenderSnippetCallbacksOptions {
-  /** The snippet config value. */
-  callbacks?: Partial<XEventListeners>;
+  /** The callbacks value to be provided. */
+  callbacks?: XEventListeners;
 }
 
 /**

--- a/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
+++ b/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
@@ -1,0 +1,94 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import { installNewXPlugin } from '../../__tests__/utils';
+import { baseSnippetConfig } from '../../views/base-config';
+import { XEventListeners } from '../../x-installer/api/api.types';
+import SnippetCallbacks from '../snippet-callbacks.vue';
+
+function renderSnippetCallbacks({
+  callbacks = {}
+}: RenderSnippetCallbacksOptions = {}): RenderSnippetCallbacksAPI {
+  const [, localVue] = installNewXPlugin();
+  const wrapper = mount(
+    {
+      components: { SnippetCallbacks },
+      template: '<SnippetCallbacks />'
+    },
+    {
+      provide: {
+        snippetConfig: localVue.observable({ ...baseSnippetConfig, callbacks })
+      },
+      localVue
+    }
+  );
+
+  return {
+    wrapper
+  };
+}
+
+describe('testing SnippetCallbacks component', () => {
+  it('executes a callback injected from the snippetConfig', () => {
+    const acceptedAQueryCallback = jest.fn(payload => payload);
+    const clickedColumnPickerCallback = jest.fn(payload => payload);
+    const { wrapper } = renderSnippetCallbacks({
+      callbacks: {
+        UserAcceptedAQuery: acceptedAQueryCallback,
+        UserClickedColumnPicker: clickedColumnPickerCallback
+      }
+    });
+
+    wrapper.vm.$x.emit('UserAcceptedAQuery', 'lego');
+
+    expect(acceptedAQueryCallback).toHaveBeenCalledTimes(1);
+    expect(acceptedAQueryCallback).toHaveBeenCalledWith('lego', {
+      location: undefined,
+      moduleName: null
+    });
+
+    expect(clickedColumnPickerCallback).not.toHaveBeenCalled();
+  });
+
+  it('emits a SnippetCallbackExecuted event when a callback is executed', () => {
+    const acceptedAQueryCallback = jest.fn(payload => payload);
+    const clickedColumnPickerCallback = jest.fn(payload => payload);
+    const { wrapper } = renderSnippetCallbacks({
+      callbacks: {
+        UserAcceptedAQuery: acceptedAQueryCallback,
+        UserClickedColumnPicker: clickedColumnPickerCallback
+      }
+    });
+
+    const eventSpy = jest.fn();
+    wrapper.vm.$x.on('SnippetCallbackExecuted').subscribe(eventSpy);
+
+    wrapper.vm.$x.emit('UserAcceptedAQuery', 'playmobil');
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+    expect(eventSpy).toHaveBeenCalledWith({
+      event: 'UserAcceptedAQuery',
+      callbackReturn: 'playmobil'
+    });
+
+    wrapper.vm.$x.emit('UserClickedColumnPicker', 3);
+    expect(eventSpy).toHaveBeenCalledTimes(2);
+    expect(eventSpy).toHaveBeenCalledWith({
+      event: 'UserClickedColumnPicker',
+      callbackReturn: 3
+    });
+  });
+});
+
+/**
+ * Options to configure how the snippet callbacks component should be rendered.
+ */
+interface RenderSnippetCallbacksOptions {
+  /** The snippet config value. */
+  callbacks?: Partial<XEventListeners>;
+}
+
+/**
+ * Tools to test how the snippet callbacks component behaves.
+ */
+interface RenderSnippetCallbacksAPI {
+  /** The wrapper of the container element. */
+  wrapper: Wrapper<Vue>;
+}

--- a/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
+++ b/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
@@ -40,6 +40,16 @@ describe('testing SnippetCallbacks component', () => {
     });
 
     expect(clickedColumnPickerCallback).not.toHaveBeenCalled();
+
+    wrapper.vm.$x.emit('UserClickedColumnPicker', 1);
+
+    expect(acceptedAQueryCallback).toHaveBeenCalledTimes(1);
+
+    expect(clickedColumnPickerCallback).toHaveBeenCalledTimes(1);
+    expect(clickedColumnPickerCallback).toHaveBeenCalledWith(1, {
+      location: undefined,
+      moduleName: null
+    });
   });
 
   it('emits a SnippetCallbackExecuted event when a callback is executed', () => {

--- a/packages/x-components/src/components/global-x-bus.vue
+++ b/packages/x-components/src/components/global-x-bus.vue
@@ -2,15 +2,8 @@
   import { Component } from 'vue-property-decorator';
   import { Subscription } from 'rxjs';
   import { reduce } from '../utils/object';
-  import { WireMetadata, XEvent, XEventPayload } from '../wiring';
+  import { XEventListeners } from '../x-installer/api/api.types';
   import { NoElement } from './no-element';
-
-  /**
-   * Map type of every {@link XEvent} and a callback with the payload and metadata for that event.
-   */
-  type XEventListeners = {
-    [Event in XEvent]: (payload: XEventPayload<Event>, metadata: WireMetadata) => void;
-  };
 
   /**
    * This component helps subscribing to any {@link XEvent} with custom callbacks using Vue

--- a/packages/x-components/src/components/index.ts
+++ b/packages/x-components/src/components/index.ts
@@ -25,6 +25,7 @@ export { default as MultiColumnMaxWidthLayout } from './layouts/multi-column-max
 export { default as SingleColumnLayout } from './layouts/single-column-layout.vue';
 export { default as LocationProvider } from './location-provider.vue';
 export { default as GlobalXBus } from './global-x-bus.vue';
+export { default as SnippetCallbacks } from './snippet-callbacks.vue';
 
 // Utils
 export * from './decorators/bus.decorators';

--- a/packages/x-components/src/components/snippet-callbacks.vue
+++ b/packages/x-components/src/components/snippet-callbacks.vue
@@ -1,7 +1,5 @@
 <template>
-  <NoElement>
-    <GlobalXBus v-on="eventListeners" />
-  </NoElement>
+  <GlobalXBus v-on="eventListeners" />
 </template>
 
 <script lang="ts">
@@ -11,7 +9,6 @@
   import { WireMetadata } from '../wiring';
   import { SnippetConfig, XEventListeners } from '../x-installer/api/api.types';
   import GlobalXBus from './global-x-bus.vue';
-  import { NoElement } from './no-element';
 
   /**
    * This component subscribes to any {@link XEvent} with a custom callbacks provided by the snippet
@@ -20,7 +17,7 @@
    * @public
    */
   @Component({
-    components: { NoElement, GlobalXBus }
+    components: { GlobalXBus }
   })
   export default class SnippetCallbacks extends Vue {
     /**

--- a/packages/x-components/src/components/snippet-callbacks.vue
+++ b/packages/x-components/src/components/snippet-callbacks.vue
@@ -13,6 +13,12 @@
   import GlobalXBus from './global-x-bus.vue';
   import { NoElement } from './no-element';
 
+  /**
+   * This component subscribes to any {@link XEvent} with a custom callbacks provided by the snippet
+   * configuration.
+   *
+   * @public
+   */
   @Component({
     components: { NoElement, GlobalXBus }
   })

--- a/packages/x-components/src/components/snippet-callbacks.vue
+++ b/packages/x-components/src/components/snippet-callbacks.vue
@@ -9,8 +9,7 @@
   import Vue from 'vue';
   import { map } from '../utils/object';
   import { WireMetadata } from '../wiring';
-  import { SnippetConfig } from '../x-installer';
-  import { XEventListeners } from '../x-installer/api/api.types';
+  import { SnippetConfig, XEventListeners } from '../x-installer/api/api.types';
   import GlobalXBus from './global-x-bus.vue';
   import { NoElement } from './no-element';
 
@@ -31,6 +30,8 @@
      *
      * @returns The event listeners with the {@link XEventsTypes.SnippetCallbackExecuted} emit in
      * the callback.
+     *
+     * @internal
      *
      */
     protected get eventListeners(): XEventListeners {

--- a/packages/x-components/src/components/snippet-callbacks.vue
+++ b/packages/x-components/src/components/snippet-callbacks.vue
@@ -1,0 +1,79 @@
+<template>
+  <NoElement>
+    <GlobalXBus v-on="eventListeners" />
+  </NoElement>
+</template>
+
+<script lang="ts">
+  import { Component, Inject } from 'vue-property-decorator';
+  import Vue from 'vue';
+  import { map } from '../utils/object';
+  import { WireMetadata } from '../wiring';
+  import { SnippetConfig } from '../x-installer';
+  import { XEventListeners } from '../x-installer/api/api.types';
+  import GlobalXBus from './global-x-bus.vue';
+  import { NoElement } from './no-element';
+
+  @Component({
+    components: { NoElement, GlobalXBus }
+  })
+  export default class SnippetCallbacks extends Vue {
+    /**
+     * Injects {@link SnippetConfig} provided by an ancestor as snippetConfig.
+     *
+     * @internal
+     */
+    @Inject('snippetConfig')
+    public snippetConfig!: SnippetConfig;
+
+    /**
+     * It maps all the callbacks provided by the {@link snippetConfig} and adds an emit to each one.
+     *
+     * @returns The event listeners with the {@link XEventsTypes.SnippetCallbackExecuted} emit in
+     * the callback.
+     *
+     */
+    protected get eventListeners(): XEventListeners {
+      const { callbacks } = this.snippetConfig;
+      return callbacks
+        ? map(callbacks, (eventName, callback) => {
+            return (payload: unknown, metadata: WireMetadata) => {
+              const callbackReturn = callback(payload as never, metadata);
+              this.$x.emit('SnippetCallbackExecuted', {
+                event: eventName,
+                callbackReturn
+              });
+            };
+          })
+        : ({} as XEventListeners);
+    }
+  }
+</script>
+
+<docs lang="mdx">
+## Events
+
+The `SnippetCallbacks` will emit the `SnippetCallbackExecuted` each time a callback provided by the
+snippetConfig is fired.
+
+## See it in action
+
+This component does not render anything. Its only responsibility is to receive any callback that
+will be triggered once its listened event is emitted.
+
+```vue
+<template>
+  <SnippetCallbacks />
+</template>
+
+<script>
+  import { SnippetCallbacks } from '@empathyco/x-components';
+  export default {
+    name: 'SnippetCallbacksTest',
+    components: {
+      SnippetCallbacks
+    }
+  };
+</script>
+```
+</docs>

--- a/packages/x-components/src/components/snippet-callbacks.vue
+++ b/packages/x-components/src/components/snippet-callbacks.vue
@@ -32,7 +32,7 @@
     public snippetConfig!: SnippetConfig;
 
     /**
-     * It maps all the callbacks provided by the {@link snippetConfig} and adds an emit to each one.
+     * It maps all the callbacks provided by the snippetConfig and adds an emit to each one.
      *
      * @returns The event listeners with the {@link XEventsTypes.SnippetCallbackExecuted} emit in
      * the callback.

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -49,6 +49,8 @@ export interface XAPI {
 
 /**
  * Map type of every {@link XEvent} and a callback with the payload and metadata for that event.
+ *
+ * @public
  */
 export type XEventListeners = {
   [Event in XEvent]: (payload: XEventPayload<Event>, metadata: WireMetadata) => void;

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -1,5 +1,7 @@
 import { XBus } from '../../plugins/x-bus.types';
 import { DocumentDirection } from '../../plugins/x-plugin.types';
+import { XEvent, XEventPayload } from '../../wiring/events.types';
+import { WireMetadata } from '../../wiring/wiring.types';
 
 /**
  * Interface with the API functions exposes as X
@@ -46,6 +48,13 @@ export interface XAPI {
 }
 
 /**
+ * Map type of every {@link XEvent} and a callback with the payload and metadata for that event.
+ */
+export type XEventListeners = {
+  [Event in XEvent]: (payload: XEventPayload<Event>, metadata: WireMetadata) => void;
+};
+
+/**
  * Interface with the possible parameters to receive through the snippet integration.
  *
  * @public
@@ -67,6 +76,8 @@ export interface SnippetConfig {
   documentDirection?: DocumentDirection;
   /** The currency name. There should be a currency format associated to this name in the app. */
   currency?: string;
+  /** Callbacks to be triggered when an XEvent is emitted. */
+  callbacks?: XEventListeners;
   /** Any extra param to send in all backend calls. */
   [extra: string]: any;
 }

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -52,9 +52,11 @@ export interface XAPI {
  *
  * @public
  */
-export type XEventListeners = {
-  [Event in XEvent]: (payload: XEventPayload<Event>, metadata: WireMetadata) => void;
-};
+export type XEventListeners = Partial<
+  {
+    [Event in XEvent]: (payload: XEventPayload<Event>, metadata: WireMetadata) => void;
+  }
+>;
 
 /**
  * Interface with the possible parameters to receive through the snippet integration.


### PR DESCRIPTION
A new componen has been created called `SnippetCallbacks`, when importing this component and used in a view, it will get all the listeners from the `callbacks` property of the `snippetConfig` and will map them to add the `SnippetCallbackExecuted` emit.

## Motivation and context

This is part of the development that will allow the user to load its own callbacks that will listen to any desired `XEvents` using the `snippetConfig`.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## What is the destination branch of this PR?

- [x] `Main`

## How has this been tested?

You can try it by yourself in two simple steps:

1. Add a `callbacks` property in the `snippetConfig` with something like:
```
      callbacks: {
        UserAcceptedAQuery: (query) => query,
      }
```
2. Add the component in the view and put a listener in the `SnippetCallbackExecuted` event:
`    <SnippetCallbacks />
`
```
    @XOn('SnippetCallbackExecuted')
    printThings(payload: any): void {
      console.log('event emited with payload:', payload);
    }
```

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
