### PR TITLE
[EX-5377] Add extra-params test

### DIFF
--- a/packages/x-components/tests/e2e/cucumber/extra-params.feature
+++ b/packages/x-components/tests/e2e/cucumber/extra-params.feature
@@ -1,0 +1,29 @@
+Feature: Extra-params component
+
+  Background:
+    Given a next queries API
+    And   a suggestions API
+    And   a related tags API
+    And   a recommendations API with a known response
+    And   a results API with a known response
+    And   no special config for layout view
+
+  Scenario Outline: 1. Search request includes extra-params from Snippet Config
+    When  start button is clicked
+    And   "<query>" is searched
+    And   search request contains parameter "<ExtraParamName>" with value "<ExtraParamValue>"
+    And   related results are displayed
+    Examples:
+      | query | ExtraParamName | ExtraParamValue |
+      | lego  | store          | Portugal        |
+
+  Scenario Outline: 2. Search request includes renderless extra-param
+    When  start button is clicked
+    And   "<query>" is searched
+    Then  search request contains parameter "<RenderlessExtraParamName>" with value "<InitialExtraParamValue>"
+    And   related results are displayed
+    When  store is changed to "<RenderlessExtraParamValue>"
+    Then  search request contains parameter "<RenderlessExtraParamName>" with value "<RenderlessExtraParamValue>"
+    Examples:
+      | query | RenderlessExtraParamName | InitialExtraParamValue | RenderlessExtraParamValue |
+      | lego  | store                    | Portugal               | Spain                     |


### PR DESCRIPTION
## Motivation and context

The aim of this PR is to create a couple of tests checking that the extra-params are sent in the search request as expected. For this purpose, in `Home.vue` we have 2 different types of extra-params combined:

- SnippetConfigExtraParams: `store = 'Portugal'`
- RenderlessExtraParams: during test execution (2nd scenario) store value is changed from `'Portugal'` to `'Spain'`

The reasons why ExtraParams is not added are the following:

They are not supposed to co-exist. Whether the client uses SnippetConfigExtraParams or ExtraParams.
SnippetConfigExtraParams is build on the top of ExtraParams.
Existing component tests should cover the different scenarios.
Forcing them to co-exist causes a side effect, adding to the URL the extra-param coming from the snippet.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

As usual, change line 11 in `cypress.json` in order to execute the test independently.

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
