### PR TITLE
Feature/EX-5384: Add setSnippetConfig function in the API

### DIFF
--- a/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
+++ b/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
@@ -1,4 +1,7 @@
+import { createLocalVue } from '@vue/test-utils';
+import { SearchAdapterDummy } from '../../../__tests__/adapter.dummy';
 import { BaseXBus } from '../../../plugins/x-bus';
+import { XInstaller } from '../../x-installer/x-installer';
 import { BaseXAPI } from '../base-api';
 
 describe('testing default X API', () => {
@@ -27,5 +30,33 @@ describe('testing default X API', () => {
     const productId = '123abc';
     defaultXAPI.addProductToCart(productId);
     expect(listener).toHaveBeenCalledWith(productId);
+  });
+
+  it('changes the `SnippetConfig` when calling the `setSnippetConfig` function', async () => {
+    const vue = createLocalVue();
+    const snippetConfig = {
+      instance: 'test',
+      scope: 'test',
+      lang: 'es'
+    };
+    const installerApp = vue.extend({
+      inject: ['snippetConfig'],
+      render(h) {
+        // Vue does not provide type safety for inject
+        const lang = (this as any).snippetConfig.lang;
+        return h('h1', [lang]);
+      }
+    });
+
+    const { api, app } = await new XInstaller({
+      adapter: SearchAdapterDummy,
+      api: defaultXAPI,
+      app: installerApp
+    }).init(snippetConfig);
+
+    expect(app?.$el).toHaveTextContent(snippetConfig.lang);
+    api?.setSnippetConfig({ lang: 'en' });
+    await vue.nextTick();
+    expect(app?.$el).toHaveTextContent('en');
   });
 });

--- a/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
+++ b/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
@@ -2,6 +2,7 @@ import { createLocalVue } from '@vue/test-utils';
 import { SearchAdapterDummy } from '../../../__tests__/adapter.dummy';
 import { BaseXBus } from '../../../plugins/x-bus';
 import { XInstaller } from '../../x-installer/x-installer';
+import { SnippetConfig } from '../api.types';
 import { BaseXAPI } from '../base-api';
 
 describe('testing default X API', () => {
@@ -34,7 +35,7 @@ describe('testing default X API', () => {
 
   it('changes the `SnippetConfig` when calling the `setSnippetConfig` function', async () => {
     const vue = createLocalVue();
-    const snippetConfig = {
+    const snippetConfig: SnippetConfig = {
       instance: 'test',
       scope: 'test',
       lang: 'es'
@@ -44,7 +45,11 @@ describe('testing default X API', () => {
       render(h) {
         // Vue does not provide type safety for inject
         const lang = (this as any).snippetConfig.lang;
-        return h('h1', [lang]);
+        const store = (this as any).snippetConfig.store;
+        return h('div', [
+          h('h1', { class: 'lang-test' }, [lang]),
+          h('h1', { class: 'store-test' }, [store])
+        ]);
       }
     });
 
@@ -54,9 +59,17 @@ describe('testing default X API', () => {
       app: installerApp
     }).init(snippetConfig);
 
-    expect(app?.$el).toHaveTextContent(snippetConfig.lang);
+    const langElement = app?.$el.getElementsByClassName('lang-test')[0];
+    const storeElement = app?.$el.getElementsByClassName('store-test')[0];
+
+    expect(langElement).toHaveTextContent(snippetConfig.lang);
     api?.setSnippetConfig({ lang: 'en' });
     await vue.nextTick();
-    expect(app?.$el).toHaveTextContent('en');
+    expect(langElement).toHaveTextContent('en');
+
+    expect(storeElement).toHaveTextContent('');
+    api?.setSnippetConfig({ store: 'Portugal' });
+    await vue.nextTick();
+    expect(storeElement).toHaveTextContent('Portugal');
   });
 });

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -38,6 +38,24 @@ export interface XAPI {
   setInitCallback(initCallback: (config: SnippetConfig) => void): void;
 
   /**
+   * To set or update any property of the {@link SnippetConfig}.
+   *
+   * @param config - The properties to be changed.
+   *
+   * @public
+   */
+  setSnippetConfig(config: Partial<SnippetConfig>): void;
+
+  /**
+   * To set the snippet config callback.
+   *
+   * @param callback - Hello.
+   *
+   * @internal
+   */
+  setSnippetConfigCallback(callback: (config: Partial<SnippetConfig>) => void): void;
+
+  /**
    * Dispatch a search with the query parameter.
    *
    * @param query - Query to be searched.

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -49,7 +49,7 @@ export interface XAPI {
   /**
    * To set the snippet config callback.
    *
-   * @param callback - Hello.
+   * @param callback - Function to be called.
    *
    * @internal
    */

--- a/packages/x-components/src/x-installer/api/base-api.ts
+++ b/packages/x-components/src/x-installer/api/base-api.ts
@@ -30,6 +30,14 @@ export class BaseXAPI implements XAPI {
   protected initCallback!: (config: SnippetConfig) => any;
 
   /**
+   * Callback that allows to update the snippet config. The logic of initialization is out of this
+   * API since this API is just a facade.
+   *
+   * @internal
+   */
+  protected snippetCallback!: (config: Partial<SnippetConfig>) => void;
+
+  /**
    * Tracks that a product was added to cart from PDP.
    *
    * @param productId - The product id that was added to cart.
@@ -59,6 +67,28 @@ export class BaseXAPI implements XAPI {
   }
 
   /**
+   * Setter for the callback to modify the snippet config.
+   *
+   * @param snippetCallback - The callback to call.
+   *
+   * @internal
+   */
+  setSnippetConfigCallback(snippetCallback: (config: Partial<SnippetConfig>) => void): void {
+    this.snippetCallback = snippetCallback;
+  }
+
+  /**
+   * Sets or updates the snippet config.
+   *
+   * @param config - A part or all the snippet config.
+   *
+   * @public
+   */
+  setSnippetConfig(config: Partial<SnippetConfig>): void {
+    this?.snippetCallback(config);
+  }
+
+  /**
    * Searches the query parameter as user query.
    *
    * @param query - Query to be searched.
@@ -75,7 +105,7 @@ export class BaseXAPI implements XAPI {
   /**
    * Initializes the Application passing the {@link SnippetConfig}.
    *
-   * @param config - The config comming from the customer snippet.
+   * @param config - The config coming from the customer snippet.
    *
    * @public
    */

--- a/packages/x-components/src/x-installer/x-installer/x-installer.ts
+++ b/packages/x-components/src/x-installer/x-installer/x-installer.ts
@@ -305,13 +305,12 @@ export class XInstaller {
     if (this.options.app !== undefined) {
       const vue = this.getVue();
       this.snippetConfig = vue.observable(snippetConfig);
-      const snippetConfigObservable = this.snippetConfig;
       return new vue({
         ...extraPlugins,
         ...this.options.vueOptions,
         provide() {
           return {
-            snippetConfig: snippetConfigObservable
+            snippetConfig
           };
         },
         store: this.options.store,

--- a/packages/x-components/src/x-installer/x-installer/x-installer.ts
+++ b/packages/x-components/src/x-installer/x-installer/x-installer.ts
@@ -100,9 +100,7 @@ export class XInstaller {
   private api?: XAPI;
 
   /**
-   * Creates the public {@link XAPI} using the `api` option from {@link InstallXOptions}. If this
-   * `api` option is not passed, then a default {@link BaseXAPI} is created. To disable the API
-   * creation the value `false` must be passed in the `api` option.
+   * The configuration coming from the snippet {@link SnippetConfig}.
    *
    * @internal
    */
@@ -358,11 +356,7 @@ export class XInstaller {
    */
   protected updateSnippetConfig(snippetConfig: Partial<SnippetConfig>): void {
     forEach(snippetConfig, (name, value) => {
-      if (this.snippetConfig[name]) {
-        Object.assign(this.snippetConfig, { [name]: value });
-      } else {
-        Vue.set(this.snippetConfig, name, value);
-      }
+      this.getVue().set(this.snippetConfig, name, value);
     });
   }
 }

--- a/packages/x-components/src/x-modules/extra-params/components/extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/extra-params.vue
@@ -20,7 +20,7 @@
      * values were already set by XComponents initialization (url, plugin config, etc.).
      */
     mounted(): void {
-      this.$x.emit('ExtraParamsInitialized', this.values);
+      this.$x.emit('ExtraParamsInitialized', { ...this.values });
       this.$x.emit('ExtraParamsProvided', { ...this.values, ...this.storeExtraParams });
     }
 

--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -73,7 +73,7 @@
      */
     @Watch('snippetConfig', { deep: true, immediate: true })
     syncExtraParams(snippetConfig: SnippetConfig): void {
-      forEach({ ...snippetConfig, ...this.values }, (name, value) => {
+      forEach({ ...this.values, ...snippetConfig }, (name, value) => {
         if (this.notAllowedExtraParams.includes(name)) {
           return;
         }


### PR DESCRIPTION
EX-5384

Adding a `setSnippetConfig` function in the API in order to modify the `snippetConfig`. The implementation is found in the `XInstaller` but it gets exposed in the API throughout a facade. Also:

- Had to change the payload in the `ExtraParamsInitialized` to be a clone of the object instead. This avoids having this reference in the store, and we can change the `extraParams` properties without `Vuex` complaining.
- Changed the priority of how the `SnippetConfigExtraParams` adds properties in the `extraParams` object.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
