### PR TITLE
feat(utils): add `interpolate` function

### DIFF
--- a/packages/x-adapter/jest.config.js
+++ b/packages/x-adapter/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  moduleFileExtensions: ['ts', 'js'],
+  transform: {
+    '^.+\\.ts?$': 'ts-jest'
+  },
+  testMatch: ['<rootDir>/**/*.spec.ts']
+};

--- a/packages/x-adapter/package.json
+++ b/packages/x-adapter/package.json
@@ -28,6 +28,7 @@
     "build": "concurrently \"npm run build:*\"",
     "build:cjs": "tsc --project tsconfig.json",
     "build:esm": "tsc --project tsconfig.esm.json",
+    "test": "jest",
     "postbuild": "npm pack",
     "prepublishOnly": "npm run build"
   },
@@ -35,8 +36,11 @@
     "tslib": "~2.3.0"
   },
   "devDependencies": {
+    "@types/jest": "~27.0.3",
     "concurrently": "~7.0.0",
+    "jest": "~27.3.1",
     "rimraf": "~3.0.2",
+    "ts-jest": "~27.0.7",
     "typescript": "~4.6.2"
   },
   "publishConfig": {

--- a/packages/x-adapter/src/index.ts
+++ b/packages/x-adapter/src/index.ts
@@ -1,3 +1,4 @@
+export * from './utils/interpolate';
 export * from './adapter.types';
 export * from './http-client.types';
 export * from './mapper.types';

--- a/packages/x-adapter/src/utils/__tests__/interpolate.spec.ts
+++ b/packages/x-adapter/src/utils/__tests__/interpolate.spec.ts
@@ -1,0 +1,53 @@
+import { interpolate } from '../interpolate';
+
+describe('testing interpolate function', () => {
+  it('interpolates values when the parameter is passed', () => {
+    expect(
+      interpolate('https://{env}.empathy.co/{instance}', {
+        env: 'live',
+        instance: 'demo'
+      })
+    ).toBe('https://live.empathy.co/demo');
+    expect(
+      interpolate('https://{(api-)env}.empathy.co/{instance}', {
+        env: 'live',
+        instance: 'demo'
+      })
+    ).toBe('https://api-live.empathy.co/demo');
+    expect(
+      interpolate('https://api.{env(.)}empathy.co/{instance}', {
+        env: 'live',
+        instance: 'demo'
+      })
+    ).toBe('https://api.live.empathy.co/demo');
+    expect(
+      interpolate('https://{(api-)env(.)}empathy.co/{instance}', {
+        env: 'live',
+        instance: 'demo'
+      })
+    ).toBe('https://api-live.empathy.co/demo');
+  });
+
+  it('hides values when the parameter is not passed', () => {
+    expect(
+      interpolate('https://{env}.empathy.co/{instance}', {
+        env: 'live'
+      })
+    ).toBe('https://live.empathy.co/');
+    expect(
+      interpolate('https://search{(api-)env}.empathy.co/{instance}', {
+        instance: 'demo'
+      })
+    ).toBe('https://search.empathy.co/demo');
+    expect(
+      interpolate('https://api.{env(.)}empathy.co/{instance}', {
+        instance: 'demo'
+      })
+    ).toBe('https://api.empathy.co/demo');
+    expect(
+      interpolate('https://search.{(api-)env(.)}empathy.co/{instance}', {
+        instance: 'demo'
+      })
+    ).toBe('https://search.empathy.co/demo');
+  });
+});

--- a/packages/x-adapter/src/utils/interpolate.ts
+++ b/packages/x-adapter/src/utils/interpolate.ts
@@ -15,6 +15,13 @@
 const STRING_PARAMETERS = /{([^}]+)}/g;
 
 /**
+ * Shape of the optional head and tail parts of the {@link STRING_PARAMETER_CONTENT} regex.
+ * This can be anything wrapped into parentheses.
+ *
+ * @internal
+ */
+const HEAD_OR_TAIL = '(?:\\((.+)\\))?';
+/**
  * Syntax of a single string parameter. A string parameter shape is composed by
  * the name of the property that should be replaced. This property name can be preceded
  * or followed by an optional string to prepend or to append to the property value
@@ -30,7 +37,7 @@ const STRING_PARAMETERS = /{([^}]+)}/g;
  * ```
  * @internal
  */
-const STRING_PARAMETER_CONTENT = /^(?:\((.+)\))?([^(]+)(?:\((.+)\))?$/g;
+const STRING_PARAMETER_CONTENT = new RegExp(`^${HEAD_OR_TAIL}([^(]+)${HEAD_OR_TAIL}$`, 'g');
 
 /**
  * Interpolates different parameters into a string.

--- a/packages/x-adapter/src/utils/interpolate.ts
+++ b/packages/x-adapter/src/utils/interpolate.ts
@@ -1,0 +1,99 @@
+/**
+ * Syntax to detect and extract string parameters. A string parameter contains a property name
+ * with an optional header or tail to concatenate wrapped in curly braces (`{}`).
+ * The different parts of a string parameter are explained in {@link STRING_PARAMETER_CONTENT}.
+ *
+ * @example Different string parameters
+ * ```js
+ *   "\{env\}" // No optional head or tail.
+ *   "\{(.)env\}" // Optional `.` head.
+ *   "\{env(-api)\}" // Optional `-api` tail.
+ *   "\{(api-)env(.)\}" // Optional `api-` head and `.` tail.
+ * ```
+ * @internal
+ */
+const STRING_PARAMETERS = /{([^}]+)}/g;
+
+/**
+ * Syntax of a single string parameter. A string parameter shape is composed by
+ * the name of the property that should be replaced. This property name can be preceded
+ * or followed by an optional string to prepend or to append to the property value
+ * in case it is defined.
+ *
+ * @example Valid string parameters content
+ * ```js
+ *   "env" // No optional head or tail to concatenate.
+ *   "(.)env" // The `.` character will be prepended as long as the `env` property is defined.
+ *   "env(-api)" // The `-api` string will be appended as long as the `env` property is defined.
+ *   "(api-)env(.)" // The `api-` string and the `.` character will be added as long as
+ *   // the `env` property is defined.
+ * ```
+ * @internal
+ */
+const STRING_PARAMETER_CONTENT = /^(?:\((.+)\))?([^(]+)(?:\((.+)\))?$/g;
+
+/**
+ * Interpolates different parameters into a string.
+ * The provided string can set the parameters to replace wrapping a parameter name in curly
+ * braces. This will then be replaced by the parameter value as long as it is defined. If it
+ * is not provided, the parameter  name will just be removed from the final string.
+ *
+ * @param string - The string to interpolate different parameters in.
+ * @param parameters - Value of the different parameters to interpolate.
+ * @returns The interpolated string.
+ * @example Different usages of the interpolate function.
+ * ```js
+ *  interpolate('https://{env}.empathy.co/{instance}', {
+ *    env: 'live',
+ *    instance: 'demo'
+ *  })     // 'https://live.empathy.co/demo'
+ *
+ *  interpolate('https://{(api-)env}.empathy.co/{instance}', {
+ *    env: 'live',
+ *    instance: 'demo'
+ *  }) // 'https://api-live.empathy.co/demo'
+ *
+ *  interpolate('https://api.{env(.)}empathy.co/{instance}', {
+ *    env: 'live',
+ *    instance: 'demo'
+ *  }) // 'https://api.live.empathy.co/demo'
+ *
+ *  interpolate('https://{(api-)env(.)}empathy.co/{instance}', {
+ *    env: 'live',
+ *    instance: 'demo'
+ *  }) // 'https://api-live.empathy.co/demo'
+ *
+ *  interpolate('https://{env}.empathy.co/{instance}', {
+ *    env: 'live'
+ *  }) // 'https://live.empathy.co/'
+ *
+ *  interpolate('https://search{(api-)env}.empathy.co/{instance}', {
+ *    instance: 'demo'
+ *  }) // 'https://search.empathy.co/demo'
+ *
+ *  interpolate('https://api.{env(.)}empathy.co/{instance}', {
+ *    instance: 'demo'
+ *  }) // 'https://api.empathy.co/demo'
+ *
+ *  interpolate('https://search.{(api-)env(.)}empathy.co/{instance}', {
+ *    instance: 'demo'
+ *  }) // 'https://search.empathy.co/demo'
+ * ```
+ * @public
+ */
+export function interpolate(
+  string: string,
+  parameters: Record<string, string | boolean | number>
+): string {
+  return string.replace(STRING_PARAMETERS, (_match, propertyToReplace: string) =>
+    propertyToReplace.replace(
+      STRING_PARAMETER_CONTENT,
+      (_match, head = '', property: string, tail = '') =>
+        /* As the replacer function has a very dynamic signature, it is typed as a function with
+         * `any` arguments. This makes it impossible for TS to infer the correct `string`
+         * type that we are using as default values here. */
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        property in parameters ? `${head}${parameters[property].toString()}${tail}` : ''
+    )
+  );
+}

--- a/packages/x-adapter/tsconfig.json
+++ b/packages/x-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     "inlineSources": true,
     "esModuleInterop": true,
     "importHelpers": true,
+    "types": ["jest"],
     "lib": ["dom", "esnext"]
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
Adds a small utility to interpolate parameters in the `endpoint` field of each one of the `EndpointAdapter`.