### PR TITLE
fix(search): rows and start parameters calculations moved from getter to action to avoid multiple requests

### DIFF
--- a/packages/x-components/src/x-modules/search/events.types.ts
+++ b/packages/x-components/src/x-modules/search/events.types.ts
@@ -7,7 +7,7 @@ import {
   Promoted,
   Banner
 } from '@empathyco/x-types';
-import { PageableSearchRequest } from './types';
+import { InternalSearchRequest } from './types';
 
 /**
  * Dictionary of the events of Search XModule, where each key is the event name, and the value is
@@ -36,7 +36,7 @@ export interface SearchXEvents {
    * * Payload: The new search request or `null` if there is not enough data in the state
    * to conform a valid request.
    */
-  SearchRequestChanged: PageableSearchRequest | null;
+  SearchRequestChanged: InternalSearchRequest | null;
   /**
    * Query tagging has been changed.
    * * Payload: The new query tagging object.

--- a/packages/x-components/src/x-modules/search/events.types.ts
+++ b/packages/x-components/src/x-modules/search/events.types.ts
@@ -1,4 +1,3 @@
-import { SearchRequest } from '@empathyco/x-adapter';
 import {
   Facet,
   Result,
@@ -8,6 +7,7 @@ import {
   Promoted,
   Banner
 } from '@empathyco/x-types';
+import { PageableSearchRequest } from './types';
 
 /**
  * Dictionary of the events of Search XModule, where each key is the event name, and the value is
@@ -36,7 +36,7 @@ export interface SearchXEvents {
    * * Payload: The new search request or `null` if there is not enough data in the state
    * to conform a valid request.
    */
-  SearchRequestChanged: SearchRequest | null;
+  SearchRequestChanged: PageableSearchRequest | null;
   /**
    * Query tagging has been changed.
    * * Payload: The new query tagging object.

--- a/packages/x-components/src/x-modules/search/index.ts
+++ b/packages/x-components/src/x-modules/search/index.ts
@@ -2,5 +2,6 @@ export * from './components';
 export * from './config.types';
 export * from './events.types';
 export * from './store';
+export * from './types';
 export * from './wiring';
 export * from './x-module';

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -57,14 +57,30 @@ describe('testing search module actions', () => {
   });
 
   describe('fetchAndSaveSearchResponse', () => {
-    it('should include the origin in the request', async () => {
+    it('should include the origin, start and rows properties in the request', async () => {
       resetSearchStateWith(store, { query: 'lego', origin: 'search_box:external' });
+      const { page, ...restRequest } = store.getters.request!;
       await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
 
       expect(adapter.search).toHaveBeenCalledTimes(1);
       expect(adapter.search).toHaveBeenCalledWith({
-        ...store.getters.request,
-        origin: 'search_box:external'
+        ...restRequest,
+        origin: 'search_box:external',
+        start: 0,
+        rows: 24
+      });
+    });
+
+    it('should calculate correctly the start and rows properties', async () => {
+      resetSearchStateWith(store, { query: 'lego', config: { pageSize: 48 } });
+      const { page, ...restRequest } = store.getters.request!;
+      await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
+
+      expect(adapter.search).toHaveBeenCalledTimes(1);
+      expect(adapter.search).toHaveBeenCalledWith({
+        ...restRequest,
+        start: 0,
+        rows: 24
       });
     });
 

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -72,15 +72,20 @@ describe('testing search module actions', () => {
     });
 
     it('should calculate correctly the start and rows properties', async () => {
-      resetSearchStateWith(store, { query: 'lego', config: { pageSize: 48 } });
+      resetSearchStateWith(store, {
+        config: { pageSize: 48 },
+        page: 2,
+        query: 'lego',
+        results: getResultsStub(48)
+      });
       const { page, ...restRequest } = store.getters.request!;
       await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
 
       expect(adapter.search).toHaveBeenCalledTimes(1);
       expect(adapter.search).toHaveBeenCalledWith({
         ...restRequest,
-        start: 0,
-        rows: 24
+        start: 48,
+        rows: 48
       });
     });
 

--- a/packages/x-components/src/x-modules/search/store/__tests__/getters.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/getters.spec.ts
@@ -1,11 +1,9 @@
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
-import { SearchRequest } from '@empathyco/x-adapter';
 import { map } from '../../../../utils';
+import { PageableSearchRequest } from '../../types';
 import { searchXStoreModule } from '../module';
 import { SearchState } from '../types';
-import { getSelectedRelatedTagsStub } from '../../../../__stubs__/related-tags-stubs.factory';
-import { getSimpleFilterStub } from '../../../../__stubs__/filters-stubs.factory';
 import { resetSearchStateWith } from './utils';
 
 describe('testing search module getters', () => {
@@ -18,7 +16,7 @@ describe('testing search module getters', () => {
   });
 
   describe(`${gettersKeys.request} getter`, () => {
-    it('should return a request object if there is a query', () => {
+    it('should return a request object if there is a query with module properties', () => {
       resetSearchStateWith(store, {
         query: 'doraemon',
         params: {
@@ -26,41 +24,13 @@ describe('testing search module getters', () => {
         }
       });
 
-      expect(store.getters[gettersKeys.request]).toEqual<SearchRequest>({
+      expect(store.getters[gettersKeys.request]).toEqual<PageableSearchRequest>({
         query: 'doraemon',
         relatedTags: [],
         filters: {},
         sort: '',
-        rows: 24,
-        start: 0,
+        page: 1,
         catalog: 'es'
-      });
-    });
-
-    it('calculates the search request with the module properties', () => {
-      const selectedFilters: SearchState['selectedFilters'] = { category: [getSimpleFilterStub()] };
-      const relatedTags = getSelectedRelatedTagsStub();
-      resetSearchStateWith(store, {
-        query: 'salchipapa',
-        sort: 'price-asc',
-        relatedTags,
-        selectedFilters,
-        config: {
-          pageSize: 48
-        },
-        params: {
-          warehouse: 1234
-        }
-      });
-
-      expect(store.getters[gettersKeys.request]).toEqual<SearchRequest>({
-        query: 'salchipapa',
-        sort: 'price-asc',
-        filters: selectedFilters,
-        relatedTags,
-        rows: 48,
-        start: 0,
-        warehouse: 1234
       });
     });
 
@@ -73,89 +43,6 @@ describe('testing search module getters', () => {
         query: ' '
       });
       expect(store.getters[gettersKeys.request]).toBeNull();
-    });
-
-    it('calculates the start parameter correctly when the page changes', () => {
-      resetSearchStateWith(store, {
-        query: 'salchipapa',
-        page: 2,
-        config: {
-          pageSize: 24
-        }
-      });
-
-      expect(store.getters[gettersKeys.request]).toEqual<SearchRequest>({
-        query: 'salchipapa',
-        filters: {},
-        relatedTags: [],
-        sort: '',
-        rows: 48,
-        start: 0
-      });
-
-      resetSearchStateWith(store, { query: 'salchipapa', page: 5 });
-
-      expect(store.getters[gettersKeys.request]).toEqual<SearchRequest>({
-        query: 'salchipapa',
-        filters: {},
-        relatedTags: [],
-        sort: '',
-        rows: 120,
-        start: 0
-      });
-
-      resetSearchStateWith(store, { query: 'salchipapa', page: 1 });
-
-      expect(store.getters[gettersKeys.request]).toEqual<SearchRequest>({
-        query: 'salchipapa',
-        filters: {},
-        relatedTags: [],
-        sort: '',
-        rows: 24,
-        start: 0
-      });
-    });
-
-    it('calculates the start and rows parameters correctly when there is scroll down', () => {
-      resetSearchStateWith(store, {
-        query: 'salchipapa',
-        page: 2,
-        config: {
-          pageSize: 24
-        },
-        isAppendResults: true
-      });
-
-      expect(store.getters[gettersKeys.request]).toEqual<SearchRequest>({
-        query: 'salchipapa',
-        filters: {},
-        relatedTags: [],
-        sort: '',
-        rows: 24,
-        start: 24
-      });
-
-      resetSearchStateWith(store, { query: 'salchipapa', page: 5, isAppendResults: true });
-
-      expect(store.getters[gettersKeys.request]).toEqual<SearchRequest>({
-        query: 'salchipapa',
-        filters: {},
-        relatedTags: [],
-        sort: '',
-        rows: 24,
-        start: 96
-      });
-
-      resetSearchStateWith(store, { query: 'salchipapa', page: 1, isAppendResults: true });
-
-      expect(store.getters[gettersKeys.request]).toEqual<SearchRequest>({
-        query: 'salchipapa',
-        filters: {},
-        relatedTags: [],
-        sort: '',
-        rows: 24,
-        start: 0
-      });
     });
   });
 });

--- a/packages/x-components/src/x-modules/search/store/__tests__/getters.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/getters.spec.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
 import { map } from '../../../../utils';
-import { PageableSearchRequest } from '../../types';
+import { InternalSearchRequest } from '../../types';
 import { searchXStoreModule } from '../module';
 import { SearchState } from '../types';
 import { resetSearchStateWith } from './utils';
@@ -19,17 +19,18 @@ describe('testing search module getters', () => {
     it('should return a request object if there is a query with module properties', () => {
       resetSearchStateWith(store, {
         query: 'doraemon',
+        page: 3,
         params: {
           catalog: 'es'
         }
       });
 
-      expect(store.getters[gettersKeys.request]).toEqual<PageableSearchRequest>({
+      expect(store.getters[gettersKeys.request]).toEqual<InternalSearchRequest>({
         query: 'doraemon',
         relatedTags: [],
         filters: {},
         sort: '',
-        page: 1,
+        page: 3,
         catalog: 'es'
       });
     });

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -1,18 +1,15 @@
 import { SearchResponse, SearchRequest } from '@empathyco/x-adapter';
 import { createFetchAndSaveActions } from '../../../../store/utils/fetch-and-save-action.utils';
-import { SearchActionContext } from '../types';
+import { PageableSearchRequest } from '../../types';
+import { SearchActionContext, SearchState } from '../types';
 
 const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   SearchActionContext,
-  SearchRequest | null,
+  PageableSearchRequest | null,
   SearchResponse
 >({
-  fetch({ dispatch, state: { origin } }, request) {
-    if (request && origin) {
-      request.origin = origin;
-    }
-
-    return dispatch('fetchSearchResponse', request);
+  fetch({ dispatch, state }, request) {
+    return dispatch('fetchSearchResponse', request ? enrichRequest(request, state) : null);
   },
   onSuccess(
     { commit, state },
@@ -50,6 +47,34 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
     commit('setSpellcheck', spellcheck ?? '');
   }
 });
+
+/**
+ * Enriches the {@link SearchRequest} object with the origin and page properties taken from the
+ * {@link SearchState | search state}.
+ *
+ * @param request - The {@link PageableSearchRequest}.
+ * @param state - {@link SearchState}.
+ *
+ * @returns The search request.
+ * @internal
+ */
+function enrichRequest(request: PageableSearchRequest, state: SearchState): SearchRequest {
+  const { page, ...restRequest } = request;
+  const {
+    config: { pageSize },
+    origin,
+    results
+  } = state;
+  const start = page === 1 ? 0 : results.length;
+
+  return {
+    ...restRequest,
+    // eslint-disable-next-line @typescript-eslint/no-extra-parens
+    ...(origin && { origin }),
+    start,
+    rows: pageSize * page! - start
+  };
+}
 
 /**
  * Default implementation for {@link SearchActions.fetchAndSaveSearchResponse} action.

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -1,11 +1,11 @@
 import { SearchResponse, SearchRequest } from '@empathyco/x-adapter';
 import { createFetchAndSaveActions } from '../../../../store/utils/fetch-and-save-action.utils';
-import { PageableSearchRequest } from '../../types';
+import { InternalSearchRequest } from '../../types';
 import { SearchActionContext, SearchState } from '../types';
 
 const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   SearchActionContext,
-  PageableSearchRequest | null,
+  InternalSearchRequest | null,
   SearchResponse
 >({
   fetch({ dispatch, state }, request) {
@@ -52,13 +52,13 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
  * Enriches the {@link SearchRequest} object with the origin and page properties taken from the
  * {@link SearchState | search state}.
  *
- * @param request - The {@link PageableSearchRequest}.
+ * @param request - The {@link InternalSearchRequest}.
  * @param state - {@link SearchState}.
  *
  * @returns The search request.
  * @internal
  */
-function enrichRequest(request: PageableSearchRequest, state: SearchState): SearchRequest {
+function enrichRequest(request: InternalSearchRequest, state: SearchState): SearchRequest {
   const { page, ...restRequest } = request;
   const {
     config: { pageSize },
@@ -72,7 +72,7 @@ function enrichRequest(request: PageableSearchRequest, state: SearchState): Sear
     // eslint-disable-next-line @typescript-eslint/no-extra-parens
     ...(origin && { origin }),
     start,
-    rows: pageSize * page! - start
+    rows: pageSize * page - start
   };
 }
 

--- a/packages/x-components/src/x-modules/search/store/getters/request.getter.ts
+++ b/packages/x-components/src/x-modules/search/store/getters/request.getter.ts
@@ -10,22 +10,19 @@ import { SearchXStoreModule } from '../types';
  * @public
  */
 export const request: SearchXStoreModule['getters']['request'] = ({
-  query,
+  page,
   params,
-  config,
+  query,
   relatedTags,
   selectedFilters,
-  sort,
-  page,
-  isAppendResults
+  sort
 }) => {
   return query.trim()
     ? {
         query,
         relatedTags,
         sort,
-        rows: isAppendResults ? config.pageSize : config.pageSize * page,
-        start: isAppendResults ? config.pageSize * (page - 1) : 0,
+        page,
         filters: selectedFilters,
         ...params
       }

--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -88,9 +88,6 @@ export const searchXStoreModule: SearchXStoreModule = {
     },
     setPage(state, page) {
       state.page = page;
-      if (page === 1) {
-        state.isAppendResults = false;
-      }
     },
     setPageSize(state, pageSize) {
       state.config.pageSize = pageSize;

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -17,6 +17,7 @@ import { QueryOrigin, QueryOriginInit } from '../../../types/origin';
 import { UrlParams } from '../../../types/url-params';
 import { Dictionary } from '../../../utils/types';
 import { SearchConfig } from '../config.types';
+import { PageableSearchRequest } from '../types';
 
 /**
  * Search store state.
@@ -71,7 +72,7 @@ export interface SearchState extends StatusState {
 export interface SearchGetters {
   /** The adapter request object for retrieving the results, or null if there is not
    * valid data to create a request. */
-  request: SearchRequest | null;
+  request: PageableSearchRequest | null;
 }
 
 /**
@@ -209,7 +210,7 @@ export interface SearchActions {
   /**
    * Fetches a new search response and stores them in the module state.
    */
-  fetchAndSaveSearchResponse(request: SearchRequest | null): void;
+  fetchAndSaveSearchResponse(request: PageableSearchRequest | null): void;
   /**
    * Fetches the search response and returns them.
    *

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -17,7 +17,7 @@ import { QueryOrigin, QueryOriginInit } from '../../../types/origin';
 import { UrlParams } from '../../../types/url-params';
 import { Dictionary } from '../../../utils/types';
 import { SearchConfig } from '../config.types';
-import { PageableSearchRequest } from '../types';
+import { InternalSearchRequest } from '../types';
 
 /**
  * Search store state.
@@ -72,7 +72,7 @@ export interface SearchState extends StatusState {
 export interface SearchGetters {
   /** The adapter request object for retrieving the results, or null if there is not
    * valid data to create a request. */
-  request: PageableSearchRequest | null;
+  request: InternalSearchRequest | null;
 }
 
 /**
@@ -210,7 +210,7 @@ export interface SearchActions {
   /**
    * Fetches a new search response and stores them in the module state.
    */
-  fetchAndSaveSearchResponse(request: PageableSearchRequest | null): void;
+  fetchAndSaveSearchResponse(request: InternalSearchRequest | null): void;
   /**
    * Fetches the search response and returns them.
    *

--- a/packages/x-components/src/x-modules/search/types.ts
+++ b/packages/x-components/src/x-modules/search/types.ts
@@ -2,7 +2,7 @@ import { SearchRequest } from '@empathyco/x-adapter';
 
 /**
  * An internal search request containing the page used to calculate the start and rows properties of
- * a {@link SearchRequest}.
+ * a {@link @empathyco/x-adapter#SearchRequest}.
  *
  * @public
  */

--- a/packages/x-components/src/x-modules/search/types.ts
+++ b/packages/x-components/src/x-modules/search/types.ts
@@ -1,11 +1,12 @@
 import { SearchRequest } from '@empathyco/x-adapter';
 
 /**
- * A pageable search request.
+ * An internal search request containing the page used to calculate the start and rows properties of
+ * a {@link SearchRequest}.
  *
  * @public
  */
-export interface PageableSearchRequest extends SearchRequest {
+export interface InternalSearchRequest extends SearchRequest {
   /** The page number. */
-  page?: number;
+  page: number;
 }

--- a/packages/x-components/src/x-modules/search/types.ts
+++ b/packages/x-components/src/x-modules/search/types.ts
@@ -1,0 +1,11 @@
+import { SearchRequest } from '@empathyco/x-adapter';
+
+/**
+ * A pageable search request.
+ *
+ * @public
+ */
+export interface PageableSearchRequest extends SearchRequest {
+  /** The page number. */
+  page?: number;
+}


### PR DESCRIPTION
EX-5047

## Motivation and context
There is a bug with the request pagination, infinite scroll and search input causing multiple requests to be made. The `request` getter depends on `isAppendResults` triggering the getter, thus emitting a new `SearchRequestChanged`.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## How has this been tested?

Added unit tests.

## Checklist:

- [X] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [X] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [X] My changes generate **no new warnings**.
- [X] I have added **tests** that prove my fix is effective or that my feature works.
- [X] New and existing **unit tests pass locally** with my changes.
