### PR TITLE
feat(components): fix 'BaseRating' component styles

### DIFF
--- a/packages/x-components/src/components/base-rating.vue
+++ b/packages/x-components/src/components/base-rating.vue
@@ -85,14 +85,14 @@
     display: inline-block;
 
     &--empty {
-      overflow-x: hidden;
+      overflow: hidden;
       display: flex;
     }
 
     &--filled {
       display: flex;
       position: absolute;
-      overflow-x: hidden;
+      overflow: hidden;
       top: 0;
       left: 0;
     }


### PR DESCRIPTION
## Description

This is a very simple PR. It changes the styles of the BaseRating component in order to fit images not only horizontally but vertically also. This happens when using icons that somehow are bigger than the `line-height` and `font-size` being applied by the design tokens.
