### PR TITLE
fix(components): Fix infinite scroll not working in Android Chrome.

### DIFF
--- a/packages/x-components/src/directives/infinite-scroll/infinite-scroll.ts
+++ b/packages/x-components/src/directives/infinite-scroll/infinite-scroll.ts
@@ -111,7 +111,8 @@ function createIntersectionObserver({
   vNode
 }: ObserverOptions): IntersectionObserver {
   // This hack allows the root element to always contain the observed element.
-  const rootMargin = `20000000px 0px ${margin}px`;
+  // not overpass the top margin more than 1700000 because it doesn't work in Android chrome
+  const rootMargin = `1000000% 0px ${margin}px 0px`;
 
   return new IntersectionObserver(
     ([entry]) => {


### PR DESCRIPTION
EX-5181

We don't know why, but a rootMargin over ~1700000 in the IntersectionObserver doesn't work in Android Chrome