### PR TITLE
feat(design-system): Add bottom variant to `x-shadow` utility in the Design System.

### DIFF
--- a/packages/x-components/src/design-system/utilities/box-shadow.scss
+++ b/packages/x-components/src/design-system/utilities/box-shadow.scss
@@ -9,5 +9,8 @@
     &--#{$i} {
       box-shadow: var(--x-string-box-shadow-#{$i}) !important;
     }
+    &--bottom-#{$i} {
+      box-shadow: var(--x-string-box-shadow-bottom-#{$i}) !important;
+    }
   }
 }

--- a/packages/x-components/src/design-system/utilities/box-shadow.tokens.scss
+++ b/packages/x-components/src/design-system/utilities/box-shadow.tokens.scss
@@ -34,4 +34,36 @@
   /* Shadow 24dp */
   --x-string-box-shadow-10: 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12),
     0 11px 15px -7px rgba(0, 0, 0, 0.2);
+
+  /* BOTTOM ONLY SHADOW (not overflows on top of the element) */
+  /* Shadow 1dp */
+  --x-string-box-shadow-bottom-01: 0 2px 1px -1px rgba(0, 0, 0, 0.14),
+    0 2px 1px -1px rgba(0, 0, 0, 0.12), 0 4px 3px -3px rgba(0, 0, 0, 0.2);
+  /* Shadow 2dp */
+  --x-string-box-shadow-bottom-02: 0 4px 2px -2px rgba(0, 0, 0, 0.14),
+    0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 6px 5px -5px rgba(0, 0, 0, 0.2);
+  /* Shadow 3dp */
+  --x-string-box-shadow-bottom-03: 0 7px 4px -4px rgba(0, 0, 0, 0.14),
+    0 4px 3px -3px rgba(0, 0, 0, 0.12), 0 9px 8px -8px rgba(0, 0, 0, 0.2);
+  /* Shadow 4dp */
+  --x-string-box-shadow-bottom-04: 0 9px 5px -5px rgba(0, 0, 0, 0.14),
+    0 11px 10px -10px rgba(0, 0, 0, 0.12), 0 5px 4px -4px rgba(0, 0, 0, 0.2);
+  /* Shadow 6dp */
+  --x-string-box-shadow-bottom-05: 0 16px 10px -10px rgba(0, 0, 0, 0.14),
+    0 19px 18px -18px rgba(0, 0, 0, 0.12), 0 8px 5px -6px rgba(0, 0, 0, 0.2);
+  /* Shadow 8dp */
+  --x-string-box-shadow-bottom-06: 0 19px 10px -10px rgba(0, 0, 0, 0.14),
+    0 19px 14px -14px rgba(0, 0, 0, 0.12), 0 7px 5px -5px rgba(0, 0, 0, 0.2);
+  /* Shadow 9dp */
+  --x-string-box-shadow-bottom-07: 0 22px 12px -12px rgba(0, 0, 0, 0.14),
+    0 21px 16px -16px rgba(0, 0, 0, 0.12), 0 8px 6px -6px rgba(0, 0, 0, 0.2);
+  /* Shadow 12dp */
+  --x-string-box-shadow-bottom-08: 0 31px 17px -17px rgba(0, 0, 0, 0.14),
+    0 27px 22px -22px rgba(0, 0, 0, 0.12), 0 11px 8px -8px rgba(0, 0, 0, 0.2);
+  /* Shadow 16dp */
+  --x-string-box-shadow-bottom-09: 0 22px 24px -4px rgba(0, 0, 0, 0.14),
+    0 21px 30px -10px rgba(0, 0, 0, 0.12), 0 8px 10px -5px rgba(0, 0, 0, 0.2);
+  /* Shadow 24dp */
+  --x-string-box-shadow-bottom-10: 0 34px 38px -7px rgba(0, 0, 0, 0.14),
+    0 29px 46px -12px rgba(0, 0, 0, 0.12), 0 11px 15px -7px rgba(0, 0, 0, 0.2);
 }

--- a/packages/x-components/src/views/design-system/design-system-utilities.vue
+++ b/packages/x-components/src/views/design-system/design-system-utilities.vue
@@ -262,6 +262,18 @@
           Shadow {{ size }}
         </div>
       </div>
+
+      <h3 class="x-title3">Shadow Bottom</h3>
+      <div class="x-list x-list--wrap x-list--gap-06 x-list--align-start">
+        <div
+          v-for="size in shadowsSizes"
+          :key="size"
+          class="x-padding--06"
+          :class="'x-shadow--bottom-' + size"
+        >
+          Shadow Bottom {{ size }}
+        </div>
+      </div>
     </article>
 
     <article class="x-list x-list--vertical x-list--gap-06 x-padding-bottom--06">


### PR DESCRIPTION

EX-5184


The new variant is to add shadow to an element, but not to overflow that shadow over the top of the element. 
This is needed in BSH setup.