### PR TITLE
feat(EX-5278): build archetype in chunks

### DIFF
--- a/packages/x-components/build-helpers/plugins/polyfills-wrapper.plugin.js
+++ b/packages/x-components/build-helpers/plugins/polyfills-wrapper.plugin.js
@@ -20,12 +20,11 @@ export default function xComponentsPolyfillsWrapperPlugin(polyfillsOptions) {
       if (!chunk.isEntry) {
         return null;
       }
-      const appMagicString = new MagicString(code);
+      const importString = chunk.imports[0] ? `await import('./${chunk.imports[0]}')` : code;
+      const appMagicString = new MagicString(importString);
       const [header, footer] = generateWrapperFunctionTuple(polyfillsOptions);
 
-      appMagicString
-        .prepend(`(${ header }`)
-        .append(`${ footer })()`);
+      appMagicString.prepend(`(${header}`).append(`${footer})()`);
 
       return {
         code: appMagicString.toString(),
@@ -33,4 +32,4 @@ export default function xComponentsPolyfillsWrapperPlugin(polyfillsOptions) {
       };
     }
   };
-};
+}

--- a/packages/x-components/build-helpers/utils/polyfills.util.js
+++ b/packages/x-components/build-helpers/utils/polyfills.util.js
@@ -43,7 +43,7 @@ export function generateWrapperFunctionTuple({
       document.body.appendChild(polyfillsScript);
     }
 
-    function loadXComponents() {
+    async function loadXComponents() {
       /* <InsertXComponents> */
       const overrideOptions = options;
       if (window.initX !== undefined) {

--- a/packages/x-components/src/plugins/x-plugin.ts
+++ b/packages/x-components/src/plugins/x-plugin.ts
@@ -233,8 +233,8 @@ export class XPlugin implements PluginObject<XPluginOptions> {
     if (!this.installedXModules.has(xModule.name)) {
       const customizedXModule = this.customizeXModule(xModule);
       this.registerStoreModule(customizedXModule);
-      this.registerWiring(customizedXModule);
       this.registerStoreEmitters(customizedXModule);
+      this.registerWiring(customizedXModule);
       this.installedXModules.add(xModule.name);
     }
   }

--- a/packages/x-components/src/plugins/x-plugin.ts
+++ b/packages/x-components/src/plugins/x-plugin.ts
@@ -234,6 +234,8 @@ export class XPlugin implements PluginObject<XPluginOptions> {
       const customizedXModule = this.customizeXModule(xModule);
       this.registerStoreModule(customizedXModule);
       this.registerStoreEmitters(customizedXModule);
+      // The wiring must be registered after the store emitters
+      // to allow lazy loaded modules work properly.
       this.registerWiring(customizedXModule);
       this.installedXModules.add(xModule.name);
     }

--- a/packages/x-components/src/x-modules/related-tags/wiring.ts
+++ b/packages/x-components/src/x-modules/related-tags/wiring.ts
@@ -95,6 +95,9 @@ export const setUrlParamsWire = wireDispatch('setUrlParams');
  * @internal
  */
 export const relatedTagsWiring = createWiring({
+  ParamsLoadedFromUrl: {
+    setUrlParamsWire
+  },
   UserAcceptedAQuery: {
     setRelatedTagsQuery,
     clearSelectedRelatedTags
@@ -115,8 +118,5 @@ export const relatedTagsWiring = createWiring({
   },
   ExtraParamsChanged: {
     setRelatedTagsExtraParams
-  },
-  ParamsLoadedFromUrl: {
-    setUrlParamsWire
   }
 });


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

## Motivation and context

This PR enhances the rollup plugin polyfills-wrapper to be compatible with dynamic imports. It also modifies the plugin to work with lazy loaded modules. See https://github.com/empathyco/x-archetype/pull/66

<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: [EX-5278](https://searchbroker.atlassian.net/browse/EX-5278)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

This has to be tested along with the archetype branch from https://github.com/empathyco/x-archetype/pull/66. 
