### PR TITLE
feat(scroll): add scroll data state to the alias API

### DIFF
--- a/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
@@ -64,6 +64,7 @@ describe('testing plugin alias', () => {
       recommendations: [],
       redirections: [],
       relatedTags: [],
+      scroll: {},
       selectedFilters: [],
       selectedRelatedTags: [],
       spellcheckedQuery: null,

--- a/packages/x-components/src/plugins/x-plugin.alias.ts
+++ b/packages/x-components/src/plugins/x-plugin.alias.ts
@@ -92,6 +92,9 @@ export function getAliasAPI(component: Vue): XComponentAliasAPI {
     get relatedTags() {
       return component.$store.getters[getGetterPath('relatedTags', 'relatedTags')] ?? [];
     },
+    get scroll() {
+      return component.$store.state.x.scroll?.data ?? {};
+    },
     get selectedFilters() {
       return component.$store.getters[getGetterPath('facets', 'selectedFilters')] ?? [];
     },

--- a/packages/x-components/src/plugins/x-plugin.types.ts
+++ b/packages/x-components/src/plugins/x-plugin.types.ts
@@ -20,6 +20,7 @@ import { StoreEmitters } from '../store/utils/store-emitters.utils';
 import { DeepPartial, PropsWithType } from '../utils';
 import { XEvent, XEventPayload, XEventsTypes } from '../wiring/events.types';
 import { WireMetadata, Wiring } from '../wiring/wiring.types';
+import { ScrollComponentState } from '../x-modules/scroll/index';
 import { AnyXModule, ExtractState, XModuleName, XModulesTree } from '../x-modules/x-modules.types';
 import { XBus } from './x-bus.types';
 
@@ -113,6 +114,8 @@ export interface XComponentAliasAPI {
   readonly redirections: ReadonlyArray<Redirection>;
   /** The {@link RelatedTagsXModule} related tags (Both selected and deselected). */
   readonly relatedTags: ReadonlyArray<RelatedTag>;
+  /** The {@link ScrollXModule} status. */
+  readonly scroll: Record<string, ScrollComponentState>;
   /** The {@link FacetsXModule} selected filters. */
   readonly selectedFilters: Filter[];
   /** The {@link RelatedTagsXModule} selected related tags. */


### PR DESCRIPTION
Go to any component and inside a function write the following code:

`this.$x.scroll['main-scroll'].WHATEVER` check the different values that it is offering. You can print these values to check that everything is working as expected when you use the scroll.

Or you can add it in the scroll.vue component, inside the emitScroll function:

` protected emitScroll(position: number): void {
     console.log(this.$x.scroll['main-scroll'].hasReachedStart);
      this.$x.emit('UserScrolled', position, this.createEventMetadata());
 }`

<img src="https://media2.giphy.com/media/3o7btNa0RUYa5E7iiQ/giphy.gif"/>
EX-5248