### PR TITLE
feat(history-queries): add toggle to enable/disable the feature

### DIFF
--- a/packages/x-components/src/x-modules/history-queries/events.types.ts
+++ b/packages/x-components/src/x-modules/history-queries/events.types.ts
@@ -43,4 +43,9 @@ export interface HistoryQueriesXEvents {
    * * Payload: The {@link @empathyco/x-types#HistoryQuery | history query} selected.
    */
   UserSelectedAHistoryQuery: HistoryQuery;
+  /**
+   * The user has toggled the history queries.
+   * * Payload: whether it has been set to enable or disable.
+   */
+  UserToggledHistoryQueries: boolean;
 }

--- a/packages/x-components/src/x-modules/history-queries/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/__tests__/actions.spec.ts
@@ -32,7 +32,6 @@ describe('testing history queries module actions', () => {
   function resetStateWith(state: DeepPartial<HistoryQueriesState>): void {
     resetHistoryQueriesStateWith(store, state);
     localStorageService.setItem(store.getters.storageKey, store.state.historyQueries);
-    localStorageService.setItem(HISTORY_QUERIES_ENABLED_KEY, store.state.isEnabled);
   }
 
   function expectHistoryQueriesToEqual(historyQueries: HistoryQuery[]): void {
@@ -264,10 +263,10 @@ describe('testing history queries module actions', () => {
     });
 
     it('stores the enabled/disabled value in local storage', async () => {
-      expect(localStorageService.getItem<boolean>(HISTORY_QUERIES_ENABLED_KEY)).toBe(true);
-
-      await store.dispatch('toggleHistoryQueries', false);
       expect(localStorageService.getItem<boolean>(HISTORY_QUERIES_ENABLED_KEY)).toBe(false);
+
+      await store.dispatch('toggleHistoryQueries', true);
+      expect(localStorageService.getItem<boolean>(HISTORY_QUERIES_ENABLED_KEY)).toBe(true);
     });
   });
 });

--- a/packages/x-components/src/x-modules/history-queries/store/actions/set-history-queries.action.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/actions/set-history-queries.action.ts
@@ -13,9 +13,11 @@ export const setHistoryQueries: HistoryQueriesXStoreModule['actions']['setHistor
   { commit, state, getters },
   historyQueries
 ) => {
-  if (historyQueries.length > state.config.maxItemsToStore) {
-    historyQueries = historyQueries.slice(0, state.config.maxItemsToStore);
+  if (state.isEnabled) {
+    if (historyQueries.length > state.config.maxItemsToStore) {
+      historyQueries = historyQueries.slice(0, state.config.maxItemsToStore);
+    }
+    commit('setHistoryQueries', historyQueries);
+    localStorageService.setItem(getters.storageKey, historyQueries);
   }
-  commit('setHistoryQueries', historyQueries);
-  localStorageService.setItem(getters.storageKey, historyQueries);
 };

--- a/packages/x-components/src/x-modules/history-queries/store/actions/toggle-history-queries.action.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/actions/toggle-history-queries.action.ts
@@ -1,0 +1,13 @@
+import { localStorageService } from '../../../../utils/storage';
+import { HISTORY_QUERIES_ENABLED_KEY } from '../constants';
+import { HistoryQueriesXStoreModule } from '../types';
+
+export const toggleHistoryQueries: HistoryQueriesXStoreModule['actions']['toggleHistoryQueries'] =
+  async ({ dispatch, commit }, isEnabled) => {
+    if (!isEnabled) {
+      await dispatch('setHistoryQueries', []);
+    }
+
+    commit('setIsEnabled', isEnabled);
+    localStorageService.setItem(HISTORY_QUERIES_ENABLED_KEY, isEnabled);
+  };

--- a/packages/x-components/src/x-modules/history-queries/store/constants.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/constants.ts
@@ -1,2 +1,3 @@
 export const HISTORY_QUERIES_STORAGE_KEY = 'history-queries';
 export const SESSION_TIME_STAMP_STORAGE_KEY = 'session-time-stamp';
+export const HISTORY_QUERIES_ENABLED_KEY = 'history-queries-enabled';

--- a/packages/x-components/src/x-modules/history-queries/store/module.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/module.ts
@@ -1,4 +1,5 @@
 import { setQuery } from '../../../store/utils/query.utils';
+import { localStorageService } from '../../../utils/storage';
 import { addQueryToHistory } from './actions/add-query-to-history.action';
 // eslint-disable-next-line max-len
 import { loadHistoryQueriesFromBrowserStorage } from './actions/load-history-queries-from-browser-storage.action';
@@ -6,6 +7,8 @@ import { refreshSession } from './actions/refresh-session.action';
 import { removeFromHistory } from './actions/remove-query-from-history.action';
 import { setHistoryQueries } from './actions/set-history-queries.action';
 import { setUrlParams } from './actions/set-url-params.action';
+import { toggleHistoryQueries } from './actions/toggle-history-queries.action';
+import { HISTORY_QUERIES_ENABLED_KEY } from './constants';
 import { historyQueries } from './getters/history-queries.getter';
 import { normalizedQuery } from './getters/normalized-query.getter';
 import { sessionHistoryQueries } from './getters/session-history-queries.getter';
@@ -27,7 +30,8 @@ export const historyQueriesXStoreModule: HistoryQueriesXStoreModule = {
     },
     query: '',
     historyQueries: [],
-    sessionTimeStampInMs: Date.now()
+    sessionTimeStampInMs: Date.now(),
+    isEnabled: localStorageService.getItem<boolean>(HISTORY_QUERIES_ENABLED_KEY) ?? true
   }),
   getters: {
     historyQueries,
@@ -42,7 +46,10 @@ export const historyQueriesXStoreModule: HistoryQueriesXStoreModule = {
     setSessionTimeStamp(state, sessionTimeStamp) {
       state.sessionTimeStampInMs = sessionTimeStamp;
     },
-    setQuery
+    setQuery,
+    setIsEnabled(state, isEnabled) {
+      state.isEnabled = isEnabled;
+    }
   },
   actions: {
     addQueryToHistory,
@@ -50,6 +57,7 @@ export const historyQueriesXStoreModule: HistoryQueriesXStoreModule = {
     refreshSession,
     removeFromHistory,
     setHistoryQueries,
-    setUrlParams
+    setUrlParams,
+    toggleHistoryQueries
   }
 };

--- a/packages/x-components/src/x-modules/history-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/types.ts
@@ -27,6 +27,10 @@ export interface HistoryQueriesState extends QueryState {
    * The current query for searching into the {@link HistoryQueriesState.historyQueries}.
    */
   query: string;
+  /**
+   * Whether the history queries are enabled or disabled.
+   */
+  isEnabled: boolean;
 }
 
 /**
@@ -77,6 +81,12 @@ export interface HistoryQueriesMutations extends QueryMutations {
    * @param query - The new {@link HistoryQueriesState.query }.
    */
   setQuery(query: string): void;
+  /**
+   * Sets the {@link HistoryQueriesState.isEnabled } property.
+   *
+   * @param isEnabled - The new {@link HistoryQueriesState.isEnabled }.
+   */
+  setIsEnabled(isEnabled: boolean): void;
 }
 /**
  * HistoryQueries store actions.
@@ -158,6 +168,13 @@ export interface HistoryQueriesActions {
    * @param urlParams - List of params from the url.
    */
   setUrlParams(urlParams: UrlParams): void;
+  /**
+   * Toggles the history queries and stores the state in the browser storage. It also cleans the
+   * history queries when disabling them.
+   *
+   * @param isEnabled - Whether to enable or disable the history queries.
+   */
+  toggleHistoryQueries(isEnabled: boolean): void;
 }
 /**
  * HistoryQueries type safe store module.

--- a/packages/x-components/src/x-modules/history-queries/wiring.ts
+++ b/packages/x-components/src/x-modules/history-queries/wiring.ts
@@ -91,6 +91,12 @@ export const clearHistoryQueries = wireDispatch('setHistoryQueries', []);
  * @public
  */
 export const removeHistoryQuery = wireDispatch('removeFromHistory');
+/**
+ * Enables or disables history queries.
+ *
+ * @public
+ */
+export const toggleHistoryQueries = wireDispatch('toggleHistoryQueries');
 
 /**
  * Debounce function for the module.
@@ -131,5 +137,8 @@ export const historyQueriesWiring = createWiring({
   },
   UserPressedRemoveHistoryQuery: {
     removeHistoryQuery
+  },
+  UserToggledHistoryQueries: {
+    toggleHistoryQueries
   }
 });


### PR DESCRIPTION
The goal of this PR is to create an action that allows to enable or disable the HistoryQueries feature for the end user of the layer. When disabling, the current history queries will be deleted from the local storage and won't be seen by the end user. No new history queries will be created until the user enables this feature again.

This change will be stored in the localStorage. As we haven't decided yet where to recover this value when the page loads, I set it in the state itself.

## Test it
The best way to try to emit somehow a `UserToggledHistoryQueries` event in any part of the code. You can pass a `boolean` value to it and see if the history queries are enabled or disabled.

---

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: [EX-5600](https://searchbroker.atlassian.net/browse/EX-5600)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
