### PR TITLE
fix(components): Fix BaseGrid auto columns CSS.

### DIFF
--- a/packages/x-components/src/components/base-grid.vue
+++ b/packages/x-components/src/components/base-grid.vue
@@ -137,7 +137,7 @@
       return {
         gridTemplateColumns: this.columns
           ? `repeat(${this.columns}, minmax(0, 1fr))`
-          : 'repeat(auto-fill, minmax(var(--x-size-min-width-grid-item, 150px), auto))'
+          : 'repeat(auto-fill, minmax(var(--x-size-min-width-grid-item, 150px), 1fr))'
       };
     }
 


### PR DESCRIPTION
[EX-5295]

Fix auto columns base grid:

When the columns prop is set to 0 in the BaseGrid component, the CSS grid is configured as follow:

repeat(auto-fill, minmax(var(--x-size-min-width-grid-item, 150px), auto))

This is causing the elements may have different sizes:
![image](https://user-images.githubusercontent.com/5759712/150746432-fb835eee-5c94-4c2f-8d93-55fc8ce0b250.png)

I think the problem is the auto of the minmax. Changing it to 1fr works:
![image](https://user-images.githubusercontent.com/5759712/150746453-b2da0238-0345-4a3e-8e2f-c929cd54b1be.png)

