### PR TITLE
ci: add `concurrency` option to `build` `workflow`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Check branch is releasable and release alpha on main branch update
 on: [push, pull_request]
+concurrency: ${{ github.workflow }}-${{ github.ref_name }}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Check branch is releasable and release alpha on main branch update
 on: [push, pull_request]
-concurrency: ${{ github.workflow }}-${{ github.ref_name }}
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
EX-5357

Avoid overlapping multiple executions of the `build` `workflow`.

## Testing

We've tested this option in a dummy repository and seems to be working as expected.