### PR TITLE
docs: change h1 to be h2

### DIFF
--- a/packages/x-components/src/components/animations/animate-width.vue
+++ b/packages/x-components/src/components/animations/animate-width.vue
@@ -34,7 +34,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The AnimateWidth component is intended to be used as a prop in animatable components but also works
 as a transition to animate the width of an element.

--- a/packages/x-components/src/components/animations/collapse-from-top.vue
+++ b/packages/x-components/src/components/animations/collapse-from-top.vue
@@ -77,7 +77,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The CollapseTop component is intended to be used as animation to wrap an element with v-if or v-show
 and animate it. The animation consists on scale its vertical size from 0 to 1, and after this show

--- a/packages/x-components/src/components/animations/collapse-height.vue
+++ b/packages/x-components/src/components/animations/collapse-height.vue
@@ -40,7 +40,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The CollapseHeight component is intended to be used as animation to wrap an element with v-if or
 v-show and animate it. The animation consists on scale its height size from 0 to auto. This

--- a/packages/x-components/src/components/animations/collapse-width.vue
+++ b/packages/x-components/src/components/animations/collapse-width.vue
@@ -40,7 +40,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The CollapseWidth component is intended to be used as animation to wrap an element with v-if or
 v-show and animate it. The animation consists on scale its width size from 0 to auto. This

--- a/packages/x-components/src/components/animations/cross-fade.vue
+++ b/packages/x-components/src/components/animations/cross-fade.vue
@@ -38,7 +38,7 @@
 </style>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The `CrossFade` component is intended to be used as animation to wrap an element with v-if or v-show
 and animate it. The animation fades the new element into the previous one.

--- a/packages/x-components/src/components/animations/fade-and-slide.vue
+++ b/packages/x-components/src/components/animations/fade-and-slide.vue
@@ -58,7 +58,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The FadeAndSlide component is intended to be used as a prop in animatable components but also works
 as a wrapper of a transition group that can receive the tag it will render to as a prop.

--- a/packages/x-components/src/components/animations/translate-from-left.vue
+++ b/packages/x-components/src/components/animations/translate-from-left.vue
@@ -34,7 +34,7 @@
 </style>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The `TranslateFromRight` component is intended to be used as animation to wrap an element with v-if
 or v-show and animate it. The animation translates the item from/to left 100%.

--- a/packages/x-components/src/components/animations/translate-from-right.vue
+++ b/packages/x-components/src/components/animations/translate-from-right.vue
@@ -34,7 +34,7 @@
 </style>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The `TranslateFromRight` component is intended to be used as animation to wrap an element with v-if
 or v-show and animate it. The animation translates the item from/to right 100%.

--- a/packages/x-components/src/components/base-dropdown.vue
+++ b/packages/x-components/src/components/base-dropdown.vue
@@ -456,7 +456,7 @@
 </style>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The `Dropdown` component is a simple yet customizable select component. The component needs to work
 the list of items available to select, which are passed using the `items` prop, and the selected

--- a/packages/x-components/src/components/base-event-button.vue
+++ b/packages/x-components/src/components/base-event-button.vue
@@ -39,9 +39,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 The event prop is required. It will render a <button></button> that emits the event passed as prop
 with the value as payload on click:

--- a/packages/x-components/src/components/base-grid.vue
+++ b/packages/x-components/src/components/base-grid.vue
@@ -177,7 +177,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component renders a list of elements in different slots depending on their modelName. In order
 to achieve this, it exposes a scopedSlot for each different modelName. In case the items used do not
@@ -185,7 +185,7 @@ have modelName property, the default slot is used instead. It has a required pro
 to render, and an optional one, the number of `columns` the grid is divided in. If the number of
 columns is not specified, the grid automatically fills the rows with as many columns as it can fit.
 
-## Basic example
+### Basic example
 
 It renders a list of items using the default slot:
 
@@ -199,7 +199,7 @@ It renders a list of items using the default slot:
 </template>
 ```
 
-## Configuring the number of columns
+### Configuring the number of columns
 
 It renders a grid with 12 columns instead of 6, which is the default value:
 
@@ -213,7 +213,7 @@ It renders a grid with 12 columns instead of 6, which is the default value:
 </template>
 ```
 
-## Rendering usage
+### Rendering usage
 
 Configuring the number of columns.
 

--- a/packages/x-components/src/components/base-keyboard-navigation.vue
+++ b/packages/x-components/src/components/base-keyboard-navigation.vue
@@ -145,7 +145,7 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component has a slot to inject other components inside it. The component expects a required
 prop, navigationHijacker, which is an array of objects containing: the xEvent to listen to, the
@@ -153,7 +153,7 @@ moduleName in charge of emitting the event and to which direction it should reac
 control of the navigation. It has another prop, optional in this case, to emit an xEvent when
 reaching the navigation limit in any direction.
 
-## Basic Usage
+### Basic Usage
 
 ```vue
 <KeyboardNavigation>
@@ -161,7 +161,7 @@ reaching the navigation limit in any direction.
 </KeyboardNavigation>
 ```
 
-## Defining multiple conditions to take navigation's control
+### Defining multiple conditions to take navigation's control
 
 ```vue
 <KeyboardNavigation
@@ -182,7 +182,7 @@ reaching the navigation limit in any direction.
 </KeyboardNavigation>
 ```
 
-## Defining events to emit when reaching a navigation limit
+### Defining events to emit when reaching a navigation limit
 
 ```vue
 <KeyboardNavigation

--- a/packages/x-components/src/components/base-rating.vue
+++ b/packages/x-components/src/components/base-rating.vue
@@ -109,18 +109,18 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component receives a `value` as prop and renders a set of elements, which will be filled based
 on this value.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <BaseRating :value="5.23" />
 ```
 
-## Customizing its contents
+### Customizing its contents
 
 ```vue
 <BaseRating :value="7.15" :max="10">

--- a/packages/x-components/src/components/base-variable-column-grid.vue
+++ b/packages/x-components/src/components/base-variable-column-grid.vue
@@ -72,7 +72,7 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The `BaseVariableColumnGrid` component is a wrapper of the `BaseGrid` component that listens to the
 `ColumnsNumberProvided` events and passes the selected amount of columns to the grid. It also allows

--- a/packages/x-components/src/components/column-picker/base-column-picker-dropdown.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-dropdown.vue
@@ -73,17 +73,17 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 Column picker dropdown component renders a dropdown component which options are the different
 columns you can set for a grid.
 
-## Usage
+### Usage
 
 Notice that the slots provided match with the `BaseDropdown` component. The `item` slot is required
 unlike the `toggle`, which renders the same `item` slot defined by default.
 
-### Default usage
+#### Default usage
 
 ```vue
 <template>

--- a/packages/x-components/src/components/column-picker/base-column-picker-list.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-list.vue
@@ -88,13 +88,13 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component renders a list of elements in different slots depending on the columns prop. Each
 element will emit the needed events to sync other instances of columns pickers, or grids with the
 number of columns that it is being selected when it is clicked.
 
-## Default usage
+### Default usage
 
 It is required to send the columns prop.
 
@@ -116,7 +116,7 @@ It is required to send the columns prop.
 </script>
 ```
 
-### Using v-model
+#### Using v-model
 
 It is possible to do two way binding in order to synchronize the value with the parents. It will be
 updated if it changed the value or if the parent changes it.
@@ -139,9 +139,9 @@ updated if it changed the value or if the parent changes it.
 </script>
 ```
 
-## Customized usage
+### Customized usage
 
-### Overriding the slots
+#### Overriding the slots
 
 It is possible to override the column picker button content.
 

--- a/packages/x-components/src/components/currency/base-currency.vue
+++ b/packages/x-components/src/components/currency/base-currency.vue
@@ -106,15 +106,13 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 Renders the value received as a property, which always must be a JavaScript number, with the proper
 format provided as string property. The rendered tag is a span in order to render a default inline
 HTML element.
 
-## Basic usage
-
-### Example
+### Basic usage
 
 ```vue
 <BaseCurrency :value="12345678.87654321" format="i.iii,ddd? €" />

--- a/packages/x-components/src/components/filters/labels/base-price-filter-label.vue
+++ b/packages/x-components/src/components/filters/labels/base-price-filter-label.vue
@@ -88,7 +88,7 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 Renders a label for a price filter, allowing to select different messages depending on the value of
 the filter.
@@ -103,7 +103,7 @@ the filter.
 This component uses internally the `BaseCurrency` one, so you can pass the same props to configure
 how the price should look like.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <template>

--- a/packages/x-components/src/components/filters/labels/base-rating-filter-label.vue
+++ b/packages/x-components/src/components/filters/labels/base-rating-filter-label.vue
@@ -64,18 +64,18 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 Renders a label for a rating filter, allowing to override the elements used to paint the rating. The
 filter label must be a valid number string. For example: '3', '2.5', '0.25'
 
-## Basic usage
+### Basic usage
 
 ```vue
 <BaseRatingFilterLabel :filter="filter" />
 ```
 
-## Customizing color
+### Customizing color
 
 Its possible to change the default color directly with color CSS attribute. For more elaborated
 styles it's possible to style the inner svg icons.
@@ -84,7 +84,7 @@ styles it's possible to style the inner svg icons.
 <BaseRatingFilterLabel :filter="filter" style="color: gold" />
 ```
 
-## Customizing its contents
+### Customizing its contents
 
 The `max` prop can be used to set the max rating number. It will render as many icons as the this
 `max` value.

--- a/packages/x-components/src/components/layouts/fixed-header-and-asides-layout.vue
+++ b/packages/x-components/src/components/layouts/fixed-header-and-asides-layout.vue
@@ -261,7 +261,7 @@
 </style>
 
 <docs lang="mdx">
-# Layout
+## Layout
 
 This component has the following layout with fixed headers and collapsible fixed asides:
 
@@ -272,7 +272,7 @@ This component has the following layout with fixed headers and collapsible fixed
 |            |    main    |               |
 |            |            | scroll-to-top |
 
-# Design Tokens
+## Design Tokens
 
 The component has also the following `Design Tokens` to configure it:
 

--- a/packages/x-components/src/components/layouts/multi-column-max-width-layout.vue
+++ b/packages/x-components/src/components/layouts/multi-column-max-width-layout.vue
@@ -437,7 +437,7 @@
 </style>
 
 <docs lang="mdx">
-# Layout
+## Layout
 
 This component has the following layout with fixed headers and collapsible fixed asides:
 
@@ -448,7 +448,7 @@ This component has the following layout with fixed headers and collapsible fixed
 |  main-aside   |     main      |               |
 |               |               | scroll-to-top |
 
-# Design Tokens
+## Design Tokens
 
 The component has also the following `Design Tokens` to configure it:
 

--- a/packages/x-components/src/components/modals/base-events-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-close.vue
@@ -37,11 +37,11 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The `BaseEventsModalClose` component can be used to close the `BaseEventsModal` component.
 
-## Basic example
+### Basic example
 
 On clicked, the component closes the `BaseEventsModal`. The only needed thing is the content that
 the button should render, that can be any thing: a text, an image, an icon, a combination of the two
@@ -66,7 +66,7 @@ of them...
 </script>
 ```
 
-## Defining another event to emit when clicking the button
+### Defining another event to emit when clicking the button
 
 By default it uses the same `closingEvent` that the `BaseEventsModal` is listening by default too.
 This event can be changed using the `closingEvent` prop.

--- a/packages/x-components/src/components/modals/base-events-modal-open.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-open.vue
@@ -37,11 +37,11 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component serves to open the `BaseEventsModal`.
 
-## Basic example
+### Basic example
 
 On clicked, the component closes the `BaseEventsModal`. The only needed thing is the content that
 the button should render, that can be any thing: a text, an image, an icon, a combination of the two
@@ -67,7 +67,7 @@ of them...
 </script>
 ```
 
-## Defining another event to emit when clicking the button
+### Defining another event to emit when clicking the button
 
 By default it uses the same `openingEvent` that the `BaseEventsModal` is listening by default too.
 This event can be changed using the `openingEvent` prop, but remember to change it in the target

--- a/packages/x-components/src/components/modals/base-events-modal.vue
+++ b/packages/x-components/src/components/modals/base-events-modal.vue
@@ -114,13 +114,13 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The `BaseEventsModal` component handles the modal open/close state via the events passed via props.
 Its configured by default to work as a modal for a whole search application, but if the events are
 changed, it can work as a modal that is opened/closed when the events it is listening are emitted.
 
-## Basic usage
+### Basic usage
 
 The component interacts with the open and close components, which are preconfigured by default to
 emit the same events that the `BaseEventsModal` component is listening to:
@@ -149,7 +149,7 @@ emit the same events that the `BaseEventsModal` component is listening to:
 </script>
 ```
 
-## Customizing the events
+### Customizing the events
 
 If needed, the events to open/close the modal can be changed. The modal can listen one or more
 events. To do so, the `eventsToCloseModal` and `eventsToOpenModal` props can be used. Below you can

--- a/packages/x-components/src/components/modals/base-id-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-id-modal-close.vue
@@ -36,12 +36,12 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Component containing an event button that emits `UserClickedCloseModal` when clicked with the
 modalId as payload. It has a default slot to customize its contents.
 
-## Basic example
+### Basic example
 
 The component renders whatever is passed to it in the default slot and closing the modal with
 modalId `my-modal`.

--- a/packages/x-components/src/components/modals/base-id-modal-open.vue
+++ b/packages/x-components/src/components/modals/base-id-modal-open.vue
@@ -36,12 +36,12 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Component containing an event button that emits `UserClickedOpenModal` when it is clicked with the
 modalId as payload. It has a default slot to customize its contents.
 
-## Basic example
+### Basic example
 
 The component rendering content passed to the default slot and opening the modal with modalId
 `my-modal`.

--- a/packages/x-components/src/components/modals/base-id-modal.vue
+++ b/packages/x-components/src/components/modals/base-id-modal.vue
@@ -93,13 +93,13 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The `BaseIdModal` component reacts to the `UserClickedOpenModal`, `UserClickedCloseModal` and
 `UserClickedOutOfModal` to handle its open/close state. The component filters out the events which
 payload doesn't match its `modalId` prop and reacts only to those who match this criteria.
 
-## Basic usage
+### Basic usage
 
 The component interacts with both `BaseIdModalOpen` and `BaseIdModalClose` components, which have to
 share the same value in their `modalId` prop to work:

--- a/packages/x-components/src/components/modals/base-modal.vue
+++ b/packages/x-components/src/components/modals/base-modal.vue
@@ -183,7 +183,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 The `BaseModal` is a simple component that serves to create complex modals. Its open state has to be
 passed via prop. It also accepts an animation to use for opening & closing.

--- a/packages/x-components/src/components/panels/base-header-toggle-panel.vue
+++ b/packages/x-components/src/components/panels/base-header-toggle-panel.vue
@@ -87,12 +87,12 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Toggle panel which uses the base toggle panel, adds a header and manage the open / close state of
 the panel.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <BaseHeaderTogglePanel :animation="collapseHeight" :start-collapsed="false">
@@ -105,7 +105,7 @@ the panel.
 </BaseHeaderTogglePanel>
 ```
 
-## Custom header
+### Custom header
 
 ```vue
 <BaseHeaderTogglePanel :animation="collapseHeight" :start-collapsed="true">
@@ -119,7 +119,7 @@ the panel.
 </BaseHeaderTogglePanel>
 ```
 
-## Vue Events
+## Events
 
 A list of events that the component will emit:
 

--- a/packages/x-components/src/components/panels/base-id-toggle-panel-button.vue
+++ b/packages/x-components/src/components/panels/base-id-toggle-panel-button.vue
@@ -68,9 +68,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 The component rendering content passed to the default slot and opening the panel toggle with panelId
 `my-toggle`.

--- a/packages/x-components/src/components/panels/base-id-toggle-panel.vue
+++ b/packages/x-components/src/components/panels/base-id-toggle-panel.vue
@@ -97,9 +97,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic usage
+### Basic usage
 
 Using default slot:
 

--- a/packages/x-components/src/components/panels/base-toggle-panel.vue
+++ b/packages/x-components/src/components/panels/base-toggle-panel.vue
@@ -39,12 +39,12 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Simple panel that receives its open state via prop, which is responsible of rendering default slot
 inside a configurable transition.
 
-## Basic usage
+### Basic usage
 
 Using default slot:
 

--- a/packages/x-components/src/components/result/base-result-add-to-cart.vue
+++ b/packages/x-components/src/components/result/base-result-add-to-cart.vue
@@ -48,12 +48,12 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Renders a button with a default slot. It receives the result with the data and emits an event
 `UserClickedResultAddToCart` to the bus on click mouse event.
 
-## Basic example
+### Basic example
 
 This component is a button to emit `UserClickedResultAddToCart` whe clicked by the user
 

--- a/packages/x-components/src/components/result/base-result-current-price.vue
+++ b/packages/x-components/src/components/result/base-result-current-price.vue
@@ -71,9 +71,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 This component shows the current price formatted. You can provide the `format` by property or let
 the `BaseCurrency` component use an injected one.
@@ -82,7 +82,7 @@ the `BaseCurrency` component use an injected one.
 <BaseResultCurrentPrice :value="result" :format="'i.iii,ddd €'" />
 ```
 
-## Overriding default slot
+### Overriding default slot
 
 ```vue
 <BaseResultCurrentPrice :result="result">

--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -202,9 +202,9 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 This component is for the result image. It may be part of the search result page, recommendations or
 other section which needs to include results.
@@ -215,7 +215,7 @@ The result prop is required. It will render a `<img/>` with the result image:
 <BaseResultImage :result="result" />
 ```
 
-## Customizing slots content
+### Customizing slots content
 
 Fallback and placeholder contents can be customized.
 

--- a/packages/x-components/src/components/result/base-result-link.vue
+++ b/packages/x-components/src/components/result/base-result-link.vue
@@ -88,9 +88,9 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 This component is a wrapper for the result contents (images, name, price...) It may be part of the
 search result page, recommendations or other section which needs to include results.

--- a/packages/x-components/src/components/result/base-result-previous-price.vue
+++ b/packages/x-components/src/components/result/base-result-previous-price.vue
@@ -60,9 +60,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 This component shows the previous price formatted if it has discount. The component has two optional
 props. `format` to select the currency format to be applied.
@@ -71,7 +71,7 @@ props. `format` to select the currency format to be applied.
 <BaseResultPreviousPrice :value="result" :format="'i.iii,ddd €'" />
 ```
 
-## Overriding default slot
+### Overriding default slot
 
 ```vue
 <BaseResultPreviousPrice :result="result">

--- a/packages/x-components/src/components/scroll/base-scroll.vue
+++ b/packages/x-components/src/components/scroll/base-scroll.vue
@@ -26,7 +26,7 @@
 </style>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The BaseScroll is a component that manage the states of scroll of a specified element. The component
 does the necessary calculations for knowing the direction of scroll, if the scroll has reached to
@@ -82,7 +82,7 @@ movement that realize the user:
 </script>
 ```
 
-## Avoid reset scroll on query change
+### Avoid reset scroll on query change
 
 Set to false the reset scroll on query change feature which is true by default.
 

--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -242,7 +242,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component allows for any other component or element inside it to be horizontally navigable. It
 also implements customizable buttons as well as other minor customizations to its general behavior.
@@ -250,7 +250,7 @@ The component uses the method `scrollBy` from `Element` to function, and it does
 all browsers. A polyfill for the `scrollBy` would be needed for the component to behave as expected
 in those browsers.
 
-## Default usage
+### Default usage
 
 Simplest implementation of the component, just a list-based component inside its slot.
 
@@ -260,7 +260,7 @@ Simplest implementation of the component, just a list-based component inside its
 </SlidingPanel>
 ```
 
-## Behavior customization
+### Behavior customization
 
 Edit how much the scroll travels when navigating with the buttons by changing the `scrollFactor`.
 
@@ -280,7 +280,7 @@ just by swiping.
 </SlidingPanel>
 ```
 
-## Overriding Button content
+### Overriding Button content
 
 By default the buttons show an arrow depicting the direction the scroll would go to when clicked,
 but this content can be customized with anything, from characters to SVG and images.

--- a/packages/x-components/src/components/staggering-transition-group.vue
+++ b/packages/x-components/src/components/staggering-transition-group.vue
@@ -468,9 +468,9 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 Apart from all the props and events that the classic transition group has, the staggering transition
 group also exposes a new `stagger` property, which allows to configure the delay for each one of the

--- a/packages/x-components/src/components/suggestions/base-suggestion.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestion.vue
@@ -174,19 +174,19 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This default suggestion component expects a suggestion to render and pass to its default slot, a
 normalized query to compare with the suggestion's query and highlight its matching parts and events
 to emit when the suggestion is selected.
 
-## Default usage
+### Default usage
 
 ```vue
 <BaseSuggestion v-bind="{ query, suggestion, suggestionSelectedEvents }" />
 ```
 
-## Customized usage
+### Customized usage
 
 ```vue
 <BaseSuggestion v-bind="{ query, suggestion, suggestionSelectedEvents }">

--- a/packages/x-components/src/components/suggestions/base-suggestions.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestions.vue
@@ -112,7 +112,7 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 For this component to work, you will need to set a list of suggestions as prop, and also to
 implement the component for single suggestion, which handles the click event. In the following

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -130,7 +130,7 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component will listen to the configured events in `eventsToOpenEmpathize` and
 `eventsToCloseEmpathize` props and open/close itself accordingly. By default, those props values
@@ -140,7 +140,7 @@ are:
 - Close: `UserClosedEmpathize`, `UserSelectedASuggestion`, `UserPressedEnter`,
   'UserBlurredSearchBox`
 
-## Basic examples
+### Basic examples
 
 The component rendering the query suggestions, popular searches and history queries with keyboard
 navigation.

--- a/packages/x-components/src/x-modules/extra-params/components/renderless-extra-param.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/renderless-extra-param.vue
@@ -65,12 +65,12 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Renders default slot content. It binds to the default slot the name of the extra parameter and the
 default value of it.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/facets/components/clear-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/clear-filters.vue
@@ -134,18 +134,18 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component renders a button, which on clicked emits the `UserClickedClearAllFilters` or
 `UserClickedClearAllFilters` event.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <ClearFilters />
 ```
 
-## Customizing its contents
+### Customizing its contents
 
 In this example, show the custom message in button.
 

--- a/packages/x-components/src/x-modules/facets/components/facets/facets-provider.vue
+++ b/packages/x-components/src/x-modules/facets/components/facets/facets-provider.vue
@@ -124,7 +124,7 @@
 </style>
 
 <docs lang="mdx">
-# Example
+## Example
 
 This component allows to provide facets by prop, to add them to the state of the `Facets X-Module`.
 These facets will be added to the `Facets X-Module` state together with the facets emitted by the

--- a/packages/x-components/src/x-modules/facets/components/facets/facets.vue
+++ b/packages/x-components/src/x-modules/facets/components/facets/facets.vue
@@ -206,7 +206,7 @@
 </style>
 
 <docs lang="mdx">
-# Example
+## Example
 
 This component renders the list of facets stored in the Facets module. Facets can be rendered
 differently based on their purpose and this can be achieved using the exposed slots:
@@ -217,7 +217,7 @@ differently based on their purpose and this can be achieved using the exposed sl
 
 Below, there are some examples showing how to use the component with its different configurations.
 
-## Default usage
+### Default usage
 
 The default slot of this component is mandatory. If no other slot is defined, every Facet will be
 rendered as specified in the default slot.
@@ -249,7 +249,7 @@ rendered as specified in the default slot.
 </script>
 ```
 
-## Customized usage
+### Customized usage
 
 Customized compositions for a specific Facet can be achieved by using a slot with the same id as the
 facet to customize. For example, the Facet with the id "color" requires a composition that differs
@@ -292,7 +292,7 @@ just to the "color" Facet. The other facets will fallback to the composition of 
 </script>
 ```
 
-## Render specific facets I
+### Render specific facets I
 
 By default, this component will render all existing facets. However, it has the renderableFacets
 prop to filter which facets will be rendered. Its value is a string containing the different facets
@@ -326,7 +326,7 @@ ones. In the following example, the component will only render color and categor
 </script>
 ```
 
-## Render specific facets II
+### Render specific facets II
 
 Exclude facets so the component does not render them. In the following example, the component will
 render every facet except color and price.
@@ -357,7 +357,7 @@ render every facet except color and price.
 </script>
 ```
 
-## Integrating with the filters components
+### Integrating with the filters components
 
 There are many components that will help you build your own awesome filters list. `Facets` just
 renders the list, but what to render for each facet is up to you. Below you can see an example. of

--- a/packages/x-components/src/x-modules/facets/components/filters/all-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/all-filter.vue
@@ -89,19 +89,19 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component receives a required `facet` as prop and renders a button, which on clicked emits the
 UserClickedAllFilter event. By default the rendered button displays a message with the facet label
 but this content is customizable through the default slot.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <AllFilter :facet="facet" />
 ```
 
-## Customizing its content
+### Customizing its content
 
 ```vue
 <AllFilter v-slot="{ facet }" :facet="facet">
@@ -109,7 +109,7 @@ but this content is customizable through the default slot.
 </AllFilter>
 ```
 
-## Basic example within facets
+### Basic example within facets
 
 ```vue
 <Facets>
@@ -122,7 +122,7 @@ but this content is customizable through the default slot.
 </Facets>
 ```
 
-## Custom example within facets
+### Custom example within facets
 
 ```vue
 <Facets>

--- a/packages/x-components/src/x-modules/facets/components/filters/base-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/base-filter.vue
@@ -85,19 +85,19 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component receives a `filter` as prop and renders a button, which on clicked emits the
 `UserClickedAFilter` event. If more events are needed to be emitted they can be passed using the
 `clickEvents` prop. By default it renders the filter label as the button text.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <BaseFilter :filter="filter" />
 ```
 
-## Customizing its contents
+### Customizing its contents
 
 ```vue
 <BaseFilter :filter="filter" v-slot="{ filter }">
@@ -106,7 +106,7 @@ This component receives a `filter` as prop and renders a button, which on clicke
 </BaseFilter>
 ```
 
-## Extending the emitted events
+### Extending the emitted events
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
@@ -295,7 +295,7 @@
 </style>
 
 <docs lang="mdx">
-# Example
+## Example
 
 Renders an editable number range filter. It has two input fields to handle min and max values,
 emitting the needed events when clicked.
@@ -309,7 +309,7 @@ to confirm to do it. False by default.
 If `clear` prop is true, clear button, which sets to null component min and max values, is rendered.
 True by default.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <template>
@@ -341,7 +341,7 @@ True by default.
 </script>
 ```
 
-## Properties
+### Properties
 
 ```vue
 <template>
@@ -373,7 +373,7 @@ True by default.
 </script>
 ```
 
-## Customizing content slots
+### Customizing content slots
 
 ```vue
 <template>
@@ -408,7 +408,7 @@ True by default.
 </script>
 ```
 
-## Customizing default slot
+### Customizing default slot
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
@@ -154,14 +154,14 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component renders a button, which on clicked emits the `UserClickedAFilter` and
 `UserClickedAHierarchicalFilter` events. By default it renders the filter label as the button text.
 If the provided filter has children filters, this component will render them recursively. Changing
 the slot content will change it for all of the children.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <template>
@@ -172,7 +172,7 @@ the slot content will change it for all of the children.
 </template>
 ```
 
-## Customizing the default slot content
+### Customizing the default slot content
 
 In this example, the child filters will also include the label and checkbox.
 
@@ -185,7 +185,7 @@ In this example, the child filters will also include the label and checkbox.
 </HierarchicalFilter>
 ```
 
-## Customizing the label slot content
+### Customizing the label slot content
 
 ```vue
 <HierarchicalFilter :filter="filter">

--- a/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
@@ -66,18 +66,18 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component renders a button, which on clicked emits the `UserClickedAFilter` and the
 `UserClickedANumberRangeFilter` events. By default, it renders the filter label as the button text.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <NumberRangeFilter :filter="filter" />
 ```
 
-## Customizing its contents
+### Customizing its contents
 
 ```vue
 <NumberRangeFilter :filter="filter" v-slot="{ filter }">

--- a/packages/x-components/src/x-modules/facets/components/filters/renderless-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/renderless-filter.vue
@@ -95,18 +95,18 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Renders default slot content. It binds to the default slot a filter, the events that will be emitted
 when clicking the content, the css classes and if the content should be disabled.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <RenderlessFilter :filter="filter" />
 ```
 
-## Customizing its contents and adding new events
+### Customizing its contents and adding new events
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
@@ -94,13 +94,13 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component renders a button, which on clicked emits the `UserClickedAFilter` and the
 `UserClickedASimpleFilter` events. By default, it renders a `button` with the `filter.label`
 property as text.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <template>
@@ -131,7 +131,7 @@ property as text.
 </script>
 ```
 
-## Rendering an input
+### Rendering an input
 
 You can change the rendered control using the default slot. Note that because of the current Vue
 limitations, you must only render one single root node in this slot. There you will receive all the
@@ -172,7 +172,7 @@ data and methods needed:
 </script>
 ```
 
-## Changing default button content
+### Changing default button content
 
 You can change the content rendered by the default button using the `label` slot. There you will
 receive the filter data.

--- a/packages/x-components/src/x-modules/facets/components/lists/exclude-filters-with-no-results.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/exclude-filters-with-no-results.vue
@@ -41,7 +41,7 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The `ExcludeFiltersWithNoResults` component filters the provided list of filter, excluding those
 which have the `totalResults` property exactly equal to `0`. It won't remove filters with no
@@ -50,13 +50,13 @@ which have the `totalResults` property exactly equal to `0`. It won't remove fil
 The new list of filters is bound to the default scoped slot. As this component does not render no
 root element, this default slot must contain a single root node.
 
-## Important
+### Important
 
 The component has two ways of receive the filters list, it can be injected by another component or
 be send it as a prop. If the component doesnt have a parent component that receive and exposed a
 filters list to their children, it is mandatory to send it as prop.
 
-## Basic Usage
+### Basic Usage
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/facets/components/lists/filters-list.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/filters-list.vue
@@ -92,18 +92,18 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Renders a list with a list item per each filter in the filters prop array. Each list item has a
 scoped slot, passing the filter as slot prop.
 
-## Important
+### Important
 
 The component has two ways of receive the filters list, it can be injected by another component or
 be send it as a prop. If the component doesnt have a parent component that receive and exposed a
 filters list to their children, it is mandatory to send it as prop.
 
-## Basic usage
+### Basic usage
 
 Using default slot:
 

--- a/packages/x-components/src/x-modules/facets/components/lists/filters-search.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/filters-search.vue
@@ -134,7 +134,7 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 It renders an input and a list of filters passed as prop or being injected. The list of filters can
 be sifted with the query typed in the input. This component has also a debounce prop to set the time
@@ -143,13 +143,13 @@ customize the search triggering with three slot props; the query, a function to 
 sifting and a third one for cleaning the query. The second scoped slot is required and it is for
 displaying the list of filters sifted. It has a slot prop with these filters sifted.
 
-## Important
+### Important
 
 The component has two ways of receive the filters list, it can be injected by another component or
 be send it as a prop. If the component doesnt have a parent component that receive and exposed a
 filters list to their children, it is mandatory to send it as prop.
 
-## Basic usage
+### Basic usage
 
 Using default and required slot:
 

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters-list.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters-list.vue
@@ -115,7 +115,7 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 This component renders a list of selected filters from every facet, or from the facet which facet id
 is passed as property. It uses the SelectedFilters component (state).
@@ -125,7 +125,7 @@ exposes the filter and renders the filter label by default.
 
 The property "alwaysVisible" handles if the component is rendered if no filters are selected.
 
-## Default usage
+### Default usage
 
 ```vue
 <template>
@@ -143,7 +143,7 @@ The property "alwaysVisible" handles if the component is rendered if no filters 
 </script>
 ```
 
-## Customized usage
+### Customized usage
 
 ```vue
 <template>
@@ -182,7 +182,7 @@ The property "alwaysVisible" handles if the component is rendered if no filters 
 </script>
 ```
 
-## Always visible
+#### Always visible
 
 If "alwaysVisible" is true, the component is rendered no matter if there are some filter selected.
 If "alwaysVisible" is false (default), the component is rendered if there are some filter selected.
@@ -199,7 +199,7 @@ Output:
 </div>
 ```
 
-## Providing a facet id
+#### Providing a facet id
 
 In this example, the selected filters computed are the ones that match the facet passed as property.
 

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
@@ -96,20 +96,20 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 Provides a scoped slot with the selected filters from every facet, or from the facet which facet id
 is passed as property.
 
 The default slot renders the length of the selected filters array.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <SelectedFilters />
 ```
 
-## Always visible
+### Always visible
 
 If "alwaysVisible" is true, the component is rendered no matter if there are some filter selected.
 If "alwaysVisible" is false (default), the component is rendered if there are some filter selected.
@@ -124,7 +124,7 @@ Output:
 <div class="x-selected-filters">1</div>
 ```
 
-## Customizing its content
+### Customizing its content
 
 In this example, renders a custom message using the default scoped slot.
 

--- a/packages/x-components/src/x-modules/facets/components/lists/sliced-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/sliced-filters.vue
@@ -130,7 +130,7 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The sliced filters component, takes a list of filters, and the maximum number of filters to render
 as prop. Then, it slices the list of filters using the `max` prop, and returns this new filters list
@@ -144,13 +144,13 @@ This component is usually integrated with the `Facets` and `Filters` component. 
 there are lots of available filters for a single facet, helping to improve the app performance, as
 less nodes are rendered.
 
-## Important
+### Important
 
 The component has two ways of receive the filters list, it can be injected by another component or
 be send it as a prop. If the component doesnt have a parent component that receive and exposed a
 filters list to their children, it is mandatory to send it as prop.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/facets/components/lists/sorted-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/sorted-filters.vue
@@ -41,12 +41,12 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The sorted filters component takes a list of filters and returns this new filters list sorted by the
 `selected` filter property.
 
-## Remarks
+### Remarks
 
 - The component can receive the filters list by property or using the XInjection feature.
 - It also provides the resultant list bound in the default slot or with the XProvide feature.
@@ -55,9 +55,9 @@ Both XInjection and XProvide features are from the extended FiltersInjectionMixi
 use XInjection and XProvide together, e.g. you can use pass the filters using a prop and then
 returns the result with XProvide.
 
-## Basic usage
+### Basic usage
 
-### Using props and binding the result
+#### Using props and binding the result
 
 ```vue
 <template>
@@ -83,7 +83,7 @@ returns the result with XProvide.
 </script>
 ```
 
-### Using XInject and XProvide
+#### Using XInject and XProvide
 
 ```vue
 <Facets v-slot="{ facet }">

--- a/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
@@ -77,9 +77,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 The component exposes a single default slot, where you can add icons or text.
 

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -96,11 +96,11 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component renders a list of suggestions coming from the user queries history
 
-## Default usage
+### Default usage
 
 No props are required for the usage of this component.
 
@@ -115,7 +115,7 @@ The component has two optional props. `animation` to render the component with a
 <HistoryQueries :animation="FadeAndSlide" :maxItemsToRender="10" />
 ```
 
-## Overriding Suggestion component
+### Overriding Suggestion component
 
 The default `HistoryQuery` component that is used in every suggestion can be replaced. To do so, the
 `suggestion` slot is available, containing the history query data under the `suggestion` property.
@@ -131,7 +131,7 @@ to be implemented emitting the needed events.
 </HistoryQueries>
 ```
 
-## Overriding suggestion-content and suggestion-remove-content slot
+### Overriding suggestion-content and suggestion-remove-content slot
 
 The content of the `HistoryQuery` component can be overridden. For replacing the default suggestion
 content, the `suggestion-content` slot is available, containing the history query suggestion (in the

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -85,9 +85,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic usage
+### Basic usage
 
 This component only requires a prop called `suggestion`
 
@@ -95,7 +95,7 @@ This component only requires a prop called `suggestion`
 <HistoryQuery :suggestion="historyQuery" />
 ```
 
-## Customizing slots content
+### Customizing slots content
 
 Suggestion and remove buttons contents can be customized.
 

--- a/packages/x-components/src/x-modules/history-queries/components/remove-history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/remove-history-query.vue
@@ -50,9 +50,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic Example
+### Basic Example
 
 You can customize the content that this component renders. To do so, simply use the default slot.
 

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
@@ -70,12 +70,12 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component renders an identifier result value and highlights its matching part with the query
 from the state. Receives as prop the result data
 
-## Basic usage:
+### Basic usage:
 
 ```vue
 <IdentifierResult v-bind="{ result }" />

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
@@ -70,9 +70,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Adding a IdentifierResult component within a BaseResultLink
+### Adding a IdentifierResult component within a BaseResultLink
 
 A IdentifierResult **must** be used inside the IdentifierResults component. In the example below the
 BaseResultLink is used as a wrapper and its default slot is filled with the IdentifierResult

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -79,9 +79,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 You don't need to pass any props, or slots. Simply add the component, and when it has any next
 queries it will show them
@@ -97,7 +97,7 @@ The component has two optional props. `animation` to render the component with a
 <NextQueries :animation="FadeAndSlide" :maxItemsToRender="10" />
 ```
 
-## Overriding Next Queries' Content
+### Overriding Next Queries' Content
 
 You can use your custom implementation of the Next Query's content. In the example below, instead of
 using the default Next Query's content, an icon is added, as well as a span with the query of the
@@ -112,7 +112,7 @@ Next Query suggestion.
 </NextQueries>
 ```
 
-## Adding a custom next query component
+### Adding a custom next query component
 
 You can use your custom implementation of a next query component. To work correctly, it should use
 the `emitNextQuerySelected` function when the next query is selected. In the example below, instead

--- a/packages/x-components/src/x-modules/next-queries/components/next-query.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-query.vue
@@ -60,12 +60,12 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This components expects just a suggestion as a prop to be rendered. It has a slot to override the
 content. By default, it renders the suggestion query of the next query.
 
-## Basic Usage
+### Basic Usage
 
 Using default slot:
 
@@ -73,7 +73,7 @@ Using default slot:
 <NextQuery :suggestion="suggestion" />
 ```
 
-## Overriding default slot.
+### Overriding default slot.
 
 The default slot allows you to replace the content of the suggestion button.
 

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
@@ -60,18 +60,18 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This components expects just a suggestion as a prop to be rendered. It has a slot to override the
 content. By default, it renders the suggestion query of the popular search.
 
-## Basic Usage
+### Basic Usage
 
 ```vue
 <PopularSearch :suggestion="suggestion" />
 ```
 
-## Custom Usage
+### Custom Usage
 
 ```vue
 <PopularSearch :suggestion="suggestion">

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -78,9 +78,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Default Usage
+### Default Usage
 
 You don't need to pass any props, or slots. Simply add the component, and when it has any popular
 searches it will show them.
@@ -96,7 +96,7 @@ The component has two optional props. `animation` to render the component with a
 <PopularSearches :animation="FadeAndSlide" :maxItemsToRender="10" />
 ```
 
-## Overriding Popular Search's Content
+### Overriding Popular Search's Content
 
 You can use your custom implementation of the Popular Search's content. In the example below,
 instead of using the default Popular Search's content, an icon is added, as well as a span with the
@@ -111,7 +111,7 @@ query of the Popular Search's suggestion.
 </PopularSearches>
 ```
 
-## Adding a Custom Popular Search Item
+### Adding a Custom Popular Search Item
 
 You can use your custom implementation for the whole Popular Search item. In the example below, we
 change the default implementation of the Popular Search in Popular Searches. A custom Popular Search

--- a/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
+++ b/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
@@ -111,16 +111,16 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 It renders a list of recommendations from recommendations state by default. The component provides
 the slot layout which wraps the whole component with the recommendations bound. It also provides the
 default slot to customize the item, which is within the layout slot, with the recommendation bound.
 Each recommendation should be represented by a BaseResultLink component besides any other component.
 
-## Basic example
+### Basic example
 
-## Adding a custom BaseResultLink component
+### Adding a custom BaseResultLink component
 
 A BaseResultLink **must** be used inside the Recommendations component. In the example below the
 BaseResultLink default slot is filled with an image of the result and a span for the title. Besides
@@ -140,7 +140,7 @@ that, an additional button has been added.
 </Recommendations>
 ```
 
-## Overriding layout content
+### Overriding layout content
 
 It renders a list of recommendations customizing the layout slot. In the example below, instead of
 using the default Recommendations content, a BaseGrid component is used to render the

--- a/packages/x-components/src/x-modules/scroll/components/scroll-to-top.vue
+++ b/packages/x-components/src/x-modules/scroll/components/scroll-to-top.vue
@@ -141,9 +141,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 The component renders whatever is passed to it in the default slot and scrolls to top the scroll
 with an id `scrollId`.

--- a/packages/x-components/src/x-modules/scroll/components/scroll.vue
+++ b/packages/x-components/src/x-modules/scroll/components/scroll.vue
@@ -139,26 +139,13 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The Scroll is a component that wraps the BaseScroll and provides it for a unique id.
 
-## Events
+### Customized usage
 
-A list of events that the component will emit:
-
-- `UserScrolled`: emitted after the user scrolls in this container. The payload is the scroll top
-  distance in pixels.
-- `UserChangedScrollDirection`: emitted when the user changes the scroll direction. The payload is
-  the new scrolling direction.
-- `UserReachedScrollStart`: emitted when the user scrolls up to the initial position of the scroll.
-- `UserAlmostReachedScrollEnd`: emitted when the user is about to reach the bottom part of the
-  scroll.
-- `UserReachedScrollEnd`: emitted when the user has reached the bottom part of the scroll.
-
-## Customized usage
-
-### Overriding the properties
+#### Overriding the properties
 
 It renders an element with scroll, with the content passed in the `default slot`.
 
@@ -184,9 +171,7 @@ It renders an element with scroll, with the content passed in the `default slot`
 </script>
 ```
 
-## Customized usage
-
-### Using scroll events.
+#### Using scroll events.
 
 ```vue
 <template>
@@ -236,9 +221,7 @@ It renders an element with scroll, with the content passed in the `default slot`
 </script>
 ```
 
-## Customized usage
-
-### Using XEvents.
+#### Using XEvents.
 
 You can use the XEvents subscribing to them.
 
@@ -280,4 +263,17 @@ You can use the XEvents subscribing to them.
   };
 </script>
 ```
+
+## Events
+
+A list of events that the component will emit:
+
+- `UserScrolled`: emitted after the user scrolls in this container. The payload is the scroll top
+  distance in pixels.
+- `UserChangedScrollDirection`: emitted when the user changes the scroll direction. The payload is
+  the new scrolling direction.
+- `UserReachedScrollStart`: emitted when the user scrolls up to the initial position of the scroll.
+- `UserAlmostReachedScrollEnd`: emitted when the user is about to reach the bottom part of the
+  scroll.
+- `UserReachedScrollEnd`: emitted when the user has reached the bottom part of the scroll.
 </docs>

--- a/packages/x-components/src/x-modules/scroll/components/window-scroll.vue
+++ b/packages/x-components/src/x-modules/scroll/components/window-scroll.vue
@@ -93,16 +93,16 @@
 </script>
 
 <docs lang="mdx">
-# Example
+## Example
 
 The `WindowScroll` component manages the scroll state of the `body` or `html` elements. It does the
 necessary calculations for knowing the direction of scroll, if the scroll has reached its starting
 position, if it is about to reach its ending position or if it has already reached it end. Whenever
 this state changes, it emits the appropiate X Event to the rest of the application
 
-## Custom usage
+### Custom usage
 
-### Overriding the properties and using document scroll events.
+#### Overriding the properties and using document scroll events.
 
 ```vue
 <template>
@@ -148,9 +148,9 @@ this state changes, it emits the appropiate X Event to the rest of the applicati
 </script>
 ```
 
-## Customized usage
+### Customized usage
 
-### Using body and XEvents.
+#### Using body and XEvents.
 
 If we want to listen scroll body we should do some changes in css for body. This is an example, so
 therefore the height of body can be get any value that you want. The template style should have a

--- a/packages/x-components/src/x-modules/search/components/partial-query-button.vue
+++ b/packages/x-components/src/x-modules/search/components/partial-query-button.vue
@@ -60,9 +60,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 A button that when pressed emits the {@link XEventsTypes.UserAcceptedAQuery} and {@link
 SearchXEvents.UserClickedPartialQuery} events, expressing the user intention to set the partial
@@ -77,7 +77,7 @@ The component sets the current query as the new query and emits the `UserAccepte
 </template>
 ```
 
-## Customizing its contents
+### Customizing its contents
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/search/components/partial-results-list.vue
+++ b/packages/x-components/src/x-modules/search/components/partial-results-list.vue
@@ -81,11 +81,11 @@
 </style>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This component loops through an array of partials an exposed a slot to use customize each partial.
 
-## Basic example
+### Basic example
 
 It renders a list of partial results using the default slot:
 
@@ -99,7 +99,7 @@ It renders a list of partial results using the default slot:
 </template>
 ```
 
-## Configuring the number of partials
+### Configuring the number of partials
 
 It sets the maximum partials to show to 3.
 
@@ -113,7 +113,7 @@ It sets the maximum partials to show to 3.
 </template>
 ```
 
-## Rendering usage
+### Rendering usage
 
 It renders a list of partial results using the default slot. It will show the query, the partial
 results and a button to update the query with the partial one.

--- a/packages/x-components/src/x-modules/search/components/sort-dropdown.vue
+++ b/packages/x-components/src/x-modules/search/components/sort-dropdown.vue
@@ -76,7 +76,7 @@
 </script>
 
 <docs lang="mdx">
-# Sort Dropdown
+## Sort Dropdown
 
 The `SortDropdown` component can be used to change the way the search results are ordered.
 

--- a/packages/x-components/src/x-modules/search/components/sort-list.vue
+++ b/packages/x-components/src/x-modules/search/components/sort-list.vue
@@ -92,7 +92,7 @@
 </script>
 
 <docs lang="mdx">
-# Sort List
+## Sort List
 
 The `SortList` component can be used to change the way the search results are ordered.
 

--- a/packages/x-components/src/x-modules/search/components/spellcheck-button.vue
+++ b/packages/x-components/src/x-modules/search/components/spellcheck-button.vue
@@ -65,9 +65,9 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
-## Basic example
+### Basic example
 
 The component sets the current spellcheckedQuery as the new query and emits the `UserAcceptedAQuery`
 and `UserAcceptedSpellcheckQuery` events.
@@ -76,7 +76,7 @@ and `UserAcceptedSpellcheckQuery` events.
 <SpellcheckButton />
 ```
 
-## Customizing its contents
+### Customizing its contents
 
 ```vue
 <SpellcheckButton>

--- a/packages/x-components/src/x-modules/search/components/spellcheck.vue
+++ b/packages/x-components/src/x-modules/search/components/spellcheck.vue
@@ -43,20 +43,20 @@
 </script>
 
 <docs lang="mdx">
-# Examples
+## Examples
 
 This default spellcheck component expects a query and a spellcheckedQuery to render and pass to its
 default slot.
 
 This two props should be show like a message comparing them.
 
-## Basic usage
+### Basic usage
 
 ```vue
 <Spellcheck />
 ```
 
-## Customizing its contents
+### Customizing its contents
 
 ```vue
 <Spellcheck>


### PR DESCRIPTION
Changed h1 like #Example to be h2 like ## Example and nest all the titles that should be inside of ## Example adding more # depending on the level.

EX-5064