### PR TITLE
fix(build): Fix build side effects to include css.

### DIFF
--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -29,6 +29,7 @@
   "sideEffects": [
     "./tests/**/*",
     "**/*.scss",
+    "**/*.scss.js",
     "**/*.css",
     "**/*.vue"
   ],


### PR DESCRIPTION
EX-5396

The CSS imported in a js file is removed from the build of the Archetype and Setup projects due to the treeShaking. To avoid this, we have to indicate in the `sideEffects` property of the `package.json` of the XComponents, what imported files to include even they are not used directly in the code. Like what happens with the CSS:

<img width="881" alt="image" src="https://user-images.githubusercontent.com/5759712/154053683-922a0984-ab3a-4f96-a8f2-6ecde92aee99.png">

As you can see in the previous screenshot, the CSS is imported but not used directly in the code. So Rollup take this out from final build when it does the "treeShaking".

The `"**/*.scss.js"` is added to indicate to the build of the projects that use XComponents, to include this files from XComponents. The `.js` is added because what is actually built in XComponents are JavaScript files including the CSS.