### PR TITLE
[EX-5377] Add extra-params tests

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="x">
     <Tagging :consent="false" />
-    <SnippetConfigExtraParams :values="initialExtraParams" />
+    <SnippetConfigExtraParams :values="initialSnippetExtraParams" />
+    <ExtraParams :values="initialExtraParams" />
     <UrlHandler query="q" store="store" />
     <SnippetCallbacks />
     <BaseEventsModalOpen>Start</BaseEventsModalOpen>
@@ -473,6 +474,7 @@
   import RenderlessExtraParams from '../../x-modules/extra-params/components/renderless-extra-param.vue';
   // eslint-disable-next-line max-len
   import SnippetConfigExtraParams from '../../x-modules/extra-params/components/snippet-config-extra-params.vue';
+  import ExtraParams from '../../x-modules/extra-params/components/extra-params.vue';
   import ClearFilters from '../../x-modules/facets/components/clear-filters.vue';
   import FacetsProvider from '../../x-modules/facets/components/facets/facets-provider.vue';
   import Facets from '../../x-modules/facets/components/facets/facets.vue';
@@ -550,6 +552,7 @@
       ClearSearchInput,
       CrossIcon,
       ExcludeFiltersWithNoResults,
+      ExtraParams,
       Facets,
       FacetsProvider,
       FiltersList,
@@ -598,7 +601,8 @@
   })
   export default class App extends Vue {
     protected stores = ['Spain', 'Portugal', 'Italy'];
-    protected initialExtraParams = { store: 'Portugal' };
+    protected initialSnippetExtraParams = { store: 'Portugal' };
+    protected initialExtraParams = { lang: 'es' };
     protected columnPickerValues = [0, 4, 6];
     protected resultsAnimation = StaggeredFadeAndSlide;
     protected modalAnimation = animateClipPath();

--- a/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/common-steps.spec.ts
@@ -121,7 +121,6 @@ Then('related results have changed', () => {
 });
 
 // Search Box
-
 When('search-input is focused', () => {
   cy.focusSearchInput();
 });
@@ -161,6 +160,22 @@ Then(
 
 When('tab is reloaded', () => {
   cy.reload();
+});
+
+// Search Request
+Then(
+  'search request contains parameter {string} with value {string}',
+  (key: string, value: string | number) => {
+    cy.wait('@interceptedResults')
+      .its('request.body')
+      .then(JSON.parse)
+      .should('have.property', key, value);
+  }
+);
+
+// Store
+When('store is changed to {string}', (store: string) => {
+  cy.getByDataTest('store-selector').click().contains(store).click();
 });
 
 // PDP

--- a/packages/x-components/tests/e2e/cucumber/extra-params.feature
+++ b/packages/x-components/tests/e2e/cucumber/extra-params.feature
@@ -1,0 +1,33 @@
+Feature: Tagging component
+
+  Background:
+    Given a next queries API
+    And   a suggestions API
+    And   a related tags API
+    And   a recommendations API with a known response
+    And   a query tagging API
+    And   a click tagging API
+    And   an add to cart tagging API
+    And   a results API with a known response
+    And   no special config for layout view
+
+  Scenario Outline: 1. Search request includes extra-params from Snippet Config and no-Snippet Config
+    When  start button is clicked
+    And   "<query>" is searched
+    And   search request contains parameter "<ExtraParamName>" with value "<ExtraParamValue>"
+    And   related results are displayed
+    Examples:
+      | query | ExtraParamName | ExtraParamValue |
+      | lego  | store          | Portugal        |
+      | lego  | lang           | es              |
+
+  Scenario Outline: 2. Search request includes renderless extra-param
+    When  start button is clicked
+    And   "<query>" is searched
+    Then  search request contains parameter "<RenderlessExtraParamName>" with value "<InitialExtraParamValue>"
+    And   related results are displayed
+    When  store is changed to "<RenderlessExtraParamValue>"
+    Then  search request contains parameter "<RenderlessExtraParamName>" with value "<RenderlessExtraParamValue>"
+    Examples:
+      | query | RenderlessExtraParamName | InitialExtraParamValue | RenderlessExtraParamValue |
+      | lego  | store                    | Portugal               | Spain                     |

--- a/packages/x-components/tests/e2e/cucumber/scroll.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/scroll.spec.ts
@@ -27,7 +27,3 @@ Then('scroll position is at top', () => {
     expect(scrollContainer.scrollTop()).to.equal(0);
   });
 });
-
-When('store is changed to {string}', (store: string) => {
-  cy.getByDataTest('store-selector').click().contains(store).click();
-});

--- a/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/url/url.spec.ts
@@ -1,19 +1,9 @@
-import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { And, Given, When } from 'cypress-cucumber-preprocessor/steps';
 
 // Scenario 1
 Given('a URL with query parameter {string}', (query: string) => {
   cy.visit(`/?useMockedAdapter=true&q=${query}`);
 });
-
-Then(
-  'search request contains parameter {string} with value {string}',
-  (key: string, value: string) => {
-    cy.wait('@interceptedResults')
-      .its('request.body')
-      .then(JSON.parse)
-      .should('have.property', key, value);
-  }
-);
 
 // Scenario 2
 When('navigating back', () => {


### PR DESCRIPTION
## Motivation and context
The aim of this PR is to create a couple of tests checking that the extra-params are sent in the search request as expected. For this purpose, in Home.vue we have 3 different types of extra-params combined:

- SnippetConfigExtraParams: `store = 'Portugal'`
- ExtraParams: `lang = 'es'`
- RenderlessExtraParams: during test execution (2nd scenario) `store` value is changed from `'Portugal'` to `'Spain'`

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

As usual, change line #11 in `cypress.json` in order to execute the test independently.

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
