### PR TITLE
feat(utils): now `origin` only requires the `feature`

### DIFF
--- a/packages/x-components/src/types/origin.ts
+++ b/packages/x-components/src/types/origin.ts
@@ -58,6 +58,7 @@ export type FeatureLocation =
   | 'external'
   | 'no_query'
   | 'no_results'
+  | 'none'
   | 'predictive_layer'
   | 'results'
   | 'pdp'

--- a/packages/x-components/src/utils/__tests__/origin.spec.ts
+++ b/packages/x-components/src/utils/__tests__/origin.spec.ts
@@ -1,16 +1,10 @@
 import { createOrigin } from '../origin';
 
 describe(`testing ${createOrigin.name} utility method`, () => {
-  it('returns null when the feature or the location is undefined', () => {
+  it('returns null when the feature is undefined', () => {
     expect(
       createOrigin({
         feature: undefined,
-        location: undefined
-      })
-    ).toBeNull();
-    expect(
-      createOrigin({
-        feature: 'history_query',
         location: undefined
       })
     ).toBeNull();
@@ -22,12 +16,21 @@ describe(`testing ${createOrigin.name} utility method`, () => {
     ).toBeNull();
   });
 
-  it('returns `feature:location` when the feature and the location are provided', () => {
+  it('returns `feature:location` when the feature is provided', () => {
     expect(
       createOrigin({
         feature: 'url',
         location: 'results'
       })
     ).toEqual('url:results');
+  });
+
+  it('returns `feature:none` when the feature is provided but the location is not', () => {
+    expect(
+      createOrigin({
+        feature: 'url',
+        location: undefined
+      })
+    ).toEqual('url:none');
   });
 });

--- a/packages/x-components/src/utils/__tests__/origin.spec.ts
+++ b/packages/x-components/src/utils/__tests__/origin.spec.ts
@@ -16,7 +16,7 @@ describe(`testing ${createOrigin.name} utility method`, () => {
     ).toBeNull();
   });
 
-  it('returns `feature:location` when the feature is provided', () => {
+  it('returns `feature:location` when the feature and the location are provided', () => {
     expect(
       createOrigin({
         feature: 'url',

--- a/packages/x-components/src/utils/origin.ts
+++ b/packages/x-components/src/utils/origin.ts
@@ -3,19 +3,21 @@ import { QueryOrigin, QueryOriginInit, ResultOrigin } from '../types/origin';
 /**
  * Creates a {@link QueryOrigin} or a {@link ResultOrigin} string given a {@link QueryFeature} and
  * a {@link FeatureLocation}.
- * If it can't be created, it returns `undefined`.
+ * If it can't be created, it returns `null`.
  *
  * @param originInit - An object containing the needed properties to create a {@link QueryOrigin} or
  * a {@link ResultOrigin}.
+ *
  * @returns The composed origin, or `null` if it is not able to create the origin.
+ *
  * @internal
  */
 export function createOrigin({
   feature,
   location
 }: QueryOriginInit): QueryOrigin | ResultOrigin | null {
-  if (location && feature) {
-    return `${feature}:${location}`;
+  if (feature) {
+    return `${feature}:${location ?? 'none'}`;
   }
   return null;
 }

--- a/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
@@ -159,9 +159,6 @@ describe('testing identifier results module actions', () => {
       await store.dispatch('saveOrigin', { location: 'predictive_layer' });
       expect(store.state.origin).toBeNull();
 
-      await store.dispatch('saveOrigin', { feature: 'search_box' });
-      expect(store.state.origin).toBeNull();
-
       await store.dispatch('saveOrigin', {});
       expect(store.state.origin).toBeNull();
     });

--- a/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
@@ -149,8 +149,10 @@ describe('testing identifier results module actions', () => {
       resetIdentifierResultsStateWith(store);
 
       await store.dispatch('saveOrigin', { feature: 'search_box', location: 'predictive_layer' });
-
       expect(store.state.origin).toEqual('search_box:predictive_layer');
+
+      await store.dispatch('saveOrigin', { feature: 'search_box' });
+      expect(store.state.origin).toEqual('search_box:none');
     });
 
     it('saves `null` if it is impossible to create an origin', async () => {

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -327,8 +327,10 @@ describe('testing search module actions', () => {
       resetSearchStateWith(store);
 
       await store.dispatch('saveOrigin', { feature: 'search_box', location: 'predictive_layer' });
-
       expect(store.state.origin).toEqual('search_box:predictive_layer');
+
+      await store.dispatch('saveOrigin', { feature: 'search_box' });
+      expect(store.state.origin).toEqual('search_box:none');
     });
 
     it('saves `null` if it is impossible to create an origin', async () => {

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -337,9 +337,6 @@ describe('testing search module actions', () => {
       await store.dispatch('saveOrigin', { location: 'predictive_layer' });
       expect(store.state.origin).toBeNull();
 
-      await store.dispatch('saveOrigin', { feature: 'search_box' });
-      expect(store.state.origin).toBeNull();
-
       await store.dispatch('saveOrigin', {});
       expect(store.state.origin).toBeNull();
     });


### PR DESCRIPTION
This PR removes the `location` to be not required. Only the feature will be required.

EX-5077