### PR TITLE
fix(design-system): Fix grid styles to stretch cells.

### DIFF
--- a/packages/x-components/src/design-system/components/grid/default.scss
+++ b/packages/x-components/src/design-system/components/grid/default.scss
@@ -9,6 +9,11 @@
   padding: var(--x-size-padding-grid);
   gap: var(--x-size-gap-grid);
 
+  &__item {
+    display: flex;
+    flex-flow: column nowrap;
+  }
+
   &--cols-auto .x-grid__item {
     // layout
     min-width: var(--x-size-min-width-grid-item);

--- a/packages/x-components/src/design-system/components/grid/default.scss
+++ b/packages/x-components/src/design-system/components/grid/default.scss
@@ -9,10 +9,6 @@
   padding: var(--x-size-padding-grid);
   gap: var(--x-size-gap-grid);
 
-  &__item {
-    display: flex;
-  }
-
   &--cols-auto .x-grid__item {
     // layout
     min-width: var(--x-size-min-width-grid-item);

--- a/packages/x-components/src/design-system/components/grid/default.scss
+++ b/packages/x-components/src/design-system/components/grid/default.scss
@@ -4,9 +4,14 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(var(--x-size-min-width-grid-item), auto));
   grid-auto-flow: dense;
+  align-items: stretch;
   list-style: none;
   padding: var(--x-size-padding-grid);
   gap: var(--x-size-gap-grid);
+
+  &__item {
+    display: flex;
+  }
 
   &--cols-auto .x-grid__item {
     // layout

--- a/packages/x-components/src/design-system/components/result/default.scss
+++ b/packages/x-components/src/design-system/components/result/default.scss
@@ -8,7 +8,7 @@
     [overlay-start]
     auto
     [picture-end overlay-end description-start]
-    auto
+    1fr
     [description-end];
   box-sizing: border-box;
 


### PR DESCRIPTION
EX-5239

The idea is to stretch the `grid__item`s inside the `x-grid`, to allow set all the items with the same height.
