### PR TITLE
chore(desing-system): Fix sliding panel bug.

### DIFF
--- a/packages/x-components/src/design-system/components/sliding-panel/default.scss
+++ b/packages/x-components/src/design-system/components/sliding-panel/default.scss
@@ -96,6 +96,12 @@
         );
       }
     }
+
+    &.x-sliding-panel--at-start.x-sliding-panel--at-end {
+      .x-sliding-panel__scroll {
+        mask: none;
+      }
+    }
   }
 
   &__scroll {


### PR DESCRIPTION
EX-5240

The problem is when the sliding panel doesn't have elements enough to have scroll, it shows the gradient at the beginning anyway: 
![image](https://user-images.githubusercontent.com/5759712/148036330-0be75322-1f15-499f-a4c5-f309b33dd59d.png)
