### PR TITLE
fix: merge extra params with snippet extra params

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="x">
     <Tagging :consent="false" />
-    <ExtraParams :values="initialExtraParams" />
+    <SnippetConfigExtraParams :values="initialExtraParams" />
     <UrlHandler query="q" store="store" />
     <SnippetCallbacks />
     <BaseEventsModalOpen>Start</BaseEventsModalOpen>
@@ -499,7 +499,6 @@
   import { infiniteScroll } from '../../directives/infinite-scroll/infinite-scroll';
   import { XEvent } from '../../wiring/index';
   import Empathize from '../../x-modules/empathize/components/empathize.vue';
-  import ExtraParams from '../../x-modules/extra-params/components/extra-params.vue';
   // eslint-disable-next-line max-len
   import RenderlessExtraParams from '../../x-modules/extra-params/components/renderless-extra-param.vue';
   // eslint-disable-next-line max-len
@@ -593,7 +592,6 @@
       CrossTinyIcon,
       Empathize,
       ExcludeFiltersWithNoResults,
-      ExtraParams,
       Facets,
       FacetsProvider,
       FiltersList,

--- a/packages/x-components/src/x-modules/extra-params/components/__tests__/snippet-config-extra-params.spec.ts
+++ b/packages/x-components/src/x-modules/extra-params/components/__tests__/snippet-config-extra-params.spec.ts
@@ -9,7 +9,7 @@ import { extraParamsXModule } from '../../x-module';
 import SnippetConfigExtraParams from '../snippet-config-extra-params.vue';
 
 describe('testing snippet config extra params component', () => {
-  function renderSnippetConfigExtraParams(): RenderExtraParamsApi {
+  function renderSnippetConfigExtraParams(values?: Dictionary<unknown>): RenderExtraParamsApi {
     XPlugin.resetInstance();
     const [, localVue] = installNewXPlugin();
     XPlugin.registerXModule(extraParamsXModule);
@@ -18,11 +18,12 @@ describe('testing snippet config extra params component', () => {
     const wrapper = mount(
       {
         template: `
-            <SnippetConfigExtraParams />
+            <SnippetConfigExtraParams :values="values"/>
         `,
         components: {
           SnippetConfigExtraParams
         },
+        props: ['values'],
         provide() {
           return {
             snippetConfig
@@ -30,7 +31,10 @@ describe('testing snippet config extra params component', () => {
         }
       },
       {
-        localVue
+        localVue,
+        propsData: {
+          values
+        }
       }
     );
 
@@ -71,6 +75,22 @@ describe('testing snippet config extra params component', () => {
       2,
       expect.objectContaining({
         eventPayload: { warehouse: 45678 }
+      })
+    );
+  });
+
+  // eslint-disable-next-line max-len
+  it('emits the ExtraParamsProvided event with the values from the snippet config and the extra params', () => {
+    const { wrapper } = renderSnippetConfigExtraParams({ scope: 'mobile' });
+
+    const extraParamsProvidedCallback = jest.fn();
+
+    wrapper.vm.$x.on('ExtraParamsProvided', true).subscribe(extraParamsProvidedCallback);
+
+    expect(extraParamsProvidedCallback).toHaveBeenNthCalledWith<[WirePayload<Dictionary<unknown>>]>(
+      1,
+      expect.objectContaining({
+        eventPayload: { warehouse: 1234, scope: 'mobile' }
       })
     );
   });

--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts">
   import Vue from 'vue';
-  import { Component, Watch, Inject } from 'vue-property-decorator';
+  import { Component, Watch, Inject, Prop } from 'vue-property-decorator';
   import { xComponentMixin } from '../../../components';
   import { Dictionary, forEach } from '../../../utils';
   import { SnippetConfig } from '../../../x-installer';
@@ -29,6 +29,14 @@
      */
     @Inject('snippetConfig')
     public snippetConfig!: SnippetConfig;
+
+    /**
+     * A Dictionary where the keys are the extra param names and its values.
+     *
+     * @public
+     */
+    @Prop()
+    protected values?: Dictionary<unknown>;
 
     /**
      * Custom object containing the extra params from the snippet config.
@@ -65,7 +73,7 @@
       currency,
       ...snippetExtraParams
     }: SnippetConfig): void {
-      forEach(snippetExtraParams, (name, value) => {
+      forEach({ ...snippetExtraParams, ...this.values }, (name, value) => {
         if (this.notAllowedExtraParams.includes(name)) {
           return;
         }

--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -53,7 +53,16 @@
      *
      * @internal
      */
-    protected notAllowedExtraParams: Array<keyof SnippetConfig> = ['callbacks', 'productId'];
+    protected notAllowedExtraParams: Array<keyof SnippetConfig> = [
+      'callbacks',
+      'productId',
+      'instance',
+      'lang',
+      'searchLang',
+      'consent',
+      'documentDirection',
+      'currency'
+    ];
 
     /**
      * Updates the extraParams object when the snippet config changes.
@@ -63,17 +72,8 @@
      * @internal
      */
     @Watch('snippetConfig', { deep: true, immediate: true })
-    syncExtraParams({
-      instance,
-      scope,
-      lang,
-      searchLang,
-      consent,
-      documentDirection,
-      currency,
-      ...snippetExtraParams
-    }: SnippetConfig): void {
-      forEach({ ...snippetExtraParams, ...this.values }, (name, value) => {
+    syncExtraParams(snippetConfig: SnippetConfig): void {
+      forEach({ ...snippetConfig, ...this.values }, (name, value) => {
         if (this.notAllowedExtraParams.includes(name)) {
           return;
         }


### PR DESCRIPTION
With this approach instead of using multiple ExtraParams component, only one SnippetExtraParams component will be used. So to test it, just launch the server and see how the extra params are loaded and emitted correctly, you can try to add more values at home.vue in:

` protected initialExtraParams = { store: 'Portugal' };`

to check that you can add more params and they will be combined with snippet one.


EX-5205