### PR TITLE
fix(related-tags): clear selected related tags when user changes extr…

### DIFF
--- a/packages/x-components/src/x-modules/related-tags/wiring.ts
+++ b/packages/x-components/src/x-modules/related-tags/wiring.ts
@@ -102,6 +102,9 @@ export const relatedTagsWiring = createWiring({
   UserPickedARelatedTag: {
     toggleRelatedTagWire
   },
+  UserChangedExtraParams: {
+    clearSelectedRelatedTags
+  },
   RelatedTagsRequestChanged: {
     fetchAndSaveRelatedTagsWire
   },


### PR DESCRIPTION
EX-5188

Just clears the related tags when the extra params change because of a user action.