### PR TITLE
docs: activating ready live-examples

### DIFF
--- a/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
@@ -83,10 +83,30 @@
 
 The component exposes a single default slot, where you can add icons or text.
 
-```vue
-<ClearHistoryQueries>
-  <img class="x-history-query__icon" src="./my-icon.svg"/>
-</ClearHistoryQueries>
+```vue live
+<template>
+  <SearchInput />
+  <ClearHistoryQueries>Clear history queries</ClearHistoryQueries>
+  <HistoryQueries :animation="'FadeAndSlide'" :maxItemsToRender="10" />
+</template>
+
+<script>
+  import Vue from 'vue';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { HistoryQueries, ClearHistoryQueries } from '@empathyco/x-components/history-queries';
+  import { FadeAndSlide } from '@empathyco/x-components';
+
+  // Registering the animation as a global component
+  Vue.component('FadeAndSlide', FadeAndSlide);
+  export default {
+    name: 'ClearHistoryQueriesDemo',
+    components: {
+      SearchInput,
+      HistoryQueries,
+      ClearHistoryQueries
+    }
+  };
+</script>
 ```
 
 ## Events

--- a/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
@@ -85,9 +85,11 @@ The component exposes a single default slot, where you can add icons or text.
 
 ```vue live
 <template>
-  <SearchInput />
-  <ClearHistoryQueries>Clear history queries</ClearHistoryQueries>
-  <HistoryQueries :animation="'FadeAndSlide'" :maxItemsToRender="10" />
+  <div>
+    <SearchInput />
+    <ClearHistoryQueries>Clear history queries</ClearHistoryQueries>
+    <HistoryQueries :animation="'FadeAndSlide'" :maxItemsToRender="10" />
+  </div>
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -191,7 +191,7 @@ In this example, the [`HistoryQuery`](./x-components.history-query.md) component
   <div>
     <SearchInput />
     <HistoryQueries #suggestion="{ suggestion }">
-      <HistoryQuery :suggestion="suggestion"></HistoryQuery>
+      <HistoryQuery :suggestion="suggestion" />
     </HistoryQueries>
   </div>
 </template>

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -50,7 +50,6 @@
   import BaseSuggestions from '../../../components/suggestions/base-suggestions.vue';
   import { Getter } from '../../../components/decorators/store.decorators';
   import { xComponentMixin } from '../../../components/x-component.mixin';
-  import SearchInput from '../../search-box/components/search-input.vue';
   import { historyQueriesXModule } from '../x-module';
   import HistoryQuery from './history-query.vue';
 
@@ -66,7 +65,7 @@
    * @public
    */
   @Component({
-    components: { SearchInput, BaseSuggestions, HistoryQuery },
+    components: { BaseSuggestions, HistoryQuery },
     mixins: [xComponentMixin(historyQueriesXModule)]
   })
   export default class HistoryQueries extends Vue {

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -50,6 +50,7 @@
   import BaseSuggestions from '../../../components/suggestions/base-suggestions.vue';
   import { Getter } from '../../../components/decorators/store.decorators';
   import { xComponentMixin } from '../../../components/x-component.mixin';
+  import SearchInput from '../../search-box/components/search-input.vue';
   import { historyQueriesXModule } from '../x-module';
   import HistoryQuery from './history-query.vue';
 
@@ -65,7 +66,7 @@
    * @public
    */
   @Component({
-    components: { BaseSuggestions, HistoryQuery },
+    components: { SearchInput, BaseSuggestions, HistoryQuery },
     mixins: [xComponentMixin(historyQueriesXModule)]
   })
   export default class HistoryQueries extends Vue {
@@ -104,17 +105,22 @@ This component doesn't emit events.
 
 Here you have a basic example of how the HistoryQueries is rendered.
 
-```vue
+```vue live
 <template>
-  <HistoryQueries />
+  <div>
+    <SearchInput />
+    <HistoryQueries />
+  </div>
 </template>
 
 <script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
   import { HistoryQueries } from '@empathyco/x-components/history-queries';
 
   export default {
     name: 'HistoryQueriesDemo',
     components: {
+      SearchInput,
       HistoryQueries
     }
   };
@@ -126,17 +132,22 @@ Here you have a basic example of how the HistoryQueries is rendered.
 In this example, the history queries have been limited to render a maximum of 10 queries (by default
 it is 5).
 
-```vue
+```vue live
 <template>
-  <HistoryQueries :maxItemsToRender="10" />
+  <div>
+    <SearchInput />
+    <HistoryQueries :maxItemsToRender="10" />
+  </div>
 </template>
 
 <script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
   import { HistoryQueries } from '@empathyco/x-components/history-queries';
 
   export default {
     name: 'HistoryQueriesDemo',
     components: {
+      SearchInput,
       HistoryQueries
     }
   };
@@ -145,24 +156,27 @@ it is 5).
 
 ### Play with the animation
 
-```vue
+```vue live
 <template>
-  <HistoryQueries :animation="fadeAndSlide" />
+  <div>
+    <SearchInput />
+    <HistoryQueries :animation="'FadeAndSlide'" />
+  </div>
 </template>
 
 <script>
+  import Vue from 'vue';
+  import { SearchInput } from '@empathyco/x-components/search-box';
   import { HistoryQueries } from '@empathyco/x-components/history-queries';
   import { FadeAndSlide } from '@empathyco/x-components';
 
+  // Registering the animation as a global component
+  Vue.component('FadeAndSlide', FadeAndSlide);
   export default {
     name: 'HistoryQueriesDemo',
     components: {
+      SearchInput,
       HistoryQueries
-    },
-    data() {
-      return {
-        fadeAndSlide: FadeAndSlide
-      };
     }
   };
 </script>
@@ -173,19 +187,24 @@ it is 5).
 In this example, the [`HistoryQuery`](./x-components.history-query.md) component is passed in the
 `suggestion` slot (although any other component could potentially be passed).
 
-```vue
+```vue live
 <template>
-  <HistoryQueries #suggestion="{ suggestion }">
-    <HistoryQuery :suggestion="suggestion"></HistoryQuery>
-  </HistoryQueries>
+  <div>
+    <SearchInput />
+    <HistoryQueries #suggestion="{ suggestion }">
+      <HistoryQuery :suggestion="suggestion"></HistoryQuery>
+    </HistoryQueries>
+  </div>
 </template>
 
 <script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
   import { HistoryQueries, HistoryQuery } from '@empathyco/x-components/history-queries';
 
   export default {
     name: 'HistoryQueriesDemo',
     components: {
+      SearchInput,
       HistoryQueries,
       HistoryQuery
     }
@@ -199,19 +218,24 @@ To continue the previous example, the [`HistoryQuery`](./x-components.history-qu
 passed in the `suggestion-content` slot, but in addition, an HTML span tag for the text are also
 passed.
 
-```vue
+```vue live
 <template>
-  <HistoryQueries #suggestion-content="{ suggestion }">
-    <span>{{ suggestion.query }}</span>
-  </HistoryQueries>
+  <div>
+    <SearchInput />
+    <HistoryQueries #suggestion-content="{ suggestion }">
+      <span>{{ suggestion.query }}</span>
+    </HistoryQueries>
+  </div>
 </template>
 
 <script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
   import { HistoryQueries } from '@empathyco/x-components/history-queries';
 
   export default {
     name: 'HistoryQueriesDemo',
     components: {
+      SearchInput,
       HistoryQueries
     }
   };
@@ -224,20 +248,25 @@ To continue the previous example, the [`HistoryQuery`](./x-components.history-qu
 passed in the `suggestion-content` slot, but in addition, a cross icon is also passed to change the
 icon to remove the history query.
 
-```vue
+```vue live
 <template>
-  <HistoryQueries #suggestion-content-remove="{ suggestion }">
-    <CrossIcon />
-  </HistoryQueries>
+  <div>
+    <SearchInput />
+    <HistoryQueries #suggestion-remove-content="{ suggestion }">
+      <CrossIcon />
+    </HistoryQueries>
+  </div>
 </template>
 
 <script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
   import { HistoryQueries } from '@empathyco/x-components/history-queries';
   import { CrossIcon } from '@empathyco/x-components';
 
   export default {
     name: 'HistoryQueriesDemo',
     components: {
+      SearchInput,
       HistoryQueries,
       CrossIcon
     }

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -132,12 +132,12 @@ that serves to remove this query from the history. This slot only has one proper
 <template>
   <HistoryQuery :suggestion="suggestion">
     <template #default="{ suggestion, queryHTML }">
-      <img class="x-history-query__history-icon" src="/assets/icons/bulb.svg"/>
-      <span class="x-history-query__matching-part" v-html="queryHTML"/>
+      <img class="x-history-query__history-icon" src="/assets/icons/bulb.svg" />
+      <span class="x-history-query__matching-part" v-html="queryHTML" />
     </template>
 
     <template #remove-button-content="{ suggestion }">
-      <img class="x-history-query__remove-icon" src="/assets/icons/cross-dark.svg"/>
+      <img class="x-history-query__remove-icon" src="/assets/icons/cross-dark.svg" />
     </template>
   </HistoryQuery>
 </template>

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -97,12 +97,10 @@ This component only requires a prop called `suggestion`
 </template>
 
 <script>
-  import { SearchInput } from '@empathyco/x-components/search-box';
   import { HistoryQuery } from '@empathyco/x-components/history-queries';
   export default {
     name: 'HistoryQueryDemo',
     components: {
-      SearchInput,
       HistoryQuery
     },
     data() {
@@ -143,12 +141,10 @@ that serves to remove this query from the history. This slot only has one proper
 </template>
 
 <script>
-  import { SearchInput } from '@empathyco/x-components/search-box';
   import { HistoryQuery } from '@empathyco/x-components/history-queries';
   export default {
     name: 'HistoryQueryDemo',
     components: {
-      SearchInput,
       HistoryQuery
     },
     data() {

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -130,22 +130,26 @@ that serves to remove this query from the history. This slot only has one proper
 <template>
   <HistoryQuery :suggestion="suggestion">
     <template #default="{ suggestion, queryHTML }">
-      <img class="x-history-query__history-icon" src="/assets/icons/bulb.svg" />
+      <HistoryIcon />
       <span class="x-history-query__matching-part" v-html="queryHTML" />
     </template>
 
     <template #remove-button-content="{ suggestion }">
-      <img class="x-history-query__remove-icon" src="/assets/icons/cross-dark.svg" />
+      <CrossIcon />
     </template>
   </HistoryQuery>
 </template>
 
 <script>
   import { HistoryQuery } from '@empathyco/x-components/history-queries';
+  import { HistoryIcon, CrossIcon } from '@empathyco/x-components';
+
   export default {
     name: 'HistoryQueryDemo',
     components: {
-      HistoryQuery
+      HistoryQuery,
+      HistoryIcon,
+      CrossIcon
     },
     data() {
       return {

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -93,7 +93,6 @@ This component only requires a prop called `suggestion`
 
 ```vue live
 <template>
-  <SearchInput />
   <HistoryQuery :suggestion="suggestion" />
 </template>
 
@@ -131,7 +130,6 @@ that serves to remove this query from the history. This slot only has one proper
 
 ```vue live
 <template>
-  <SearchInput />
   <HistoryQuery :suggestion="suggestion">
     <template #default="{ suggestion, queryHTML }">
       <img class="x-history-query__history-icon" src="/assets/icons/bulb.svg"/>

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -91,8 +91,32 @@
 
 This component only requires a prop called `suggestion`
 
-```vue
-<HistoryQuery :suggestion="historyQuery" />
+```vue live
+<template>
+  <SearchInput />
+  <HistoryQuery :suggestion="suggestion" />
+</template>
+
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { HistoryQuery } from '@empathyco/x-components/history-queries';
+  export default {
+    name: 'HistoryQueryDemo',
+    components: {
+      SearchInput,
+      HistoryQuery
+    },
+    data() {
+      return {
+        suggestion: {
+          modelName: 'HistoryQuery',
+          query: 'trousers',
+          facets: []
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Customizing slots content
@@ -105,18 +129,47 @@ the suggestion itself, and a `string` of HTML with the matched query.
 The other slot is called `remove-button-content`, and allows you to set the content of the button
 that serves to remove this query from the history. This slot only has one property, the suggestion.
 
-````vue
-<HistoryQuery :suggestion="historyQuery">
-  <template #default="{ suggestion, queryHTML }">
-    <img class="x-history-query__history-icon" src="./history-icon.svg"/>
-    <span class="x-history-query__matching-part" v-html="queryHTML"/>
-  </template>
+```vue live
+<template>
+  <SearchInput />
+  <HistoryQuery :suggestion="suggestion">
+    <template #default="{ suggestion, queryHTML }">
+      <img class="x-history-query__history-icon" src="/assets/icons/bulb.svg"/>
+      <span class="x-history-query__matching-part" v-html="queryHTML"/>
+    </template>
 
-  <template #remove-button-content="{ suggestion }">
-    <img class="x-history-query__remove-icon" src="./remove-icon.svg"/>
-  </template>
-</HistoryQuery>
-``` ## Events A list of events that the component will emit: - `UserSelectedAHistoryQuery`: the
-event is emitted after the user clicks the button. The event payload is the history query data.
-````
+    <template #remove-button-content="{ suggestion }">
+      <img class="x-history-query__remove-icon" src="/assets/icons/cross-dark.svg"/>
+    </template>
+  </HistoryQuery>
+</template>
+
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { HistoryQuery } from '@empathyco/x-components/history-queries';
+  export default {
+    name: 'HistoryQueryDemo',
+    components: {
+      SearchInput,
+      HistoryQuery
+    },
+    data() {
+      return {
+        suggestion: {
+          modelName: 'HistoryQuery',
+          query: 'trousers',
+          facets: []
+        }
+      };
+    }
+  };
+</script>
+```
+
+## Events
+
+A list of events that the component will emit:
+
+- `UserSelectedAHistoryQuery`: the event is emitted after the user clicks the button. The event
+  payload is the history query data.
 </docs>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -157,7 +157,7 @@ Usually, this component is going to be used together with the `ResultsList` one.
 will be inserted between the results, guiding users to discover new searches directly from the
 results list.
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput />
@@ -192,7 +192,7 @@ Finally, a third group will be inserted at index `192`. Because `maxGroups` is c
 more groups will be inserted. Each one of this groups will have up to `6` next queries
 (`maxNextQueriesPerGroup`).
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput />

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -164,7 +164,7 @@ Next Query suggestion.
     <SearchInput />
     <NextQueries>
       <template #suggestion-content="{ suggestion }">
-        <img src="/assets/icons/bulb.svg" class="x-next-query__icon" />
+        <Nq1Icon />
         <span class="x-next-query__query">{{ suggestion.query }}</span>
       </template>
     </NextQueries>
@@ -174,12 +174,14 @@ Next Query suggestion.
 <script>
   import { SearchInput } from '@empathyco/x-components/search-box';
   import { NextQueries } from '@empathyco/x-components/next-queries';
+  import { Nq1Icon } from '@empathyco/x-components';
 
   export default {
     name: 'NextQueriesDemo',
     components: {
       SearchInput,
-      NextQueries
+      NextQueries,
+      Nq1Icon
     }
   };
 </script>
@@ -200,7 +202,7 @@ is wrapped in a `span`
       <template #suggestion="{ suggestion }">
         <NextQuery :suggestion="suggestion" class="x-next-queries__suggestion">
           <template #default="{ suggestion }">
-            <img src="/assets/icons/bulb.svg" class="x-next-query__icon" />
+            <Nq1Icon />
             <span class="x-next-query__query">{{ suggestion.query }}</span>
           </template>
         </NextQuery>
@@ -213,13 +215,15 @@ is wrapped in a `span`
 <script>
   import { SearchInput } from '@empathyco/x-components/search-box';
   import { NextQueries, NextQuery } from '@empathyco/x-components/next-queries';
+  import { Nq1Icon } from '@empathyco/x-components';
 
   export default {
     name: 'NextQueriesDemo',
     components: {
       SearchInput,
       NextQueries,
-      NextQuery
+      NextQuery,
+      Nq1Icon
     }
   };
 </script>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -100,16 +100,52 @@
 You don't need to pass any props, or slots. Simply add the component, and when it has any next
 queries it will show them
 
-```vue
-<NextQueries />
+```vue live
+<template>
+  <SearchInput />
+  <NextQueries />
+</template>
+
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { NextQueries } from '@empathyco/x-components/next-queries';
+
+  export default {
+    name: 'NextQueriesDemo',
+    components: {
+      SearchInput,
+      NextQueries
+    }
+  };
+</script>
 ```
 
 The component has three optional props. `animation` to render the component with an animation,
 `maxItemToRender` to limit the number of next queries will be rendered (by default it is 5) and
 `highlightCurated` to indicate if the curated Next Queries inside the list should be highlighted.
 
-```vue
-<NextQueries :animation="FadeAndSlide" :maxItemsToRender="10" :highlightCurated="true" />
+```vue live
+<template>
+  <SearchInput />
+  <NextQueries :animation="'FadeAndSlide'" :maxItemsToRender="10" :highlightCurated="true" />
+</template>
+
+<script>
+  import Vue from 'vue';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { NextQueries } from '@empathyco/x-components/next-queries';
+  import { FadeAndSlide } from '@empathyco/x-components';
+
+  // Registering the animation as a global component
+  Vue.component('FadeAndSlide', FadeAndSlide);
+  export default {
+    name: 'NextQueriesDemo',
+    components: {
+      SearchInput,
+      NextQueries
+    }
+  };
+</script>
 ```
 
 ### Overriding Next Queries' Content
@@ -118,13 +154,29 @@ You can use your custom implementation of the Next Query's content. In the examp
 using the default Next Query's content, an icon is added, as well as a span with the query of the
 Next Query suggestion.
 
-```vue
-<NextQueries>
-  <template #suggestion-content="{suggestion}">
-    <img src="./next-query-icon.svg" class="x-next-query__icon"/>
-    <span class="x-next-query__query">{{ suggestion.query }}</span>
-  </template>
-</NextQueries>
+```vue live
+<template>
+  <SearchInput />
+  <NextQueries>
+    <template #suggestion-content="{ suggestion }">
+      <img src="/assets/icons/bulb.svg" class="x-next-query__icon" />
+      <span class="x-next-query__query">{{ suggestion.query }}</span>
+    </template>
+  </NextQueries>
+</template>
+
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { NextQueries } from '@empathyco/x-components/next-queries';
+
+  export default {
+    name: 'NextQueriesDemo',
+    components: {
+      SearchInput,
+      NextQueries
+    }
+  };
+</script>
 ```
 
 ### Adding a custom next query component
@@ -134,17 +186,34 @@ the `emitNextQuerySelected` function when the next query is selected. In the exa
 of using the default `button` tag for a next query, an icon is added, and the text of the next query
 is wrapped in a `span`
 
-```vue
-<NextQueries>
-  <template #suggestion="{suggestion}">
-    <NextQuery :suggestion="suggestion" class="x-next-queries__suggestion">
-      <template #default="{suggestion}">
-        <img src="./next-query-icon.svg" class="x-next-query__icon"/>
-        <span class="x-next-query__query">{{ suggestion.query }}</span>
-      </template>
-    </NextQuery>
-    <button>Custom Behaviour</button>
-  </template>
-</NextQueries>
+```vue live
+<template>
+  <SearchInput />
+  <NextQueries>
+    <template #suggestion="{ suggestion }">
+      <NextQuery :suggestion="suggestion" class="x-next-queries__suggestion">
+        <template #default="{ suggestion }">
+          <img src="/assets/icons/bulb.svg" class="x-next-query__icon" />
+          <span class="x-next-query__query">{{ suggestion.query }}</span>
+        </template>
+      </NextQuery>
+      <button>Custom Behaviour</button>
+    </template>
+  </NextQueries>
+</template>
+
+<script>
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { NextQueries, NextQuery } from '@empathyco/x-components/next-queries';
+
+  export default {
+    name: 'NextQueriesDemo',
+    components: {
+      SearchInput,
+      NextQueries,
+      NextQuery
+    }
+  };
+</script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -102,8 +102,10 @@ queries it will show them
 
 ```vue live
 <template>
-  <SearchInput />
-  <NextQueries />
+  <div>
+    <SearchInput />
+    <NextQueries />
+  </div>
 </template>
 
 <script>
@@ -126,8 +128,10 @@ The component has three optional props. `animation` to render the component with
 
 ```vue live
 <template>
-  <SearchInput />
-  <NextQueries :animation="'FadeAndSlide'" :maxItemsToRender="10" :highlightCurated="true" />
+  <div>
+    <SearchInput />
+    <NextQueries :animation="'FadeAndSlide'" :maxItemsToRender="10" :highlightCurated="true" />
+  </div>
 </template>
 
 <script>
@@ -156,13 +160,15 @@ Next Query suggestion.
 
 ```vue live
 <template>
-  <SearchInput />
-  <NextQueries>
-    <template #suggestion-content="{ suggestion }">
-      <img src="/assets/icons/bulb.svg" class="x-next-query__icon" />
-      <span class="x-next-query__query">{{ suggestion.query }}</span>
-    </template>
-  </NextQueries>
+  <div>
+    <SearchInput />
+    <NextQueries>
+      <template #suggestion-content="{ suggestion }">
+        <img src="/assets/icons/bulb.svg" class="x-next-query__icon" />
+        <span class="x-next-query__query">{{ suggestion.query }}</span>
+      </template>
+    </NextQueries>
+  </div>
 </template>
 
 <script>
@@ -188,18 +194,20 @@ is wrapped in a `span`
 
 ```vue live
 <template>
-  <SearchInput />
-  <NextQueries>
-    <template #suggestion="{ suggestion }">
-      <NextQuery :suggestion="suggestion" class="x-next-queries__suggestion">
-        <template #default="{ suggestion }">
-          <img src="/assets/icons/bulb.svg" class="x-next-query__icon" />
-          <span class="x-next-query__query">{{ suggestion.query }}</span>
-        </template>
-      </NextQuery>
-      <button>Custom Behaviour</button>
-    </template>
-  </NextQueries>
+  <div>
+    <SearchInput />
+    <NextQueries>
+      <template #suggestion="{ suggestion }">
+        <NextQuery :suggestion="suggestion" class="x-next-queries__suggestion">
+          <template #default="{ suggestion }">
+            <img src="/assets/icons/bulb.svg" class="x-next-query__icon" />
+            <span class="x-next-query__query">{{ suggestion.query }}</span>
+          </template>
+        </NextQuery>
+        <button>Custom Behaviour</button>
+      </template>
+    </NextQueries>
+  </div>
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/next-queries/components/next-query.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-query.vue
@@ -126,7 +126,7 @@ The default slot allows you to replace the content of the suggestion button.
 <template>
   <NextQuery :suggestion="suggestion">
     <template #default="{ suggestion }">
-      <img class="x-next-query__icon" src="/assets/icons/bulb.svg" />
+      <Nq1Icon />
       <span class="x-next-query__query" :aria-label="suggestion.query">{{ suggestion.query }}</span>
     </template>
   </NextQuery>
@@ -134,11 +134,13 @@ The default slot allows you to replace the content of the suggestion button.
 
 <script>
   import { NextQuery } from '@empathyco/x-components/next-queries';
+  import { Nq1Icon } from '@empathyco/x-components';
 
   export default {
     name: 'NextQueryDemo',
     components: {
-      NextQuery
+      NextQuery,
+      Nq1Icon
     },
     data() {
       return {

--- a/packages/x-components/src/x-modules/next-queries/components/next-query.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-query.vue
@@ -92,21 +92,65 @@ CSS class.
 
 Using default slot:
 
-```vue
-<NextQuery :suggestion="suggestion" />
+```vue live
+<template>
+  <NextQuery :suggestion="suggestion" />
+</template>
+
+<script>
+  import { NextQuery } from '@empathyco/x-components/next-queries';
+
+  export default {
+    name: 'NextQueryDemo',
+    components: {
+      NextQuery
+    },
+    data() {
+      return {
+        suggestion: {
+          modelName: 'NextQuery',
+          query: 'tshirt',
+          facets: []
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Overriding default slot.
 
 The default slot allows you to replace the content of the suggestion button.
 
-```vue
-<NextQuery :suggestion="suggestion">
-  <template #default="{ suggestion }">
-    <img class="x-next-query__icon" src="./next-query.svg" />
-    <span class="x-next-query__query" :aria-label="suggestion.query">{{ suggestion.query }}</span>
-  </template>
-</NextQuery>
+```vue live
+<template>
+  <NextQuery :suggestion="suggestion">
+    <template #default="{ suggestion }">
+      <img class="x-next-query__icon" src="/assets/icons/bulb.svg" />
+      <span class="x-next-query__query" :aria-label="suggestion.query">{{ suggestion.query }}</span>
+    </template>
+  </NextQuery>
+</template>
+
+<script>
+  import { NextQuery } from '@empathyco/x-components/next-queries';
+
+  export default {
+    name: 'NextQueryDemo',
+    components: {
+      NextQuery
+    },
+    data() {
+      return {
+        suggestion: {
+          modelName: 'NextQuery',
+          query: 'tshirt',
+          facets: []
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ## Dynamic Classes

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
@@ -98,9 +98,7 @@ content. By default, it renders the suggestion query of the popular search.
 <template>
   <PopularSearch :suggestion="suggestion">
     <template #default="{ suggestion }">
-      <svg height="10" width="10">
-        <circle cx="5" cy="5" r="4" stroke="black" />
-      </svg>
+      <TrendingIcon />
       <span :aria-label="suggestion.query">{{ suggestion.query }}</span>
     </template>
   </PopularSearch>
@@ -108,10 +106,13 @@ content. By default, it renders the suggestion query of the popular search.
 
 <script>
   import { PopularSearch } from '@empathyco/x-components/popular-searches';
+  import { TrendingIcon } from '@empathyco/x-components';
+
   export default {
     name: 'PopularSearchDemo',
     components: {
-      PopularSearch
+      PopularSearch,
+      TrendingIcon
     },
     data() {
       return {

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
@@ -67,21 +67,63 @@ content. By default, it renders the suggestion query of the popular search.
 
 ### Basic Usage
 
-```vue
-<PopularSearch :suggestion="suggestion" />
+```vue live
+<template>
+  <PopularSearch :suggestion="suggestion" />
+</template>
+
+<script>
+  import { PopularSearch } from '@empathyco/x-components/popular-searches';
+  export default {
+    name: 'PopularSearchDemo',
+    components: {
+      PopularSearch
+    },
+    data() {
+      return {
+        suggestion: {
+          modelName: 'PopularSearch',
+          query: 'tshirt',
+          facets: []
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Custom Usage
 
-```vue
-<PopularSearch :suggestion="suggestion">
-  <template #default="{ suggestion }">
-    <svg height="10" width="10">
-      <circle cx="5" cy="5" r="4" stroke="black" />
-    </svg>
-    <span :aria-label="suggestion.query">{{ suggestion.query }}</span>
-  </template>
-</PopularSearch>
+```vue live
+<template>
+  <PopularSearch :suggestion="suggestion">
+    <template #default="{ suggestion }">
+      <svg height="10" width="10">
+        <circle cx="5" cy="5" r="4" stroke="black" />
+      </svg>
+      <span :aria-label="suggestion.query">{{ suggestion.query }}</span>
+    </template>
+  </PopularSearch>
+</template>
+
+<script>
+  import { PopularSearch } from '@empathyco/x-components/popular-searches';
+  export default {
+    name: 'PopularSearchDemo',
+    components: {
+      PopularSearch
+    },
+    data() {
+      return {
+        suggestion: {
+          modelName: 'PopularSearch',
+          query: 'tshirt',
+          facets: []
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ## Events

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -85,15 +85,45 @@
 You don't need to pass any props, or slots. Simply add the component, and when it has any popular
 searches it will show them.
 
-```vue
-<PopularSearches />
+```vue live
+<template>
+  <PopularSearches />
+</template>
+
+<script>
+  import { PopularSearches } from '@empathyco/x-components/popular-searches';
+  export default {
+    name: 'PopularSearchesDemo',
+    components: {
+      PopularSearches
+    }
+  };
+</script>
 ```
 
 The component has two optional props. `animation` to render the component with an animation and
 `maxItemToRender` to limit the number of popular searches will be rendered (by default it is 5).
 
-```vue
-<PopularSearches :animation="FadeAndSlide" :maxItemsToRender="10" />
+```vue live
+<template>
+  <PopularSearches :animation="'FadeAndSlide'" :maxItemsToRender="10" />
+</template>
+
+<script>
+  import Vue from 'vue';
+  import { PopularSearches } from '@empathyco/x-components/popular-searches';
+  import FadeAndSlide from '@empathyco/x-components';
+
+  // Registering the animation as a global component
+  Vue.component('FadeAndSlide', FadeAndSlide);
+  export default {
+    name: 'PopularSearchesDemo',
+    components: {
+      PopularSearches,
+      FadeAndSlide
+    }
+  };
+</script>
 ```
 
 ### Overriding Popular Search's Content
@@ -102,13 +132,25 @@ You can use your custom implementation of the Popular Search's content. In the e
 instead of using the default Popular Search's content, an icon is added, as well as a span with the
 query of the Popular Search's suggestion.
 
-```vue
-<PopularSearches>
-  <template #suggestion-content="{ suggestion }">
-    <img class="x-popular-search__icon" src="./popular-search-icon.svg" />
-    <span class="x-popular-search__query">{{ suggestion.query }}</span>
-  </template>
-</PopularSearches>
+```vue live
+<template>
+  <PopularSearches>
+    <template #suggestion-content="{ suggestion }">
+      <img class="x-popular-search__icon" src="/assets/icons/bulb.svg" />
+      <span class="x-popular-search__query">{{ suggestion.query }}</span>
+    </template>
+  </PopularSearches>
+</template>
+
+<script>
+  import { PopularSearches } from '@empathyco/x-components/popular-searches';
+  export default {
+    name: 'PopularSearchesDemo',
+    components: {
+      PopularSearches
+    }
+  };
+</script>
 ```
 
 ### Adding a Custom Popular Search Item
@@ -119,17 +161,29 @@ implementation is added, it has an image and a span as content (as in the previo
 button with a user customized behaviour is added at the same hierarchical level as the Popular
 Search component.
 
-```vue
-<PopularSearches>
-  <template #suggestion="{suggestion}">
-    <PopularSearch :suggestion="suggestion">
-      <template #default="{suggestion}">
-        <img class="x-popular-search__icon" src="./popular-search-icon.svg" />
-        <span class="x-popular-search__query">{{ suggestion.query }}</span>
-      </template>
-    </PopularSearch>
-    <button>Custom Behaviour</button>
-  </template>
-</PopularSearches>
+```vue live
+<template>
+  <PopularSearches>
+    <template #suggestion="{ suggestion }">
+      <PopularSearch :suggestion="suggestion">
+        <template #default="{ suggestion }">
+          <img class="x-popular-search__icon" src="/assets/icons/bulb.svg" />
+          <span class="x-popular-search__query">{{ suggestion.query }}</span>
+        </template>
+      </PopularSearch>
+      <button>Custom Behaviour</button>
+    </template>
+  </PopularSearches>
+</template>
+
+<script>
+  import { PopularSearches } from '@empathyco/x-components/popular-searches';
+  export default {
+    name: 'PopularSearchesDemo',
+    components: {
+      PopularSearches
+    }
+  };
+</script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -136,7 +136,7 @@ query of the Popular Search's suggestion.
 <template>
   <PopularSearches>
     <template #suggestion-content="{ suggestion }">
-      <img class="x-popular-search__icon" src="/assets/icons/bulb.svg" />
+      <TrendingIcon />
       <span class="x-popular-search__query">{{ suggestion.query }}</span>
     </template>
   </PopularSearches>
@@ -144,10 +144,13 @@ query of the Popular Search's suggestion.
 
 <script>
   import { PopularSearches } from '@empathyco/x-components/popular-searches';
+  import { TrendingIcon } from '@empathyco/x-components';
+
   export default {
     name: 'PopularSearchesDemo',
     components: {
-      PopularSearches
+      PopularSearches,
+      TrendingIcon
     }
   };
 </script>
@@ -167,7 +170,7 @@ Search component.
     <template #suggestion="{ suggestion }">
       <PopularSearch :suggestion="suggestion">
         <template #default="{ suggestion }">
-          <img class="x-popular-search__icon" src="/assets/icons/bulb.svg" />
+          <TrendingIcon />
           <span class="x-popular-search__query">{{ suggestion.query }}</span>
         </template>
       </PopularSearch>
@@ -178,11 +181,14 @@ Search component.
 
 <script>
   import { PopularSearches, PopularSearch } from '@empathyco/x-components/popular-searches';
+  import { TrendingIcon } from '@empathyco/x-components';
+
   export default {
     name: 'PopularSearchesDemo',
     components: {
       PopularSearches,
-      PopularSearch
+      PopularSearch,
+      TrendingIcon
     }
   };
 </script>

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -177,11 +177,12 @@ Search component.
 </template>
 
 <script>
-  import { PopularSearches } from '@empathyco/x-components/popular-searches';
+  import { PopularSearches, PopularSearch } from '@empathyco/x-components/popular-searches';
   export default {
     name: 'PopularSearchesDemo',
     components: {
-      PopularSearches
+      PopularSearches,
+      PopularSearch
     }
   };
 </script>

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestion.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestion.vue
@@ -86,7 +86,7 @@ implemented.
 
 Here you can see how a single query suggestion is rendered using the `suggestion` prop.
 
-```vue
+```vue live
 <template>
   <QuerySuggestion :suggestion="suggestion" />
 </template>
@@ -102,7 +102,7 @@ Here you can see how a single query suggestion is rendered using the `suggestion
       return {
         suggestion: {
           modelName: 'QuerySuggestion',
-          query: 'beer',
+          query: 'tshirt',
           facets: []
         }
       };
@@ -116,7 +116,7 @@ Here you can see how a single query suggestion is rendered using the `suggestion
 In this example, the query suggestion is painted in blue by passing a color style in the HTML span
 element.
 
-```vue
+```vue live
 <template>
   <QuerySuggestion :suggestion="suggestion" #default="{ queryHTML }">
     <span v-html="queryHTML" style="color: blue;" />
@@ -134,7 +134,7 @@ element.
       return {
         suggestion: {
           modelName: 'QuerySuggestion',
-          query: 'beer',
+          query: 'tshirt',
           facets: []
         }
       };
@@ -148,7 +148,7 @@ element.
 In this example, when you click on the query suggestion, a message is displayed to illustrate that
 the `UserSelectedAQuerySuggestion` event has been triggered.
 
-```vue
+```vue live
 <template>
   <QuerySuggestion :suggestion="suggestion" @UserSelectedAQuerySuggestion="alertSuggestion" />
 </template>
@@ -164,7 +164,7 @@ the `UserSelectedAQuerySuggestion` event has been triggered.
       return {
         suggestion: {
           modelName: 'QuerySuggestion',
-          query: 'beer',
+          query: 'tshirt',
           facets: []
         }
       };

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
@@ -90,12 +90,12 @@ implemented.
 <!-- prettier-ignore-end -->
 
 In this example, a list of query suggestions is displayed. See how the suggestions change as you
-type “puzzle”. If you click on a suggestion, the search term in the search input is updated and the
+type “sandal”. If you click on a suggestion, the search term in the search input is updated and the
 query suggestions are changed to reflect the new search term.
 
-_Type “puzzle” or another toy in the input field to try it out!_
+_Type “sandal” or another fashion term in the input field to try it out!_
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput />
@@ -122,22 +122,23 @@ _Type “puzzle” or another toy in the input field to try it out!_
 In this example, an `StaggeredFadeAndSlide` animation component has been passed as prop, so that the
 matching query suggestions are shuffled with a slight delay as more letters of the term are typed.
 
-_Type “puzzle” or another toy in the input field to try it out!_
+_Type “lipstick” or another fashion term in the input field to try it out!_
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput />
-    <QuerySuggestions animation="StaggeredFadeAndSlide" />
+    <QuerySuggestions :animation="'StaggeredFadeAndSlide'" />
   </div>
 </template>
 
 <script>
+  import Vue from 'vue';
   import { QuerySuggestions } from '@empathyco/x-components/query-suggestions';
   import { SearchInput } from '@empathyco/x-components/search-box';
   import { StaggeredFadeAndSlide } from '@empathyco/x-components';
 
-  // Register the animation as a global component
+  // Registering the animation as a global component
   Vue.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide);
   export default {
     name: 'QuerySuggestionsDemo',
@@ -153,9 +154,9 @@ _Type “puzzle” or another toy in the input field to try it out!_
 
 Here, the `suggestion` binding property passes the suggestion data.
 
-_Type “puzzle” or another toy in the input field to try it out!_
+_Type “bag” or another fashion term in the input field to try it out!_
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput />
@@ -186,7 +187,7 @@ If you're not using the [`QuerySuggestion`](./query-suggestion.md) component, th
 you must implement the `UserAcceptedAQuery` and `UserSelectedAQuerySuggestion` events in
 `QuerySuggestions`.
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput />
@@ -233,9 +234,9 @@ you must implement the `UserAcceptedAQuery` and `UserSelectedAQuerySuggestion` e
 In this example, the `suggestion` and `queryHTML` bindings have been passed in the
 `suggestion-content` slot to paint the resulting query suggestions in blue.
 
-_Type “puzzle” or another toy in the input field to try it out!_
+_Type “trousers” or another toy in the input field to try it out!_
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput />
@@ -265,9 +266,9 @@ Components can be combined and communicate with each other. Commonly, the `Query
 component communicates with the [`SearchInput`](../search-box/x-components.search-input.md),
 updating the term in the search input.
 
-_Type “puzzle” or another toy in the input field to try it out!_
+_Type “pants” or another toy in the input field to try it out!_
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput />

--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -182,10 +182,9 @@ _Here you can see how the RelatedTag component is rendered._
       return {
         tag: {
           modelName: 'RelatedTag',
-          previous: 'shoe',
           query: 'high heel',
-          selected: false,
-          tag: 'heels'
+          isCurated: false,
+          tag: 'heel'
         }
       };
     }
@@ -218,10 +217,9 @@ _See how the related tag can be rendered._
       return {
         tag: {
           modelName: 'RelatedTag',
-          previous: 'shoe',
           query: 'high heel',
-          selected: false,
-          tag: 'heels'
+          isCurated: false,
+          tag: 'heel'
         }
       };
     }
@@ -253,10 +251,9 @@ _See how the event is triggered when the related tag is clicked._
       return {
         tag: {
           modelName: 'RelatedTag',
-          previous: 'shoe',
           query: 'high heel',
-          selected: false,
-          tag: 'heels'
+          isCurated: false,
+          tag: 'heel'
         }
       };
     },

--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -167,7 +167,7 @@ _Here you can see how the RelatedTag component is rendered._
 
 ```vue live
 <template>
-  <RelatedTag :relatedTag="tag"></RelatedTag>
+  <RelatedTag :relatedTag="tag" />
 </template>
 
 <script>
@@ -236,7 +236,7 @@ _See how the event is triggered when the related tag is clicked._
 
 ```vue live
 <template>
-  <RelatedTag :relatedTag="tag" @UserSelectedARelatedTag="alertRelatedTag"></RelatedTag>
+  <RelatedTag :relatedTag="tag" @UserSelectedARelatedTag="alertRelatedTag" />
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -165,7 +165,7 @@ In this example related tag data is passed as a prop.
 
 _Here you can see how the RelatedTag component is rendered._
 
-```vue
+```vue live
 <template>
   <RelatedTag :relatedTag="tag"></RelatedTag>
 </template>
@@ -182,10 +182,10 @@ _Here you can see how the RelatedTag component is rendered._
       return {
         tag: {
           modelName: 'RelatedTag',
-          previous: 'toy',
-          query: 'toy story',
+          previous: 'shoe',
+          query: 'high heel',
           selected: false,
-          tag: 'story'
+          tag: 'heels'
         }
       };
     }
@@ -199,7 +199,7 @@ In this example, an HTML span element is passed in the `default` slot.
 
 _See how the related tag can be rendered._
 
-```vue
+```vue live
 <template>
   <RelatedTag :relatedTag="tag" #default="{ relatedTag }">
     <span :aria-label="relatedTag.tag">{{ relatedTag.tag }}</span>
@@ -218,10 +218,10 @@ _See how the related tag can be rendered._
       return {
         tag: {
           modelName: 'RelatedTag',
-          previous: 'toy',
-          query: 'toy story',
+          previous: 'shoe',
+          query: 'high heel',
           selected: false,
-          tag: 'story'
+          tag: 'heels'
         }
       };
     }
@@ -236,7 +236,7 @@ event is implemented, as illustrated by the “Tag” message returned.
 
 _See how the event is triggered when the related tag is clicked._
 
-```vue
+```vue live
 <template>
   <RelatedTag :relatedTag="tag" @UserSelectedARelatedTag="alertRelatedTag"></RelatedTag>
 </template>
@@ -253,10 +253,10 @@ _See how the event is triggered when the related tag is clicked._
       return {
         tag: {
           modelName: 'RelatedTag',
-          previous: 'toy',
-          query: 'toy story',
+          previous: 'shoe',
+          query: 'high heel',
           selected: false,
-          tag: 'story'
+          tag: 'heels'
         }
       };
     },

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -112,9 +112,9 @@ To use this component, the QuerySignals microservice must be implemented.
 
 This example shows how related tags can be rendered without any additional effects.
 
-_Search for a toy and press enter._
+_Search for a fashion term like "sandal" or "lipstick"._
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput></SearchInput>
@@ -141,13 +141,13 @@ _Search for a toy and press enter._
 In this example, the number of related tags rendered has been limited to 3. A fade and slide effect
 has been added so that the related tags appear with a delay, then slide upwards and fade.
 
-_Search for a toy and press Enter to see the related tags with the animation effect._
+_Search for a fashion term and see the related tags with the animation effect._
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput></SearchInput>
-    <RelatedTags animation="StaggeredFadeAndSlide" :maxItemsToRender="3"></RelatedTags>
+    <RelatedTags :animation="'StaggeredFadeAndSlide'" :maxItemsToRender="3"></RelatedTags>
   </div>
 </template>
 
@@ -157,6 +157,7 @@ _Search for a toy and press Enter to see the related tags with the animation eff
   import { RelatedTags } from '@empathyco/x-components/related-tags';
   import { StaggeredFadeAndSlide } from '@empathyco/x-components';
 
+  // Registering the animation as a global component
   Vue.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide);
   export default {
     name: 'RelatedTagsDemo',
@@ -173,9 +174,9 @@ _Search for a toy and press Enter to see the related tags with the animation eff
 In this example, the [`RelatedTag`](./x-components.related-tag.md) component is passed in the
 `related-tag` slot (although any other component could potentially be passed).
 
-_Search for a toy and see how the related tags can be rendered._
+_Search for a fashion term and see how the related tags can be rendered._
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput></SearchInput>
@@ -206,9 +207,9 @@ To continue the previous example, the [`RelatedTag`](./x-components.related-tag.
 passed in the `related-tag-content` slot, but in addition, an HTML span tag for the text are also
 passed.
 
-_Search for a toy and see how the related tags are rendered._
+_Search for a fashion term and see how the related tags are rendered._
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput></SearchInput>
@@ -237,14 +238,18 @@ _Search for a toy and see how the related tags are rendered._
 Components can be combined and communicate with each other. The `RelatedTags` component can
 communicate with the [`SearchInput`](../search-box/x-components.search-input.md) as follows:
 
-_Search for a toy and see how the related tags can be rendered._
+_Search for a fashion term and see how the related tags can be rendered._
 
-```vue
+```vue live
 <template>
   <div>
     <SearchInput></SearchInput>
     <RelatedTags></RelatedTags>
-    <ResultsList></ResultsList>
+    <ResultsList #result="{ item }">
+      <span class="result">
+        {{ item.name }}
+      </span>
+    </ResultsList>
   </div>
 </template>
 

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -117,8 +117,8 @@ _Search for a fashion term like "sandal" or "lipstick"._
 ```vue live
 <template>
   <div>
-    <SearchInput></SearchInput>
-    <RelatedTags></RelatedTags>
+    <SearchInput />
+    <RelatedTags />
   </div>
 </template>
 
@@ -146,8 +146,8 @@ _Search for a fashion term and see the related tags with the animation effect._
 ```vue live
 <template>
   <div>
-    <SearchInput></SearchInput>
-    <RelatedTags :animation="'StaggeredFadeAndSlide'" :maxItemsToRender="3"></RelatedTags>
+    <SearchInput />
+    <RelatedTags :animation="'StaggeredFadeAndSlide'" :maxItemsToRender="3" />
   </div>
 </template>
 
@@ -179,9 +179,9 @@ _Search for a fashion term and see how the related tags can be rendered._
 ```vue live
 <template>
   <div>
-    <SearchInput></SearchInput>
+    <SearchInput />
     <RelatedTags #related-tag="{ relatedTag }">
-      <RelatedTag :relatedTag="relatedTag"></RelatedTag>
+      <RelatedTag :relatedTag="relatedTag" />
     </RelatedTags>
   </div>
 </template>
@@ -212,7 +212,7 @@ _Search for a fashion term and see how the related tags are rendered._
 ```vue live
 <template>
   <div>
-    <SearchInput></SearchInput>
+    <SearchInput />
     <RelatedTags #related-tag-content="{ relatedTag }">
       <span>{{ relatedTag.tag }}</span>
     </RelatedTags>
@@ -243,8 +243,8 @@ _Search for a fashion term and see how the related tags can be rendered._
 ```vue live
 <template>
   <div>
-    <SearchInput></SearchInput>
-    <RelatedTags></RelatedTags>
+    <SearchInput />
+    <RelatedTags />
     <ResultsList #result="{ item }">
       <span class="result">
         {{ item.name }}

--- a/packages/x-components/src/x-modules/search-box/components/clear-search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/clear-search-input.vue
@@ -128,8 +128,10 @@ _Click the Clear button to try it out!_
 
 ```vue live
 <template>
-  <ClearSearchInput @UserPressedClearSearchBoxButton="message = 'clear'">Clear</ClearSearchInput>
-  {{ message }}
+  <div>
+    <ClearSearchInput @UserPressedClearSearchBoxButton="message = 'clear'">Clear</ClearSearchInput>
+    {{ message }}
+  </div>
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/search-box/components/clear-search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/clear-search-input.vue
@@ -74,10 +74,12 @@ Here a basic example of how the clear button is rendered.
 
 _Type any term in the input field and then click the Clear button to try it out!_
 
-```vue
+```vue live
 <template>
-  <SearchInput />
-  <ClearSearchInput />
+  <div style="display: flex;">
+    <SearchInput />
+    <ClearSearchInput />
+  </div>
 </template>
 
 <script>
@@ -100,7 +102,7 @@ customize the button content.
 
 _Click the icon button to try it out!_
 
-```vue
+```vue live
 <template>
   <ClearSearchInput>Clear</ClearSearchInput>
 </template>
@@ -124,11 +126,10 @@ In this example, the `UserPressedClearSearchBoxButton` event is implemented, tri
 
 _Click the Clear button to try it out!_
 
-```vue
+```vue live
 <template>
-  <ClearSearchInput @UserPressedClearSearchBoxButton="logUserPressedClearSearchBoxButton">
-    Clear
-  </ClearSearchInput>
+  <ClearSearchInput @UserPressedClearSearchBoxButton="message = 'clear'">Clear</ClearSearchInput>
+  {{ message }}
 </template>
 
 <script>
@@ -139,10 +140,10 @@ _Click the Clear button to try it out!_
     components: {
       ClearSearchInput
     },
-    methods: {
-      logUserPressedClearSearchBoxButton() {
-        console.log('User pressed clear search box button');
-      }
+    data() {
+      return {
+        message: ''
+      };
     }
   };
 </script>
@@ -156,20 +157,22 @@ entered.
 
 _Type any term in the input field and then click the icon button to try it out!_
 
-```vue
+```vue live
 <template>
-  <SearchInput />
-  <ClearSearchInput />
+  <div style="display: flex;">
+    <SearchInput />
+    <ClearSearchInput />
+  </div>
 </template>
 
 <script>
-  import { ClearSearchInput, SearchInput } from '@empathyco/x-components/search-box';
+  import { SearchInput, ClearSearchInput } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'ClearSearchInputDemo',
     components: {
-      ClearSearchInput,
-      SearchInput
+      SearchInput,
+      ClearSearchInput
     }
   };
 </script>

--- a/packages/x-components/src/x-modules/search-box/components/search-button.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-button.vue
@@ -98,7 +98,7 @@ In this example, a clickable button is rendered.
 
 _Click the Search button to try it out!_
 
-```vue
+```vue live
 <template>
   <SearchButton />
 </template>
@@ -117,11 +117,11 @@ _Click the Search button to try it out!_
 
 ### Play with default slot
 
-Here an icon is passed in the default slot instead of text to customize the button content.
+Here text is passed in the default slot instead of an icon to customize the button content.
 
 _Click the icon button to try it out!_
 
-```vue
+```vue live
 <template>
   <SearchButton>Search</SearchButton>
 </template>
@@ -145,24 +145,34 @@ search term and click the Search button, the search term is displayed as a messa
 
 _Type any term in the input field and then click the Search button to try it out!_
 
-```vue
+```vue live
 <template>
-  <SearchButton
-    @UserPressedSearchButton="
-      query => {
-        message = query;
-      }
-    "
-  />
+  <div style="display: flex;">
+    <SearchInput />
+    <SearchButton
+      @UserPressedSearchButton="
+        query => {
+          message = query;
+        }
+      "
+    />
+  </div>
+  {{ message }}
 </template>
 
 <script>
-  import { SearchButton } from '@empathyco/x-components/search-box';
+  import { SearchInput, SearchButton } from '@empathyco/x-components/search-box';
 
   export default {
     name: 'SearchButtonDemo',
     components: {
+      SearchInput,
       SearchButton
+    },
+    data() {
+      return {
+        message: ''
+      };
     }
   };
 </script>
@@ -176,10 +186,13 @@ you enter a search term and click the Search button, the â€œLooking for resultsâ
 
 _Type any term in the input field and then click the Search button to try it out!_
 
-```vue
+```vue live
 <template>
-  <SearchInput />
-  <SearchButton @UserAcceptedAQuery="message = 'looking for results'">Search</SearchButton>
+  <div style="display: flex;">
+    <SearchInput />
+    <SearchButton @UserAcceptedAQuery="message = 'looking for results'">Search</SearchButton>
+  </div>
+  {{ message }}
 </template>
 
 <script>
@@ -190,6 +203,11 @@ _Type any term in the input field and then click the Search button to try it out
     components: {
       SearchButton,
       SearchInput
+    },
+    data() {
+      return {
+        message: ''
+      };
     }
   };
 </script>

--- a/packages/x-components/src/x-modules/search-box/components/search-button.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-button.vue
@@ -147,17 +147,19 @@ _Type any term in the input field and then click the Search button to try it out
 
 ```vue live
 <template>
-  <div style="display: flex;">
-    <SearchInput />
-    <SearchButton
-      @UserPressedSearchButton="
-        query => {
-          message = query;
-        }
-      "
-    />
+  <div>
+    <div style="display: flex;">
+      <SearchInput />
+      <SearchButton
+        @UserPressedSearchButton="
+          query => {
+            message = query;
+          }
+        "
+      />
+    </div>
+    {{ message }}
   </div>
-  {{ message }}
 </template>
 
 <script>
@@ -188,11 +190,13 @@ _Type any term in the input field and then click the Search button to try it out
 
 ```vue live
 <template>
-  <div style="display: flex;">
-    <SearchInput />
-    <SearchButton @UserAcceptedAQuery="message = 'looking for results'">Search</SearchButton>
+  <div>
+    <div style="display: flex;">
+      <SearchInput />
+      <SearchButton @UserAcceptedAQuery="message = 'looking for results'">Search</SearchButton>
+    </div>
+    {{ message }}
   </div>
-  {{ message }}
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -321,12 +321,14 @@ _Type any term in the input field to try it out!_
 
 ```vue live
 <template>
-  <SearchInput
-    @UserPressedEnterKey="value = 'enter'"
-    @UserFocusedSearchBox="value = 'focus'"
-    @UserIsTypingAQuery="value = 'typing'"
-  />
-  {{ value }}
+  <div>
+    <SearchInput
+      @UserPressedEnterKey="value = 'enter'"
+      @UserFocusedSearchBox="value = 'focus'"
+      @UserIsTypingAQuery="value = 'typing'"
+    />
+    {{ value }}
+  </div>
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -324,10 +324,12 @@ _Type any term in the input field to try it out!_
   <div>
     <SearchInput
       @UserPressedEnterKey="value = 'enter'"
-      @UserFocusedSearchBox="value = 'focus'"
+      @UserFocusedSearchBox="hasFocus = true"
+      @UserBlurredSearchBox="hasFocus = false"
       @UserIsTypingAQuery="value = 'typing'"
     />
-    {{ value }}
+    <strong>{{ value }}</strong>
+    {{ hasFocus ? 'focused' : 'unfocused' }}
   </div>
 </template>
 
@@ -341,7 +343,8 @@ _Type any term in the input field to try it out!_
     },
     data() {
       return {
-        value: ''
+        value: '',
+        hasFocus: false
       };
     }
   };

--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -329,7 +329,7 @@ _Type any term in the input field to try it out!_
       @UserIsTypingAQuery="value = 'typing'"
     />
     <strong>{{ value }}</strong>
-    {{ hasFocus ? 'focused' : 'unfocused' }}
+    <span>{{ hasFocus ? 'focused' : 'unfocused' }}</span>
   </div>
 </template>
 

--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -268,7 +268,7 @@ Here you have a basic example of how the search input is rendered.
 
 _Type any term in the input field to try it out!_
 
-```vue
+```vue live
 <template>
   <SearchInput />
 </template>
@@ -293,7 +293,7 @@ after 1000 milliseconds without typing.
 
 _Type a term with more than 5 characters to try it out!_
 
-```vue
+```vue live
 <template>
   <SearchInput :maxLength="5" :autofocus="false" :instant="true" :instantDebounceInMs="1000" />
 </template>
@@ -319,14 +319,14 @@ the message “enter” appears.
 
 _Type any term in the input field to try it out!_
 
-```vue
+```vue live
 <template>
   <SearchInput
-    @UserPressedEnterKey="logUserPressedEnter"
-    @UserFocusedSearchBox="hasFocus = true"
-    @UserBlurredSearchBox="hasFocus = false"
-    @UserIsTypingAQuery="value = 'focus'"
+    @UserPressedEnterKey="value = 'enter'"
+    @UserFocusedSearchBox="value = 'focus'"
+    @UserIsTypingAQuery="value = 'typing'"
   />
+  {{ value }}
 </template>
 
 <script>
@@ -339,14 +339,8 @@ _Type any term in the input field to try it out!_
     },
     data() {
       return {
-        value: '',
-        hasFocus: false
+        value: ''
       };
-    },
-    methods: {
-      logUserPressedEnter() {
-        console.log('User pressed enter');
-      }
     }
   };
 </script>
@@ -360,9 +354,9 @@ communicates with the [`SearchButton`](x-components.search-button.md) and the
 Furthermore, you can use it together with the [`QuerySuggestions`](query-suggestions.md) component
 to autocomplete the typed search term.
 
-_Type “puzzle” or another toy in the input field and then click the clear icon to try it out!_
+_Type “trousers” or another fashion term in the input field and then click the clear icon to try it out!_
 
-```vue
+```vue live
 <template>
   <div>
     <div style="display: flex; flex-flow: row nowrap;">
@@ -377,11 +371,7 @@ _Type “puzzle” or another toy in the input field and then click the clear ic
 </template>
 
 <script>
-  import {
-    SearchInput,
-    ClearSearchInput,
-    ClearSearchButton
-  } from '@empathyco/x-components/search-box';
+  import { SearchInput, ClearSearchInput, SearchButton } from '@empathyco/x-components/search-box';
   import { QuerySuggestions } from '@empathyco/x-components/query-suggestions';
 
   export default {
@@ -389,7 +379,7 @@ _Type “puzzle” or another toy in the input field and then click the clear ic
     components: {
       SearchInput,
       ClearSearchInput,
-      ClearSearchButton,
+      SearchButton,
       QuerySuggestions
     }
   };

--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -356,7 +356,8 @@ communicates with the [`SearchButton`](x-components.search-button.md) and the
 Furthermore, you can use it together with the [`QuerySuggestions`](query-suggestions.md) component
 to autocomplete the typed search term.
 
-_Type “trousers” or another fashion term in the input field and then click the clear icon to try it out!_
+_Type “trousers” or another fashion term in the input field and then click the clear icon to try it
+out!_
 
 ```vue live
 <template>


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->
# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.-->
Hello✖️  team! I prepared some **Live examples** through various components that are working right now in the eDocs portal. 

I would divide them in:
- Examples activated without further changes needed:
  - [ ] NextQueriesList
  - [ ] QuerySuggestion

- Examples where proposed some context changes (to match new API, juguettos --> Platform API, for example):
  - [ ] QuerySuggestions
  - [ ] RelatedTags
  - [ ] RelatedTag

- Examples where added the `<script>` tag to match the new format of the examples, included imports, `SearchInput` to test it out, basic data, etc. (but didn't need further changes)
  - [ ] HistoryQueries
  - [ ] HistoryQuery
  - [ ] ClearHistoryQueries
  - [ ] NextQueries
  - [ ] NextQuery
  - [ ] PopularSearches
  - [ ] PopularSearch
 
- Examples where proposed important changes to the given example
  - [ ] SearchInput
  - [ ] SearchButton
  - [ ] ClearSearchInput

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
This is created as a start point facilitated by eDocs to start activating again **Live examples** in the components documentation (and search for improvements by our own).

Our idea is to start delegating this effort in X team, giving you control to test the examples via [X Sandbox](https://docs-dev.empathy.co/x-sandbox/), and to open tasks for eDocs if you see improvements or errors in the tool.

A caveat right now, animations are registered globally in our portal (`FadeAndSlide`, `StaggeredFadeAndSlide`...), when doing this, we are doing an 'abstraction':

```
import Vue from 'vue';
...
import { FadeAndSlide } from '@empathyco/x-components';

// Registering the animation as a global component
Vue.component('FadeAndSlide', FadeAndSlide);
```

We are working in a way to do this more directly and we are adding [some documentation](https://docs-dev.empathy.co/x-sandbox/x-sandbox-documentation.html) ("Animations" section) refering to this. Ideas or recommendations are welcomed. 😄 
 
<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->
- [x] Dependencies. If any, specify: **Technical Writters**, checking that "text changes" are correct
## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update
## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:
## How has this been tested?
<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
Applying this same changes to the eDocs project and checking that no errors were raised
## Checklist:
- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation: ([open PR](https://github.com/empathyco/docs-empathy/pull/510/files) in eDocs with new documentation, [doc page](https://docs-dev.empathy.co/x-sandbox/x-sandbox-documentation.html))
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.