### PR TITLE
feat(history-queries): add `my-history` component 

### DIFF
--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
@@ -1,9 +1,26 @@
-import { mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import { HistoryQuery } from '@empathyco/x-types';
+import { createLocalVue, mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex, { Store } from 'vuex';
+import { createHistoryQueries } from '../../../../__stubs__/index';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
+import { getXComponentXModuleName, isXComponent } from '../../../../components/index';
+import { RootXStoreState } from '../../../../store/index';
+import { DeepPartial } from '../../../../utils/index';
+import { historyQueriesXModule } from '../../x-module';
 import MyHistory from '../my-history.vue';
+import { resetXHistoryQueriesStateWith } from './utils';
 
-function renderMyHistory({ template = '<MyHistory />' }: MyHistoryOptions = {}): MyHistoryAPI {
-  const [, localVue] = installNewXPlugin();
+function renderMyHistory({
+  template = '<MyHistory />',
+  historyQueries = []
+}: MyHistoryOptions = {}): MyHistoryAPI {
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+
+  const store = new Store<DeepPartial<RootXStoreState>>({});
+  installNewXPlugin({ store, initialXModules: [historyQueriesXModule] }, localVue);
+  resetXHistoryQueriesStateWith(store, { historyQueries });
 
   const wrapper = mount(
     {
@@ -13,50 +30,108 @@ function renderMyHistory({ template = '<MyHistory />' }: MyHistoryOptions = {}):
       }
     },
     {
-      localVue
+      localVue,
+      store,
+      propsData: {
+        historyQueries
+      }
     }
   );
   return {
-    wrapper,
+    wrapper: wrapper.findComponent(MyHistory),
     search(query) {
       wrapper.vm.$x.emit('UserAcceptedAQuery', query);
       return wrapper.vm.$nextTick();
     },
     getListItems() {
       return wrapper.findAll(getDataTestSelector('suggestion-item'));
+    },
+    findAllInWrapper(selector) {
+      return wrapper.findAll(getDataTestSelector(selector));
     }
   };
 }
 
 describe('testing MyHistory component', () => {
+  it('is an XComponent which has an XModule', () => {
+    const { wrapper } = renderMyHistory();
+    expect(isXComponent(wrapper.vm)).toEqual(true);
+    expect(getXComponentXModuleName(wrapper.vm)).toEqual('historyQueries');
+  });
+
+  it('does not render the component if history is empty', () => {
+    const { wrapper } = renderMyHistory();
+    expect(wrapper.html()).toEqual('');
+  });
+
   it('renders the list of searched queries', async () => {
     const { search, getListItems } = renderMyHistory();
 
     await search('lego');
     const suggestionsWrappers = getListItems();
     expect(suggestionsWrappers.wrappers).toHaveLength(1);
-    expect(suggestionsWrappers.at(0).text()).toEqual('lego');
+    expect(suggestionsWrappers.at(0).text()).toEqual('lego ✕');
   });
 
-  it('allows to change the content for each previous search', async () => {
-    const { search, getListItems } = renderMyHistory({
-      template: `
-      <MyHistory #default="{ suggestion, index }">{{ suggestion.query }} - {{ index }}</MyHistory>`
-    });
+  describe('changing history query content', () => {
+    it('allows changing history query content and render the list of history queries', () => {
+      const historyQueries = createHistoryQueries(
+        'moura',
+        'calamares',
+        'rubia galega',
+        'pulpo',
+        'cachelos',
+        'navajas',
+        'croquetas',
+        'zamburiñas'
+      );
 
-    await search('lego');
-    const suggestionWrappers = getListItems();
-    expect(suggestionWrappers.wrappers).toHaveLength(1);
-    expect(suggestionWrappers.at(0).text()).toEqual('lego - 0');
+      const { findAllInWrapper } = renderMyHistory({
+        template: `
+          <MyHistory>
+            <template #suggestion-content="suggestionContentScope">
+              <img src="./history-icon.svg" data-test="suggestion-history-icon"/>
+              <span :data-index="suggestionContentScope.index"
+                    v-html="suggestionContentScope.queryHTML"></span>
+            </template>
+            <template #suggestion-remove-content>
+              <img src="./remove-icon.svg" data-test="suggestion-remove-icon"/>
+            </template>
+          </MyHistory>
+        `,
+        historyQueries
+      });
+
+      const suggestionContentWrappers = findAllInWrapper('suggestion-history-icon');
+      const suggestionRemoveWrappers = findAllInWrapper('suggestion-remove-icon');
+
+      expect(suggestionContentWrappers).toHaveLength(historyQueries.length);
+      expect(suggestionRemoveWrappers).toHaveLength(historyQueries.length);
+    });
   });
 });
 
+/**
+ * The options for the `renderMyHistory` function.
+ */
 interface MyHistoryOptions {
+  /** The template to render.*/
   template?: string;
+  /** List of {@link HistoryQuery} that are going to be rendered. */
+  historyQueries?: HistoryQuery[];
 }
 
+/**
+ * Test API for the {@link MyHistory} component.
+ */
 interface MyHistoryAPI {
+  /** The wrapper for my history component. */
   wrapper: Wrapper<Vue>;
+  /** Helper method to search a query. */
   search: (query: string) => Promise<void>;
+  /** Retrieves the wrapper for the items of the list rendered by the {@link MyHistory}
+   * component. */
   getListItems: () => WrapperArray<Vue>;
+  /** Retrieves the wrapper for the items that matches with the selector. */
+  findAllInWrapper: (selector: string) => WrapperArray<Vue>;
 }

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
@@ -1,0 +1,62 @@
+import { mount, Wrapper, WrapperArray } from '@vue/test-utils';
+import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
+import MyHistory from '../my-history.vue';
+
+function renderMyHistory({ template = '<MyHistory />' }: MyHistoryOptions = {}): MyHistoryAPI {
+  const [, localVue] = installNewXPlugin();
+
+  const wrapper = mount(
+    {
+      template,
+      components: {
+        MyHistory
+      }
+    },
+    {
+      localVue
+    }
+  );
+  return {
+    wrapper,
+    search(query) {
+      wrapper.vm.$x.emit('UserAcceptedAQuery', query);
+      return wrapper.vm.$nextTick();
+    },
+    getListItems() {
+      return wrapper.findAll(getDataTestSelector('suggestion-item'));
+    }
+  };
+}
+
+describe('testing MyHistory component', () => {
+  it('renders the list of searched queries', async () => {
+    const { search, getListItems } = renderMyHistory();
+
+    await search('lego');
+    const suggestionsWrappers = getListItems();
+    expect(suggestionsWrappers.wrappers).toHaveLength(1);
+    expect(suggestionsWrappers.at(0).text()).toEqual('lego');
+  });
+
+  it('allows to change the content for each previous search', async () => {
+    const { search, getListItems } = renderMyHistory({
+      template: `
+      <MyHistory #default="{ suggestion, index }">{{ suggestion.query }} - {{ index }}</MyHistory>`
+    });
+
+    await search('lego');
+    const suggestionWrappers = getListItems();
+    expect(suggestionWrappers.wrappers).toHaveLength(1);
+    expect(suggestionWrappers.at(0).text()).toEqual('lego - 0');
+  });
+});
+
+interface MyHistoryOptions {
+  template?: string;
+}
+
+interface MyHistoryAPI {
+  wrapper: Wrapper<Vue>;
+  search: (query: string) => Promise<void>;
+  getListItems: () => WrapperArray<Vue>;
+}

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
@@ -2,11 +2,11 @@ import { HistoryQuery } from '@empathyco/x-types';
 import { createLocalVue, mount, Wrapper, WrapperArray } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
-import { createHistoryQueries } from '../../../../__stubs__/index';
+import { createHistoryQueries } from '../../../../__stubs__/history-queries-stubs.factory';
+import { RootXStoreState } from '../../../../store/store.types';
+import { DeepPartial } from '../../../../utils/types';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
-import { RootXStoreState } from '../../../../store/index';
-import { DeepPartial } from '../../../../utils/index';
 import { historyQueriesXModule } from '../../x-module';
 import MyHistory from '../my-history.vue';
 import { resetXHistoryQueriesStateWith } from './utils';
@@ -85,11 +85,11 @@ describe('testing MyHistory component', () => {
     const { findAllInWrapper } = renderMyHistory({
       template: `
           <MyHistory>
-            <template #suggestion-content="suggestionContentScope">
+            <template #suggestion-content="{suggestion, index}">
               <img src="./history-icon.svg" data-test="suggestion-history-icon"/>
-              <span :data-index="suggestionContentScope.index"
+              <span :data-index="index"
                     data-test="suggestion-content-slot"
-                    v-html="suggestionContentScope.queryHTML"></span>
+                    v-html="suggestion.query"></span>
             </template>
             <template #suggestion-remove-content>
               <img src="./remove-icon.svg" data-test="suggestion-remove-icon"/>
@@ -99,13 +99,17 @@ describe('testing MyHistory component', () => {
       historyQueries
     });
 
-    const suggestionContentWrappers = findAllInWrapper('suggestion-history-icon');
-    const suggestionRemoveWrappers = findAllInWrapper('suggestion-remove-icon');
-    const suggestionContentSlotWrappers = findAllInWrapper('suggestion-content-slot');
+    const suggestionIconWrappers = findAllInWrapper('suggestion-history-icon');
+    const suggestionRemoveIconWrappers = findAllInWrapper('suggestion-remove-icon');
+    const suggestionContentWrappers = findAllInWrapper('suggestion-content-slot');
 
+    expect(suggestionIconWrappers).toHaveLength(historyQueries.length);
+    expect(suggestionRemoveIconWrappers).toHaveLength(historyQueries.length);
     expect(suggestionContentWrappers).toHaveLength(historyQueries.length);
-    expect(suggestionRemoveWrappers).toHaveLength(historyQueries.length);
-    expect(suggestionContentSlotWrappers).toHaveLength(historyQueries.length);
+    suggestionContentWrappers.wrappers.forEach((contentWrapper, index) => {
+      expect(contentWrapper.attributes('data-index')).toEqual(index.toString());
+      expect(contentWrapper.text()).toEqual(historyQueries[index].query);
+    });
   });
 });
 

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
@@ -4,7 +4,7 @@ import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
 import { createHistoryQueries } from '../../../../__stubs__/index';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
-import { getXComponentXModuleName, isXComponent } from '../../../../components/index';
+import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import { RootXStoreState } from '../../../../store/index';
 import { DeepPartial } from '../../../../utils/index';
 import { historyQueriesXModule } from '../../x-module';
@@ -31,10 +31,7 @@ function renderMyHistory({
     },
     {
       localVue,
-      store,
-      propsData: {
-        historyQueries
-      }
+      store
     }
   );
   return {
@@ -73,25 +70,25 @@ describe('testing MyHistory component', () => {
     expect(suggestionsWrappers.at(0).text()).toEqual('lego ✕');
   });
 
-  describe('changing history query content', () => {
-    it('allows changing history query content and render the list of history queries', () => {
-      const historyQueries = createHistoryQueries(
-        'moura',
-        'calamares',
-        'rubia galega',
-        'pulpo',
-        'cachelos',
-        'navajas',
-        'croquetas',
-        'zamburiñas'
-      );
+  it('allows changing history query content and render the list of history queries', () => {
+    const historyQueries = createHistoryQueries(
+      'moura',
+      'calamares',
+      'rubia galega',
+      'pulpo',
+      'cachelos',
+      'navajas',
+      'croquetas',
+      'zamburiñas'
+    );
 
-      const { findAllInWrapper } = renderMyHistory({
-        template: `
+    const { findAllInWrapper } = renderMyHistory({
+      template: `
           <MyHistory>
             <template #suggestion-content="suggestionContentScope">
               <img src="./history-icon.svg" data-test="suggestion-history-icon"/>
               <span :data-index="suggestionContentScope.index"
+                    data-test="suggestion-content-slot"
                     v-html="suggestionContentScope.queryHTML"></span>
             </template>
             <template #suggestion-remove-content>
@@ -99,15 +96,16 @@ describe('testing MyHistory component', () => {
             </template>
           </MyHistory>
         `,
-        historyQueries
-      });
-
-      const suggestionContentWrappers = findAllInWrapper('suggestion-history-icon');
-      const suggestionRemoveWrappers = findAllInWrapper('suggestion-remove-icon');
-
-      expect(suggestionContentWrappers).toHaveLength(historyQueries.length);
-      expect(suggestionRemoveWrappers).toHaveLength(historyQueries.length);
+      historyQueries
     });
+
+    const suggestionContentWrappers = findAllInWrapper('suggestion-history-icon');
+    const suggestionRemoveWrappers = findAllInWrapper('suggestion-remove-icon');
+    const suggestionContentSlotWrappers = findAllInWrapper('suggestion-content-slot');
+
+    expect(suggestionContentWrappers).toHaveLength(historyQueries.length);
+    expect(suggestionRemoveWrappers).toHaveLength(historyQueries.length);
+    expect(suggestionContentSlotWrappers).toHaveLength(historyQueries.length);
   });
 });
 

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -96,56 +96,152 @@
 </script>
 
 <docs lang="mdx">
-## Examples
+## Events
 
-This component renders a list of suggestions coming from the user queries history
+This component doesn't emit events.
 
-### Default usage
+## See it in action
 
-No props are required for the usage of this component.
+Here you have a basic example of how the HistoryQueries is rendered.
 
 ```vue
-<HistoryQueries />
+<template>
+  <HistoryQueries />
+</template>
+
+<script>
+  import { HistoryQueries } from '@empathyco/x-components/history-queries';
+
+  export default {
+    name: 'HistoryQueriesDemo',
+    components: {
+      HistoryQueries
+    }
+  };
+</script>
 ```
 
-The component has two optional props. `animation` to render the component with an animation and
-`maxItemToRender` to limit the number of history queries will be rendered (by default it is 5).
+### Play with props
+
+In this example, the history queries has been limited to render a maximum of 10 queries (by default
+it is 5).
 
 ```vue
-<HistoryQueries :animation="FadeAndSlide" :maxItemsToRender="10" />
+<template>
+  <HistoryQueries :maxItemsToRender="10" />
+</template>
+
+<script>
+  import { HistoryQueries } from '@empathyco/x-components/history-queries';
+
+  export default {
+    name: 'HistoryQueriesDemo',
+    components: {
+      HistoryQueries
+    }
+  };
+</script>
 ```
 
-### Overriding Suggestion component
-
-The default `HistoryQuery` component that is used in every suggestion can be replaced. To do so, the
-`suggestion` slot is available, containing the history query data under the `suggestion` property.
-Remember that if HistoryQuery component wasn't used the `handleHistoryQuerySelection` method needs
-to be implemented emitting the needed events.
+### Play with the animation
 
 ```vue
-<HistoryQueries>
-  <template #suggestion="{ suggestion }">
-    <img class="x-history-query__icon" src="./history-query-extra-icon.svg"/>
-    <HistoryQuery :suggestion="suggestion"/>
-  </template>
-</HistoryQueries>
+<template>
+  <HistoryQueries :animation="fadeAndSlide" />
+</template>
+
+<script>
+  import { HistoryQueries } from '@empathyco/x-components/history-queries';
+  import { FadeAndSlide } from '@empathyco/x-components/animations';
+
+  export default {
+    name: 'HistoryQueriesDemo',
+    components: {
+      HistoryQueries
+    },
+    data() {
+      return {
+        fadeAndSlide: FadeAndSlide
+      };
+    }
+  };
+</script>
 ```
 
-### Overriding suggestion-content and suggestion-remove-content slot
+### Play with suggestion slot
 
-The content of the `HistoryQuery` component can be overridden. For replacing the default suggestion
-content, the `suggestion-content` slot is available, containing the history query suggestion (in the
-`suggestion` property), and the matching query part HTML (in the `queryHTML` property).
+In this example, the [`HistoryQuery`](./x-components.history-query.md) component is passed in the
+`suggestion` slot (although any other component could potentially be passed).
 
 ```vue
-<HistoryQueries>
-  <template #suggestion-content="{ queryHTML }">
-    <img class="x-history-query__history-icon" src="./history-icon.svg"/>
-    <span class="x-history-query__matching-part" v-html="queryHTML"></span>
-  </template>
-  <template #suggestion-remove-content>
-    <img class="x-history-queries__remove" src="./remove-icon.svg"/>
-  </template>
-</HistoryQueries>
+<template>
+  <HistoryQueries #suggestion="{ suggestion }">
+    <HistoryQuery :suggestion="suggestion"></HistoryQuery>
+  </HistoryQueries>
+</template>
+
+<script>
+  import { HistoryQueries, HistoryQuery } from '@empathyco/x-components/history-queries';
+
+  export default {
+    name: 'HistoryQueriesDemo',
+    components: {
+      HistoryQueries,
+      HistoryQuery
+    }
+  };
+</script>
+```
+
+### Play with suggestion-content slot
+
+To continue the previous example, the [`HistoryQuery`](./x-components.history-query.md) component is
+passed in the `suggestion-content` slot, but in addition, an HTML span tag for the text are also
+passed.
+
+```vue
+<template>
+  <HistoryQueries #suggestion-content="{ suggestion }">
+    <span>{{ suggestion.query }}</span>
+  </HistoryQueries>
+</template>
+
+<script>
+  import { HistoryQueries } from '@empathyco/x-components/history-queries';
+
+  export default {
+    name: 'HistoryQueriesDemo',
+    components: {
+      HistoryQueries
+    }
+  };
+</script>
+```
+
+### Play with suggestion-content-remove slot
+
+To continue the previous example, the [`HistoryQuery`](./x-components.history-query.md) component is
+passed in the `suggestion-content` slot, but in addition, a cross icon is also passed to change the
+icon to remove the history query.
+
+```vue
+<template>
+  <HistoryQueries #suggestion-content-remove="{ suggestion }">
+    <CrossIcon />
+  </HistoryQueries>
+</template>
+
+<script>
+  import { HistoryQueries } from '@empathyco/x-components/history-queries';
+  import { CrossIcon } from '@empathyco/x-components';
+
+  export default {
+    name: 'HistoryQueriesDemo',
+    components: {
+      HistoryQueries,
+      CrossIcon
+    }
+  };
+</script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -152,7 +152,7 @@ it is 5).
 
 <script>
   import { HistoryQueries } from '@empathyco/x-components/history-queries';
-  import { FadeAndSlide } from '@empathyco/x-components/animations';
+  import { FadeAndSlide } from '@empathyco/x-components';
 
   export default {
     name: 'HistoryQueriesDemo',

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -123,7 +123,7 @@ Here you have a basic example of how the HistoryQueries is rendered.
 
 ### Play with props
 
-In this example, the history queries has been limited to render a maximum of 10 queries (by default
+In this example, the history queries have been limited to render a maximum of 10 queries (by default
 it is 5).
 
 ```vue

--- a/packages/x-components/src/x-modules/history-queries/components/index.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/index.ts
@@ -1,4 +1,5 @@
 export { default as ClearHistoryQueries } from './clear-history-queries.vue';
 export { default as HistoryQueries } from './history-queries.vue';
 export { default as HistoryQuery } from './history-query.vue';
+export { default as MyHistory } from './my-history.vue';
 export { default as RemoveHistoryQuery } from './remove-history-query.vue';

--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -46,7 +46,8 @@
   import { HistoryQuery } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { State, xComponentMixin } from '../../../components';
+  import { xComponentMixin } from '../../../components/x-component.mixin';
+  import { State } from '../../../components/decorators/store.decorators';
   import BaseSuggestions from '../../../components/suggestions/base-suggestions.vue';
   import { historyQueriesXModule } from '../x-module';
   import HistoryQueryComponent from './history-query.vue';
@@ -120,7 +121,7 @@ Here you have a basic example of how the MyHistory is rendered.
 
 <script>
   import { MyHistory } from '@empathyco/x-components/history-queries';
-  import { FadeAndSlide } from '@empathyco/x-components/animations';
+  import { FadeAndSlide } from '@empathyco/x-components';
 
   export default {
     name: 'MyHistoryDemo',

--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -1,28 +1,215 @@
 <template>
-  <BaseSuggestions #default="{ suggestion, index }" :suggestions="historyQueries">
-    <slot v-bind="{ suggestion, index }">
-      {{ suggestion.query }}
-    </slot>
+  <BaseSuggestions
+    :suggestions="historyQueries"
+    class="x-my-history-queries"
+    data-test="my-history-queries"
+    :animation="animation"
+  >
+    <template #default="{ suggestion, index }">
+      <!--
+        @slot History Query item
+            @binding {Suggestion} suggestion - History Query suggestion data
+            @binding {number} index - History Query suggestion index
+      -->
+      <slot name="suggestion" v-bind="{ suggestion, index }">
+        <HistoryQuery
+          :suggestion="suggestion"
+          data-test="history-query-item"
+          class="x-history-queries__item"
+        >
+          <template #default="{ queryHTML }">
+            <!-- eslint-disable max-len -->
+            <!--
+              @slot History Query content
+                  @binding {Suggestion} suggestion - History Query suggestion data
+                  @binding {string} queryHTML - Suggestion's query with the matching part inside a span tag
+                  @binding {number} index - History Query suggestion index
+            -->
+            <!-- eslint-enable max-len -->
+            <slot name="suggestion-content" v-bind="{ suggestion, index, queryHTML }" />
+          </template>
+          <template #remove-button-content>
+            <!--
+              @slot History Query remove button content
+                  @binding {Suggestion} suggestion - History Query suggestion data
+                  @binding {number} index - History Query suggestion index
+            -->
+            <slot name="suggestion-remove-content" v-bind="{ suggestion, index }" />
+          </template>
+        </HistoryQuery>
+      </slot>
+    </template>
   </BaseSuggestions>
 </template>
 
 <script lang="ts">
   import { HistoryQuery } from '@empathyco/x-types';
   import Vue from 'vue';
-  import { Component } from 'vue-property-decorator';
+  import { Component, Prop } from 'vue-property-decorator';
   import { State, xComponentMixin } from '../../../components';
   import BaseSuggestions from '../../../components/suggestions/base-suggestions.vue';
   import { historyQueriesXModule } from '../x-module';
   import HistoryQueryComponent from './history-query.vue';
 
+  /**
+   * This component renders the complete list of suggestions coming from the user queries history.
+   *
+   * @remarks
+   *
+   * Allows the user to select one of them, emitting the needed events.
+   * A history query is just another type of suggestion that contains a query that the user has
+   * made in the past.
+   *
+   * @public
+   */
   @Component({
     components: { HistoryQuery: HistoryQueryComponent, BaseSuggestions },
     mixins: [xComponentMixin(historyQueriesXModule)]
   })
   export default class MyHistory extends Vue {
+    /**
+     * Animation component that will be used to animate the suggestions.
+     *
+     * @public
+     */
+    @Prop()
+    protected animation!: Vue;
+
+    /**
+     * The list of history queries.
+     *
+     * @internal
+     */
     @State('historyQueries', 'historyQueries')
     public historyQueries!: HistoryQuery[];
   }
 </script>
 
-<style scoped></style>
+<docs lang="mdx">
+## Events
+
+This component doesn't emit events.
+
+## See it in action
+
+Here you have a basic example of how the MyHistory is rendered.
+
+```vue
+<template>
+  <MyHistory />
+</template>
+
+<script>
+  import { MyHistory } from '@empathyco/x-components/history-queries';
+
+  export default {
+    name: 'MyHistoryDemo',
+    components: {
+      MyHistory
+    }
+  };
+</script>
+```
+
+### Play with the animation
+
+```vue
+<template>
+  <MyHistory :animation="fadeAndSlide" />
+</template>
+
+<script>
+  import { MyHistory } from '@empathyco/x-components/history-queries';
+  import { FadeAndSlide } from '@empathyco/x-components/animations';
+
+  export default {
+    name: 'MyHistoryDemo',
+    components: {
+      MyHistory
+    },
+    data() {
+      return {
+        fadeAndSlide: FadeAndSlide
+      };
+    }
+  };
+</script>
+```
+
+### Play with suggestion slot
+
+In this example, the [`HistoryQuery`](./x-components.history-query.md) component is passed in the
+`suggestion` slot (although any other component could potentially be passed).
+
+```vue
+<template>
+  <MyHistory #suggestion="{ suggestion }">
+    <HistoryQuery :suggestion="suggestion"></HistoryQuery>
+  </MyHistory>
+</template>
+
+<script>
+  import { MyHistory, HistoryQuery } from '@empathyco/x-components/history-queries';
+
+  export default {
+    name: 'MyHistoryDemo',
+    components: {
+      MyHistory,
+      HistoryQuery
+    }
+  };
+</script>
+```
+
+### Play with suggestion-content slot
+
+To continue the previous example, the [`HistoryQuery`](./x-components.history-query.md) component is
+passed in the `suggestion-content` slot, but in addition, an HTML span tag for the text are also
+passed.
+
+```vue
+<template>
+  <MyHistory #suggestion-content="{ suggestion }">
+    <span>{{ suggestion.query }}</span>
+  </MyHistory>
+</template>
+
+<script>
+  import { MyHistory } from '@empathyco/x-components/history-queries';
+
+  export default {
+    name: 'MyHistoryDemo',
+    components: {
+      MyHistory
+    }
+  };
+</script>
+```
+
+### Play with suggestion-content-remove slot
+
+To continue the previous example, the [`HistoryQuery`](./x-components.history-query.md) component is
+passed in the `suggestion-content` slot, but in addition, a cross icon is also passed to change the
+icon to remove the history query.
+
+```vue
+<template>
+  <MyHistory #suggestion-content-remove="{ suggestion }">
+    <CrossIcon />
+  </MyHistory>
+</template>
+
+<script>
+  import { MyHistory } from '@empathyco/x-components/history-queries';
+  import { CrossIcon } from '@empathyco/x-components';
+
+  export default {
+    name: 'MyHistoryDemo',
+    components: {
+      MyHistory,
+      CrossIcon
+    }
+  };
+</script>
+```
+</docs>

--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -17,16 +17,15 @@
           data-test="history-query-item"
           class="x-history-queries__item"
         >
-          <template #default="{ queryHTML }">
+          <template #default>
             <!-- eslint-disable max-len -->
             <!--
               @slot History Query content
                   @binding {Suggestion} suggestion - History Query suggestion data
-                  @binding {string} queryHTML - Suggestion's query with the matching part inside a span tag
                   @binding {number} index - History Query suggestion index
             -->
             <!-- eslint-enable max-len -->
-            <slot name="suggestion-content" v-bind="{ suggestion, index, queryHTML }" />
+            <slot name="suggestion-content" v-bind="{ suggestion, index }" />
           </template>
           <template #remove-button-content>
             <!--

--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -1,0 +1,28 @@
+<template>
+  <BaseSuggestions #default="{ suggestion, index }" :suggestions="historyQueries">
+    <slot v-bind="{ suggestion, index }">
+      {{ suggestion.query }}
+    </slot>
+  </BaseSuggestions>
+</template>
+
+<script lang="ts">
+  import { HistoryQuery } from '@empathyco/x-types';
+  import Vue from 'vue';
+  import { Component } from 'vue-property-decorator';
+  import { State, xComponentMixin } from '../../../components';
+  import BaseSuggestions from '../../../components/suggestions/base-suggestions.vue';
+  import { historyQueriesXModule } from '../x-module';
+  import HistoryQueryComponent from './history-query.vue';
+
+  @Component({
+    components: { HistoryQuery: HistoryQueryComponent, BaseSuggestions },
+    mixins: [xComponentMixin(historyQueriesXModule)]
+  })
+  export default class MyHistory extends Vue {
+    @State('historyQueries', 'historyQueries')
+    public historyQueries!: HistoryQuery[];
+  }
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
The component is the same as history-queries component. I was talking with @javieri-empathy about the implementation, he thinks that it is better to leave it as it is, because in the future we will change the components list or we will improve the my-history component, and maybe the template will be different.

 If you are not happy with this, we can extend one component with the other one to avoid using the same template again. With this approach, we will lose the data-test and the class.
 
 ` export default class MyHistory extends HistoryQueries `
 

EX-3582