### PR TITLE
feat(alias): add selected sort

### DIFF
--- a/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
@@ -85,7 +85,6 @@ describe('testing plugin alias', () => {
     componentInstance.vm.$store.commit('x/querySuggestions/setQuery', 'working');
     componentInstance.vm.$store.commit('x/relatedTags/setQuery', 'properly');
     componentInstance.vm.$store.commit('x/search/setQuery', 'nice');
-    componentInstance.vm.$store.commit('x/search/setSort', 'super!');
 
     expect(componentInstance.vm.$x.query).toEqual({
       searchBox: 'this',
@@ -94,7 +93,6 @@ describe('testing plugin alias', () => {
       relatedTags: 'properly',
       search: 'nice'
     });
-    expect(componentInstance.vm.$x.selectedSort).toBe('super!');
   });
 
   it('updates the status values when the module is registered', () => {

--- a/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
@@ -67,7 +67,8 @@ describe('testing plugin alias', () => {
       selectedFilters: [],
       selectedRelatedTags: [],
       spellcheckedQuery: null,
-      totalResults: 0
+      totalResults: 0,
+      selectedSort: ''
     };
     expect(componentInstance.vm.$x).toMatchObject(defaultValues);
   });
@@ -84,6 +85,7 @@ describe('testing plugin alias', () => {
     componentInstance.vm.$store.commit('x/querySuggestions/setQuery', 'working');
     componentInstance.vm.$store.commit('x/relatedTags/setQuery', 'properly');
     componentInstance.vm.$store.commit('x/search/setQuery', 'nice');
+    componentInstance.vm.$store.commit('x/search/setSort', 'super!');
 
     expect(componentInstance.vm.$x.query).toEqual({
       searchBox: 'this',
@@ -92,6 +94,7 @@ describe('testing plugin alias', () => {
       relatedTags: 'properly',
       search: 'nice'
     });
+    expect(componentInstance.vm.$x.selectedSort).toBe('super!');
   });
 
   it('updates the status values when the module is registered', () => {

--- a/packages/x-components/src/plugins/x-plugin.alias.ts
+++ b/packages/x-components/src/plugins/x-plugin.alias.ts
@@ -103,6 +103,9 @@ export function getAliasAPI(component: Vue): XComponentAliasAPI {
     },
     get totalResults() {
       return component.$store.state.x.search?.totalResults ?? 0;
+    },
+    get selectedSort() {
+      return component.$store.state.x.search?.sort ?? '';
     }
   };
 }

--- a/packages/x-components/src/plugins/x-plugin.types.ts
+++ b/packages/x-components/src/plugins/x-plugin.types.ts
@@ -123,6 +123,8 @@ export interface XComponentAliasAPI {
   readonly status: XComponentAliasStatusAPI;
   /** The {@link SearchXModule} total results. */
   readonly totalResults: number;
+  /** The {@link SearchXModule} selected sort. */
+  readonly selectedSort: string;
 }
 
 /**


### PR DESCRIPTION
Add the `<span>{{ $x.selectedSort }}</span>` in the layout next to the sort dropdown.

EX-5165