### PR TITLE
test(e2e): fix tagging tests

### DIFF
--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
@@ -11,14 +11,14 @@ Feature: Tagging component
   Scenario: 1. Navigating to a URL with a query triggers the query tagging.
     Given a results API with a known response
     And   a URL with query parameter "lego"
-    Then  query tagging request is triggered
+    Then  query tagging request should be triggered
 
   Scenario: 2. Searching triggers the query tagging.
     Given a results API with a known response
     And no special config for layout view
     When  start button is clicked
     And "lego" is searched
-    Then  query tagging request is triggered
+    Then  query tagging request should be triggered
 
   Scenario: 3. Clicking a result triggers the result click tagging.
     Given a results API with a known response
@@ -34,7 +34,7 @@ Feature: Tagging component
     When start button is clicked
     And "lego" is searched
     And first result is clicked
-    Then  query tagging request is triggered
+    Then  query tagging request has been triggered
 
   Scenario: 5. Clicking a promoted triggers the query tagging
     Given a results API with a promoted
@@ -42,7 +42,7 @@ Feature: Tagging component
     When start button is clicked
     And "lego" is searched
     And first promoted is clicked
-    Then query tagging request is triggered
+    Then query tagging request has been triggered
 
   Scenario: 6. Clicking a banner triggers the query tagging
     Given a results API with a banner
@@ -50,7 +50,7 @@ Feature: Tagging component
     When start button is clicked
     And "lego" is searched
     And first banner is clicked
-    Then query tagging request is triggered
+    Then query tagging request has been triggered
 
   Scenario: 7. A redirection triggers query tagging
     Given a results API with a redirection
@@ -58,13 +58,15 @@ Feature: Tagging component
     When start button is clicked
     And "lego" is searched
     And first redirection is clicked
-    Then query tagging request is triggered
+    Then query tagging request has been triggered
 
   Scenario: 8. Infinite scrolling triggers query tagging
     Given a results API with 2 pages
     And no special config for layout view
     When start button is clicked
     And "lego" is searched
-    And scrolls down to next page
-    Then query tagging request is triggered
+    Then results page number 1 is loaded
+    When scrolls down to next page
+    Then results page number 2 is loaded
+    And query tagging request has been triggered
     And second page query tagging request is triggered

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -37,10 +37,7 @@ Then('query tagging request has been triggered', () => {
 });
 
 Then('second page query tagging request is triggered', () => {
-  cy.wait('@queryTagging', { timeout: 10000 })
-    .its('request.body')
-    .then(JSON.parse)
-    .should('have.property', 'page', 2);
+  cy.wait('@queryTagging').its('request.body').then(JSON.parse).should('have.property', 'page', 2);
 });
 
 Then('results page number {int} is loaded', (page: number) => {

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -21,17 +21,28 @@ When('first redirection is clicked', () => {
 });
 
 When('scrolls down to next page', () => {
-  cy.getByDataTest('result-link').last().scrollIntoView();
+  cy.getByDataTest('result-link').last().scrollIntoView({ easing: 'linear', duration: 2000 });
 });
 
 Then('result click tagging request is triggered', () => {
-  cy.wait('@clickTagging');
+  cy.get('@clickTagging').should('exist');
 });
 
-Then('query tagging request is triggered', () => {
+Then('query tagging request should be triggered', () => {
   cy.wait('@queryTagging');
 });
 
+Then('query tagging request has been triggered', () => {
+  cy.get('@queryTagging').should('exist');
+});
+
 Then('second page query tagging request is triggered', () => {
-  cy.wait('@queryTagging').its('request.body').then(JSON.parse).should('have.property', 'page', 2);
+  cy.wait('@queryTagging', { timeout: 10000 })
+    .its('request.body')
+    .then(JSON.parse)
+    .should('have.property', 'page', 2);
+});
+
+Then('results page number {int} is loaded', (page: number) => {
+  cy.getByDataTest('result-link').should('have.length', 24 * page);
 });


### PR DESCRIPTION
EX-5161

This should fix tagging e2e tests which could fail on slower machines. Previously throttling the tests it could happen that the tracking calls were already made before cypress had time to wait for them, so it couldn't see them.

This also happened in the infinite scroll query tagging test, where some times it was expecting the first query tagging call to be the second one, or it could even fail scrolling down and loading the next page.