### PR TITLE
Feature/ex 5189 reset scroll on more events

### DIFF
--- a/packages/x-components/src/components/scroll/__tests__/base-scroll.spec.ts
+++ b/packages/x-components/src/components/scroll/__tests__/base-scroll.spec.ts
@@ -1,6 +1,6 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import { getDataTestSelector, installNewXPlugin } from '../../../__tests__/utils';
-import { XEvent } from '../../../wiring/index';
+import { XEvent } from '../../../wiring/events.types';
 import BaseScroll from '../base-scroll.vue';
 
 /**
@@ -196,7 +196,7 @@ describe('testing Base Scroll Component', () => {
     expect(wrapper.emitted('scroll:almost-at-end')).toEqual([[true], [false], [true]]);
   });
 
-  it('resets the scroll', async () => {
+  it('resets the scroll when the given events are emitted', async () => {
     const { wrapper, scroll } = await renderBaseScroll({
       resetOn: ['UserAcceptedAQuery']
     });
@@ -212,7 +212,7 @@ describe('testing Base Scroll Component', () => {
     expect(wrapper.element.scrollTop).toEqual(0);
   });
 
-  it('allows disabling reseting the scroll', async () => {
+  it('allows disabling resetting the scroll when certain events are emitted', async () => {
     const { wrapper, scroll } = await renderBaseScroll({
       resetOn: ['UserAcceptedAQuery'],
       resetOnChange: false
@@ -225,6 +225,7 @@ describe('testing Base Scroll Component', () => {
     expect(wrapper.element.scrollTop).toEqual(300);
 
     wrapper.vm.$x.emit('UserAcceptedAQuery', 'milk');
+    await wrapper.vm.$nextTick();
     expect(wrapper.element.scrollTop).toEqual(300);
   });
 });

--- a/packages/x-components/src/components/scroll/base-scroll.vue
+++ b/packages/x-components/src/components/scroll/base-scroll.vue
@@ -28,10 +28,10 @@
 <docs lang="mdx">
 ## Example
 
-The BaseScroll is a component that manage the states of scroll of a specified element. The component
-does the necessary calculations for knowing the direction of scroll, if the scroll has reached to
-start or to end, and is about to reaching to end. The components emits the next events depending of
-movement that realize the user:
+The `BaseScroll` is a component that manages the state of scroll of a specified element. The
+component does the necessary calculations for knowing the direction of scroll, if the scroll has
+reached to start or to end, and is about to reaching to end. The components emits the next events
+depending of movement that realize the user:
 
 ```vue
 <template>
@@ -41,8 +41,8 @@ movement that realize the user:
     @scroll:at-start="scrollAtStart"
     @scroll:almost-at-end="scrollAlmostAtEnd"
     @scroll:at-end="scrollAtEnd"
-    throttleMs="1000"
-    distanceToBottom="200"
+    :throttleMs="1000"
+    :distanceToBottom="200"
   >
     <template>
       <div class="content-scroll">
@@ -88,15 +88,7 @@ Set to false the reset scroll on query change feature which is true by default.
 
 ```vue
 <template>
-  <BaseScroll
-    @scroll="scroll"
-    @scroll:direction-change="scrollDirectionChange"
-    @scroll:at-start="scrollAtStart"
-    @scroll:almost-at-end="scrollAlmostAtEnd"
-    @scroll:at-end="scrollAtEnd"
-    throttleMs="1000"
-    distanceToBottom="200"
-  >
+  <BaseScroll @scroll="scroll" :resetOnChange="false">
     <template>
       <div class="content-scroll">
         <span>content1</span>
@@ -117,18 +109,44 @@ Set to false the reset scroll on query change feature which is true by default.
     methods: {
       scroll(position) {
         console.log('scroll', position);
-      },
-      scrollDirectionChange(direction) {
-        console.log('scroll:direction-change', direction);
-      },
-      scrollAtStart() {
-        console.log('scroll:at-start');
-      },
-      scrollAlmostAtEnd(distance) {
-        console.log('scroll:almost-at-end', distance);
-      },
-      scrollAtEnd() {
-        console.log('scroll:at-end');
+      }
+    }
+  };
+</script>
+```
+
+### Reset scroll
+
+You can configure which events make the scroll position be reset using the `resetOn` prop.
+
+```vue
+<template>
+  <BaseScroll @scroll="scroll" :resetOn="resetScrollEvents">
+    <template>
+      <div class="content-scroll">
+        <span>content1</span>
+        <span>content1</span>
+      </div>
+    </template>
+  </BaseScroll>
+</template>
+
+<script>
+  import { BaseScroll } from '@empathyco/x-components';
+
+  export default {
+    name: 'ScrollTest',
+    components: {
+      BaseScroll
+    },
+    data() {
+      return {
+        resetScrollEvents: ['UserAcceptedAQuery']
+      };
+    },
+    methods: {
+      scroll(position) {
+        console.log('scroll', position);
       }
     }
   };

--- a/packages/x-components/src/components/scroll/base-scroll.vue
+++ b/packages/x-components/src/components/scroll/base-scroll.vue
@@ -117,7 +117,7 @@ Set to false the reset scroll on query change feature which is true by default.
 
 ### Reset scroll
 
-You can configure which events make the scroll position be reset using the `resetOn` prop.
+You can configure which events reset the scroll position using the `resetOn` prop.
 
 ```vue
 <template>

--- a/packages/x-components/src/components/scroll/scroll.mixin.ts
+++ b/packages/x-components/src/components/scroll/scroll.mixin.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { throttle } from '../../utils/throttle';
+import { XEvent } from '../../wiring/index';
 import { XOn } from '../decorators/bus.decorators';
 import { ScrollDirection } from './scroll.types';
 
@@ -49,6 +50,23 @@ export default class ScrollMixin extends Vue {
    */
   @Prop({ type: Boolean, default: true })
   protected resetOnChange!: boolean;
+
+  /**
+   * List of events that should reset the scroll when emitted.
+   *
+   * @public
+   */
+  @Prop({
+    default: () => [
+      'SearchBoxQueryChanged',
+      'SortChanged',
+      'SelectedFiltersChanged',
+      'SelectedRelatedTagsChanged',
+      'UserChangedExtraParams'
+    ]
+  })
+  public resetOn!: XEvent;
+
   /**
    * Property for getting the client height of scroll.
    *
@@ -178,12 +196,7 @@ export default class ScrollMixin extends Vue {
    *
    * @internal
    */
-  @XOn([
-    'SearchBoxQueryChanged',
-    'SortChanged',
-    'SelectedFiltersChanged',
-    'SelectedRelatedTagsChanged'
-  ])
+  @XOn(instance => (instance as ScrollMixin).resetOn)
   resetScroll(): void {
     this.$nextTick().then(() => {
       if (this.resetOnChange) {

--- a/packages/x-components/src/components/scroll/scroll.mixin.ts
+++ b/packages/x-components/src/components/scroll/scroll.mixin.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { throttle } from '../../utils/throttle';
-import { XEvent } from '../../wiring/index';
+import { XEvent } from '../../wiring/events.types';
 import { XOn } from '../decorators/bus.decorators';
 import { ScrollDirection } from './scroll.types';
 

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -172,6 +172,7 @@
               <BaseDropdown
                 @change="updateValue"
                 class="x-dropdown x-dropdown--round x-dropdown--right x-dropdown--l"
+                data-test="store-selector"
                 :value="value"
                 :items="stores"
               />

--- a/packages/x-components/src/x-modules/scroll/components/scroll.vue
+++ b/packages/x-components/src/x-modules/scroll/components/scroll.vue
@@ -7,8 +7,7 @@
     @scroll:at-end="emitScrollAtEnd"
     v-on="$listeners"
     :id="id"
-    :throttleMs="throttleMs"
-    :distanceToBottom="distanceToBottom"
+    v-bind="$attrs"
   >
     <slot />
   </BaseScroll>
@@ -26,9 +25,8 @@
   import { MainScrollId } from './scroll.const';
 
   /**
-   * Base scroll component that depending on base scroll component and the user interaction emits
-   * different x events for knowing when the user scrolls, the direction of scroll and if user
-   * reaches the start or end.
+   * Scrollable container that emits scroll related X Events. It exposes all the listeners
+   * and props from the {@link BaseScroll} component.
    *
    * @public
    */
@@ -37,24 +35,6 @@
     components: { BaseScroll }
   })
   export default class Scroll extends Vue {
-    /**
-     * Time duration to ignore the subsequent scroll events after an emission.
-     * Higher values will decrease events precision but can prevent performance issues.
-     *
-     * @public
-     */
-    @Prop()
-    public throttleMs!: number;
-
-    /**
-     * Distance to the end of the scroll that when reached will emit the
-     * `scroll:about-to-end` event.
-     *
-     * @public
-     */
-    @Prop()
-    public distanceToBottom!: number;
-
     /**
      * Id to identify the component.
      *

--- a/packages/x-components/tests/e2e/cucumber/mocked-responses.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/mocked-responses.spec.ts
@@ -20,6 +20,7 @@ import {
   createRelatedTagStub,
   createResultStub,
   createSimpleFacetStub,
+  getFacetsStub,
   getNextQueriesStub,
   getPopularSearchesStub,
   getQuerySuggestionsStub,
@@ -494,7 +495,7 @@ function createSearchResponse(partial?: Partial<SearchResponse>): SearchResponse
   return {
     banners: [],
     promoteds: [],
-    facets: [],
+    facets: getFacetsStub(),
     results: getResultsStub(),
     redirections: [],
     partialResults: [],

--- a/packages/x-components/tests/e2e/cucumber/scroll.feature
+++ b/packages/x-components/tests/e2e/cucumber/scroll.feature
@@ -6,62 +6,62 @@ Feature: Exclude filters with no results component
     And   a tracking API
     And   no special config for layout view
 
-#  Scenario Outline: 1. Scroll is kept in the URL
-#    When  start button is clicked
-#    And   "<query>" is searched
-#    Then  related results are displayed
-#    When  scrolling down to result "<resultId>"
-#    Then  url is updated with result "<resultId>"
-#    When  tab is reloaded
-#    Then  related results are displayed
-#    And   first visible result is "<resultId>"
-#
-#    Examples:
-#      | query | resultId  |
-#      | lego  | result-12 |
-#
-#  Scenario Outline: 2. Scroll position is reset when a new query is searched
-#    When  start button is clicked
-#    And   "<query1>" is searched
-#    Then  related results are displayed
-#    When  scrolling down to result "<resultId>"
-#    And  "<query2>" is searched
-#    Then scroll position is at top
-#
-#    Examples:
-#      | query1 | resultId  | query2        |
-#      | lego    | result-12 | lego star wars |
-#
-#  Scenario Outline: 3. Scroll position is reset when a new filter is clicked
-#    When  start button is clicked
-#    And   "<query1>" is searched
-#    Then  related results are displayed
-#    When  scrolling down to result "<resultId>"
-#    And  filter number <filterIndex> is clicked in facet "<filterFacet>"
-#    Then scroll position is at top
-#    When  scrolling down to result "<resultId>"
-#    And  filter number <filterIndex> is clicked in facet "<filterFacet>"
-#    Then scroll position is at top
-#
-#    Examples:
-#      | query1 | resultId  | filterIndex | filterFacet |
-#      | lego   | result-12 | 1           | brand_facet |
-#
-#  Scenario Outline: 4. Scroll position is reset when a related tag is clicked
-#    Given a related tags API with a known response
-#    When  start button is clicked
-#    And   "<query1>" is searched
-#    Then  related results are displayed
-#    When  scrolling down to result "<resultId>"
-#    And  related tag number <relatedTagIndex> is clicked
-#    Then scroll position is at top
-#    When scrolling down to result "<resultId>"
-#    And related tag number <relatedTagIndex> is clicked
-#    Then scroll position is at top
-#
-#    Examples:
-#      | query1 | resultId  | relatedTagIndex |
-#      | lego   | result-12 | 0               |
+  Scenario Outline: 1. Scroll is kept in the URL
+    When  start button is clicked
+    And   "<query>" is searched
+    Then  related results are displayed
+    When  scrolling down to result "<resultId>"
+    Then  url is updated with result "<resultId>"
+    When  tab is reloaded
+    Then  related results are displayed
+    And   first visible result is "<resultId>"
+
+    Examples:
+      | query | resultId  |
+      | lego  | result-12 |
+
+  Scenario Outline: 2. Scroll position is reset when a new query is searched
+    When  start button is clicked
+    And   "<query1>" is searched
+    Then  related results are displayed
+    When  scrolling down to result "<resultId>"
+    And  "<query2>" is searched
+    Then scroll position is at top
+
+    Examples:
+      | query1 | resultId  | query2         |
+      | lego   | result-12 | lego star wars |
+
+  Scenario Outline: 3. Scroll position is reset when a new filter is clicked
+    When  start button is clicked
+    And   "<query1>" is searched
+    Then  related results are displayed
+    When  scrolling down to result "<resultId>"
+    And  filter number <filterIndex> is clicked in facet "<filterFacet>"
+    Then scroll position is at top
+    When  scrolling down to result "<resultId>"
+    And  filter number <filterIndex> is clicked in facet "<filterFacet>"
+    Then scroll position is at top
+
+    Examples:
+      | query1 | resultId  | filterIndex | filterFacet |
+      | lego   | result-12 | 1           | brand_facet |
+
+  Scenario Outline: 4. Scroll position is reset when a related tag is clicked
+    Given a related tags API with a known response
+    When  start button is clicked
+    And   "<query1>" is searched
+    Then  related results are displayed
+    When  scrolling down to result "<resultId>"
+    And  related tag number <relatedTagIndex> is clicked
+    Then scroll position is at top
+    When scrolling down to result "<resultId>"
+    And related tag number <relatedTagIndex> is clicked
+    Then scroll position is at top
+
+    Examples:
+      | query1 | resultId  | relatedTagIndex |
+      | lego   | result-12 | 0               |
 
   Scenario Outline: 5. Scroll position is reset when an extra param is changed
     When  start button is clicked

--- a/packages/x-components/tests/e2e/cucumber/scroll.feature
+++ b/packages/x-components/tests/e2e/cucumber/scroll.feature
@@ -6,16 +6,71 @@ Feature: Exclude filters with no results component
     And   a tracking API
     And   no special config for layout view
 
-  Scenario Outline: 1. Scroll is kept in the URL
+#  Scenario Outline: 1. Scroll is kept in the URL
+#    When  start button is clicked
+#    And   "<query>" is searched
+#    Then  related results are displayed
+#    When  scrolling down to result "<resultId>"
+#    Then  url is updated with result "<resultId>"
+#    When  tab is reloaded
+#    Then  related results are displayed
+#    And   first visible result is "<resultId>"
+#
+#    Examples:
+#      | query | resultId  |
+#      | lego  | result-12 |
+#
+#  Scenario Outline: 2. Scroll position is reset when a new query is searched
+#    When  start button is clicked
+#    And   "<query1>" is searched
+#    Then  related results are displayed
+#    When  scrolling down to result "<resultId>"
+#    And  "<query2>" is searched
+#    Then scroll position is at top
+#
+#    Examples:
+#      | query1 | resultId  | query2        |
+#      | lego    | result-12 | lego star wars |
+#
+#  Scenario Outline: 3. Scroll position is reset when a new filter is clicked
+#    When  start button is clicked
+#    And   "<query1>" is searched
+#    Then  related results are displayed
+#    When  scrolling down to result "<resultId>"
+#    And  filter number <filterIndex> is clicked in facet "<filterFacet>"
+#    Then scroll position is at top
+#    When  scrolling down to result "<resultId>"
+#    And  filter number <filterIndex> is clicked in facet "<filterFacet>"
+#    Then scroll position is at top
+#
+#    Examples:
+#      | query1 | resultId  | filterIndex | filterFacet |
+#      | lego   | result-12 | 1           | brand_facet |
+#
+#  Scenario Outline: 4. Scroll position is reset when a related tag is clicked
+#    Given a related tags API with a known response
+#    When  start button is clicked
+#    And   "<query1>" is searched
+#    Then  related results are displayed
+#    When  scrolling down to result "<resultId>"
+#    And  related tag number <relatedTagIndex> is clicked
+#    Then scroll position is at top
+#    When scrolling down to result "<resultId>"
+#    And related tag number <relatedTagIndex> is clicked
+#    Then scroll position is at top
+#
+#    Examples:
+#      | query1 | resultId  | relatedTagIndex |
+#      | lego   | result-12 | 0               |
+
+  Scenario Outline: 5. Scroll position is reset when an extra param is changed
     When  start button is clicked
-    And   "<query>" is searched
+    And   "<query1>" is searched
     Then  related results are displayed
     When  scrolling down to result "<resultId>"
-    Then  url is updated with result "<resultId>"
-    When  tab is reloaded
-    Then  related results are displayed
-    And   first visible result is "<resultId>"
+    And  store is changed to "<store>"
+    Then scroll position is at top
 
     Examples:
-      | query | resultId  |
-      | lego  | result-12 |
+      | query1 | resultId  | store |
+      | lego   | result-12 | Italy |

--- a/packages/x-components/tests/e2e/cucumber/scroll.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/scroll.spec.ts
@@ -21,3 +21,13 @@ Then('first visible result is {string}', (resultId: string) => {
       });
     });
 });
+
+Then('scroll position is at top', () => {
+  cy.get('#main-scroll').should(scrollContainer => {
+    expect(scrollContainer.scrollTop()).to.equal(0);
+  });
+});
+
+When('store is changed to {string}', (store: string) => {
+  cy.getByDataTest('store-selector').click().contains(store).click();
+});


### PR DESCRIPTION
EX-5189

- Exposes a prop to change the events that should reset the scroll position. For example, when searching, changing filters, related tags. 
- Changing an extra param has also been added as a trigger for resetting the scroll position
- Adds e2e tests for this feature.