### PR TITLE
feat(tagging): track pending query

### DIFF
--- a/packages/x-components/src/__stubs__/banners-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/banners-stubs.factory.ts
@@ -24,7 +24,7 @@ export function createBannerStub(identifier: string): Banner {
   return {
     id: `xb-${identifier}`,
     title: `Banner ${identifier}`,
-    url: `http://x-components-banner-${identifier}.com`,
+    url: `/banner/${identifier}`,
     image: `xb-${identifier}.jpg`,
     tagging: {
       click: {

--- a/packages/x-components/src/__stubs__/promoteds-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/promoteds-stubs.factory.ts
@@ -24,7 +24,7 @@ export function createPromotedStub(identifier: string): Promoted {
   return {
     id: `xp-${identifier}`,
     title: `Promoted ${identifier}`,
-    url: `http://x-components-promoted-${identifier}.com`,
+    url: `/promoted/${identifier}`,
     image: `xp-${identifier}.jpg`,
     tagging: {
       click: {

--- a/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/redirections-stubs.factory.ts
@@ -23,7 +23,7 @@ export function getRedirectionsStub(): Redirection[] {
 export function createRedirectionStub(id: string): Redirection {
   return {
     id: `xr-${id}`,
-    url: `https://picsum.photos/seed/${id}/500`,
+    url: `/redirection/${id}`,
     tagging: {
       click: {
         params: {},

--- a/packages/x-components/src/__stubs__/results-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/results-stubs.factory.ts
@@ -81,7 +81,7 @@ function getResultTagging(productId: string): Tagging {
  */
 function getTaggingByAction(action: string, params: Record<string, any>): TaggingInfo {
   return {
-    url: `http://x-components.com/tagging/${action}`,
+    url: `https://api.empathy.co/track/${action}`,
     params: {
       lang: 'es',
       ...params

--- a/packages/x-components/src/adapter/mocked-adapter.ts
+++ b/packages/x-components/src/adapter/mocked-adapter.ts
@@ -16,6 +16,7 @@ import {
   TopRecommendationsResponse,
   TrackingRequest
 } from '@empathyco/x-adapter';
+import { noOp } from '../utils/index';
 import { configureAdapterWithToysrus } from './util';
 
 declare global {
@@ -71,7 +72,10 @@ class E2ETestsAdapter extends EmpathyAdapter {
   }
 
   track(request: TrackingRequest): Promise<void> {
-    return mockFetch(request, 'track');
+    return fetch(request.url, {
+      method: 'POST',
+      body: JSON.stringify(request.params)
+    }).then(noOp);
   }
 
   searchById(request: SearchByIdRequest): Promise<SearchByIdResponse> {

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -315,7 +315,9 @@
               Your search matches a special place in our website, to visit it, your are being
               redirected
             </p>
-            <a @click="redirect" :href="redirection.url">{{ redirection.url }}</a>
+            <a @click="redirect" :href="redirection.url" data-test="redirection-link">
+              {{ redirection.url }}
+            </a>
             <div class="x-list x-list--horizontal x-list--gap-07">
               <button
                 @click="abortRedirect"

--- a/packages/x-components/src/x-modules/search/components/banner.vue
+++ b/packages/x-components/src/x-modules/search/components/banner.vue
@@ -32,8 +32,9 @@
     public banner!: BannerModel;
 
     /**
-     * Emits the promoted click event.
+     * Emits the banner click event.
      *
+     * @internal
      */
     protected emitClickEvent(): void {
       this.$x.emit('UserClickedABanner', this.banner);

--- a/packages/x-components/src/x-modules/search/components/banner.vue
+++ b/packages/x-components/src/x-modules/search/components/banner.vue
@@ -1,5 +1,5 @@
 <template>
-  <a :href="banner.url" class="x-banner" data-test="banner">
+  <a @click="emitClickEvent" :href="banner.url" class="x-banner" data-test="banner">
     <img :src="banner.image" class="x-banner__image" alt="" />
     <h2 class="x-banner__title">{{ banner.title }}</h2>
   </a>
@@ -30,6 +30,14 @@
      */
     @Prop({ required: true })
     public banner!: BannerModel;
+
+    /**
+     * Emits the promoted click event.
+     *
+     */
+    protected emitClickEvent(): void {
+      this.$x.emit('UserClickedABanner', this.banner);
+    }
   }
 </script>
 

--- a/packages/x-components/src/x-modules/search/components/promoted.vue
+++ b/packages/x-components/src/x-modules/search/components/promoted.vue
@@ -34,6 +34,7 @@
     /**
      * Emits the promoted click event.
      *
+     * @internal
      */
     protected emitClickEvent(): void {
       this.$x.emit('UserClickedAPromoted', this.promoted);

--- a/packages/x-components/src/x-modules/search/components/promoted.vue
+++ b/packages/x-components/src/x-modules/search/components/promoted.vue
@@ -1,5 +1,5 @@
 <template>
-  <a :href="promoted.url" class="x-promoted" data-test="promoted">
+  <a @click="emitClickEvent" :href="promoted.url" class="x-promoted" data-test="promoted">
     <img :src="promoted.image" class="x-promoted__image" alt="" />
     <h2 class="x-promoted__title">{{ promoted.title }}</h2>
   </a>
@@ -30,6 +30,14 @@
      */
     @Prop({ required: true })
     public promoted!: PromotedModel;
+
+    /**
+     * Emits the promoted click event.
+     *
+     */
+    protected emitClickEvent(): void {
+      this.$x.emit('UserClickedAPromoted', this.promoted);
+    }
   }
 </script>
 

--- a/packages/x-components/src/x-modules/search/components/redirection.vue
+++ b/packages/x-components/src/x-modules/search/components/redirection.vue
@@ -54,7 +54,7 @@
      *
      * @internal
      */
-    protected timeoutId!: number;
+    protected timeoutId?: number;
 
     /**
      * Boolean flag which indicates if the redirection is running.

--- a/packages/x-components/src/x-modules/search/events.types.ts
+++ b/packages/x-components/src/x-modules/search/events.types.ts
@@ -1,5 +1,13 @@
 import { SearchRequest } from '@empathyco/x-adapter';
-import { Facet, Result, Sort, Redirection, TaggingInfo } from '@empathyco/x-types';
+import {
+  Facet,
+  Result,
+  Sort,
+  Redirection,
+  TaggingInfo,
+  Promoted,
+  Banner
+} from '@empathyco/x-types';
 
 /**
  * Dictionary of the events of Search XModule, where each key is the event name, and the value is
@@ -71,6 +79,16 @@ export interface SearchXEvents {
    * * Payload: The clicked redirection.
    */
   UserClickedARedirection: Redirection;
+  /**
+   * The user has clicked a promoted.
+   * * Payload: The clicked promoted.
+   */
+  UserClickedAPromoted: Promoted;
+  /**
+   * The user has clicked a banner.
+   * * Payload: The clicked banner.
+   */
+  UserClickedABanner: Banner;
   /**
    * The user has aborted a redirection.
    */

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -81,7 +81,16 @@ export const setSessionDuration = wireCommit('setSessionDuration');
 export const trackQueryWire = moduleDebounce(
   wireDispatch('track'),
   ({ state }) => state.config.queryTaggingDebounceMs,
-  { cancelOn: 'UserClearedQuery' }
+  {
+    cancelOn: 'UserClearedQuery',
+    forceOn: [
+      'UserClickedAResult',
+      'UserClickedAPromoted',
+      'UserClickedABanner',
+      'UserClickedARedirection',
+      'UserReachedResultsListEnd'
+    ]
+  }
 );
 
 /**

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -1,12 +1,12 @@
 import { Result } from '@empathyco/x-types';
-import { mapWire, filter } from '../../wiring/wires.operators';
-import { namespacedDebounce } from '../../wiring/namespaced-wires.operators';
-import { Wire } from '../../wiring/wiring.types';
 import {
   namespacedWireCommit,
   namespacedWireDispatch
 } from '../../wiring/namespaced-wires.factory';
+import { namespacedDebounce } from '../../wiring/namespaced-wires.operators';
 import { wireServiceWithoutPayload } from '../../wiring/wires.factory';
+import { filter } from '../../wiring/wires.operators';
+import { Wire } from '../../wiring/wiring.types';
 import { createWiring } from '../../wiring/wiring.utils';
 import { DefaultSessionService } from './service/session.service';
 
@@ -117,7 +117,7 @@ export const trackAddToCartWire = createTrackResultWire('add2cart');
  */
 function createTrackResultWire(property: keyof Result['tagging']): Wire<Result> {
   return filter(
-    mapWire(wireDispatch('track'), ({ tagging }) => tagging[property]!),
+    wireDispatch('track', ({ eventPayload: { tagging } }) => tagging[property]!),
     ({ eventPayload: { tagging } }) => !!tagging?.[property]
   );
 }

--- a/packages/x-components/tests/e2e/cucumber/mocked-responses.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/mocked-responses.spec.ts
@@ -6,13 +6,17 @@ import {
   SuggestionsResponse,
   TopRecommendationsResponse
 } from '@empathyco/x-adapter';
+import { SearchRequest } from '@empathyco/x-adapter/src/index';
 import { Given } from 'cypress-cucumber-preprocessor/steps';
 import {
+  createBannerStub,
   createHierarchicalFacetStub,
   createNextQueryStub,
   createNumberRangeFacetStub,
   createPopularSearch,
+  createPromotedStub,
   createQuerySuggestion,
+  createRedirectionStub,
   createRelatedTagStub,
   createResultStub,
   createSimpleFacetStub,
@@ -101,7 +105,7 @@ Given('a results API with partial results', () => {
       spellcheck: '',
       totalResults: 1,
       queryTagging: {
-        url: 'https://tagging.empathy.co/',
+        url: 'https://api.empathy.co/',
         params: {}
       },
       redirections: [],
@@ -235,279 +239,279 @@ Given('a related tags API with a selected one', () => {
 // Results
 Given('a results API with a known response', () => {
   cy.intercept(searchEndpoint, req => {
-    req.reply(<SearchResponse>{
-      banners: [],
-      promoteds: [],
-      redirections: [],
-      partialResults: [],
-      queryTagging: {
-        url: 'https://analytics.com',
-        params: {}
-      },
-      spellcheck: '',
-      facets: [
-        createSimpleFacetStub('brand_facet', createSimpleFilter => [
-          createSimpleFilter('Juguetes deportivos', false, 3),
-          createSimpleFilter('Puzzles', false, 0),
-          createSimpleFilter('Construcción', false, 7),
-          createSimpleFilter('Construye', false, 6),
-          createSimpleFilter('Disfraces', false, 0)
-        ]),
-        createNumberRangeFacetStub('price_facet', createNumberRangeFilter => [
-          createNumberRangeFilter({ min: 0, max: 10 }, false),
-          createNumberRangeFilter({ min: 10, max: 20 }, false),
-          createNumberRangeFilter({ min: 20, max: 30 }, false),
-          createNumberRangeFilter({ min: 30, max: 40 }, false),
-          createNumberRangeFilter({ min: 40, max: 60 }, false),
-          createNumberRangeFilter({ min: 60, max: 100 }, false)
-        ]),
-        createNumberRangeFacetStub('age_facet', createNumberRangeFilter => [
-          createNumberRangeFilter({ min: 0, max: 1 }, false),
-          createNumberRangeFilter({ min: 1, max: 3 }, false),
-          createNumberRangeFilter({ min: 3, max: 6 }, false),
-          createNumberRangeFilter({ min: 6, max: 9 }, false),
-          createNumberRangeFilter({ min: 9, max: 12 }, false),
-          createNumberRangeFilter({ min: 12, max: 99 }, false)
-        ]),
-        createHierarchicalFacetStub('hierarchical_category', createFilter => [
-          ...createFilter('Vehículos y pistas', false, createFilter => [
-            ...createFilter('Radiocontrol', false)
+    req.reply(
+      createSearchResponse({
+        facets: [
+          createSimpleFacetStub('brand_facet', createSimpleFilter => [
+            createSimpleFilter('Juguetes deportivos', false, 3),
+            createSimpleFilter('Puzzles', false, 0),
+            createSimpleFilter('Construcción', false, 7),
+            createSimpleFilter('Construye', false, 6),
+            createSimpleFilter('Disfraces', false, 0)
           ]),
-          ...createFilter('Juguetes electrónicos', false, createFilter => [
-            ...createFilter('Imagen y audio', false)
+          createNumberRangeFacetStub('price_facet', createNumberRangeFilter => [
+            createNumberRangeFilter({ min: 0, max: 10 }, false),
+            createNumberRangeFilter({ min: 10, max: 20 }, false),
+            createNumberRangeFilter({ min: 20, max: 30 }, false),
+            createNumberRangeFilter({ min: 30, max: 40 }, false),
+            createNumberRangeFilter({ min: 40, max: 60 }, false),
+            createNumberRangeFilter({ min: 60, max: 100 }, false)
           ]),
-          ...createFilter('Educativos', false, createFilter => [
-            ...createFilter('Juguetes educativos', false)
+          createNumberRangeFacetStub('age_facet', createNumberRangeFilter => [
+            createNumberRangeFilter({ min: 0, max: 1 }, false),
+            createNumberRangeFilter({ min: 1, max: 3 }, false),
+            createNumberRangeFilter({ min: 3, max: 6 }, false),
+            createNumberRangeFilter({ min: 6, max: 9 }, false),
+            createNumberRangeFilter({ min: 9, max: 12 }, false),
+            createNumberRangeFilter({ min: 12, max: 99 }, false)
           ]),
-          ...createFilter('Creativos', false, createFilter => [...createFilter('Crea', false)]),
-          ...createFilter('Muñecas', false, createFilter => [
-            ...createFilter('Peluches', false),
-            ...createFilter('Ropa y accesorios', false),
-            ...createFilter('Playsets', false),
-            ...createFilter('Bebés', false),
-            ...createFilter('Carros', false)
-          ]),
-          ...createFilter('Construcción', false, createFilter => [
-            ...createFilter('Construye', false)
+          createHierarchicalFacetStub('hierarchical_category', createFilter => [
+            ...createFilter('Vehículos y pistas', false, createFilter => [
+              ...createFilter('Radiocontrol', false)
+            ]),
+            ...createFilter('Juguetes electrónicos', false, createFilter => [
+              ...createFilter('Imagen y audio', false)
+            ]),
+            ...createFilter('Educativos', false, createFilter => [
+              ...createFilter('Juguetes educativos', false)
+            ]),
+            ...createFilter('Creativos', false, createFilter => [...createFilter('Crea', false)]),
+            ...createFilter('Muñecas', false, createFilter => [
+              ...createFilter('Peluches', false),
+              ...createFilter('Ropa y accesorios', false),
+              ...createFilter('Playsets', false),
+              ...createFilter('Bebés', false),
+              ...createFilter('Carros', false)
+            ]),
+            ...createFilter('Construcción', false, createFilter => [
+              ...createFilter('Construye', false)
+            ])
           ])
-        ])
-      ],
-      results: [
-        createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
-          images: ['https://picsum.photos/seed/1/100/100'],
-          price: {
-            hasDiscount: false,
-            originalValue: 59.99,
-            value: 59.99
-          }
-        }),
-        createResultStub('LEGO Duplo Classic Caja de Ladrillos - 1091', {
-          images: ['https://picsum.photos/seed/2/100/100'],
-          price: {
-            hasDiscount: false,
-            originalValue: 29.99,
-            value: 29.99
-          }
-        }),
-        createResultStub('LEGO City Coche Patrulla de Policía - 60239', {
-          images: ['https://picsum.photos/seed/3/100/100'],
-          price: {
-            hasDiscount: false,
-            originalValue: 11.99,
-            value: 11.99
-          }
-        }),
-        createResultStub('LEGO City Police Caja de Ladrillos - 60270', {
-          images: ['https://picsum.photos/seed/4/100/100'],
-          price: {
-            hasDiscount: false,
-            originalValue: 39.99,
-            value: 39.99
-          }
-        }),
-        createResultStub('LEGO Friends Parque para Cachorros - 41396', {
-          images: ['https://picsum.photos/seed/5/100/100'],
-          price: {
-            hasDiscount: false,
-            originalValue: 11.99,
-            value: 11.99
-          }
-        }),
-        createResultStub('LEGO Creator Ciberdrón - 31111', {
-          images: ['https://picsum.photos/seed/6/100/100'],
-          price: {
-            hasDiscount: false,
-            originalValue: 11.99,
-            value: 11.99
-          }
-        }),
-        createResultStub('LEGO Technic Dragster - 42103', {
-          images: ['https://picsum.photos/seed/7/100/100'],
-          price: {
-            hasDiscount: false,
-            originalValue: 22.99,
-            value: 22.99
-          }
-        })
-      ],
-      totalResults: 7
-    });
+        ],
+        results: [
+          createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
+            images: ['https://picsum.photos/seed/1/100/100'],
+            price: {
+              hasDiscount: false,
+              originalValue: 59.99,
+              value: 59.99
+            }
+          }),
+          createResultStub('LEGO Duplo Classic Caja de Ladrillos - 1091', {
+            images: ['https://picsum.photos/seed/2/100/100'],
+            price: {
+              hasDiscount: false,
+              originalValue: 29.99,
+              value: 29.99
+            }
+          }),
+          createResultStub('LEGO City Coche Patrulla de Policía - 60239', {
+            images: ['https://picsum.photos/seed/3/100/100'],
+            price: {
+              hasDiscount: false,
+              originalValue: 11.99,
+              value: 11.99
+            }
+          }),
+          createResultStub('LEGO City Police Caja de Ladrillos - 60270', {
+            images: ['https://picsum.photos/seed/4/100/100'],
+            price: {
+              hasDiscount: false,
+              originalValue: 39.99,
+              value: 39.99
+            }
+          }),
+          createResultStub('LEGO Friends Parque para Cachorros - 41396', {
+            images: ['https://picsum.photos/seed/5/100/100'],
+            price: {
+              hasDiscount: false,
+              originalValue: 11.99,
+              value: 11.99
+            }
+          }),
+          createResultStub('LEGO Creator Ciberdrón - 31111', {
+            images: ['https://picsum.photos/seed/6/100/100'],
+            price: {
+              hasDiscount: false,
+              originalValue: 11.99,
+              value: 11.99
+            }
+          }),
+          createResultStub('LEGO Technic Dragster - 42103', {
+            images: ['https://picsum.photos/seed/7/100/100'],
+            price: {
+              hasDiscount: false,
+              originalValue: 22.99,
+              value: 22.99
+            }
+          })
+        ],
+        totalResults: 7
+      })
+    );
   }).as('interceptedResults');
 });
 
 Given('a second results API with a known response', () => {
   cy.intercept(searchEndpoint, req => {
-    req.reply(<SearchResponse>{
-      banners: [],
-      promoteds: [],
-      facets: [],
-      results: [
-        createResultStub('LEGO Duplo Disney Tren de Cumpleaños de Mickey y Minnie - 10941', {
-          images: ['https://picsum.photos/seed/8/100/100']
-        }),
-        createResultStub('LEGO Disney Granja de Mickey Mouse y el Pato Donald - 10775', {
-          images: ['https://picsum.photos/seed/10/100/100']
-        })
-      ],
-      redirections: [],
-      partialResults: [],
-      totalResults: 7,
-      queryTagging: {
-        url: 'https://tagging.empathy.co',
-        params: {}
-      },
-      spellcheck: ''
-    });
+    req.reply(
+      createSearchResponse({
+        results: [
+          createResultStub('LEGO Duplo Disney Tren de Cumpleaños de Mickey y Minnie - 10941', {
+            images: ['https://picsum.photos/seed/8/100/100']
+          }),
+          createResultStub('LEGO Disney Granja de Mickey Mouse y el Pato Donald - 10775', {
+            images: ['https://picsum.photos/seed/10/100/100']
+          })
+        ],
+        totalResults: 7
+      })
+    );
   }).as('interceptedNewResults');
 });
 
 Given('a results API with {int} results', (resultsLength: number) => {
   cy.intercept(searchEndpoint, req => {
-    req.reply(<SearchResponse>{
-      banners: [],
-      promoteds: [],
-      redirections: [],
-      partialResults: [],
-      queryTagging: {
-        url: 'https://analytics.com',
-        params: {}
-      },
-      spellcheck: '',
-      facets: [],
-      results: Array.from({ length: resultsLength }, (_, index) =>
-        createResultStub(`Result ${index}`, {
-          images: [`https://picsum.photos/seed/${index}/100/100`]
-        })
-      ),
-      totalResults: 24
-    });
+    req.reply(
+      createSearchResponse({
+        results: Array.from({ length: resultsLength }, (_, index) =>
+          createResultStub(`Result ${index}`, {
+            images: [`https://picsum.photos/seed/${index}/100/100`]
+          })
+        ),
+        totalResults: resultsLength
+      })
+    );
   }).as('interceptedResults');
 });
 
 Given('a results API with no results', () => {
   cy.intercept(searchEndpoint, req => {
-    req.reply(<SearchResponse>{
-      banners: [],
-      promoteds: [],
-      redirections: [],
-      partialResults: [],
-      queryTagging: {
-        url: 'https://analytics.com',
-        params: {}
-      },
-      spellcheck: '',
-      facets: [],
-      results: [],
-      totalResults: 0
-    });
+    req.reply(
+      createSearchResponse({
+        results: [],
+        totalResults: 0
+      })
+    );
   }).as('interceptedNoResults');
 });
 
 Given('a results API with broken images', () => {
   cy.intercept(searchEndpoint, req => {
-    req.reply(<SearchResponse>{
-      banners: [],
-      promoteds: [],
-      redirections: [],
-      facets: [],
-      totalResults: 3,
-      partialResults: [],
-      spellcheck: '',
-      queryTagging: {
-        url: 'https://tagging.empathy.co',
-        params: {}
-      },
-      results: [
-        createResultStub('Result 1', {
-          images: ['https://picsum.photos/seed/18/100/100', 'https://picsum.photos/seed/2/100/100'],
-          price: {
-            hasDiscount: false,
-            originalValue: 59.99,
-            value: 59.99
-          }
-        }),
-        createResultStub('Result 2', {
-          images: ['https://notexistsimage1.com', 'https://notexistsimage2.com'],
-          price: {
-            hasDiscount: false,
-            originalValue: 59.99,
-            value: 59.99
-          }
-        }),
-        createResultStub('Result 3', {
-          images: [
-            'https://notexistsimage1.com',
-            'https://notexistsimage2.com',
-            'https://notexistsimage3.com',
-            'https://picsum.photos/seed/20/100/100'
-          ],
-          price: {
-            hasDiscount: false,
-            originalValue: 59.99,
-            value: 59.99
-          }
-        })
-      ]
-    });
+    req.reply(
+      createSearchResponse({
+        totalResults: 3,
+        results: [
+          createResultStub('Result 1', {
+            images: [
+              'https://picsum.photos/seed/18/100/100',
+              'https://picsum.photos/seed/2/100/100'
+            ],
+            price: {
+              hasDiscount: false,
+              originalValue: 59.99,
+              value: 59.99
+            }
+          }),
+          createResultStub('Result 2', {
+            images: ['https://notexistsimage1.com', 'https://notexistsimage2.com'],
+            price: {
+              hasDiscount: false,
+              originalValue: 59.99,
+              value: 59.99
+            }
+          }),
+          createResultStub('Result 3', {
+            images: [
+              'https://notexistsimage1.com',
+              'https://notexistsimage2.com',
+              'https://notexistsimage3.com',
+              'https://picsum.photos/seed/20/100/100'
+            ],
+            price: {
+              hasDiscount: false,
+              originalValue: 59.99,
+              value: 59.99
+            }
+          })
+        ]
+      })
+    );
   }).as('interceptedFallbackResults');
+});
+
+Given('a results API with {int} pages', (numberOfPages: number) => {
+  cy.intercept(searchEndpoint, req => {
+    const { rows = 24, start = 0 }: SearchRequest = JSON.parse(req.body);
+    req.reply(
+      createSearchResponse({
+        results: Array.from({ length: rows }, (_, index) =>
+          createResultStub(`Result ${start + index}`, {
+            images: [`https://picsum.photos/seed/${start + index}/100/100`]
+          })
+        ),
+        totalResults: numberOfPages * rows,
+        queryTagging: {
+          url: `${trackEndpoint}/query`,
+          params: { page: 2 }
+        }
+      })
+    );
+  }).as('interceptedResults');
 });
 
 Given('a results API', () => {
   cy.intercept('https://api.empathy.co/search', req => {
-    req.reply(<SearchResponse>{
-      redirections: [],
-      banners: [],
-      promoteds: [],
-      results: getResultsStub(),
-      spellcheck: '',
-      totalResults: 1,
-      facets: [],
-      partialResults: [],
-      queryTagging: {
-        url: 'https://tagging.empathy.co',
-        params: {}
-      }
-    });
+    req.reply(createSearchResponse());
   }).as('interceptedRawResults');
 });
+
+Given('a results API with a promoted', () => {
+  cy.intercept(searchEndpoint, req => {
+    req.reply(createSearchResponse({ promoteds: [createPromotedStub('Promotion')] }));
+  }).as('interceptedResults');
+});
+
+Given('a results API with a banner', () => {
+  cy.intercept(searchEndpoint, req => {
+    req.reply(createSearchResponse({ banners: [createBannerStub('Banner')] }));
+  }).as('interceptedResults');
+});
+
+Given('a results API with a redirection', () => {
+  cy.intercept(searchEndpoint, req => {
+    req.reply(createSearchResponse({ redirections: [createRedirectionStub('Redirection')] }));
+  }).as('interceptedResults');
+});
+
+/**
+ * Creates a search response.
+ *
+ * @param partial - Partial search response to override default fields.
+ * @returns A complete search response object.
+ */
+function createSearchResponse(partial?: Partial<SearchResponse>): SearchResponse {
+  return {
+    banners: [],
+    promoteds: [],
+    facets: [],
+    results: getResultsStub(),
+    redirections: [],
+    partialResults: [],
+    totalResults: 24,
+    queryTagging: {
+      url: `${trackEndpoint}/query`,
+      params: { page: 1 }
+    },
+    spellcheck: '',
+    ...partial
+  };
+}
 
 // Spellcheck
 Given('a results API response for a misspelled word', () => {
   cy.intercept(searchEndpoint, req => {
-    req.reply(<SearchResponse>{
-      banners: [],
-      promoteds: [],
-      facets: [],
-      results: [],
-      redirections: [],
-      partialResults: [],
-      totalResults: 7,
-      queryTagging: {
-        url: 'https://tagging.empathy.co',
-        params: {}
-      },
-      spellcheck: 'lego'
-    });
+    req.reply(createSearchResponse({ spellcheck: 'lego' }));
   });
 });
 
@@ -522,7 +526,19 @@ Given('a suggestions API', () => {
 
 // Tracking
 Given('a tracking API', () => {
-  cy.intercept(trackEndpoint, req => {
+  cy.intercept(`${trackEndpoint}/*`, req => {
     req.reply({});
   });
+});
+
+Given('a query tagging API', () => {
+  cy.intercept(`${trackEndpoint}/query`, req => {
+    req.reply({});
+  }).as('queryTagging');
+});
+
+Given('a click tagging API', () => {
+  cy.intercept(`${trackEndpoint}/click`, req => {
+    req.reply({});
+  }).as('clickTagging');
 });

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
@@ -5,13 +5,66 @@ Feature: Tagging component
     And   a suggestions API
     And   a related tags API
     And   a recommendations API with a known response
-    And   a results API with a known response
-    Given a URL with query parameter "lego"
+    And   a query tagging API
+    And   a click tagging API
 
   Scenario: 1. Navigating to a URL with a query triggers the query tagging.
+    Given a results API with a known response
+    And   a URL with query parameter "lego"
     Then  query tagging request is triggered
 
-  Scenario: 2. Clicking a result triggers the result click tagging.
-    Then query tagging request is triggered
-    Given click the first result
+  Scenario: 2. Searching triggers the query tagging.
+    Given a results API with a known response
+    And no special config for layout view
+    When  start button is clicked
+    And "lego" is searched
+    Then  query tagging request is triggered
+
+  Scenario: 3. Clicking a result triggers the result click tagging.
+    Given a results API with a known response
+    And no special config for layout view
+    When start button is clicked
+    And "lego" is searched
+    And first result is clicked
     Then result click tagging request is triggered
+
+  Scenario: 4. Clicking a result triggers the query tagging
+    Given a results API with a known response
+    And no special config for layout view
+    When start button is clicked
+    And "lego" is searched
+    And first result is clicked
+    Then  query tagging request is triggered
+
+  Scenario: 5. Clicking a promoted triggers the query tagging
+    Given a results API with a promoted
+    And no special config for layout view
+    When start button is clicked
+    And "lego" is searched
+    And first promoted is clicked
+    Then query tagging request is triggered
+
+  Scenario: 6. Clicking a banner triggers the query tagging
+    Given a results API with a banner
+    And no special config for layout view
+    When start button is clicked
+    And "lego" is searched
+    And first banner is clicked
+    Then query tagging request is triggered
+
+  Scenario: 7. A redirection triggers query tagging
+    Given a results API with a redirection
+    And no special config for layout view
+    When start button is clicked
+    And "lego" is searched
+    And first redirection is clicked
+    Then query tagging request is triggered
+
+  Scenario: 8. Infinite scrolling triggers query tagging
+    Given a results API with 2 pages
+    And no special config for layout view
+    When start button is clicked
+    And "lego" is searched
+    And scrolls down to next page
+    Then query tagging request is triggered
+    And second page query tagging request is triggered

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -1,32 +1,37 @@
-import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
-const mockedApiUrl = 'https://api.empathy.co';
-const trackEndpoint = `${mockedApiUrl}/track`;
-
-// Scenario 1
 Given('a URL with query parameter {string}', (query: string) => {
   cy.visit(`/?useMockedAdapter=true&q=${query}`);
 });
 
-Then('query tagging request is triggered', () => {
-  cy.intercept(trackEndpoint, req => {
-    req.reply({});
-  }).as('queryTagging');
-
-  cy.wait('@queryTagging')
-    .its('request.body')
-    .then(JSON.parse)
-    .should('have.property', 'url', 'https://analytics.com');
+When('first result is clicked', () => {
+  cy.getByDataTest('result-link').first().click();
 });
 
-// Scenario 2
-Given('click the first result', () => {
-  cy.getByDataTest('result-link').first().rightclick();
+When('first promoted is clicked', () => {
+  cy.getByDataTest('promoted').first().click();
+});
+
+When('first banner is clicked', () => {
+  cy.getByDataTest('banner').first().click();
+});
+
+When('first redirection is clicked', () => {
+  cy.getByDataTest('redirection-link').first().click();
+});
+
+When('scrolls down to next page', () => {
+  cy.getByDataTest('result-link').last().scrollIntoView();
 });
 
 Then('result click tagging request is triggered', () => {
-  cy.wait('@queryTagging')
-    .its('request.body')
-    .then(JSON.parse)
-    .should('have.property', 'url', 'http://x-components.com/tagging/click');
+  cy.wait('@clickTagging');
+});
+
+Then('query tagging request is triggered', () => {
+  cy.wait('@queryTagging');
+});
+
+Then('second page query tagging request is triggered', () => {
+  cy.wait('@queryTagging').its('request.body').then(JSON.parse).should('have.property', 'page', 2);
 });


### PR DESCRIPTION
EX-4963

Forces the query tracking to happen immediately in these situations:

- When a search result is clicked.
- When a promoted is clicked.
- When a banner is clicked.
- When a redirection is triggered.
- When a the user triggers the infinite scroll.

This is needed to ensure that we properly track each search request upon any user interaction with the current search response. Otherwise we might lose certain events, as the user might leave the SERP (like on click events), or load a new page (with the infinite scroll).