### PR TITLE
feat(search): change `saveOriginWire` to be used when a user interaction event is emitted

### DIFF
--- a/packages/x-components/src/x-modules/search/wiring.ts
+++ b/packages/x-components/src/x-modules/search/wiring.ts
@@ -184,6 +184,7 @@ export const searchWiring = createWiring({
     setSort
   },
   UserPickedARelatedTag: {
+    saveOriginWire,
     resetPage
   },
   UserChangedExtraParams: {
@@ -198,8 +199,7 @@ export const searchWiring = createWiring({
     fetchAndSaveSearchResponseWire
   },
   SelectedRelatedTagsChanged: {
-    setRelatedTags,
-    saveOriginWire
+    setRelatedTags
   },
   SelectedFiltersChanged: {
     setSelectedFilters


### PR DESCRIPTION
This Pr changes wiring in the modules that are setting the saveOrigin using an emitter, for those cases, we have to use a user action, for this change will be: `UserPickedARelatedTag`

EX-5078