### PR TITLE
test(e2e): make url tests intercept tracking and wait for each request

### DIFF
--- a/packages/x-components/tests/e2e/cucumber/base-column-pickers.feature
+++ b/packages/x-components/tests/e2e/cucumber/base-column-pickers.feature
@@ -6,6 +6,7 @@ Feature: Base column pickers components
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
 
   Scenario Outline: 1. Column picker dropdown sets Results columns
     Given no special config for layout view

--- a/packages/x-components/tests/e2e/cucumber/base-result-image.feature
+++ b/packages/x-components/tests/e2e/cucumber/base-result-image.feature
@@ -6,6 +6,7 @@ Feature: Base result image component
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
     And   no special config for layout view
     And   start button is clicked
 

--- a/packages/x-components/tests/e2e/cucumber/filters/clear-filters.feature
+++ b/packages/x-components/tests/e2e/cucumber/filters/clear-filters.feature
@@ -6,6 +6,7 @@ Feature: Clear selected filters
     And   a related tags API
     And   a recommendations API with a known response
     And   a results API with a known response
+    And   a tracking API
     And   no special config for layout view
     And   start button is clicked
 

--- a/packages/x-components/tests/e2e/cucumber/filters/exclude-filters.feature
+++ b/packages/x-components/tests/e2e/cucumber/filters/exclude-filters.feature
@@ -6,6 +6,7 @@ Feature: Exclude filters with no results component
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
 
   Scenario Outline: 1. Filters with total results = 0 are not shown
     Given no special config for layout view

--- a/packages/x-components/tests/e2e/cucumber/filters/filters-search.feature
+++ b/packages/x-components/tests/e2e/cucumber/filters/filters-search.feature
@@ -6,6 +6,7 @@ Feature: Filters search component
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
 
   Scenario Outline: 1. Brand filters are updated based on regular and sifted queries
     Given no special config for layout view

--- a/packages/x-components/tests/e2e/cucumber/filters/multiselect-filters.feature
+++ b/packages/x-components/tests/e2e/cucumber/filters/multiselect-filters.feature
@@ -6,6 +6,7 @@ Feature: MultiSelect filters component
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
     And   no special config for layout view
     And   start button is clicked
 

--- a/packages/x-components/tests/e2e/cucumber/filters/simple-filters.feature
+++ b/packages/x-components/tests/e2e/cucumber/filters/simple-filters.feature
@@ -4,6 +4,7 @@ Feature: Simple filters
     Given a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
     And   a recommendations API with a known response
     And   a results API with a known response
     And   no special config for layout view

--- a/packages/x-components/tests/e2e/cucumber/filters/sliced-filters.feature
+++ b/packages/x-components/tests/e2e/cucumber/filters/sliced-filters.feature
@@ -4,6 +4,7 @@ Feature: Sliced Filters components
     Given a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
     And   a recommendations API with a known response
     And   a results API with a known response
 

--- a/packages/x-components/tests/e2e/cucumber/history-queries.feature
+++ b/packages/x-components/tests/e2e/cucumber/history-queries.feature
@@ -2,9 +2,10 @@ Feature: History queries component
 
   Background:
     Given a results API with a known response
-    Given a next queries API
-    Given a suggestions API
-    Given a related tags API
+    And   a next queries API
+    And   a suggestions API
+    And   a related tags API
+    And   a tracking API
 
   Scenario Outline:  1. History query is clicked
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>

--- a/packages/x-components/tests/e2e/cucumber/identifier-results.feature
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results.feature
@@ -6,6 +6,7 @@ Feature: Identifier results component
     And   a next queries API with a known response
     And   a recommendations API with a known response
     And   a results API with no results
+    And   a tracking API
     And   no special config for layout view
 
   Scenario Outline: 1. ID search with results is made

--- a/packages/x-components/tests/e2e/cucumber/keyboard-navigation.feature
+++ b/packages/x-components/tests/e2e/cucumber/keyboard-navigation.feature
@@ -6,6 +6,7 @@ Feature: Keyboard navigation component
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
     And   no special config for layout view
     And   start button is clicked
     And   "lego" is searched

--- a/packages/x-components/tests/e2e/cucumber/mocked-responses.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/mocked-responses.spec.ts
@@ -520,8 +520,8 @@ Given('a suggestions API', () => {
   });
 });
 
-// Suggestions
-Given('a query tagging', () => {
+// Tracking
+Given('a tracking API', () => {
   cy.intercept(trackEndpoint, req => {
     req.reply({});
   });

--- a/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.feature
+++ b/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.feature
@@ -3,6 +3,7 @@ Feature: Next queries component
   Background:
     Given a next queries API with a known response
     Given a results API
+    And   a tracking API
 
   Scenario Outline: 1. Next query is clicked
     Given following config: hide session queries <hideSessionQueries>, requested items <maxItemsToRequest>, loadOnInit <loadOnInit>

--- a/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.feature
+++ b/packages/x-components/tests/e2e/cucumber/partial-results/partial-results.feature
@@ -5,6 +5,7 @@ Feature: Partial results component
     And   a query suggestions API with a known response
     And   a next queries API with a known response
     And   a recommendations API with a known response
+    And   a tracking API
 
   Scenario Outline:  1. Shows no partial results if there are enough results
     Given a results API

--- a/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.feature
+++ b/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.feature
@@ -6,6 +6,7 @@ Feature: Popular searches component
     And   a next queries API
     And   a recommendations API with a known response
     And   a related tags API
+    And   a tracking API
 
   Scenario Outline:  1. Popular searches are load together with the page
     Given following config: hide session queries <hideSessionQueries>, requested items <maxItemsToRequest>, rendered <maxItemsToRender>

--- a/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.feature
+++ b/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.feature
@@ -2,6 +2,7 @@ Feature: Query-suggestions component
 
   Background:
     Given a query suggestions API with a known response
+    And   a tracking API
 
   Scenario Outline: 1. Query suggestions are displayed while typing a query
     Given following config: hide if equals query <hideIfEqualsQuery>, requested items <maxItemsToRequest>

--- a/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.feature
+++ b/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.feature
@@ -2,7 +2,8 @@ Feature: Related tags component
 
   Background:
     Given a related tags API with a known response
-    Given a results API with a known response
+    And   a results API with a known response
+    And   a tracking API
 
   Scenario Outline: 1. Related tag is selected
     Given following config: requested items <maxItemsToRequest>, add to search-box <addToSearchBox>

--- a/packages/x-components/tests/e2e/cucumber/scroll.feature
+++ b/packages/x-components/tests/e2e/cucumber/scroll.feature
@@ -3,6 +3,7 @@ Feature: Exclude filters with no results component
   Background:
     Given a results API with 24 results
     And   a next queries API
+    And   a tracking API
     And   no special config for layout view
 
   Scenario Outline: 1. Scroll is kept in the URL

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.feature
@@ -6,7 +6,7 @@ Feature: Search-box component
     And   a related tags API
     And   a recommendations API with a known response
     And   a results API with a known response
-    And   a query tagging
+    And   a tracking API
 
   Scenario Outline: 1. Query with results is typed and <buttonOrKey> is clicked/pressed (search-box is empty)
     Given following config: hide if equals query <hideIfEqualsQuery>, instant search <instant>, debounce <instantDebounceInMs>

--- a/packages/x-components/tests/e2e/cucumber/sliding-panel.feature
+++ b/packages/x-components/tests/e2e/cucumber/sliding-panel.feature
@@ -3,6 +3,7 @@ Feature: Sliding panel component
   Background:
     Given a related tags API
     And   a results API with a known response
+    And   a tracking API
     And   no special config for layout view
     And   start button is clicked
 

--- a/packages/x-components/tests/e2e/cucumber/sort.feature
+++ b/packages/x-components/tests/e2e/cucumber/sort.feature
@@ -6,6 +6,7 @@ Feature: Search sort components
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
     And   no special config for layout view
     And   start button is clicked
 

--- a/packages/x-components/tests/e2e/cucumber/spellcheck.feature
+++ b/packages/x-components/tests/e2e/cucumber/spellcheck.feature
@@ -5,6 +5,7 @@ Feature: Spellcheck component
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
     And   no special config for layout view
     And   start button is clicked
 

--- a/packages/x-components/tests/e2e/cucumber/url/url.feature
+++ b/packages/x-components/tests/e2e/cucumber/url/url.feature
@@ -20,7 +20,7 @@ Feature: Url component
     Then  the search request contains the origin "url:external"
     When  sort option "<sort>" is selected from the sort "dropdown"
     Then  the search request contains the origin "url:external"
-    Then  navigate back
+    When  navigating back
     Then  the search request contains the origin "<origin>"
     Examples:
       | sort      | origin          |
@@ -29,8 +29,8 @@ Feature: Url component
   Scenario Outline: 3. Navigate back from pdp to serp sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
     Then  the search request contains the origin "url:external"
-    Then  click result in position 0
-    Then  navigate back
+    When  click result in position 0
+    And   navigating back
     Then  the search request contains the origin "<origin>"
     Examples:
       | origin              |

--- a/packages/x-components/tests/e2e/cucumber/url/url.feature
+++ b/packages/x-components/tests/e2e/cucumber/url/url.feature
@@ -6,10 +6,10 @@ Feature: Url component
     And   a next queries API
     And   a suggestions API
     And   a related tags API
+    And   a tracking API
 
   Scenario Outline: 1. Navigating to a URL from the outside sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
-    And   waiting for search request intercept with new origin
     Then  the search request contains the origin "<origin>"
     Examples:
       | origin        |
@@ -17,8 +17,9 @@ Feature: Url component
 
   Scenario Outline: 2. Navigate back and forth in serp sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
+    Then the search request contains the origin "url:external"
     When  sort option "<sort>" is selected from the sort "dropdown"
-    And   waiting for search request intercept with new origin
+    Then the search request contains the origin "url:external"
     Then  navigate back
     Then  the search request contains the origin "<origin>"
     Examples:
@@ -27,8 +28,8 @@ Feature: Url component
 
   Scenario Outline: 3. Navigate back from pdp to serp sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
+    Then  the search request contains the origin "url:external"
     Then  click result in position 0
-    And   waiting for search request intercept with new origin
     Then  navigate back
     Then  the search request contains the origin "<origin>"
     Examples:

--- a/packages/x-components/tests/e2e/cucumber/url/url.feature
+++ b/packages/x-components/tests/e2e/cucumber/url/url.feature
@@ -12,14 +12,14 @@ Feature: Url component
     Given a URL with query parameter "lego"
     Then  the search request contains the origin "<origin>"
     Examples:
-      | origin        |
-      | url:external  |
+      | origin       |
+      | url:external |
 
   Scenario Outline: 2. Navigate back and forth in serp sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
-    Then the search request contains the origin "url:external"
+    Then  the search request contains the origin "url:external"
     When  sort option "<sort>" is selected from the sort "dropdown"
-    Then the search request contains the origin "url:external"
+    Then  the search request contains the origin "url:external"
     Then  navigate back
     Then  the search request contains the origin "<origin>"
     Examples:

--- a/packages/x-components/tests/e2e/cucumber/url/url.feature
+++ b/packages/x-components/tests/e2e/cucumber/url/url.feature
@@ -29,7 +29,7 @@ Feature: Url component
   Scenario Outline: 3. Navigate back from pdp to serp sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
     Then  the search request contains the origin "url:external"
-    When  click result in position 0
+    When  clicking result in position 0
     And   navigating back
     Then  the search request contains the origin "<origin>"
     Examples:

--- a/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
@@ -1,4 +1,4 @@
-import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 // Scenario 1
 Given('a URL with query parameter {string}', (query: string) => {
@@ -13,11 +13,11 @@ Then('the search request contains the origin {string}', (origin: string) => {
 });
 
 // Scenario 2
-Then('navigate back', () => {
+When('navigating back', () => {
   cy.go(-1);
 });
 
 // Scenario 3
-Then('click result in position {int}', (index: number) => {
+When('clicking result in position {int}', (index: number) => {
   cy.getByDataTest('result-link').eq(index).click();
 });

--- a/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
@@ -1,16 +1,12 @@
-import { Given, And, Then } from 'cypress-cucumber-preprocessor/steps';
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 
 // Scenario 1
 Given('a URL with query parameter {string}', (query: string) => {
   cy.visit(`/?useMockedAdapter=true&q=${query}`);
 });
 
-And('waiting for search request intercept with new origin', () => {
-  cy.intercept('https://api.empathy.co/search').as('requestWithOrigin');
-});
-
 Then('the search request contains the origin {string}', (origin: string) => {
-  cy.wait('@requestWithOrigin')
+  cy.wait('@interceptedResults')
     .its('request.body')
     .then(JSON.parse)
     .should('have.property', 'origin', origin);


### PR DESCRIPTION
EX-5127

URL e2e tests where failing some times due to 2 reasons:

- Tracking was not being intercepted
- Search responses were mixed, so some times the `the search request contains the origin` step was doing the assertion over the previous request. This was specially noticeable with a 6x cpu slowdown.
