### PR TITLE
fix(components): Export Layouts components.

### DIFF
--- a/packages/x-components/src/components/__tests__/staggering-transition-group.spec.ts
+++ b/packages/x-components/src/components/__tests__/staggering-transition-group.spec.ts
@@ -1,7 +1,7 @@
 import { mount, Wrapper, WrapperArray } from '@vue/test-utils';
 import Vue, { ComponentOptions } from 'vue';
 import { getDataTestSelector } from '../../__tests__/utils';
-import StaggeringTransitionGroup from '../staggering-transition-group.vue';
+import StaggeringTransitionGroup from '../animations/staggering-transition-group.vue';
 
 describe('testing Staggering Transition Group component', () => {
   const wrapper: ComponentOptions<Vue> = {

--- a/packages/x-components/src/components/animations/index.ts
+++ b/packages/x-components/src/components/animations/index.ts
@@ -5,6 +5,7 @@ export { default as CollapseWidth } from './collapse-width.vue';
 export { default as CrossFade } from './cross-fade.vue';
 export { default as FadeAndSlide } from './fade-and-slide.vue';
 export { default as StaggeredFadeAndSlide } from './staggered-fade-and-slide.vue';
+export { default as StaggeringTransitionGroup } from './staggering-transition-group.vue';
 export { default as TranslateFromLeft } from './translate-from-left.vue';
 export { default as TranslateFromRight } from './translate-from-right.vue';
 export { createCollapseAnimationMixin } from './animations.mixin';

--- a/packages/x-components/src/components/animations/staggered-fade-and-slide.vue
+++ b/packages/x-components/src/components/animations/staggered-fade-and-slide.vue
@@ -14,7 +14,7 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
-  import StaggeringTransitionGroup from '../staggering-transition-group.vue';
+  import StaggeringTransitionGroup from '../animations/staggering-transition-group.vue';
 
   /**
    * Renders a transition group wrapping the elements passed in the default slot and animating

--- a/packages/x-components/src/components/animations/staggering-transition-group.vue
+++ b/packages/x-components/src/components/animations/staggering-transition-group.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Vue, { CreateElement, VNode } from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { noOp } from '../utils';
+  import { noOp } from '../../utils';
 
   /* eslint-disable @typescript-eslint/unbound-method */
   /**

--- a/packages/x-components/src/components/index.ts
+++ b/packages/x-components/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './column-picker';
 export * from './currency';
 export * from './filters';
 export * from './icons';
+export * from './layouts';
 export * from './modals';
 export * from './panels';
 export * from './result';
@@ -20,9 +21,6 @@ export { default as BaseVariableColumnGrid } from './base-variable-column-grid.v
 export { NoElement } from './no-element';
 export { default as SlidingPanel } from './sliding-panel.vue';
 export { default as ItemsList } from './items-list.vue';
-export { default as StaggeringTransitionGroup } from './staggering-transition-group.vue';
-export { default as MultiColumnMaxWidthLayout } from './layouts/multi-column-max-width-layout.vue';
-export { default as SingleColumnLayout } from './layouts/single-column-layout.vue';
 export { default as LocationProvider } from './location-provider.vue';
 export { default as GlobalXBus } from './global-x-bus.vue';
 export { default as SnippetCallbacks } from './snippet-callbacks.vue';

--- a/packages/x-components/src/components/layouts/index.ts
+++ b/packages/x-components/src/components/layouts/index.ts
@@ -1,0 +1,3 @@
+export { default as FixedHeaderAndAsidesLayout } from './fixed-header-and-asides-layout.vue';
+export { default as MultiColumnMaxWidthLayout } from './multi-column-max-width-layout.vue';
+export { default as SingleColumnLayout } from './single-column-layout.vue';


### PR DESCRIPTION
EX-5160

# Pull request template

- Exported `FixedHeaderAndAsidesLayout` component
- Created a barrel for all layout components
- Move `StaggeringTransitionGroup` component to `animations` folder
