### PR TITLE
fix(extraParams): prevent callbacks option from the snippet config to be taken as extra params EX-5104

### DIFF
--- a/packages/x-components/src/x-modules/extra-params/components/__tests__/snippet-config-extra-params.spec.ts
+++ b/packages/x-components/src/x-modules/extra-params/components/__tests__/snippet-config-extra-params.spec.ts
@@ -13,7 +13,7 @@ describe('testing snippet config extra params component', () => {
     XPlugin.resetInstance();
     const [, localVue] = installNewXPlugin();
     XPlugin.registerXModule(extraParamsXModule);
-    const snippetConfig = Vue.observable({ warehouse: 1234 });
+    const snippetConfig = Vue.observable({ warehouse: 1234, callbacks: {} });
 
     const wrapper = mount(
       {
@@ -99,6 +99,20 @@ describe('testing snippet config extra params component', () => {
       2,
       expect.objectContaining({
         eventPayload: { warehouse: 45678 }
+      })
+    );
+  });
+
+  it('not includes the callback configuration as extra params', () => {
+    const { wrapper } = renderSnippetConfigExtraParams();
+    const extraParamsProvidedCallback = jest.fn();
+
+    wrapper.vm.$x.on('ExtraParamsProvided', true).subscribe(extraParamsProvidedCallback);
+
+    expect(extraParamsProvidedCallback).toHaveBeenNthCalledWith<[WirePayload<Dictionary<unknown>>]>(
+      1,
+      expect.not.objectContaining({
+        eventPayload: { callbacks: {} }
       })
     );
   });

--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -41,6 +41,13 @@
     protected extraParams: Dictionary<unknown> = {};
 
     /**
+     * Collection of properties from the snippet config not allowed to be sent as extra params.
+     *
+     * @internal
+     */
+    protected notAllowedExtraParams: Array<keyof SnippetConfig> = ['callbacks'];
+
+    /**
      * Updates the extraParams object when the snippet config changes.
      *
      * @param snippetConfig - The new snippet config.
@@ -59,6 +66,9 @@
       ...snippetExtraParams
     }: SnippetConfig): void {
       forEach(snippetExtraParams, (name, value) => {
+        if (this.notAllowedExtraParams.includes(name)) {
+          return;
+        }
         this.$set(this.extraParams, name, value);
       });
     }


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

In a previous feature we included the option to configure callbacks on the snippet config. Currently every option on the snippet config is set as extra params, leading to the problem that this callbacks object is sent on every request to the backend. In order to avoid this I have added a field to the SnippetConfigExtraParams to control which options from the snippet config we want to prevent to be taken as extra params. 


<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: [EX-5103](https://searchbroker.atlassian.net/browse/EX-5103)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

I added some callbacks configuration to the snippet config on the project's demo app. I also added the SnippetConfigExtraParams component to reproduce the bug. Afterwards I have check that with my change the callbacks are not sent anymore. Besides I added a unit test.


Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
