### PR TITLE
Bugfix/ex 5374 tagging e2e tests

### DIFF
--- a/packages/x-components/src/adapter/mocked-adapter.ts
+++ b/packages/x-components/src/adapter/mocked-adapter.ts
@@ -16,7 +16,6 @@ import {
   TopRecommendationsResponse,
   TrackingRequest
 } from '@empathyco/x-adapter';
-import { noOp } from '../utils/index';
 import { configureAdapterWithToysrus } from './util';
 
 declare global {
@@ -72,10 +71,9 @@ class E2ETestsAdapter extends EmpathyAdapter {
   }
 
   track(request: TrackingRequest): Promise<void> {
-    return fetch(request.url, {
-      method: 'POST',
-      body: JSON.stringify(request.params)
-    }).then(noOp);
+    return navigator.sendBeacon(request.url, JSON.stringify(request.params))
+      ? Promise.resolve()
+      : Promise.reject();
   }
 
   searchById(request: SearchByIdRequest): Promise<SearchByIdResponse> {

--- a/packages/x-components/src/adapter/mocked-adapter.ts
+++ b/packages/x-components/src/adapter/mocked-adapter.ts
@@ -71,9 +71,9 @@ class E2ETestsAdapter extends EmpathyAdapter {
   }
 
   track(request: TrackingRequest): Promise<void> {
-    return navigator.sendBeacon(request.url, JSON.stringify(request.params))
+    return navigator.sendBeacon(request.url, JSON.stringify(request.params ?? {}))
       ? Promise.resolve()
-      : Promise.reject();
+      : Promise.reject('sendBeacon rejected');
   }
 
   searchById(request: SearchByIdRequest): Promise<SearchByIdResponse> {

--- a/packages/x-components/src/router.ts
+++ b/packages/x-components/src/router.ts
@@ -16,7 +16,7 @@ const routes: RouteConfig[] = [
   }
 ];
 
-if (!('Cypress' in window)) {
+if (process.env.NODE_ENV !== 'production') {
   routes.push(
     {
       path: '/fixed-header-layout',

--- a/packages/x-components/src/router.ts
+++ b/packages/x-components/src/router.ts
@@ -10,62 +10,67 @@ const routes: RouteConfig[] = [
     component: () => import('./views/home/Home.vue')
   },
   {
-    path: '/fixed-header-layout',
-    name: 'Fixed Header Layout',
-    component: () => import('./views/layouts/fixed-header-and-asides-layout.vue')
-  },
-  {
-    path: '/multi-column-layout',
-    name: 'Multi Column Layout',
-    component: () => import('./views/layouts/multi-column-layout.vue')
-  },
-  {
-    path: '/single-column-layout',
-    name: 'Single Column Layout',
-    component: () => import('./views/layouts/single-column-layout.vue')
-  },
-  {
-    path: '/design-system',
-    name: 'Design System',
-    component: () => import('./views/design-system/design-system.vue')
-  },
-  {
-    path: '/result-app',
-    name: 'result-app',
-    component: () => import('./views/ResultApp.vue')
-  },
-  {
-    path: '/search',
-    name: 'search',
-    component: () => import('./views/Search.vue')
-  },
-  {
-    path: '/test/infinite-scroll',
-    name: 'Infinite Scroll Container',
-    component: () => import('./views/infinite-scroll.vue')
-  },
-
-  {
-    path: '/infinite-scroll-document',
-    name: 'Infinite Scroll Document',
-    component: () => import('./views/infinite-scroll-document.vue')
-  },
-  {
-    path: '/infinite-scroll-html',
-    name: 'Infinite Scroll HTML',
-    component: () => import('./views/infinite-scroll-html.vue')
-  },
-  {
-    path: '/infinite-scroll-body',
-    name: 'Infinite Scroll Body',
-    component: () => import('./views/infinite-scroll-body.vue')
-  },
-  {
     path: '/products/:id',
     name: 'Product page',
     component: () => import('./views/pdp.vue')
   }
 ];
+
+if (!('Cypress' in window)) {
+  routes.push(
+    {
+      path: '/fixed-header-layout',
+      name: 'Fixed Header Layout',
+      component: () => import('./views/layouts/fixed-header-and-asides-layout.vue')
+    },
+    {
+      path: '/multi-column-layout',
+      name: 'Multi Column Layout',
+      component: () => import('./views/layouts/multi-column-layout.vue')
+    },
+    {
+      path: '/single-column-layout',
+      name: 'Single Column Layout',
+      component: () => import('./views/layouts/single-column-layout.vue')
+    },
+    {
+      path: '/design-system',
+      name: 'Design System',
+      component: () => import('./views/design-system/design-system.vue')
+    },
+    {
+      path: '/result-app',
+      name: 'result-app',
+      component: () => import('./views/ResultApp.vue')
+    },
+    {
+      path: '/search',
+      name: 'search',
+      component: () => import('./views/Search.vue')
+    },
+    {
+      path: '/infinite-scroll-container',
+      name: 'Infinite Scroll Container',
+      component: () => import('./views/infinite-scroll.vue')
+    },
+
+    {
+      path: '/infinite-scroll-document',
+      name: 'Infinite Scroll Document',
+      component: () => import('./views/infinite-scroll-document.vue')
+    },
+    {
+      path: '/infinite-scroll-html',
+      name: 'Infinite Scroll HTML',
+      component: () => import('./views/infinite-scroll-html.vue')
+    },
+    {
+      path: '/infinite-scroll-body',
+      name: 'Infinite Scroll Body',
+      component: () => import('./views/infinite-scroll-body.vue')
+    }
+  );
+}
 
 const router = new VueRouter({
   mode: 'history',

--- a/packages/x-components/src/utils/__tests__/object.spec.ts
+++ b/packages/x-components/src/utils/__tests__/object.spec.ts
@@ -1,4 +1,4 @@
-import { cleanUndefined, forEach, getNewAndUpdatedKeys, map, reduce } from '../object';
+import { cleanUndefined, every, forEach, getNewAndUpdatedKeys, map, reduce } from '../object';
 import { Dictionary } from '../types';
 
 class Person {
@@ -391,6 +391,16 @@ describe('testing object utils', () => {
       const oldValue = { a: 1, b: 'potatoe' };
 
       expect(getNewAndUpdatedKeys(newValue, oldValue)).toEqual(['c']);
+    });
+  });
+
+  describe('every', () => {
+    it('returns true when every entry of the given object passes the condition', () => {
+      expect(every({ a: 1, b: 2 }, (_key, value) => typeof value === 'number')).toBe(true);
+    });
+
+    it('returns false when every entry of the given object passes the condition', () => {
+      expect(every({ a: 1, b: '2' }, (_key, value) => typeof value === 'number')).toBe(false);
     });
   });
 });

--- a/packages/x-components/src/utils/__tests__/object.spec.ts
+++ b/packages/x-components/src/utils/__tests__/object.spec.ts
@@ -397,10 +397,12 @@ describe('testing object utils', () => {
   describe('every', () => {
     it('returns true when every entry of the given object passes the condition', () => {
       expect(every({ a: 1, b: 2 }, (_key, value) => typeof value === 'number')).toBe(true);
+      expect(every({ a: 1, b: undefined }, (_key, value) => typeof value === 'number')).toBe(true);
     });
 
-    it('returns false when every entry of the given object passes the condition', () => {
+    it('returns false when not every entry of the given object passes the condition', () => {
       expect(every({ a: 1, b: '2' }, (_key, value) => typeof value === 'number')).toBe(false);
+      expect(every({ a: '1', b: 2 }, (_key, value) => typeof value === 'number')).toBe(false);
     });
   });
 });

--- a/packages/x-components/src/utils/object.ts
+++ b/packages/x-components/src/utils/object.ts
@@ -140,7 +140,7 @@ export function getNewAndUpdatedKeys<ObjectType extends Dictionary>(
 }
 
 /**
- * Ensures that the given condition is met in all the entries of the object.
+ * Ensures that the given condition is met in all the non-undefined entries of the object.
  *
  * @param object - The object to check if every item meets the given condition.
  * @param condition - The condition to check in each one of the entries of the object.
@@ -156,11 +156,7 @@ export function every<ObjectType extends Dictionary>(
     index: number
   ) => boolean
 ): boolean {
-  return reduce(
-    object,
-    (paramsMatch, key, value, index) => {
-      return !paramsMatch || condition(key, value, index);
-    },
-    true as boolean
-  );
+  return Object.entries(object)
+    .filter(([, value]) => value !== undefined)
+    .every(([key, value], index) => condition(key, value, index));
 }

--- a/packages/x-components/src/utils/object.ts
+++ b/packages/x-components/src/utils/object.ts
@@ -138,3 +138,29 @@ export function getNewAndUpdatedKeys<ObjectType extends Dictionary>(
 
   return Object.keys(newValue).filter(key => !(key in oldValue) || newValue[key] !== oldValue[key]);
 }
+
+/**
+ * Ensures that the given condition is met in all the entries of the object.
+ *
+ * @param object - The object to check if every item meets the given condition.
+ * @param condition - The condition to check in each one of the entries of the object.
+ *
+ * @returns True when all the entries pass the condition. False otherwise.
+ * @public
+ */
+export function every<ObjectType extends Dictionary>(
+  object: ObjectType,
+  condition: (
+    key: keyof ObjectType,
+    value: Exclude<ObjectType[keyof ObjectType], undefined>,
+    index: number
+  ) => boolean
+): boolean {
+  return reduce(
+    object,
+    (paramsMatch, key, value, index) => {
+      return !paramsMatch || condition(key, value, index);
+    },
+    true as boolean
+  );
+}

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -11,7 +11,10 @@ export const baseSnippetConfig: SnippetConfig = {
 
 const url = new URL(location.href);
 
-const adapter = url.searchParams.has('useMockedAdapter') ? (mockedAdapter as any) : realAdapter;
+const adapter =
+  url.searchParams.get('useMockedAdapter') === 'true' || 'Cypress' in window
+    ? mockedAdapter
+    : realAdapter;
 
 const xModulesURLConfig = JSON.parse(new URL(location.href).searchParams.get('xModules') ?? '{}');
 

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -9,12 +9,7 @@ export const baseSnippetConfig: SnippetConfig = {
   scope: 'x-components-development'
 };
 
-const url = new URL(location.href);
-
-const adapter =
-  url.searchParams.get('useMockedAdapter') === 'true' || 'Cypress' in window
-    ? mockedAdapter
-    : realAdapter;
+const adapter = 'Cypress' in window ? mockedAdapter : realAdapter;
 
 const xModulesURLConfig = JSON.parse(new URL(location.href).searchParams.get('xModules') ?? '{}');
 

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -295,12 +295,9 @@
           <Redirection
             #default="{ redirection, redirect, abortRedirect, isRedirecting, delayInSeconds }"
             class="x-margin--top-03 x-margin--bottom-03"
-            delayInSeconds="5"
+            :delayInSeconds="5"
           >
-            <p>
-              Your search matches a special place in our website, to visit it, your are being
-              redirected
-            </p>
+            <p>Your search matches a special place in our website. You are being redirected to:</p>
             <a @click="redirect" :href="redirection.url" data-test="redirection-link">
               {{ redirection.url }}
             </a>

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -29,9 +29,17 @@ function getElementBy(facetName: string): Cypress.Chainable<JQuery<HTMLElement>>
 }
 
 // Init
-
 Given('no special config for layout view', () => {
-  cy.visit('/?useMockedAdapter=true');
+  cy.visit('/');
+});
+
+Given('a URL with query parameter {string}', (query: string) => {
+  cy.log(query);
+  cy.visit('/', {
+    qs: {
+      q: query
+    }
+  });
 });
 
 When('start button is clicked', () => {

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -34,7 +34,6 @@ Given('no special config for layout view', () => {
 });
 
 Given('a URL with query parameter {string}', (query: string) => {
-  cy.log(query);
   cy.visit('/', {
     qs: {
       q: query

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -29,6 +29,7 @@ function getElementBy(facetName: string): Cypress.Chainable<JQuery<HTMLElement>>
 }
 
 // Init
+
 Given('no special config for layout view', () => {
   cy.visit('/?useMockedAdapter=true');
 });

--- a/packages/x-components/tests/e2e/cucumber/filters/sliced-filters.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/filters/sliced-filters.spec.ts
@@ -3,7 +3,7 @@ import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 let totalFilters: number, hiddenFilters: number;
 
 Given('following config: max of sliced filters {int}', (slicedFiltersMax: number) => {
-  cy.visit('/?useMockedAdapter=true');
+  cy.visit('/?');
   cy.getByDataTest('sliced-filters-max').clear().type(slicedFiltersMax.toString());
 });
 

--- a/packages/x-components/tests/e2e/cucumber/filters/sliced-filters.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/filters/sliced-filters.spec.ts
@@ -3,7 +3,7 @@ import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 let totalFilters: number, hiddenFilters: number;
 
 Given('following config: max of sliced filters {int}', (slicedFiltersMax: number) => {
-  cy.visit('/?');
+  cy.visit('/');
   cy.getByDataTest('sliced-filters-max').clear().type(slicedFiltersMax.toString());
 });
 

--- a/packages/x-components/tests/e2e/cucumber/history-queries.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/history-queries.spec.ts
@@ -22,7 +22,7 @@ Given(
         }
       }
     };
-    cy.visit('/?useMockedAdapter=true', {
+    cy.visit('/?', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/history-queries.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/history-queries.spec.ts
@@ -22,7 +22,7 @@ Given(
         }
       }
     };
-    cy.visit('/?', {
+    cy.visit('/', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
@@ -12,7 +12,7 @@ Given(
       }
     };
 
-    cy.visit('/?', {
+    cy.visit('/', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/identifier-results/identifier-results.spec.ts
@@ -12,7 +12,7 @@ Given(
       }
     };
 
-    cy.visit('/?useMockedAdapter=true', {
+    cy.visit('/?', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/mocked-responses.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/mocked-responses.spec.ts
@@ -532,20 +532,8 @@ Given('a tracking API', () => {
   });
 });
 
-Given('a query tagging API', () => {
-  cy.intercept(`${trackEndpoint}/query`, req => {
-    req.reply({});
-  }).as('queryTagging');
-});
-
-Given('a click tagging API', () => {
-  cy.intercept(`${trackEndpoint}/click`, req => {
-    req.reply({});
-  }).as('clickTagging');
-});
-
-Given('an add to cart tagging API', () => {
-  cy.intercept(`${trackEndpoint}/add2cart*`, req => {
-    req.reply({});
-  }).as('addToCartTagging');
+Given('a tracking API with a known response', () => {
+  cy.intercept('**/track/query', { statusCode: 200 }).as('queryTagging');
+  cy.intercept('**/track/click', { statusCode: 200 }).as('clickTagging');
+  cy.intercept('**/track/add2cart', { statusCode: 200 }).as('addToCartTagging');
 });

--- a/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.spec.ts
@@ -21,7 +21,7 @@ Given(
       }
     };
 
-    cy.visit('/?useMockedAdapter=true', {
+    cy.visit('/?', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/next-queries/next-queries.spec.ts
@@ -21,7 +21,7 @@ Given(
       }
     };
 
-    cy.visit('/?', {
+    cy.visit('/', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.spec.ts
@@ -18,7 +18,7 @@ Given(
         }
       }
     };
-    cy.visit('/?', {
+    cy.visit('/', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/popular-searches/popular-searches.spec.ts
@@ -18,7 +18,7 @@ Given(
         }
       }
     };
-    cy.visit('/?useMockedAdapter=true', {
+    cy.visit('/?', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.spec.ts
@@ -18,7 +18,7 @@ Given(
         }
       }
     };
-    cy.visit('/?', {
+    cy.visit('/', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/query-suggestions/query-suggestions.spec.ts
@@ -18,7 +18,7 @@ Given(
         }
       }
     };
-    cy.visit('/?useMockedAdapter=true', {
+    cy.visit('/?', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.spec.ts
@@ -11,7 +11,7 @@ Given('following config: max items to store is {int}', (maxItemsToRequest: numbe
     }
   };
 
-  cy.visit('/?', {
+  cy.visit('/', {
     qs: {
       xModules: JSON.stringify(config)
     }

--- a/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/recommendations/recommendations.spec.ts
@@ -11,7 +11,7 @@ Given('following config: max items to store is {int}', (maxItemsToRequest: numbe
     }
   };
 
-  cy.visit('/?useMockedAdapter=true', {
+  cy.visit('/?', {
     qs: {
       xModules: JSON.stringify(config)
     }

--- a/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
@@ -16,7 +16,7 @@ Given(
       }
     };
 
-    cy.visit('/?useMockedAdapter=true', {
+    cy.visit('/?', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/related-tags/related-tags.spec.ts
@@ -16,7 +16,7 @@ Given(
       }
     };
 
-    cy.visit('/?', {
+    cy.visit('/', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
@@ -19,7 +19,7 @@ Given(
         }
       }
     };
-    cy.visit('/?useMockedAdapter=true', {
+    cy.visit('/?', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/search-box/search-box.spec.ts
@@ -19,7 +19,7 @@ Given(
         }
       }
     };
-    cy.visit('/?', {
+    cy.visit('/', {
       qs: {
         xModules: JSON.stringify(config)
       }

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
@@ -5,9 +5,7 @@ Feature: Tagging component
     And   a suggestions API
     And   a related tags API
     And   a recommendations API with a known response
-    And   a query tagging API
-    And   a click tagging API
-    And   an add to cart tagging API
+    And navigator.sendBeacon API
 
   Scenario: 1. Navigating to a URL with a query triggers the query tagging.
     Given a results API with a known response
@@ -84,5 +82,5 @@ Feature: Tagging component
     When  start button is clicked
     And   "lego" is searched
     And   first result is clicked
-    When   pdp add to cart button is clicked
+    When  pdp add to cart button is clicked
     Then  add product to cart tagging request has been triggered

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
@@ -5,7 +5,7 @@ Feature: Tagging component
     And   a suggestions API
     And   a related tags API
     And   a recommendations API with a known response
-    And a navigator.sendBeacon API
+    And   a tracking API with a known response
 
   Scenario: 1. Navigating to a URL with a query triggers the query tagging.
     Given a results API with a known response

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.feature
@@ -5,7 +5,7 @@ Feature: Tagging component
     And   a suggestions API
     And   a related tags API
     And   a recommendations API with a known response
-    And navigator.sendBeacon API
+    And a navigator.sendBeacon API
 
   Scenario: 1. Navigating to a URL with a query triggers the query tagging.
     Given a results API with a known response

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -1,34 +1,40 @@
 import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { every } from '../../../../src/utils/object';
+import { Dictionary } from '../../../../src/utils/types';
 
 Given('a URL with query parameter {string}', (query: string) => {
   cy.visit(`/?useMockedAdapter=true&q=${query}`);
 });
 
-Given('navigator.sendBeacon API', () => {
-  const beaconCalls: string[] = [];
+Given('a navigator.sendBeacon API', () => {
+  const sendBeaconCalls: SendBeaconCall[] = [];
   cy.on('window:before:load', win => {
-    cy.stub(win.navigator, 'sendBeacon', url => {
-      beaconCalls.push(url);
+    cy.stub(win.navigator, 'sendBeacon', (url, data) => {
+      sendBeaconCalls.push({ url, params: JSON.parse(data) });
       return true;
     });
   });
-  cy.wrap(beaconCalls).as('beacon');
+  cy.wrap(sendBeaconCalls).as('sendBeaconCalls');
 });
 
 When('first result is clicked', () => {
+  slowInteraction();
   cy.getByDataTest('result-link').first().click();
 });
 
 When('first promoted is clicked', () => {
+  slowInteraction();
   cy.getByDataTest('promoted').first().click();
 });
 
 When('first banner is clicked', () => {
+  slowInteraction();
   cy.getByDataTest('banner').first().click();
 });
 
 When('first redirection is clicked', () => {
-  cy.getByDataTest('redirection-link').first().click();
+  slowInteraction();
+  cy.getByDataTest('redirection-link').first().should('exist', {}).click();
 });
 
 When('scrolls down to next page', () => {
@@ -36,37 +42,27 @@ When('scrolls down to next page', () => {
 });
 
 Then('result click tagging request is triggered', () => {
-  cy.get<string[]>('@beacon').should(sendBeacon => {
-    expect(!!sendBeacon.find(url => /track\/click/.test(url))).to.be.true;
-  });
+  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('click'));
 });
 
 Then('query tagging request should be triggered', () => {
-  cy.get<string[]>('@beacon').should(sendBeacon => {
-    expect(!!sendBeacon.find(url => /track\/query/.test(url))).to.be.true;
-  });
+  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('query'));
 });
 
 Then('query tagging request has been triggered', () => {
-  cy.get<string[]>('@beacon').should(sendBeacon => {
-    expect(!!sendBeacon.find(url => /track\/query/.test(url))).to.be.true;
-  });
+  cy.get<SendBeaconCall[]>('@sendBeaconCalls').then(haveBeenTrackedWith('query'));
 });
 
 Then('second page query tagging request is triggered', () => {
-  cy.get<string[]>('@beacon').should(sendBeacon => {
-    expect(!!sendBeacon.find(url => /track\/query/.test(url))).to.be.true;
-  });
+  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('query', { page: 2 }));
 });
 
 Then('results page number {int} is loaded', (page: number) => {
   cy.getByDataTest('search-result').should('have.length', 24 * page);
 });
 
-Then('result click tagging includes location {string}', () => {
-  cy.get<string[]>('@beacon').should(sendBeacon => {
-    expect(!!sendBeacon.find(url => /track\/click/.test(url))).to.be.true;
-  });
+Then('result click tagging includes location {string}', location => {
+  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('click', { location }));
 });
 
 Then('url matches {string}', (match: string) => {
@@ -74,7 +70,57 @@ Then('url matches {string}', (match: string) => {
 });
 
 Then('add product to cart tagging request has been triggered', () => {
-  cy.get<string[]>('@beacon').should(sendBeacon => {
-    expect(!!sendBeacon.find(url => /track\/add2cart/.test(url))).to.be.true;
-  });
+  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('add2cart'));
 });
+
+/**
+ * Helper to check whether a tagging request has been made using the mocked adapter and the
+ * `sendBeacon` API.
+ *
+ * @param taggingKind - Expected tagging kind.
+ * @param expectedParams - Partial expected params of the tagging request.
+ * @returns A should function that asserts that the tagging calls contain one entry with the given
+ * parameters.
+ */
+function haveBeenTrackedWith(
+  taggingKind: string,
+  expectedParams: Dictionary<unknown> = {}
+): (taggingCalls: SendBeaconCall[]) => void {
+  return taggingCalls => {
+    const taggingEndpointRegex = new RegExp(`track/${taggingKind}`);
+    expect(
+      taggingCalls.find(
+        ({ url, params }) =>
+          taggingEndpointRegex.test(url) &&
+          every(expectedParams, (key, value) => params[key] === value)
+      )
+    ).not.to.be.equal(
+      undefined,
+      `Expected to find tracking request for "${taggingKind}" with parameters ${JSON.stringify(
+        expectedParams,
+        null,
+        2
+      )}.
+ Triggered tracking requests: [${JSON.stringify(taggingCalls, null, 2)}].`
+    );
+  };
+}
+
+/**
+ * Waits before performing the next iteration to ensure that the {@link XEvent}s quey has
+ * been correctly processed.
+ */
+function slowInteraction(): void {
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(250);
+}
+
+/**
+ * Contains the base url and the parameters of a tagging request.
+ */
+interface SendBeaconCall {
+  /** The base tagging url. */
+  url: string;
+  /** Parameters of the tagging request. This may include things like query, page, location... */
+  params: Dictionary<unknown>;
+}

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -23,7 +23,7 @@ When('first banner is clicked', () => {
 
 When('first redirection is clicked', () => {
   slowInteraction();
-  cy.getByDataTest('redirection-link').first().should('exist', {}).click();
+  cy.getByDataTest('redirection-link').first().click();
 });
 
 When('scrolls down to next page', () => {

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -70,7 +70,7 @@ Then('add product to cart tagging request has been triggered', () => {
 });
 
 /**
- * Waits before performing the next iteration to ensure that the {@link XEvent}s quey has
+ * Waits before performing the next iteration to ensure that the {@link XEvent}s queue has
  * been correctly processed.
  */
 function slowInteraction(): void {

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -1,20 +1,13 @@
 import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
-import { every } from '../../../../src/utils/object';
-import { Dictionary } from '../../../../src/utils/types';
 
 Given('a URL with query parameter {string}', (query: string) => {
   cy.visit(`/?useMockedAdapter=true&q=${query}`);
 });
 
-Given('a navigator.sendBeacon API', () => {
-  const sendBeaconCalls: SendBeaconCall[] = [];
-  cy.on('window:before:load', win => {
-    cy.stub(win.navigator, 'sendBeacon', (url, data) => {
-      sendBeaconCalls.push({ url, params: JSON.parse(data) });
-      return true;
-    });
-  });
-  cy.wrap(sendBeaconCalls).as('sendBeaconCalls');
+Given('a tracking API with a known response', () => {
+  cy.intercept('**/track/query', { statusCode: 200 }).as('queryTagging');
+  cy.intercept('**/track/click', { statusCode: 200 }).as('clickTagging');
+  cy.intercept('**/track/add2cart', { statusCode: 200 }).as('addToCartTagging');
 });
 
 When('first result is clicked', () => {
@@ -42,19 +35,19 @@ When('scrolls down to next page', () => {
 });
 
 Then('result click tagging request is triggered', () => {
-  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('click'));
+  cy.get('@clickTagging').should('exist');
 });
 
 Then('query tagging request should be triggered', () => {
-  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('query'));
+  cy.wait('@queryTagging').should('exist');
 });
 
 Then('query tagging request has been triggered', () => {
-  cy.get<SendBeaconCall[]>('@sendBeaconCalls').then(haveBeenTrackedWith('query'));
+  cy.get('@queryTagging', { timeout: 0 }).should('exist');
 });
 
 Then('second page query tagging request is triggered', () => {
-  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('query', { page: 2 }));
+  cy.get('@queryTagging').its('request.body').then(JSON.parse).should('have.property', 'page', 2);
 });
 
 Then('results page number {int} is loaded', (page: number) => {
@@ -62,7 +55,10 @@ Then('results page number {int} is loaded', (page: number) => {
 });
 
 Then('result click tagging includes location {string}', location => {
-  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('click', { location }));
+  cy.get('@clickTagging')
+    .its('request.body')
+    .then(JSON.parse)
+    .should('have.property', 'location', location);
 });
 
 Then('url matches {string}', (match: string) => {
@@ -70,41 +66,8 @@ Then('url matches {string}', (match: string) => {
 });
 
 Then('add product to cart tagging request has been triggered', () => {
-  cy.get<SendBeaconCall[]>('@sendBeaconCalls').should(haveBeenTrackedWith('add2cart'));
+  cy.wait('@addToCartTagging').should('exist');
 });
-
-/**
- * Helper to check whether a tagging request has been made using the mocked adapter and the
- * `sendBeacon` API.
- *
- * @param taggingKind - Expected tagging kind.
- * @param expectedParams - Partial expected params of the tagging request.
- * @returns A should function that asserts that the tagging calls contain one entry with the given
- * parameters.
- */
-function haveBeenTrackedWith(
-  taggingKind: string,
-  expectedParams: Dictionary<unknown> = {}
-): (taggingCalls: SendBeaconCall[]) => void {
-  return taggingCalls => {
-    const taggingEndpointRegex = new RegExp(`track/${taggingKind}`);
-    expect(
-      taggingCalls.find(
-        ({ url, params }) =>
-          taggingEndpointRegex.test(url) &&
-          every(expectedParams, (key, value) => params[key] === value)
-      )
-    ).not.to.be.equal(
-      undefined,
-      `Expected to find tracking request for "${taggingKind}" with parameters ${JSON.stringify(
-        expectedParams,
-        null,
-        2
-      )}.
- Triggered tracking requests: [${JSON.stringify(taggingCalls, null, 2)}].`
-    );
-  };
-}
 
 /**
  * Waits before performing the next iteration to ensure that the {@link XEvent}s quey has
@@ -113,14 +76,4 @@ function haveBeenTrackedWith(
 function slowInteraction(): void {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(250);
-}
-
-/**
- * Contains the base url and the parameters of a tagging request.
- */
-interface SendBeaconCall {
-  /** The base tagging url. */
-  url: string;
-  /** Parameters of the tagging request. This may include things like query, page, location... */
-  params: Dictionary<unknown>;
 }

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -1,10 +1,4 @@
-import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
-
-Given('a tracking API with a known response', () => {
-  cy.intercept('**/track/query', { statusCode: 200 }).as('queryTagging');
-  cy.intercept('**/track/click', { statusCode: 200 }).as('clickTagging');
-  cy.intercept('**/track/add2cart', { statusCode: 200 }).as('addToCartTagging');
-});
+import { Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 When('first result is clicked', () => {
   slowInteraction();

--- a/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/tagging/tagging.spec.ts
@@ -1,9 +1,5 @@
 import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
-Given('a URL with query parameter {string}', (query: string) => {
-  cy.visit(`/?useMockedAdapter=true&q=${query}`);
-});
-
 Given('a tracking API with a known response', () => {
   cy.intercept('**/track/query', { statusCode: 200 }).as('queryTagging');
   cy.intercept('**/track/click', { statusCode: 200 }).as('clickTagging');

--- a/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
@@ -1,10 +1,6 @@
-import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { And, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 // Scenario 1
-Given('a URL with query parameter {string}', (query: string) => {
-  cy.visit(`/?useMockedAdapter=true&q=${query}`);
-});
-
 Then(
   'search request contains parameter {string} with value {string}',
   (key: string, value: string) => {


### PR DESCRIPTION
This is the 3rd attempt to fix the flaky tagging e2e tests. Hopefully, this is the last part of this great series.

There were multiple things wrong with these tests. The issues are much easier to see using FireFox for running the tests.

# Cancelled fetch tagging requests

As you may know, fetch does not guarantee that the request is queued when it is executed in the unload process. In our case, what was happening in these tests is that usually the tracking request that was performed while leaving the page due to a click on a banner, result... was cancelled and this raised an error of an unhandled rejected promise.

Fortunately, Cypress can also intercept `navigator.sendBeacon` requests. So now this is the API that we are using in the mocked adapter for tracking requests.

# Mocked adapter was not used in tests.

Previously we had to pass a `useMockedAdapter=true` when navigating so this was the adapter used. When navigating to certain pages like the fake result ones this parameter was not passed. So in the add to cart tests for example, the real adapter was used. Now It is enough to load the demo view with Cypress.

# Cypress is too fast

I think this is the key of the issue of the randomly failing e2e tests, at least in Firefox. When asking Cypress to click a banner, result, promoted, or redirection, it did that immediately, as soon as the component was mounted to the DOM. Some of the siblings of that component weren't even yet mounted when this happened. But that is not really a problem. 

The problem was that there was a queue of asynchronous emitter events pending to be executed at the time the entity was clicked. These events sometimes included the `SearchTaggingChanged`, which is used by the `tagging` module to copy the query tagging with a defined debounce. As this event was not processed yet, the user click event (i.e. `UserClickedARedirection`), which is a synchronous event, was executed before it, and as a result it couldn't force to copy the query tagging.

TL;DR; Sometimes `UserClickedXXX` was executed before `SearchTaggingChanged` because of asynchronicity. This is (sadly) solved by adding an arbitrary wait. I couldn't find any other condition or guard to make cypress slowdown the click.

# Chunks

There was a warning that I saw a while ago complaining about the chunks order. Now I've removed unused views from the "production" environment, which is only used by Cypress. This should help us speed up our test server a little bit.