### PR TITLE
chore: create empty `x-adapter` (`x-adapter-next`) and `x-adapter-platform` packages

### DIFF
--- a/packages/x-adapter-platform/README.md
+++ b/packages/x-adapter-platform/README.md
@@ -1,0 +1,8 @@
+# x-adapter-platform
+
+`x-adapter-platform` is a library to ease the communication with `empathy.co platform search API's`.
+
+### Contributing
+
+To start contributing to the project, please take a look to our
+[Contributing Guide](../../.github/CONTRIBUTING.md).

--- a/packages/x-adapter-platform/package.json
+++ b/packages/x-adapter-platform/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@empathyco/x-adapter-platform",
+  "version": "0.1.0",
+  "description": "A search client for empathy.co's platform search API",
+  "author": "Empathy Systems Corporation S.L.",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/empathyco/x/tree/main/packages/x-adapter#readme",
+  "keywords": [
+    "search",
+    "adapter",
+    "client",
+    "fetch"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/empathyco/x.git",
+    "directory": "packages/x-adapter-platform"
+  },
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/x-adapter-platform/tsconfig.eslint.json
+++ b/packages/x-adapter-platform/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": []
+}

--- a/packages/x-adapter-platform/tsconfig.json
+++ b/packages/x-adapter-platform/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "types": ["node", "jest"],
+    "lib": ["esnext"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/x-adapter/README.md
+++ b/packages/x-adapter/README.md
@@ -1,0 +1,8 @@
+# x-adapter
+
+`x-adapter` is a library to ease the communication with `empathy.co search API's`.
+
+### Contributing
+
+To start contributing to the project, please take a look to our
+[Contributing Guide](../../.github/CONTRIBUTING.md).

--- a/packages/x-adapter/package.json
+++ b/packages/x-adapter/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@empathyco/x-adapter-next",
+  "version": "0.1.0",
+  "description": "A search client for the Empathy search API",
+  "author": "Empathy Systems Corporation S.L.",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/empathyco/x/tree/main/packages/x-adapter#readme",
+  "keywords": [
+    "search",
+    "adapter",
+    "client",
+    "fetch"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/empathyco/x.git",
+    "directory": "packages/x-adapter"
+  },
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/x-adapter/tsconfig.eslint.json
+++ b/packages/x-adapter/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": []
+}

--- a/packages/x-adapter/tsconfig.json
+++ b/packages/x-adapter/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "types": ["node", "jest"],
+    "lib": ["esnext"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
EX-5310

## Motivation and context
Create new empty `x-adapter` (`@empathyco/x-adapter-next` until we can get rid of the current adapter) and `x-adapter-platform` packages.
