### PR TITLE
feat(components): Add `payload` and `metadata` to the `SnippetCallbackExecuted` event payload.

### DIFF
--- a/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
+++ b/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
@@ -53,8 +53,8 @@ describe('testing SnippetCallbacks component', () => {
   });
 
   it('emits a SnippetCallbackExecuted event when a callback is executed', () => {
-    const acceptedAQueryCallback = jest.fn(payload => payload);
-    const clickedColumnPickerCallback = jest.fn(payload => payload);
+    const acceptedAQueryCallback = jest.fn((payload: string) => payload + '1');
+    const clickedColumnPickerCallback = jest.fn((payload: number) => payload + 1);
     const { wrapper } = renderSnippetCallbacks({
       callbacks: {
         UserAcceptedAQuery: acceptedAQueryCallback,
@@ -69,14 +69,18 @@ describe('testing SnippetCallbacks component', () => {
     expect(eventSpy).toHaveBeenCalledTimes(1);
     expect(eventSpy).toHaveBeenCalledWith({
       event: 'UserAcceptedAQuery',
-      callbackReturn: 'playmobil'
+      callbackReturn: 'playmobil1',
+      payload: 'playmobil',
+      metadata: expect.any(Object)
     });
 
     wrapper.vm.$x.emit('UserClickedColumnPicker', 3);
     expect(eventSpy).toHaveBeenCalledTimes(2);
     expect(eventSpy).toHaveBeenCalledWith({
       event: 'UserClickedColumnPicker',
-      callbackReturn: 3
+      callbackReturn: 4,
+      payload: 3,
+      metadata: expect.any(Object)
     });
   });
 });

--- a/packages/x-components/src/components/snippet-callbacks.vue
+++ b/packages/x-components/src/components/snippet-callbacks.vue
@@ -45,7 +45,9 @@
               const callbackReturn = callback(payload as never, metadata);
               this.$x.emit('SnippetCallbackExecuted', {
                 event: eventName,
-                callbackReturn
+                callbackReturn,
+                payload: payload as never,
+                metadata
               });
             };
           })

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -1,4 +1,5 @@
 import { Result, Suggestion } from '@empathyco/x-types';
+import { ExtractPayload } from '../store/index';
 import { ArrowKey, PropsWithType } from '../utils';
 import { DeviceXEvents } from '../x-modules/device';
 import { EmpathizeXEvents } from '../x-modules/empathize/events.types';
@@ -16,6 +17,7 @@ import { SearchBoxXEvents } from '../x-modules/search-box/events.types';
 import { SearchXEvents } from '../x-modules/search/events.types';
 import { TaggingXEvents } from '../x-modules/tagging/events.types';
 import { UrlXEvents } from '../x-modules/url/events.types';
+import { WireMetadata } from './wiring.types';
 
 /**
  * Dictionary of all the {@link XEvent | XEvents}, where each key is the event name, and the value
@@ -174,7 +176,12 @@ export interface XEventsTypes
    * A callback from the snippet has been executed.
    * * Payload: An object containing the event that executed the callback and the callback result.
    */
-  SnippetCallbackExecuted: { event: XEvent; callbackReturn: unknown };
+  SnippetCallbackExecuted: {
+    event: XEvent;
+    callbackReturn: unknown;
+    payload: ExtractPayload<XEvent>;
+    metadata: WireMetadata;
+  };
 }
 
 /**

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -174,7 +174,8 @@ export interface XEventsTypes
   UserSelectedASuggestion: Suggestion;
   /**
    * A callback from the snippet has been executed.
-   * * Payload: An object containing the event that executed the callback and the callback result.
+   * * Payload: An object containing the event that executed the callback, the callback result, and
+   * the original event payload and  metadata.
    */
   SnippetCallbackExecuted: {
     event: XEvent;


### PR DESCRIPTION
EX-5324

Until now, the event  `SnippetCallbackExecuted`, emitted after a callback execution, only passed the event name and the callback return. But sometimes it's necessary also to know the original payload and metadata.

So this PR is to fix that.