### PR TITLE
fix(search): next page is now requested if it has less than the page …

### DIFF
--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -271,6 +271,20 @@ describe('testing search module actions', () => {
       expect(store.state.page).toEqual(2);
     });
 
+    it('should increase page if the last page has less results than the page size', async () => {
+      resetSearchStateWith(store, { totalResults: 47, page: 1, config: { pageSize: 24 } });
+
+      await store.dispatch('increasePageAppendingResults');
+      expect(store.state.page).toEqual(2);
+    });
+
+    it('should increase page if the last page has only one result', async () => {
+      resetSearchStateWith(store, { totalResults: 25, page: 1, config: { pageSize: 24 } });
+
+      await store.dispatch('increasePageAppendingResults');
+      expect(store.state.page).toEqual(2);
+    });
+
     // eslint-disable-next-line max-len
     it('appends results to the state when the page increases and the isAppendResults is true', async () => {
       resetSearchStateWith(store, {

--- a/packages/x-components/src/x-modules/search/store/actions/increase-page-apending-results.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/increase-page-apending-results.action.ts
@@ -12,7 +12,7 @@ import { SearchXStoreModule } from '../types';
 export const increasePageAppendingResults: SearchXStoreModule['actions']['increasePageAppendingResults'] =
   ({ commit, state }) => {
     const newPage = state.page + 1;
-    if (newPage >= 1 && newPage * state.config.pageSize <= state.totalResults) {
+    if (newPage >= 1 && state.page * state.config.pageSize < state.totalResults) {
       commit('setPage', newPage);
       commit('setIsAppendResults', true);
     }


### PR DESCRIPTION
EX-5194

Search infinite scroll was not requesting the next page if it has less than the pageSize results. For example, with a `pageSize` of 24 results, and a search with 25 results, the second page was never requested.

Thanks @diegopf  and @pmareke <3 