### PR TITLE
[EX-5525] Review E2E tests in Firefox

### DIFF
--- a/packages/x-components/tests/e2e/cucumber/filters/clear-filters.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/filters/clear-filters.spec.ts
@@ -24,6 +24,7 @@ Then('no filters are selected', () => {
 // Scenario 3
 When('filter number {int} is clicked in selected filters list', (selectedFilterItem: number) => {
   cy.getByDataTest('selected-filters-list-item')
+    .getByDataTest('filter')
     .eq(selectedFilterItem)
     .click()
     .invoke('text')

--- a/packages/x-components/tests/e2e/cucumber/history-queries.feature
+++ b/packages/x-components/tests/e2e/cucumber/history-queries.feature
@@ -17,10 +17,6 @@ Feature: History queries component
     Then  the searched query is displayed in the search-box
     And   the searched query is not displayed in history queries if <hideIfEqualsQuery> is true
 
-    Examples:
-      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | historyQueryItem | list                                                                                                             |
-      | true              | 150          | 15              | 8                | true    | 7                | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry, funko pop iron, puzzle 3d harry potter, funko pop iron man |
-      | false             | 150          | 15              | 8                | true    | 6                | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry, funko pop iron, puzzle 3d harry potter, funko pop iron man |
 
   Scenario Outline: 2. History query delete button is clicked
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>
@@ -31,10 +27,6 @@ Feature: History queries component
     Then  the deleted history query is removed from history queries
     And   the number of rendered history queries is <maxItemsToRender> - 1 if <maxItemsToStore> < <maxItemsToRender>
 
-    Examples:
-      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | historyQueryItem | list                                                                                                             |
-      | true              | 150          | 15              | 5                | true    | 0                | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry, funko pop iron, puzzle 3d harry potter, funko pop iron man |
-      | false             | 150          | 5               | 8                | true    | 4                | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry, funko pop iron, puzzle 3d harry potter, funko pop iron man |
 
   Scenario Outline: 3. Clear history queries button is clicked
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>
@@ -44,10 +36,6 @@ Feature: History queries component
     And   clear history queries button is clicked
     Then  no history queries are displayed
     And   clear history queries button is disabled
-
-    Examples:
-      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | list                                                 |
-      | true              | 150          | 15              | 5                | true    | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry |
 
   Scenario Outline: 4. Query containing a history query is typed
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>
@@ -59,10 +47,6 @@ Feature: History queries component
     When   clear search button is pressed
     Then  "<query>" is deleted from history queries, whereas "<followingQuery>" remains
 
-    Examples:
-      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | query | followingQuery |
-      | true              | 150          | 15              | 5                | true    | le    | go             |
-      | true              | 150          | 15              | 5                | true    | le    | go star wars   |
 
   Scenario Outline: 5. History query is not stored if instant search is false
     Given a results API with a known response
@@ -70,10 +54,6 @@ Feature: History queries component
     And   start button is clicked
     When  a "<query>" with results is typed
     Then  no history queries are displayed after <debounceInMs> ms if <instant> is false
-    Examples:
-      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | query  |
-      | true              | 1000         | 15              | 5                | true    | barbie |
-      | true              | 1000         | 15              | 5                | false   | barbie |
 
   Scenario Outline: 6. Number and order of rendered history queries
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>
@@ -81,7 +61,8 @@ Feature: History queries component
     And   a "<list>" of queries already searched
     When  search-input is focused
     And   history query number <historyQueryItem> is clicked
-    And   clear search button is pressed
+    Then  related results are displayed
+    When  clear search button is pressed
     Then  the searched query is removed from <historyQueryItem> position in history queries
     And   the searched query is the first item in history queries
     And   displayed history queries are min of number of queries already searched, max requested items <maxItemsToStore>, max rendered items <maxItemsToRender>

--- a/packages/x-components/tests/e2e/cucumber/history-queries.feature
+++ b/packages/x-components/tests/e2e/cucumber/history-queries.feature
@@ -17,6 +17,10 @@ Feature: History queries component
     Then  the searched query is displayed in the search-box
     And   the searched query is not displayed in history queries if <hideIfEqualsQuery> is true
 
+    Examples:
+      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | historyQueryItem | list                                                                                                             |
+      | true              | 150          | 15              | 8                | true    | 7                | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry, funko pop iron, puzzle 3d harry potter, funko pop iron man |
+      | false             | 150          | 15              | 8                | true    | 6                | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry, funko pop iron, puzzle 3d harry potter, funko pop iron man |
 
   Scenario Outline: 2. History query delete button is clicked
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>
@@ -27,6 +31,10 @@ Feature: History queries component
     Then  the deleted history query is removed from history queries
     And   the number of rendered history queries is <maxItemsToRender> - 1 if <maxItemsToStore> < <maxItemsToRender>
 
+    Examples:
+      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | historyQueryItem | list                                                                                                             |
+      | true              | 150          | 15              | 5                | true    | 0                | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry, funko pop iron, puzzle 3d harry potter, funko pop iron man |
+      | false             | 150          | 5               | 8                | true    | 4                | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry, funko pop iron, puzzle 3d harry potter, funko pop iron man |
 
   Scenario Outline: 3. Clear history queries button is clicked
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>
@@ -36,6 +44,10 @@ Feature: History queries component
     And   clear history queries button is clicked
     Then  no history queries are displayed
     And   clear history queries button is disabled
+
+    Examples:
+      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | list                                                 |
+      | true              | 150          | 15              | 5                | true    | puzzle, funko, puzzle 3d, funko pop, puzzle 3d harry |
 
   Scenario Outline: 4. Query containing a history query is typed
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>
@@ -47,6 +59,10 @@ Feature: History queries component
     When   clear search button is pressed
     Then  "<query>" is deleted from history queries, whereas "<followingQuery>" remains
 
+    Examples:
+      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | query | followingQuery |
+      | true              | 150          | 15              | 5                | true    | le    | go             |
+      | true              | 150          | 15              | 5                | true    | le    | go star wars   |
 
   Scenario Outline: 5. History query is not stored if instant search is false
     Given a results API with a known response
@@ -54,6 +70,10 @@ Feature: History queries component
     And   start button is clicked
     When  a "<query>" with results is typed
     Then  no history queries are displayed after <debounceInMs> ms if <instant> is false
+    Examples:
+      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | query  |
+      | true              | 1000         | 15              | 5                | true    | barbie |
+      | true              | 1000         | 15              | 5                | false   | barbie |
 
   Scenario Outline: 6. Number and order of rendered history queries
     Given following config: hide if equals query <hideIfEqualsQuery>, debounce <debounceInMs>, requested items <maxItemsToStore>, rendered <maxItemsToRender>, instant search <instant>

--- a/packages/x-components/tests/e2e/cucumber/scroll.spec.ts
+++ b/packages/x-components/tests/e2e/cucumber/scroll.spec.ts
@@ -16,7 +16,7 @@ Then('first visible result is {string}', (resultId: string) => {
       const resultBottom = resultTop + $result.height()!;
       cy.get('#main-scroll').then($scroll => {
         const scrollTop = $scroll.offset()!.top;
-        expect(Math.round(resultTop)).to.be.lte(scrollTop);
+        expect(Math.round(resultTop)).to.be.within(scrollTop - 1, scrollTop + 1);
         expect(resultBottom).to.be.gt(scrollTop);
       });
     });


### PR DESCRIPTION
## Motivation and context
After running the E2E several times with different throttling, it was observed that 3 different tests were randomly failing in Firefox:

- Clear selected filters → Scenario 3. Remove single filter.
- History queries component → Scenario 6. Number and order of rendered history queries.
- Scroll → Scenario 1. Scroll is kept in the URL.

After analyzing each scenario, minor changes were needed.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

As usual, please change line 11 in `cypress.json` for the following to run the tests independently:
`  "testFiles": ["cucumber/**/*.feature"],`

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
