### PR TITLE
feat(facets): add facets mixin to share logic between components

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -259,7 +259,7 @@
                         :max="controls.slicedFilters.max"
                         :data-test="`${facet.label}-sliced-filters`"
                       >
-                        <SelectedFilters #default="{ selectedFilters }" :facetId="facet.id">
+                        <SelectedFilters #default="{ selectedFilters }" :facetsIds="[facet.id]">
                           <span :data-test="`${facet.label}-selected-filters`">
                             {{ selectedFilters.length }}
                           </span>

--- a/packages/x-components/src/x-modules/facets/components/clear-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/clear-filters.vue
@@ -1,6 +1,6 @@
 <template>
   <BaseEventButton
-    v-if="show"
+    v-if="isVisible"
     class="x-button x-clear-filters"
     data-test="clear-filters"
     :disabled="!hasSelectedFilters"
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-  import { Component } from 'vue-property-decorator';
+  import Component from 'vue-class-component';
   import { xComponentMixin } from '../../../components';
   import BaseEventButton from '../../../components/base-event-button.vue';
   import { VueCSSClasses } from '../../../utils';

--- a/packages/x-components/src/x-modules/facets/components/clear-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/clear-filters.vue
@@ -3,28 +3,27 @@
     v-if="show"
     class="x-button x-clear-filters"
     data-test="clear-filters"
-    :disabled="!areThereSelectedFilters"
+    :disabled="!hasSelectedFilters"
     :events="events"
     :class="cssClasses"
   >
-    <slot :selectedFilters="facetsSelectedFilters">
-      Clear Filters ({{ facetsSelectedFilters.length }})
-    </slot>
+    <slot :selectedFilters="selectedFilters">Clear Filters ({{ selectedFilters.length }})</slot>
   </BaseEventButton>
 </template>
 
 <script lang="ts">
-  import { Facet, Filter, isFacetFilter } from '@empathyco/x-types';
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
-  import { Getter, xComponentMixin } from '../../../components';
+  import { Component } from 'vue-property-decorator';
+  import { xComponentMixin } from '../../../components';
   import BaseEventButton from '../../../components/base-event-button.vue';
   import { VueCSSClasses } from '../../../utils';
   import { XEventsTypes } from '../../../wiring';
+  import FacetsMixin from '../facets.mixin';
   import { facetsXModule } from '../x-module';
 
   /**
    * Renders a simple button, emitting the needed events when clicked.
+   *
+   * @remarks It extends {@link FacetsMixin}.
    *
    * @public
    */
@@ -32,76 +31,7 @@
     components: { BaseEventButton },
     mixins: [xComponentMixin(facetsXModule)]
   })
-  export default class ClearFilters extends Vue {
-    /**
-     * It handles if the ClearFilters button is always visible no matter if there are not
-     * filters selected. If false, the ClearFilters button is not visible whether
-     * there are no filters selected.
-     *
-     * @public
-     */
-    @Prop({ default: false })
-    public alwaysVisible!: boolean;
-
-    /**
-     * Array of facets ids that will be passed to event like payload.
-     *
-     * @public
-     */
-    @Prop()
-    public facetsIds?: Array<Facet['id']>;
-
-    /**
-     * Get the selected filters from store.
-     *
-     * @internal
-     */
-    @Getter('facets', 'selectedFilters')
-    public allSelectedFilters!: Filter[];
-
-    /**
-     * If alwaysVisible prop is true, ClearAllFilters button is always shown, but disabled
-     * if there are no filters selected.
-     * If alwaysVisible prop is false, ClearAllFilters button is shown whether there
-     * are some filter selected.
-     *
-     * @returns True if alwaysVisible is true or in the opposite case true or false depends
-     * on if there are selected filters or not.
-     *
-     * @internal
-     */
-    protected get show(): boolean {
-      return this.alwaysVisible || this.areThereSelectedFilters;
-    }
-
-    /**
-     * Get selected filters.
-     * If there are facets ids, get selected filters whose facet id match with some of facets ids.
-     * If there aren't facets ids, get selected filters.
-     *
-     * @returns Array of selected filters depends on there are facets ids or not.
-     * @internal
-     */
-    protected get facetsSelectedFilters(): Filter[] {
-      if (this.facetsIds) {
-        return this.allSelectedFilters.filter(
-          filter => isFacetFilter(filter) && this.facetsIds!.includes(filter.facetId)
-        );
-      } else {
-        return this.allSelectedFilters;
-      }
-    }
-
-    /**
-     * Check if there are selected filters.
-     *
-     * @returns True or false depends on if there are facets ids and if there are selected filters.
-     * @internal
-     */
-    protected get areThereSelectedFilters(): boolean {
-      return !!this.facetsSelectedFilters.length;
-    }
-
+  export default class ClearFilters extends FacetsMixin {
     /**
      * The events that will be emitted when the button clear filters is clicked.
      *
@@ -126,8 +56,8 @@
      */
     protected get cssClasses(): VueCSSClasses {
       return {
-        'x-clear-filters--has-not-selected-filters': !this.areThereSelectedFilters,
-        'x-clear-filters--has-selected-filters': this.areThereSelectedFilters
+        'x-clear-filters--has-not-selected-filters': !this.hasSelectedFilters,
+        'x-clear-filters--has-selected-filters': this.hasSelectedFilters
       };
     }
   }

--- a/packages/x-components/src/x-modules/facets/components/clear-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/clear-filters.vue
@@ -17,8 +17,8 @@
   import BaseEventButton from '../../../components/base-event-button.vue';
   import { VueCSSClasses } from '../../../utils';
   import { XEventsTypes } from '../../../wiring';
-  import FacetsMixin from '../facets.mixin';
   import { facetsXModule } from '../x-module';
+  import FacetsMixin from './facets.mixin';
 
   /**
    * Renders a simple button, emitting the needed events when clicked.

--- a/packages/x-components/src/x-modules/facets/components/facets.mixin.ts
+++ b/packages/x-components/src/x-modules/facets/components/facets.mixin.ts
@@ -2,9 +2,9 @@ import { Facet, Filter } from '@empathyco/x-types';
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
-import { Getter } from '../../components/index';
-import { isArrayEmpty } from '../../utils/index';
-import { FiltersByFacet } from './store/index';
+import { Getter } from '../../../components/index';
+import { isArrayEmpty } from '../../../utils/index';
+import { FiltersByFacet } from '../store/index';
 
 /**
  * Mixin to share Facets logic.
@@ -30,7 +30,7 @@ export default class FacetsMixin extends Vue {
   public alwaysVisible!: boolean;
 
   /**
-   * Array of selected filters from every facet.
+   * Dictionary of filters {@link FiltersByFacet} filtered by facet id.
    *
    * @internal
    */

--- a/packages/x-components/src/x-modules/facets/components/facets/facets.vue
+++ b/packages/x-components/src/x-modules/facets/components/facets/facets.vue
@@ -51,7 +51,7 @@
   import { toKebabCase } from '../../../../utils/string';
   import { map, objectFilter } from '../../../../utils/object';
   import { Dictionary } from '../../../../utils/types';
-  import FacetsMixin from '../../facets.mixin';
+  import FacetsMixin from '../facets.mixin';
   import { facetsXModule } from '../../x-module';
 
   /**

--- a/packages/x-components/src/x-modules/facets/components/facets/facets.vue
+++ b/packages/x-components/src/x-modules/facets/components/facets/facets.vue
@@ -51,7 +51,7 @@
   import { toKebabCase } from '../../../../utils/string';
   import { map, objectFilter } from '../../../../utils/object';
   import { Dictionary } from '../../../../utils/types';
-  import { FiltersByFacet } from '../../store/types';
+  import FacetsMixin from '../../facets.mixin';
   import { facetsXModule } from '../../x-module';
 
   /**
@@ -71,12 +71,14 @@
    * - A custom slot for each facet with the facetId as its name. This allows each facet to be
    * rendered differently based on its needs.
    *
+   * @remarks It extends {@link FacetsMixin}.
+   *
    * @public
    */
   @Component({
     mixins: [xComponentMixin(facetsXModule)]
   })
-  export default class Facets extends Vue {
+  export default class Facets extends FacetsMixin {
     /**
      * Animation component that will be used to animate the facets.
      *
@@ -108,14 +110,6 @@
      */
     @Prop()
     public renderableFacets!: string | undefined;
-
-    /**
-     * Array of selected filters from every facet.
-     *
-     * @internal
-     */
-    @Getter('facets', 'selectedFiltersByFacet')
-    public selectedFiltersByFacet!: FiltersByFacet;
 
     /**
      * Dictionary of facets in the state.

--- a/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters-list.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters-list.spec.ts
@@ -132,13 +132,22 @@ describe('testing SelectedFiltersList component', () => {
   it('renders selectedFilters of the facets ids provided', async () => {
     const { selectedFiltersListWrapper, toggleFacetNthFilter } = renderSelectedFiltersList({
       template: '<SelectedFiltersList :facetsIds="facetsIds" />',
-      facetsIds: ['brand']
+      facetsIds: ['brand', 'gender']
     });
+
     expect(selectedFiltersListWrapper.text()).toBe('');
+
     await toggleFacetNthFilter('brand', 0);
-    expect(selectedFiltersListWrapper.text()).toBe('Audi');
+    await toggleFacetNthFilter('rootCategories', 1);
     await toggleFacetNthFilter('gender', 1);
-    expect(selectedFiltersListWrapper.text()).toBe('Audi');
+
+    const selectedFiltersItems = selectedFiltersListWrapper.findAll(
+      getDataTestSelector('selected-filters-list-item')
+    );
+
+    expect(selectedFiltersItems).toHaveLength(2);
+    expect(selectedFiltersItems.at(0).text()).toBe('Audi');
+    expect(selectedFiltersItems.at(1).text()).toBe('Women');
   });
 
   it('renders the component if alwaysVisible is true and no selected filters', () => {

--- a/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters-list.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters-list.spec.ts
@@ -19,7 +19,8 @@ import SelectedFiltersList from '../../lists/selected-filters-list.vue';
  * @returns The API for testing the `SelectedFiltersList` component.
  */
 function renderSelectedFiltersList({
-  template = '<SelectedFiltersList />'
+  template = '<SelectedFiltersList />',
+  facetsIds = []
 }: RenderSelectedFiltersListOptions = {}): RenderSelectedFiltersAPI {
   const facets: Record<Facet['id'], Facet> = {
     gender: createSimpleFacetStub('gender', createFilter => [
@@ -48,11 +49,15 @@ function renderSelectedFiltersList({
       components: {
         SelectedFiltersList
       },
-      template
+      template,
+      props: ['facetsIds']
     },
     {
       localVue,
-      store
+      store,
+      propsData: {
+        facetsIds
+      }
     }
   );
 
@@ -124,9 +129,10 @@ describe('testing SelectedFiltersList component', () => {
     expect(selectedFiltersItems).toHaveLength(3);
   });
 
-  it('renders selectedFilters of the facet id provided', async () => {
+  it('renders selectedFilters of the facets ids provided', async () => {
     const { selectedFiltersListWrapper, toggleFacetNthFilter } = renderSelectedFiltersList({
-      template: '<SelectedFiltersList facetId="brand" />'
+      template: '<SelectedFiltersList :facetsIds="facetsIds" />',
+      facetsIds: ['brand']
     });
     expect(selectedFiltersListWrapper.text()).toBe('');
     await toggleFacetNthFilter('brand', 0);
@@ -154,6 +160,8 @@ describe('testing SelectedFiltersList component', () => {
 interface RenderSelectedFiltersListOptions {
   /** The template to be rendered. */
   template?: string;
+  /** Array of facets ids. */
+  facetsIds?: Array<Facet['id']>;
 }
 
 interface RenderSelectedFiltersAPI {

--- a/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters.spec.ts
@@ -21,7 +21,8 @@ import SelectedFilters from '../selected-filters.vue';
  * @returns The API for testing the `SelectedFilters` component.
  */
 function renderSelectedFilters({
-  template = '<SelectedFilters />'
+  template = '<SelectedFilters />',
+  facetsIds = []
 }: RenderSelectedFiltersOptions = {}): RenderSelectedFiltersAPI {
   resetFacetsService();
 
@@ -48,11 +49,15 @@ function renderSelectedFilters({
       components: {
         SelectedFilters
       },
-      template
+      template,
+      props: ['facetsIds']
     },
     {
       localVue,
-      store
+      store,
+      propsData: {
+        facetsIds
+      }
     }
   );
 
@@ -113,7 +118,8 @@ describe('testing SelectedFilters component', () => {
 
   it('renders "nth" by default of the facet id provided', async () => {
     const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters({
-      template: '<SelectedFilters facetId="brand" :alwaysVisible="true" />'
+      template: '<SelectedFilters :facetsIds="facetsIds" :alwaysVisible="true" />',
+      facetsIds: ['brand']
     });
     expect(selectedFiltersWrapper.text()).toBe('0');
     await toggleFacetNthFilter('brand', 0);
@@ -127,11 +133,12 @@ describe('testing SelectedFilters component', () => {
   it('renders "nth selected" in its customized slot of the facet id provided', async () => {
     const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters({
       template: `
-        <SelectedFilters facetId="brand" :alwaysVisible="true">
+        <SelectedFilters :facetsIds="facetsIds" :alwaysVisible="true">
           <template #default="{ selectedFilters }">
             {{ selectedFilters.length }} selected
           </template>
-        </SelectedFilters>`
+        </SelectedFilters>`,
+      facetsIds: ['brand']
     });
 
     expect(selectedFiltersWrapper.text()).toBe('0 selected');
@@ -165,6 +172,8 @@ describe('testing SelectedFilters component', () => {
 interface RenderSelectedFiltersOptions {
   /** The template to be rendered. */
   template?: string;
+  /** Array of facets ids. */
+  facetsIds?: Array<Facet['id']>;
 }
 
 interface RenderSelectedFiltersAPI {

--- a/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters.spec.ts
@@ -54,7 +54,11 @@ function renderSelectedFilters({
         SelectedFilters
       },
       template,
-      props: ['facetsIds']
+      data() {
+        return {
+          facetsIds
+        };
+      }
     },
     {
       localVue,

--- a/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/lists/__tests__/selected-filters.spec.ts
@@ -34,6 +34,10 @@ function renderSelectedFilters({
     brand: createSimpleFacetStub('brand', createFilter => [
       createFilter('Audi', false),
       createFilter('BMW', false)
+    ]),
+    color: createSimpleFacetStub('color', createFilter => [
+      createFilter('red', false),
+      createFilter('blue', false)
     ])
   };
 
@@ -116,10 +120,10 @@ describe('testing SelectedFilters component', () => {
     expect(selectedFiltersWrapper.text()).toBe('3 selected');
   });
 
-  it('renders "nth" by default of the facet id provided', async () => {
+  it('renders "nth" by default of the facet ids provided', async () => {
     const { selectedFiltersWrapper, toggleFacetNthFilter } = renderSelectedFilters({
       template: '<SelectedFilters :facetsIds="facetsIds" :alwaysVisible="true" />',
-      facetsIds: ['brand']
+      facetsIds: ['brand', 'gender']
     });
     expect(selectedFiltersWrapper.text()).toBe('0');
     await toggleFacetNthFilter('brand', 0);
@@ -127,7 +131,9 @@ describe('testing SelectedFilters component', () => {
     await toggleFacetNthFilter('brand', 1);
     expect(selectedFiltersWrapper.text()).toBe('2');
     await toggleFacetNthFilter('gender', 0);
-    expect(selectedFiltersWrapper.text()).toBe('2');
+    expect(selectedFiltersWrapper.text()).toBe('3');
+    await toggleFacetNthFilter('color', 0);
+    expect(selectedFiltersWrapper.text()).toBe('3');
   });
 
   it('renders "nth selected" in its customized slot of the facet id provided', async () => {

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters-list.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters-list.vue
@@ -1,5 +1,9 @@
 <template>
-  <SelectedFilters v-slot="{ selectedFilters }" :facetId="facetId" :alwaysVisible="alwaysVisible">
+  <SelectedFilters
+    v-slot="{ selectedFilters }"
+    :facetsIds="facetsIds"
+    :alwaysVisible="alwaysVisible"
+  >
     <component
       :is="animation"
       class="x-list x-selected-filters-list"
@@ -35,9 +39,10 @@
 
 <script lang="ts">
   import { Component, Prop, Vue } from 'vue-property-decorator';
-  import { Facet, Filter, isFacetFilter } from '@empathyco/x-types';
+  import { Filter, isFacetFilter } from '@empathyco/x-types';
   import { xComponentMixin } from '../../../../components/x-component.mixin';
   import { toKebabCase } from '../../../../utils/string';
+  import FacetsMixin from '../../facets.mixin';
   import { facetsXModule } from '../../x-module';
   import SelectedFilters from './selected-filters.vue';
 
@@ -60,34 +65,15 @@
    *
    * The property "alwaysVisible" handles if the component is rendered if no filters are selected.
    *
+   * @remarks It extends {@link FacetsMixin}.
+   *
    * @public
    */
   @Component({
     components: { SelectedFilters },
     mixins: [xComponentMixin(facetsXModule)]
   })
-  export default class SelectedFiltersList extends Vue {
-    /**
-     * It is directly passed to the selected filters component. If a facet id is passed as prop,
-     * the component filters the selected filters for that facet.
-     *
-     * @public
-     */
-    @Prop()
-    protected facetId: Facet['id'] | undefined;
-
-    /**
-     * It is directly passed to the selected filters component. It handles if the SelectedFilters
-     * component is always rendered no matter if no filters are selected.
-     *
-     * If true, the SelectedFilters component is always rendered.
-     * If false, the SelectedFilters component is not rendered whether no filters are selected.
-     *
-     * @public
-     */
-    @Prop({ default: false })
-    protected alwaysVisible!: boolean;
-
+  export default class SelectedFiltersList extends FacetsMixin {
     /**
      * Animation component that will be used to animate the selected filters list.
      *
@@ -117,8 +103,8 @@
 <docs lang="mdx">
 ## Example
 
-This component renders a list of selected filters from every facet, or from the facet which facet id
-is passed as property. It uses the SelectedFilters component (state).
+This component renders a list of selected filters from every facet, or from the facets which facets
+ids are passed as property. It uses the SelectedFilters component (state).
 
 It provides two slots: a scoped one which name is the filter facet id; and a default one. Both
 exposes the filter and renders the filter label by default.
@@ -204,6 +190,6 @@ Output:
 In this example, the selected filters computed are the ones that match the facet passed as property.
 
 ```vue
-<SelectedFilters facetId="brand_facet" />
+<SelectedFilters :facetsIds="['brand_facet']" />
 ```
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters-list.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters-list.vue
@@ -58,7 +58,7 @@
 
   /**
    * This component renders a list of selected filters from every facet, or from the facet
-   * which facet id is passed as property. It uses the SelectedFilters component (state).
+   * ids passed as property. It uses the SelectedFilters component (state).
    *
    * It provides two slots: a scoped one which name is the filter facet id; and a default one.
    * Both exposes the filter and renders the filter label by default.
@@ -185,11 +185,12 @@ Output:
 </div>
 ```
 
-#### Providing a facet id
+#### Providing an array of facet ids
 
-In this example, the selected filters computed are the ones that match the facet passed as property.
+In this example, the selected filters computed are the ones that match the facet ids passed as
+properties.
 
 ```vue
-<SelectedFilters :facetsIds="['brand_facet']" />
+<SelectedFilters :facetsIds="['brand_facet', 'gender_facet']" />
 ```
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters-list.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters-list.vue
@@ -42,7 +42,7 @@
   import { Filter, isFacetFilter } from '@empathyco/x-types';
   import { xComponentMixin } from '../../../../components/x-component.mixin';
   import { toKebabCase } from '../../../../utils/string';
-  import FacetsMixin from '../../facets.mixin';
+  import FacetsMixin from '../facets.mixin';
   import { facetsXModule } from '../../x-module';
   import SelectedFilters from './selected-filters.vue';
 

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
@@ -8,7 +8,7 @@
   import Component from 'vue-class-component';
   import { NoElement } from '../../../../components';
   import { xComponentMixin } from '../../../../components/x-component.mixin';
-  import FacetsMixin from '../../facets.mixin';
+  import FacetsMixin from '../facets.mixin';
   import { facetsXModule } from '../../x-module';
 
   /**

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
@@ -81,11 +81,11 @@ Output:
 In this example, the selected filters computed are the ones that match the facet passed as property.
 
 ```vue
-<SelectedFilters facetId="brand_facet" />
+<SelectedFilters :facetsIds="['brand_facet']" />
 ```
 
 ```vue
-<SelectedFilters facetId="brand_facet">
+<SelectedFilters :facetsIds="['brand_facet']">
   <template #default="{ selectedFilters }">
     Selected filters: {{ selectedFilters.length }}
   </template>

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
@@ -1,11 +1,11 @@
 <template>
-  <NoElement v-if="show" class="x-selected-filters">
+  <NoElement v-if="isVisible" class="x-selected-filters">
     <slot v-bind="{ selectedFilters }">{{ selectedFilters.length }}</slot>
   </NoElement>
 </template>
 
 <script lang="ts">
-  import { Component } from 'vue-property-decorator';
+  import Component from 'vue-class-component';
   import { NoElement } from '../../../../components';
   import { xComponentMixin } from '../../../../components/x-component.mixin';
   import FacetsMixin from '../../facets.mixin';
@@ -78,14 +78,14 @@ Output:
 <div class="x-selected-filters">Selected filters: 1</div>
 ```
 
-In this example, the selected filters computed are the ones that match the facet passed as property.
+In this example, the selected filters are filtered by the facetsIds property.
 
 ```vue
 <SelectedFilters :facetsIds="['brand_facet']" />
 ```
 
 ```vue
-<SelectedFilters :facetsIds="['brand_facet']">
+<SelectedFilters :facetsIds="['brand_facet', 'gender_facet']">
   <template #default="{ selectedFilters }">
     Selected filters: {{ selectedFilters.length }}
   </template>

--- a/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/selected-filters.vue
@@ -5,12 +5,10 @@
 </template>
 
 <script lang="ts">
-  import { Facet, Filter } from '@empathyco/x-types';
-  import { Component, Prop, Vue } from 'vue-property-decorator';
-  import { Getter } from '../../../../components/decorators/store.decorators';
+  import { Component } from 'vue-property-decorator';
   import { NoElement } from '../../../../components';
   import { xComponentMixin } from '../../../../components/x-component.mixin';
-  import { FiltersByFacet } from '../../store/types';
+  import FacetsMixin from '../../facets.mixin';
   import { facetsXModule } from '../../x-module';
 
   /**
@@ -20,6 +18,8 @@
    * The default slot renders the length of the selected filters array.
    * The property "alwaysVisible" handles if the component is rendered if no filters are selected.
    *
+   * @remarks It extends {@link FacetsMixin}.
+   *
    * @public
    */
   @Component({
@@ -28,71 +28,7 @@
       NoElement
     }
   })
-  export default class SelectedFilters extends Vue {
-    /**
-     * If a facet id is passed as prop, the component filters the selected filters for that facet.
-     *
-     * @public
-     */
-    @Prop()
-    protected facetId: Facet['id'] | undefined;
-
-    /**
-     * It handles if the SelectedFilters component is always rendered no matter if no filters are
-     * selected.
-     * If true, the SelectedFilters component is always rendered.
-     * If false, the SelectedFilters component is not rendered whether no filters are selected.
-     *
-     * @public
-     */
-    @Prop({ default: false })
-    protected alwaysVisible!: boolean;
-
-    /**
-     * Array of selected filters from every facet.
-     *
-     * @public
-     */
-    @Getter('facets', 'selectedFilters')
-    public selectedFiltersGetter!: Filter[];
-
-    /**
-     * Dictionary of selected filters grouped by facet.
-     *
-     * @public
-     */
-    @Getter('facets', 'selectedFiltersByFacet')
-    public selectedFiltersByFacet!: FiltersByFacet;
-
-    /**
-     * It returns an array of selected filters. If a facet id is passed as prop to the component,
-     * only the selected filters of that facet are returned. If not, it returns selected filters of
-     * every facet.
-     *
-     * @returns Array of selected filters.
-     *
-     * @internal
-     */
-    protected get selectedFilters(): Filter[] {
-      return this.facetId === undefined
-        ? this.selectedFiltersGetter
-        : this.selectedFiltersByFacet[this.facetId] ?? [];
-    }
-
-    /**
-     * If "alwaysVisible" prop is true, returns true.
-     * If "alwaysVisible" prop is false, returns true or false depending on if there are some
-     * filter selected.
-     *
-     * @returns True if "alwaysVisible" is true. True or false depending on if there are some filter
-     * selected.
-     *
-     * @internal
-     */
-    protected get show(): boolean {
-      return this.alwaysVisible || this.selectedFilters.length > 0;
-    }
-  }
+  export default class SelectedFilters extends FacetsMixin {}
 </script>
 
 <docs lang="mdx">

--- a/packages/x-components/src/x-modules/facets/facets.mixin.ts
+++ b/packages/x-components/src/x-modules/facets/facets.mixin.ts
@@ -14,7 +14,7 @@ import { FiltersByFacet } from './store/index';
 @Component
 export default class FacetsMixin extends Vue {
   /**
-   * Array of facets ids that will be passed to event like payload.
+   * Array of facets ids used to get the selected filters for those facets.
    *
    * @public
    */
@@ -22,9 +22,7 @@ export default class FacetsMixin extends Vue {
   public facetsIds?: Array<Facet['id']>;
 
   /**
-   * It handles if the component is always visible no matter if there are not
-   * filters selected. If false, the component is not visible whether
-   * there are no filters selected.
+   * Flag to render the component even if there are no filters selected.
    *
    * @public
    */
@@ -77,17 +75,14 @@ export default class FacetsMixin extends Vue {
   }
 
   /**
-   * If alwaysVisible prop is true, component is always shown, but disabled
-   * if there are no filters selected.
-   * If alwaysVisible prop is false, component is shown whether there
-   * are some filter selected.
+   * Flag representing if the component should be visible/rendered or not.
    *
-   * @returns True if alwaysVisible is true or in the opposite case true or false depends
-   * on if there are selected filters or not.
+   * @returns True whenever alwaysVisible is true or has selected filters. False
+   * otherwise.
    *
    * @internal
    */
-  protected get show(): boolean {
+  protected get isVisible(): boolean {
     return this.alwaysVisible || this.hasSelectedFilters;
   }
 }

--- a/packages/x-components/src/x-modules/facets/facets.mixin.ts
+++ b/packages/x-components/src/x-modules/facets/facets.mixin.ts
@@ -1,0 +1,93 @@
+import { Facet, Filter } from '@empathyco/x-types';
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import { Prop } from 'vue-property-decorator';
+import { Getter } from '../../components/index';
+import { isArrayEmpty } from '../../utils/index';
+import { FiltersByFacet } from './store/index';
+
+/**
+ * Mixin to share Facets logic.
+ *
+ * @public
+ */
+@Component
+export default class FacetsMixin extends Vue {
+  /**
+   * Array of facets ids that will be passed to event like payload.
+   *
+   * @public
+   */
+  @Prop()
+  public facetsIds?: Array<Facet['id']>;
+
+  /**
+   * It handles if the component is always visible no matter if there are not
+   * filters selected. If false, the component is not visible whether
+   * there are no filters selected.
+   *
+   * @public
+   */
+  @Prop({ default: false })
+  public alwaysVisible!: boolean;
+
+  /**
+   * Array of selected filters from every facet.
+   *
+   * @internal
+   */
+  @Getter('facets', 'selectedFiltersByFacet')
+  public selectedFiltersByFacet!: FiltersByFacet;
+
+  /**
+   * Get the selected filters from store.
+   *
+   * @internal
+   */
+  @Getter('facets', 'selectedFilters')
+  public selectedFiltersGetter!: Filter[];
+
+  /**
+   * Get selected filters.
+   * If there are facets ids, get selected filters whose facet id match with some of facets ids.
+   * If there aren't facets ids, get selected filters.
+   *
+   * @returns Array of selected filters depends on there are facets ids or not.
+   * @internal
+   */
+  protected get selectedFilters(): Filter[] {
+    if (this.facetsIds) {
+      return (this.facetsIds as string[]).reduce(
+        (selectedFilters, facetId) => [...selectedFilters, ...this.selectedFiltersByFacet[facetId]],
+        [] as Filter[]
+      );
+    }
+
+    return this.selectedFiltersGetter;
+  }
+
+  /**
+   * Check if there are selected filters.
+   *
+   * @returns True or false depends on if there are selected filters.
+   * @internal
+   */
+  protected get hasSelectedFilters(): boolean {
+    return !isArrayEmpty(this.selectedFilters);
+  }
+
+  /**
+   * If alwaysVisible prop is true, component is always shown, but disabled
+   * if there are no filters selected.
+   * If alwaysVisible prop is false, component is shown whether there
+   * are some filter selected.
+   *
+   * @returns True if alwaysVisible is true or in the opposite case true or false depends
+   * on if there are selected filters or not.
+   *
+   * @internal
+   */
+  protected get show(): boolean {
+    return this.alwaysVisible || this.hasSelectedFilters;
+  }
+}

--- a/packages/x-components/src/x-modules/facets/index.ts
+++ b/packages/x-components/src/x-modules/facets/index.ts
@@ -6,3 +6,4 @@ export * from './entities';
 export * from './components';
 export * from './events.types';
 export * from './utils';
+export { default as FacetsMixin } from './facets.mixin';

--- a/packages/x-components/src/x-modules/facets/index.ts
+++ b/packages/x-components/src/x-modules/facets/index.ts
@@ -6,4 +6,4 @@ export * from './entities';
 export * from './components';
 export * from './events.types';
 export * from './utils';
-export { default as FacetsMixin } from './facets.mixin';
+export { default as FacetsMixin } from './components/facets.mixin';

--- a/packages/x-components/src/x-modules/facets/store/getters/selected-filters-by-facet.getter.ts
+++ b/packages/x-components/src/x-modules/facets/store/getters/selected-filters-by-facet.getter.ts
@@ -1,7 +1,7 @@
-import { Facet, Filter, isFacetFilter } from '@empathyco/x-types';
+import { isFacetFilter } from '@empathyco/x-types';
 import { groupItemsBy } from '../../../../utils/array';
 import { map } from '../../../../utils/object';
-import { FacetsXStoreModule } from '../types';
+import { FacetsXStoreModule, FiltersByFacet } from '../types';
 
 /**
  * Default implementation for the {@link FacetsGetters.selectedFiltersByFacet} getter.
@@ -20,9 +20,9 @@ import { FacetsXStoreModule } from '../types';
 export const selectedFiltersByFacet: FacetsXStoreModule['getters']['selectedFiltersByFacet'] = (
   state,
   getters
-): Record<Facet['id'], Filter[]> => {
+): FiltersByFacet => {
   // The `emptyRecord` is to return an empty array for those facets that haven't selected filters.
-  const emptyRecord: Record<Facet['id'], Filter[]> = map(state.facets, () => []);
+  const emptyRecord: FiltersByFacet = map(state.facets, () => []);
   const filtersByFacet = groupItemsBy(getters.selectedFilters, filter =>
     isFacetFilter(filter) ? filter.facetId : '__unknown-facet__'
   );


### PR DESCRIPTION
BREAKING-CHANGE: change the prop facetId to facetsIds in `selected-filters.vue` and `selected-filters-list.vue`, now it will be an array of facets ids instead of just one facet id.

EX-2899

## Motivation and context

We want to share logic between components that have repeated code. We saw that `selected-filters.vue` and `selected-filters-list.vue` have a prop `facetId` but in the other components is facetsIds, because in these other components we can use an array of facets ids instead just one. So to change that, we change the prop from facetId to facetsIds in those components that are receiving just one facetId to make them work with an array of facets ids. With this change we can reduce the code and share more logic between components.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

Running the test and seeing how everything is still working.
