### PR TITLE
feat(search-adapter): detect adblockers and use fetch instead of beacon for tracking when present

### DIFF
--- a/packages/search-adapter/src/empathy/requestors/beacon-tracking.requestor.ts
+++ b/packages/search-adapter/src/empathy/requestors/beacon-tracking.requestor.ts
@@ -2,6 +2,11 @@ import { injectable } from 'inversify';
 import { TrackingRequest } from '../../types';
 import { Requestor } from '../empathy-adapter.types';
 
+let isAdblockPresent = false;
+detectAdblock()
+  .then(() => (isAdblockPresent = false))
+  .catch(() => (isAdblockPresent = true));
+
 /**
  * TODO https://searchbroker.atlassian.net/browse/EX-2163
  *
@@ -9,20 +14,35 @@ import { Requestor } from '../empathy-adapter.types';
  */
 @injectable()
 export class BeaconTrackingRequestor implements Requestor<TrackingRequest, void> {
-
   request(trackingRequest: TrackingRequest): Promise<void> {
     const url = this.buildUrl(trackingRequest);
 
-    if (navigator.sendBeacon(url)) {
+    if (!isAdblockPresent && navigator.sendBeacon(url)) {
       return Promise.resolve();
     } else {
+      if (isAdblockPresent) {
+        fetch(url);
+      }
       return Promise.reject('Beacon not queued');
     }
   }
 
   private buildUrl(trackingRequest: TrackingRequest): string {
     const url = new URL(trackingRequest.url);
-    Object.entries(trackingRequest.params).forEach(([key, value]) => url.searchParams.append(key, value));
+    Object.entries(trackingRequest.params).forEach(([key, value]) =>
+      url.searchParams.append(key, value)
+    );
     return url.href;
   }
+}
+
+function detectAdblock(): Promise<Response> {
+  const flaggedURL = 'https://google.com/pagead/js/adsbygoogle.js';
+
+  return fetch(
+    new Request(flaggedURL, {
+      method: 'HEAD',
+      mode: 'no-cors'
+    })
+  );
 }

--- a/packages/search-adapter/src/empathy/requestors/beacon-tracking.requestor.ts
+++ b/packages/search-adapter/src/empathy/requestors/beacon-tracking.requestor.ts
@@ -2,11 +2,6 @@ import { injectable } from 'inversify';
 import { TrackingRequest } from '../../types';
 import { Requestor } from '../empathy-adapter.types';
 
-let isAdblockPresent = false;
-detectAdblock()
-  .then(() => (isAdblockPresent = false))
-  .catch(() => (isAdblockPresent = true));
-
 /**
  * TODO https://searchbroker.atlassian.net/browse/EX-2163
  *
@@ -14,13 +9,21 @@ detectAdblock()
  */
 @injectable()
 export class BeaconTrackingRequestor implements Requestor<TrackingRequest, void> {
+  constructor() {
+    this.detectAdblock()
+      .then(() => (this.isAdblockPresent = false))
+      .catch(() => (this.isAdblockPresent = true));
+  }
+
+  private isAdblockPresent = false;
+
   request(trackingRequest: TrackingRequest): Promise<void> {
     const url = this.buildUrl(trackingRequest);
 
-    if (!isAdblockPresent && navigator.sendBeacon(url)) {
+    if (!this.isAdblockPresent && navigator.sendBeacon(url)) {
       return Promise.resolve();
     } else {
-      if (isAdblockPresent) {
+      if (this.isAdblockPresent) {
         fetch(url);
       }
       return Promise.reject('Beacon not queued');
@@ -34,19 +37,19 @@ export class BeaconTrackingRequestor implements Requestor<TrackingRequest, void>
     );
     return url.href;
   }
-}
 
-function detectAdblock(): Promise<Response | void> {
-  const flaggedURL = 'https://google.com/pagead/js/adsbygoogle.js';
+  private detectAdblock(): Promise<Response | void> {
+    const flaggedURL = 'https://google.com/pagead/js/adsbygoogle.js';
 
-  if (!fetch) {
-    return Promise.resolve();
+    if (!('fetch' in window)) {
+      return Promise.resolve();
+    }
+
+    return fetch(
+      new Request(flaggedURL, {
+        method: 'HEAD',
+        mode: 'no-cors'
+      })
+    );
   }
-
-  return fetch(
-    new Request(flaggedURL, {
-      method: 'HEAD',
-      mode: 'no-cors'
-    })
-  );
 }

--- a/packages/search-adapter/src/empathy/requestors/beacon-tracking.requestor.ts
+++ b/packages/search-adapter/src/empathy/requestors/beacon-tracking.requestor.ts
@@ -8,23 +8,27 @@ import { Requestor } from '../empathy-adapter.types';
  * @public
  */
 @injectable()
-export class BeaconTrackingRequestor implements Requestor<TrackingRequest, void> {
-  constructor() {
-    this.detectAdblock()
-      .then(() => (this.isAdblockPresent = false))
-      .catch(() => (this.isAdblockPresent = true));
-  }
-
+export class BeaconTrackingRequestor implements Requestor<TrackingRequest, Response | void> {
   private isAdblockPresent = false;
 
-  request(trackingRequest: TrackingRequest): Promise<void> {
+  constructor() {
+    this.detectAdblock()
+      .then(() => {
+        this.isAdblockPresent = false;
+      })
+      .catch(() => {
+        this.isAdblockPresent = true;
+      });
+  }
+
+  request(trackingRequest: TrackingRequest): Promise<Response | void> {
     const url = this.buildUrl(trackingRequest);
 
     if (!this.isAdblockPresent && navigator.sendBeacon(url)) {
       return Promise.resolve();
     } else {
       if (this.isAdblockPresent) {
-        fetch(url);
+        return fetch(url);
       }
       return Promise.reject('Beacon not queued');
     }

--- a/packages/search-adapter/src/empathy/requestors/beacon-tracking.requestor.ts
+++ b/packages/search-adapter/src/empathy/requestors/beacon-tracking.requestor.ts
@@ -36,8 +36,12 @@ export class BeaconTrackingRequestor implements Requestor<TrackingRequest, void>
   }
 }
 
-function detectAdblock(): Promise<Response> {
+function detectAdblock(): Promise<Response | void> {
   const flaggedURL = 'https://google.com/pagead/js/adsbygoogle.js';
+
+  if (!fetch) {
+    return Promise.resolve();
+  }
 
   return fetch(
     new Request(flaggedURL, {


### PR DESCRIPTION
[EX-5372](https://searchbroker.atlassian.net/browse/EX-5371)

## Motivation and context
Tracking requests are being blocked by ad blocked (specifically uBlock) because they're of type `ping`. We're using `sendBeacon` for these requests and due to its nature, it's not trivial to know when the request is being blocked.
We opted for detecting when an adblock is present by sending a regular request with `fetch` to an URL that will be blocked. If an ad blocked is present then instead of sending the beacon we use a regular fetch.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
This change is aimed to solve issues in clients, so the test done was:
* Take a client's project (`x-massimoduti` for example)
* Add the local `x-adapter` as a dependency
* Override the adapter configuration so it uses the `x-adapter` `BeaconTrackingRequestor`
````javascript
configureAdapter
...
.configureContainer((container) => {
  container.rebind(DEPENDENCIES.Requestors.track).to(BeaconTrackingRequestor)
})
````
* Check that the request is sent even with uBlock on and the Beacon failing

But it can be tested any other way that triggers the `BeaconTrackingRequestor`.