### PR TITLE
fix(url): default extra params are now properly restored

### DIFF
--- a/packages/x-components/src/x-modules/url/components/url-handler.vue
+++ b/packages/x-components/src/x-modules/url/components/url-handler.vue
@@ -6,6 +6,7 @@
   import Vue from 'vue';
   import GlobalEvents from 'vue-global-events';
   import { Component, Inject } from 'vue-property-decorator';
+  import { State } from '../../../components';
   import { XOn } from '../../../components/decorators/bus.decorators';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { FeatureLocation } from '../../../types/origin';
@@ -79,6 +80,9 @@
     protected get managedParamsNames(): string[] {
       return Object.keys({ ...initialUrlState, ...this.$attrs });
     }
+
+    @State('url', 'initialExtraParams')
+    public initialExtraParams!: Dictionary<unknown>;
 
     /**
      * Returns the mapping of the param keys used in the URL is configured through $attrs. This way
@@ -260,7 +264,7 @@
           }
           return params;
         },
-        { all: { ...initialUrlState }, extra: {} }
+        { all: { ...initialUrlState }, extra: { ...this.initialExtraParams } }
       );
     }
 

--- a/packages/x-components/tests/e2e/cucumber/url/url.feature
+++ b/packages/x-components/tests/e2e/cucumber/url/url.feature
@@ -10,30 +10,53 @@ Feature: Url component
 
   Scenario Outline: 1. Navigating to a URL from the outside sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
-    Then  the search request contains the origin "<origin>"
+    Then  search request contains parameter "origin" with value "<origin>"
     Examples:
       | origin       |
       | url:external |
 
   Scenario Outline: 2. Navigate back and forth in serp sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
-    Then  the search request contains the origin "url:external"
+    Then  search request contains parameter "origin" with value "url:external"
     When  sort option "<sort>" is selected from the sort "dropdown"
-    Then  the search request contains the origin "url:external"
+    Then  search request contains parameter "origin" with value "url:external"
     When  navigating back
-    Then  the search request contains the origin "<origin>"
+    Then  search request contains parameter "origin" with value "<origin>"
     Examples:
       | sort      | origin          |
       | price asc | url:url_history |
 
   Scenario Outline: 3. Navigate back from pdp to serp sets the url origin as "<origin>"
     Given a URL with query parameter "lego"
-    Then  the search request contains the origin "url:external"
+    Then  search request contains parameter "origin" with value "url:external"
     When  clicking result in position 0
     And   navigating back
-    Then  the search request contains the origin "<origin>"
+    Then  search request contains parameter "origin" with value "<origin>"
     Examples:
       | origin              |
       | url:url_history_pdp |
+
+  Scenario Outline: 4. Extra params are properly restored when navigating
+    Given a URL with query parameter "lego"
+    Then  search request contains parameter "store" with value "<defaultStore>"
+    And   url doesn't contain parameter "store" with value "<defaultStore>"
+    When  selecting store "<store2>"
+    Then  search request contains parameter "store" with value "<store2>"
+    And   url contains parameter "store" with value "<store2>"
+    When  selecting store "<store3>"
+    Then  search request contains parameter "store" with value "<store3>"
+    And   url contains parameter "store" with value "<store3>"
+    When  navigating back
+    Then  search request contains parameter "store" with value "<store2>"
+    And   url contains parameter "store" with value "<store2>"
+    When  navigating back
+    Then  search request contains parameter "store" with value "<defaultStore>"
+    And   url doesn't contain parameter "store" with value "<defaultStore>"
+
+    Examples:
+      | defaultStore | store2 | store3 |
+      | Portugal    | Italy  | Spain  |
+
+
 
 

--- a/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
@@ -1,4 +1,4 @@
-import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 // Scenario 1
 Given('a URL with query parameter {string}', (query: string) => {
@@ -26,11 +26,11 @@ When('clicking result in position {int}', (index: number) => {
 });
 
 // Scenario 4
-Then("url doesn't contain parameter {string} with value {string}", (key: string, value: string) => {
+And("url doesn't contain parameter {string} with value {string}", (key: string, value: string) => {
   cy.location('search').should('not.contain', `${key}=${value}`);
 });
 
-Then('url contains parameter {string} with value {string}', (key: string, value: string) => {
+And('url contains parameter {string} with value {string}', (key: string, value: string) => {
   cy.location('search').should('contain', `${key}=${value}`);
 });
 

--- a/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
@@ -5,12 +5,15 @@ Given('a URL with query parameter {string}', (query: string) => {
   cy.visit(`/?useMockedAdapter=true&q=${query}`);
 });
 
-Then('the search request contains the origin {string}', (origin: string) => {
-  cy.wait('@interceptedResults')
-    .its('request.body')
-    .then(JSON.parse)
-    .should('have.property', 'origin', origin);
-});
+Then(
+  'search request contains parameter {string} with value {string}',
+  (key: string, value: string) => {
+    cy.wait('@interceptedResults')
+      .its('request.body')
+      .then(JSON.parse)
+      .should('have.property', key, value);
+  }
+);
 
 // Scenario 2
 When('navigating back', () => {
@@ -20,4 +23,18 @@ When('navigating back', () => {
 // Scenario 3
 When('clicking result in position {int}', (index: number) => {
   cy.getByDataTest('result-link').eq(index).click();
+});
+
+// Scenario 4
+Then("url doesn't contain parameter {string} with value {string}", (key: string, value: string) => {
+  cy.location('search').should('not.contain', `${key}=${value}`);
+});
+
+Then('url contains parameter {string} with value {string}', (key: string, value: string) => {
+  cy.location('search').should('contain', `${key}=${value}`);
+});
+
+When('selecting store {string}', (store: string) => {
+  cy.getByDataTest('store-selector').getByDataTest('dropdown-toggle').click();
+  cy.getByDataTest('store-selector').contains(store).click();
 });


### PR DESCRIPTION
EX-5203

Makes the `URLHandler` component use the initial extra params when parsing the URL params. This fixes the issue where selecting an extra param and navigating back (so the default value is selected again), wasn't restoring its value properly.
