### PR TITLE
fix(identifier-results): Fix default plugin config.

### DIFF
--- a/packages/x-components/src/main.ts
+++ b/packages/x-components/src/main.ts
@@ -11,11 +11,10 @@ Vue.config.productionTip = false;
 ['hierarchical_category', 'categories_facet', 'brand_facet', 'age_facet'].forEach(facetId =>
   FilterEntityFactory.instance.registerFilterModifier(facetId, [SingleSelectModifier])
 );
-const xModulesURLConfig = JSON.parse(new URL(location.href).searchParams.get('xModules') ?? '{}');
+
 new XInstaller({
   ...baseInstallXOptions,
   app: App,
-  xModules: xModulesURLConfig,
   vueOptions: {
     router
   },

--- a/packages/x-components/src/views/Layout.vue
+++ b/packages/x-components/src/views/Layout.vue
@@ -119,6 +119,18 @@
               </ClearHistoryQueries>
               <QuerySuggestions max-items-to-render="10" />
               <NextQueries max-items-to-render="10" />
+
+              <!-- IdentifierResults -->
+              <IdentifierResults #default="{ identifierResult }">
+                <BaseResultLink :result="identifierResult">
+                  <article class="x-suggestion">
+                    <IdentifierResult :result="identifierResult" />
+                    <span class="x-ellipsis" data-test="result-text">
+                      {{ identifierResult.name }}
+                    </span>
+                  </article>
+                </BaseResultLink>
+              </IdentifierResults>
             </Empathize>
           </BaseKeyboardNavigation>
         </template>
@@ -334,23 +346,6 @@
           </Redirection>
 
           <template v-if="!$x.redirections.length">
-            <!-- IdentifierResults -->
-            <IdentifierResults class="x-list x-list--horizontal">
-              <template #default="{ identifierResult }">
-                <article class="result">
-                  <BaseResultImage :result="identifierResult" class="x-picture--colored">
-                    <template #placeholder>
-                      <div style="padding-top: 100%; background-color: lightgray"></div>
-                    </template>
-                    <template #fallback>
-                      <div style="padding-top: 100%; background-color: lightsalmon"></div>
-                    </template>
-                  </BaseResultImage>
-                  <h1 class="x-title3" data-test="result-text">{{ identifierResult.name }}</h1>
-                </article>
-              </template>
-            </IdentifierResults>
-
             <!--  No Results Message  -->
             <div v-if="$x.noResults" class="x-message x-margin--top-03 x-margin--bottom-03">
               <p>

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -13,6 +13,8 @@ const url = new URL(location.href);
 
 const adapter = url.searchParams.has('useMockedAdapter') ? (mockedAdapter as any) : realAdapter;
 
+const xModulesURLConfig = JSON.parse(new URL(location.href).searchParams.get('xModules') ?? '{}');
+
 export const baseInstallXOptions: InstallXOptions = {
   adapter,
   xModules: {
@@ -20,6 +22,7 @@ export const baseInstallXOptions: InstallXOptions = {
       config: {
         identifierDetectionRegexp: '^[a-zA-Z][0-9]+'
       }
-    }
+    },
+    ...xModulesURLConfig
   }
 };

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -37,17 +37,6 @@ When('start button is clicked', () => {
   cy.getByDataTest('open-modal').click();
 });
 
-// ID Results
-Then('identifier results are displayed', () => {
-  cy.getByDataTest('identifier-results-item')
-    .should('be.visible')
-    .should('have.length.at.least', 1);
-});
-
-Then('no identifier results are displayed', () => {
-  cy.getByDataTest('identifier-results-item').should('not.exist');
-});
-
 // Facets
 When(
   'filter number {int} is clicked in facet {string}',

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.feature
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.feature
@@ -3,32 +3,20 @@ Feature: Identifier results component
   Background:
     Given following config: identifier detection Regexp "^[0-9]{2,}$"
 
-  Scenario Outline: 1. ID search with results is made
+  Scenario: 1. ID search shows results and clears them when a non id query is made
     Given an ID results API with a known response
     And   start button is clicked
-    When  a "<query>" with results is typed
+    When  a "01" with results is typed
     Then  identifier results are displayed
-
-    Examples:
-      | query |
-      | 01    |
-
-  Scenario Outline: 2. ID search with no results is made
-    Given an ID results API with no results
-    And   start button is clicked
-    When  a "<query>" with results is typed
+    When  a "lego" with results is typed
     Then  no identifier results are displayed
 
-    Examples:
-      | query |
-      | 23    |
 
-  Scenario Outline: 3. No ID search is made
+  Scenario: 2. ID search shows results and clears them when a id query with no results is made
     Given an ID results API with a known response
     And   start button is clicked
-    When  a "<query>" with results is typed
+    When  a "01" with results is typed
+    Then  identifier results are displayed
+    Given an ID results API with no results
+    When  a "23" with results is typed
     Then  no identifier results are displayed
-
-    Examples:
-      | query |
-      | lego  |

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.feature
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.feature
@@ -1,18 +1,12 @@
 Feature: Identifier results component
 
   Background:
-    Given a related tags API with a known response
-    And   a query suggestions API with a known response
-    And   a next queries API with a known response
-    And   a recommendations API with a known response
-    And   a results API with no results
-    And   a tracking API
-    And   no special config for layout view
+    Given following config: identifier detection Regexp "^[0-9]{2,}$"
 
   Scenario Outline: 1. ID search with results is made
     Given an ID results API with a known response
     And   start button is clicked
-    When  "<query>" is searched
+    When  a "<query>" with results is typed
     Then  identifier results are displayed
 
     Examples:
@@ -22,7 +16,7 @@ Feature: Identifier results component
   Scenario Outline: 2. ID search with no results is made
     Given an ID results API with no results
     And   start button is clicked
-    When  "<query>" is searched
+    When  a "<query>" with results is typed
     Then  no identifier results are displayed
 
     Examples:
@@ -32,7 +26,7 @@ Feature: Identifier results component
   Scenario Outline: 3. No ID search is made
     Given an ID results API with a known response
     And   start button is clicked
-    When  "<query>" is searched
+    When  a "<query>" with results is typed
     Then  no identifier results are displayed
 
     Examples:

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
@@ -1,0 +1,31 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
+import { XPluginOptions } from '../../../../src/plugins/x-plugin.types';
+
+Given(
+  'following config: identifier detection Regexp {string}',
+  (identifierDetectionRegexp: string) => {
+    const config = {
+      identifierResults: {
+        config: {
+          identifierDetectionRegexp
+        }
+      }
+    } as XPluginOptions['xModules'];
+
+    cy.visit('/?useMockedAdapter=true', {
+      qs: {
+        xModules: JSON.stringify(config)
+      }
+    });
+  }
+);
+
+Then('identifier results are displayed', () => {
+  cy.getByDataTest('identifier-results-item')
+    .should('be.visible')
+    .should('have.length.at.least', 1);
+});
+
+Then('no identifier results are displayed', () => {
+  cy.getByDataTest('identifier-results-item').should('not.exist');
+});

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
@@ -4,13 +4,13 @@ import { XPluginOptions } from '../../../../src/plugins/x-plugin.types';
 Given(
   'following config: identifier detection Regexp {string}',
   (identifierDetectionRegexp: string) => {
-    const config = {
+    const config: XPluginOptions['xModules'] = {
       identifierResults: {
         config: {
           identifierDetectionRegexp
         }
       }
-    } as XPluginOptions['xModules'];
+    };
 
     cy.visit('/?useMockedAdapter=true', {
       qs: {


### PR DESCRIPTION
[EX-5247]

The Identifier Result doesn't work when X-components are served.

The problem is the `baseInstallXOptions` were not used, because it was always overridden by the config coming from URL (empty object {} if not present), then the Identifier Result Regexp was not right.

- Refactored the Identifier Results in the layout.
- Refactored the Identifier Results E2E tests.

[EX-5247]: https://searchbroker.atlassian.net/browse/EX-5247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ