### PR TITLE
feat: move `origin` from `request.getter` to `fetchAndSave.action`

### DIFF
--- a/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
@@ -30,6 +30,7 @@ describe('testing identifier results module actions', () => {
 
   beforeEach(() => {
     resetIdentifierResultsStateWith(store);
+    jest.clearAllMocks();
   });
 
   describe('fetchIdentifierResults', () => {
@@ -53,9 +54,10 @@ describe('testing identifier results module actions', () => {
   });
 
   describe('fetchAndSaveIdentifierResults', () => {
+    const spiedSearchById = jest.spyOn(adapter, 'searchById');
+
     it('should include the origin in the request', async () => {
       resetIdentifierResultsStateWith(store, { query: 'xc', origin: 'search_box:external' });
-      const spiedSearchById = jest.spyOn(adapter, 'searchById');
       await store.dispatch('fetchAndSaveIdentifierResults', store.getters.identifierResultsRequest);
 
       expect(spiedSearchById).toHaveBeenCalledTimes(1);
@@ -63,7 +65,6 @@ describe('testing identifier results module actions', () => {
         ...store.getters.identifierResultsRequest,
         origin: 'search_box:external'
       });
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 

--- a/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
@@ -54,18 +54,15 @@ describe('testing identifier results module actions', () => {
   });
 
   describe('fetchAndSaveIdentifierResults', () => {
-    const spiedSearchById = jest.spyOn(adapter, 'searchById');
-
     it('should include the origin in the request', async () => {
       resetIdentifierResultsStateWith(store, { query: 'xc', origin: 'search_box:external' });
       await store.dispatch('fetchAndSaveIdentifierResults', store.getters.identifierResultsRequest);
 
-      expect(spiedSearchById).toHaveBeenCalledTimes(1);
-      expect(spiedSearchById).toHaveBeenCalledWith({
+      expect(adapter.searchById).toHaveBeenCalledTimes(1);
+      expect(adapter.searchById).toHaveBeenCalledWith({
         ...store.getters.identifierResultsRequest,
         origin: 'search_box:external'
       });
-      jest.restoreAllMocks();
     });
 
     it('should request and store identifier results in the state', async () => {

--- a/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/__tests__/actions.spec.ts
@@ -53,6 +53,20 @@ describe('testing identifier results module actions', () => {
   });
 
   describe('fetchAndSaveIdentifierResults', () => {
+    it('should include the origin in the request', async () => {
+      resetIdentifierResultsStateWith(store, { query: 'xc', origin: 'search_box:external' });
+      const spiedSearchById = jest.spyOn(adapter, 'searchById');
+      await store.dispatch('fetchAndSaveIdentifierResults', store.getters.identifierResultsRequest);
+
+      expect(spiedSearchById).toHaveBeenCalledTimes(1);
+      expect(spiedSearchById).toHaveBeenCalledWith({
+        ...store.getters.identifierResultsRequest,
+        origin: 'search_box:external'
+      });
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+    });
+
     it('should request and store identifier results in the state', async () => {
       resetIdentifierResultsStateWith(store, { query: 'xc' });
 

--- a/packages/x-components/src/x-modules/identifier-results/store/__tests__/getters.spec.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/__tests__/getters.spec.ts
@@ -18,15 +18,13 @@ describe('testing identifier results module getters', () => {
     it('should return a request object if there is a query', () => {
       resetIdentifierResultsStateWith(store, {
         query: 'shin chan',
-        params: { store: 'es' },
-        origin: 'search_box:external'
+        params: { store: 'es' }
       });
 
       expect(store.getters[gettersKeys.identifierResultsRequest]).toEqual({
         query: 'shin chan',
         rows: 10,
         start: 0,
-        origin: 'search_box:external',
         store: 'es'
       });
     });

--- a/packages/x-components/src/x-modules/identifier-results/store/actions/fetch-and-save-identifier-results.action.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/actions/fetch-and-save-identifier-results.action.ts
@@ -1,7 +1,5 @@
 import { Result } from '@empathyco/x-types';
 import { SearchByIdRequest } from '@empathyco/x-adapter';
-
-// eslint-disable-next-line max-len
 import { createFetchAndSaveActions } from '../../../../store/utils/fetch-and-save-action.utils';
 import { IdentifierResultsActionsContext } from '../types';
 
@@ -10,8 +8,12 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   SearchByIdRequest | null,
   Result[]
 >({
-  fetch({ dispatch }, request) {
-    return dispatch('fetchIdentifierResults', request);
+  fetch({ dispatch, state }, request) {
+    return dispatch('fetchIdentifierResults', {
+      ...request!,
+      // eslint-disable-next-line @typescript-eslint/no-extra-parens
+      ...(state.origin && { origin: state.origin })
+    });
   },
   onSuccess({ commit }, identifierResults) {
     commit('setIdentifierResults', identifierResults);

--- a/packages/x-components/src/x-modules/identifier-results/store/actions/fetch-and-save-identifier-results.action.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/actions/fetch-and-save-identifier-results.action.ts
@@ -9,11 +9,14 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   Result[]
 >({
   fetch({ dispatch, state }, request) {
-    return dispatch('fetchIdentifierResults', {
-      ...request!,
-      // eslint-disable-next-line @typescript-eslint/no-extra-parens
-      ...(state.origin && { origin: state.origin })
-    });
+    const newRequest = request
+      ? {
+          ...request,
+          // eslint-disable-next-line @typescript-eslint/no-extra-parens
+          ...(state.origin && { origin: state.origin })
+        }
+      : null;
+    return dispatch('fetchIdentifierResults', newRequest);
   },
   onSuccess({ commit }, identifierResults) {
     commit('setIdentifierResults', identifierResults);

--- a/packages/x-components/src/x-modules/identifier-results/store/actions/fetch-and-save-identifier-results.action.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/actions/fetch-and-save-identifier-results.action.ts
@@ -8,15 +8,12 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   SearchByIdRequest | null,
   Result[]
 >({
-  fetch({ dispatch, state }, request) {
-    const newRequest = request
-      ? {
-          ...request,
-          // eslint-disable-next-line @typescript-eslint/no-extra-parens
-          ...(state.origin && { origin: state.origin })
-        }
-      : null;
-    return dispatch('fetchIdentifierResults', newRequest);
+  fetch({ dispatch, state: { origin } }, request) {
+    if (request && origin) {
+      request.origin = origin;
+    }
+
+    return dispatch('fetchIdentifierResults', request);
   },
   onSuccess({ commit }, identifierResults) {
     commit('setIdentifierResults', identifierResults);

--- a/packages/x-components/src/x-modules/identifier-results/store/getters/identifier-results-request.getter.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/getters/identifier-results-request.getter.ts
@@ -10,15 +10,13 @@ import { IdentifierResultsXStoreModule } from '../types';
  */
 // eslint-disable-next-line max-len
 export const identifierResultsRequest: IdentifierResultsXStoreModule['getters']['identifierResultsRequest'] =
-  ({ config, origin, query, params }) => {
-    const newOrigin = origin === null ? undefined : origin;
+  ({ config, query, params }) => {
     return query.trim()
       ? {
           query,
           ...params,
           rows: config.maxItemsToRequest,
-          start: 0,
-          origin: newOrigin
+          start: 0
         }
       : null;
   };

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -56,6 +56,20 @@ describe('testing search module actions', () => {
   });
 
   describe('fetchAndSaveSearchResponse', () => {
+    it('should include the origin in the request', async () => {
+      resetSearchStateWith(store, { query: 'lego', origin: 'search_box:external' });
+      const spiedSearch = jest.spyOn(adapter, 'search');
+      await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
+
+      expect(spiedSearch).toHaveBeenCalledTimes(1);
+      expect(spiedSearch).toHaveBeenCalledWith({
+        ...store.getters.request,
+        origin: 'search_box:external'
+      });
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+    });
+
     // eslint-disable-next-line max-len
     it('should request and store results, facets, banners, promoteds, redirections and query tagging in the state', async () => {
       resetSearchStateWith(store, {

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -37,6 +37,7 @@ describe('testing search module actions', () => {
 
   beforeEach(() => {
     resetSearchStateWith(store);
+    jest.clearAllMocks();
   });
 
   describe('fetchSearchResponse', () => {
@@ -56,9 +57,10 @@ describe('testing search module actions', () => {
   });
 
   describe('fetchAndSaveSearchResponse', () => {
+    const spiedSearch = jest.spyOn(adapter, 'search');
+
     it('should include the origin in the request', async () => {
       resetSearchStateWith(store, { query: 'lego', origin: 'search_box:external' });
-      const spiedSearch = jest.spyOn(adapter, 'search');
       await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
 
       expect(spiedSearch).toHaveBeenCalledTimes(1);
@@ -66,7 +68,6 @@ describe('testing search module actions', () => {
         ...store.getters.request,
         origin: 'search_box:external'
       });
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 
@@ -158,8 +159,7 @@ describe('testing search module actions', () => {
       resetSearchStateWith(store, {
         spellcheckedQuery: 'coche'
       });
-      const actionPromise = store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
-      await actionPromise;
+      await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
       expect(store.state.spellcheckedQuery).toBe('');
     });
 

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -57,18 +57,15 @@ describe('testing search module actions', () => {
   });
 
   describe('fetchAndSaveSearchResponse', () => {
-    const spiedSearch = jest.spyOn(adapter, 'search');
-
     it('should include the origin in the request', async () => {
       resetSearchStateWith(store, { query: 'lego', origin: 'search_box:external' });
       await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
 
-      expect(spiedSearch).toHaveBeenCalledTimes(1);
-      expect(spiedSearch).toHaveBeenCalledWith({
+      expect(adapter.search).toHaveBeenCalledTimes(1);
+      expect(adapter.search).toHaveBeenCalledWith({
         ...store.getters.request,
         origin: 'search_box:external'
       });
-      jest.restoreAllMocks();
     });
 
     // eslint-disable-next-line max-len

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -7,8 +7,12 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   SearchRequest | null,
   SearchResponse
 >({
-  fetch({ dispatch }, request) {
-    return dispatch('fetchSearchResponse', request);
+  fetch({ dispatch, state }, request) {
+    return dispatch('fetchSearchResponse', {
+      ...request!,
+      // eslint-disable-next-line @typescript-eslint/no-extra-parens
+      ...(state.origin && { origin: state.origin })
+    });
   },
   onSuccess(
     { commit, state },

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -8,11 +8,14 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   SearchResponse
 >({
   fetch({ dispatch, state }, request) {
-    return dispatch('fetchSearchResponse', {
-      ...request!,
-      // eslint-disable-next-line @typescript-eslint/no-extra-parens
-      ...(state.origin && { origin: state.origin })
-    });
+    const newRequest = request
+      ? {
+          ...request,
+          // eslint-disable-next-line @typescript-eslint/no-extra-parens
+          ...(state.origin && { origin: state.origin })
+        }
+      : null;
+    return dispatch('fetchSearchResponse', newRequest);
   },
   onSuccess(
     { commit, state },

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -7,15 +7,12 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   SearchRequest | null,
   SearchResponse
 >({
-  fetch({ dispatch, state }, request) {
-    const newRequest = request
-      ? {
-          ...request,
-          // eslint-disable-next-line @typescript-eslint/no-extra-parens
-          ...(state.origin && { origin: state.origin })
-        }
-      : null;
-    return dispatch('fetchSearchResponse', newRequest);
+  fetch({ dispatch, state: { origin } }, request) {
+    if (request && origin) {
+      request.origin = origin;
+    }
+
+    return dispatch('fetchSearchResponse', request);
   },
   onSuccess(
     { commit, state },

--- a/packages/x-components/src/x-modules/search/store/getters/request.getter.ts
+++ b/packages/x-components/src/x-modules/search/store/getters/request.getter.ts
@@ -17,10 +17,8 @@ export const request: SearchXStoreModule['getters']['request'] = ({
   selectedFilters,
   sort,
   page,
-  origin,
   isAppendResults
 }) => {
-  const newOrigin = origin === null ? undefined : origin;
   return query.trim()
     ? {
         query,
@@ -28,7 +26,6 @@ export const request: SearchXStoreModule['getters']['request'] = ({
         sort,
         rows: isAppendResults ? config.pageSize : config.pageSize * page,
         start: isAppendResults ? config.pageSize * (page - 1) : 0,
-        origin: newOrigin,
         filters: selectedFilters,
         ...params
       }


### PR DESCRIPTION
EX-5079

❗ ❗ Should we flag this as a `BREAKING-CHANGE` too? ❗ ❗

## Motivation and context
Move the `origin` from `request.getter` to `fetchAndSave.action` in both `search` and `identifierResults` modules, as changing the origin should not trigger a new search request. Only certain user interactions should trigger new search requests.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## How has this been tested?

Added new unit tests in both actions to check the origin is received properly.

## Checklist:

- [X] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [X] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [X] New and existing **unit tests pass locally** with my changes.
