### PR TITLE
feat(components): Make `BaseResultAddToCart` to use the outter listeners.

### DIFF
--- a/packages/x-components/src/components/result/__tests__/base-result-add-to-cart.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-add-to-cart.spec.ts
@@ -1,47 +1,86 @@
-import { mount } from '@vue/test-utils';
+import { Result } from '@empathyco/x-types';
+import { mount, Wrapper } from '@vue/test-utils';
 import { getResultsStub } from '../../../__stubs__/results-stubs.factory';
 import { getDataTestSelector, installNewXPlugin } from '../../../__tests__/utils';
+import { XBus } from '../../../plugins/index';
+import { Dictionary } from '../../../utils/index';
 import BaseResultAddToCart from '../base-result-add-to-cart.vue';
 
 describe('testing BaseResultAddToCart component', () => {
   const result = getResultsStub()[0];
-  const [, localVue] = installNewXPlugin();
 
-  it('emits UserClickedResultAddToCart when the user click on the component', () => {
-    const resultAddToCartWrapper = mount(BaseResultAddToCart, {
-      localVue,
-      propsData: { result }
-    });
+  function renderAddToCart({
+    result = { name: 'TEST' } as Result,
+    template = '<BaseResultAddToCart :result="result"/>',
+    methods = {}
+  }: RenderAddToCartOptions): RenderAddToCartApi {
+    const [, localVue] = installNewXPlugin();
+    const wrapper = mount(
+      { template, data: () => ({ result }), methods },
+      {
+        components: { BaseResultAddToCart },
+        localVue
+      }
+    );
+    return {
+      clickAddToCart(): Promise<void> {
+        return wrapper
+          .find(getDataTestSelector('result-add-to-cart'))
+          .trigger('click') as Promise<void>;
+      },
+      on: wrapper.vm.$x.on,
+      addToCartWrapper: wrapper.find(getDataTestSelector('result-add-to-cart'))
+    };
+  }
+
+  it('emits UserClickedResultAddToCart when the user click on the component', async () => {
+    const { clickAddToCart, on } = renderAddToCart({ result });
     const listener = jest.fn();
-    resultAddToCartWrapper.vm.$x.on('UserClickedResultAddToCart').subscribe(listener);
-    resultAddToCartWrapper.trigger('click');
+    on('UserClickedResultAddToCart').subscribe(listener);
+    await clickAddToCart();
     expect(listener).toHaveBeenCalledWith(result);
   });
 
   it('renders the content overriding default slot', () => {
-    const wrapperComponent = {
+    const { addToCartWrapper } = renderAddToCart({
       template: `
         <BaseResultAddToCart :result="result">
           <img data-test="result-add-to-cart-icon" src="./add-to-cart.svg" />
           <span data-test="result-add-to-cart-text">Add to cart</span>
         </BaseResultAddToCart>
       `,
-      props: ['result'],
-      components: {
-        BaseResultAddToCart
-      }
-    };
-
-    const customResultAddToCartWrapper = mount(wrapperComponent, {
-      localVue,
-      propsData: { result }
+      result
     });
+
+    expect(addToCartWrapper.element).toBeDefined();
     expect(
-      customResultAddToCartWrapper.find(getDataTestSelector('result-add-to-cart')).element
+      addToCartWrapper.find(getDataTestSelector('result-add-to-cart-icon')).element
     ).toBeDefined();
-    expect(
-      customResultAddToCartWrapper.find(getDataTestSelector('result-add-to-cart-icon')).element
-    ).toBeDefined();
-    expect(customResultAddToCartWrapper.text()).toEqual('Add to cart');
+    expect(addToCartWrapper.text()).toEqual('Add to cart');
+  });
+
+  it('uses the listeners passed', async () => {
+    const listener = jest.fn();
+    const { clickAddToCart } = renderAddToCart({
+      template: '<BaseResultAddToCart @click="miClick" :result="result"/>',
+      result,
+      methods: {
+        miClick: listener
+      }
+    });
+    await clickAddToCart();
+
+    expect(listener).toHaveBeenCalled();
   });
 });
+
+interface RenderAddToCartOptions {
+  result: Result;
+  template?: string;
+  methods?: Dictionary<() => void>;
+}
+interface RenderAddToCartApi {
+  clickAddToCart: () => Promise<void>;
+  on: XBus['on'];
+  addToCartWrapper: Wrapper<Vue>;
+}

--- a/packages/x-components/src/components/result/base-result-add-to-cart.vue
+++ b/packages/x-components/src/components/result/base-result-add-to-cart.vue
@@ -1,5 +1,6 @@
 <template>
   <BaseEventButton
+    v-on="$listeners"
     :events="events"
     class="x-button x-result-add-to-cart"
     data-test="result-add-to-cart"


### PR DESCRIPTION
EX-5323

The point of this PR is to allow to add listeners to the `BaseResultAddToCart`. Without this we can't add a listener to the button in the Customer project:

```html
    <BaseAddToCart @click="doStuff">Add To Cart</BaseAddToCart>
```