### PR TITLE
test(e2e): make tagging tests wait for redirection before assertion

### DIFF
--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
@@ -15,59 +15,64 @@ Feature: Tagging component
 
   Scenario: 2. Searching triggers the query tagging.
     Given a results API with a known response
-    And no special config for layout view
+    And   no special config for layout view
     When  start button is clicked
-    And "lego" is searched
+    And   "lego" is searched
     Then  query tagging request should be triggered
 
   Scenario: 3. Clicking a result triggers the result click tagging.
     Given a results API with a known response
-    And no special config for layout view
-    When start button is clicked
-    And "lego" is searched
-    And first result is clicked
-    Then result click tagging request is triggered
-    And result click tagging includes location "results"
+    And   no special config for layout view
+    When  start button is clicked
+    And   "lego" is searched
+    And   first result is clicked
+    Then  url matches "/products/"
+    And   result click tagging request is triggered
+    And   result click tagging includes location "results"
 
   Scenario: 4. Clicking a result triggers the query tagging
     Given a results API with a known response
-    And no special config for layout view
-    When start button is clicked
-    And "lego" is searched
-    And first result is clicked
-    Then  query tagging request has been triggered
+    And   no special config for layout view
+    When  start button is clicked
+    And   "lego" is searched
+    And   first result is clicked
+    Then  url matches "/products/"
+    And   query tagging request has been triggered
 
   Scenario: 5. Clicking a promoted triggers the query tagging
     Given a results API with a promoted
-    And no special config for layout view
-    When start button is clicked
-    And "lego" is searched
-    And first promoted is clicked
-    Then query tagging request has been triggered
+    And   no special config for layout view
+    When  start button is clicked
+    And   "lego" is searched
+    And   first promoted is clicked
+    Then  url matches "/promoted/"
+    And   query tagging request has been triggered
 
   Scenario: 6. Clicking a banner triggers the query tagging
     Given a results API with a banner
-    And no special config for layout view
-    When start button is clicked
-    And "lego" is searched
-    And first banner is clicked
-    Then query tagging request has been triggered
+    And   no special config for layout view
+    When  start button is clicked
+    And   "lego" is searched
+    And   first banner is clicked
+    Then  url matches "/banner/"
+    And   query tagging request has been triggered
 
   Scenario: 7. A redirection triggers query tagging
     Given a results API with a redirection
-    And no special config for layout view
-    When start button is clicked
-    And "lego" is searched
-    And first redirection is clicked
-    Then query tagging request has been triggered
+    And   no special config for layout view
+    When  start button is clicked
+    And   "lego" is searched
+    And   first redirection is clicked
+    Then  url matches "/redirection/"
+    And   query tagging request has been triggered
 
   Scenario: 8. Infinite scrolling triggers query tagging
     Given a results API with 2 pages
-    And no special config for layout view
-    When start button is clicked
-    And "lego" is searched
-    Then results page number 1 is loaded
-    When scrolls down to next page
-    Then results page number 2 is loaded
-    And query tagging request has been triggered
-    And second page query tagging request is triggered
+    And   no special config for layout view
+    When  start button is clicked
+    And   "lego" is searched
+    Then  results page number 1 is loaded
+    When  scrolls down to next page
+    Then  results page number 2 is loaded
+    And   query tagging request has been triggered
+    And   second page query tagging request is triggered

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -50,3 +50,7 @@ Then('result click tagging includes location {string}', location => {
     .then(JSON.parse)
     .should('have.property', 'location', location);
 });
+
+Then('url matches {string}', (match: string) => {
+  cy.location('pathname').should('match', new RegExp(match));
+});


### PR DESCRIPTION
EX-5273

Attempts to fix (once again) the tagging e2e tests. This change makes the navigation tests wait for the navigation to be completed before asserting that the tagging request has been triggered.
