### PR TITLE
feat(components): add `buttonClass` prop in `SlidingPanel`

### DIFF
--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -3,7 +3,8 @@
     <button
       v-if="showButtons"
       @click="scrollLeft"
-      class="x-sliding-panel__button x-sliding-panel__button-left x-button x-button--round"
+      class="x-sliding-panel__button x-sliding-panel__button-left x-button"
+      :class="buttonClass"
       data-test="sliding-panel-left-button"
     >
       <!-- @slot Left button content -->
@@ -23,7 +24,8 @@
     <button
       v-if="showButtons"
       @click="scrollRight"
-      class="x-sliding-panel__button x-sliding-panel__button-right x-button x-button--round"
+      class="x-sliding-panel__button x-sliding-panel__button-right x-button"
+      :class="buttonClass"
       data-test="sliding-panel-right-button"
     >
       <!-- @slot Right button content -->
@@ -71,6 +73,14 @@
      */
     @Prop({ default: true })
     public resetOnContentChange!: boolean;
+
+    /**
+     * CSS classes to add to the buttons.
+     *
+     * @public
+     */
+    @Prop()
+    public buttonClass!: string;
 
     /**
      * Indicates if the scroll is at the start of the sliding panel.

--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -80,7 +80,7 @@
      * @public
      */
     @Prop()
-    public buttonClass!: string;
+    public buttonClass?: string;
 
     /**
      * Indicates if the scroll is at the start of the sliding panel.

--- a/packages/x-components/tests/unit/sliding-panel.spec.ts
+++ b/packages/x-components/tests/unit/sliding-panel.spec.ts
@@ -17,6 +17,7 @@ function renderSlidingPanel({
   scrollFactor,
   resetOnContentChange,
   showButtons,
+  buttonClass,
   slidingPanelWidthPx = 400,
   itemWidthPx = 100,
   template = `
@@ -51,7 +52,8 @@ function renderSlidingPanel({
       propsData: {
         scrollFactor,
         resetOnContentChange,
-        showButtons
+        showButtons,
+        buttonClass
       },
       style: `
         .wrapper {
@@ -256,6 +258,16 @@ describe('Testing sliding panel', () => {
     getLeftButton().should('be.visible');
     getRightButton().should('be.visible');
   });
+
+  it('allows adding CSS classes to the buttons', () => {
+    const { getLeftButton, getRightButton, scrollTo } = renderSlidingPanel({
+      buttonClass: 'test-x-button--round'
+    });
+
+    scrollTo(100);
+    getRightButton().should('be.visible').should('have.class', 'test-x-button--round');
+    getLeftButton().should('be.visible').should('have.class', 'test-x-button--round');
+  });
 });
 
 interface RenderSlidingPanelOptions {
@@ -273,6 +285,8 @@ interface RenderSlidingPanelOptions {
   resetOnContentChange?: boolean;
   /** The {@link SlidingPanel.showButtons} prop. */
   showButtons?: boolean;
+  /** The {@link SlidingPanel.buttonClass} prop. */
+  buttonClass?: string;
 }
 
 interface RenderSlidingPanelAPI {


### PR DESCRIPTION
BREAKING CHANGE: `SlidingPanel` buttons do not have the round variant set by default.
EX-5233

Exposes a prop for adding CSS classes to the buttons inside the `SlidingPanel`. The main use case for this is adding variant classes of our design system.