### PR TITLE
fix(base-currency): format preference goes prop to injected to default

### DIFF
--- a/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
+++ b/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
@@ -26,7 +26,7 @@ function renderInjectedBaseCurrency({ value, format }: RenderBaseCurrencyOptions
     {
       template: `
           <Provider>
-            <BaseCurrency v-bind="{ value, ...(format && { format }) }" />
+          <BaseCurrency v-bind="{ value, format }" />
           </Provider>
         `,
       components: {

--- a/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
+++ b/packages/x-components/src/components/currency/__tests__/base-currency.spec.ts
@@ -35,7 +35,7 @@ function renderInjectedBaseCurrency({ value, format }: RenderBaseCurrencyOptions
       }
     },
     {
-      data: function () {
+      data() {
         return {
           value,
           format

--- a/packages/x-components/src/components/currency/base-currency.vue
+++ b/packages/x-components/src/components/currency/base-currency.vue
@@ -64,7 +64,7 @@
      *
      * @public
      */
-    @Prop({ default: 'i.iii,dd' })
+    @Prop()
     protected format!: string;
 
     /**
@@ -83,9 +83,7 @@
      * @internal
      */
     protected get renderedFormat(): string {
-      return 'format' in this.$options.propsData!
-        ? this.format
-        : this.injectedFormat ?? this.format;
+      return this.format ?? this.injectedFormat ?? 'i.iii,dd';
     }
 
     /**
@@ -111,35 +109,272 @@ HTML element.
 ### Basic usage
 
 ```vue
-<BaseCurrency :value="12345678.87654321" />
-<!-- output: '12.345.678,87' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,ddd? €" />
-<!-- output: '12.345.678,876 €' -->
-<BaseCurrency :value="12345678" format="i.iii,ddd? €" />
-<!-- output: '12.345.678 €' -->
-<BaseCurrency :value="12345678.87654321" format="$ i.iii,dd" />
-<!-- output: '$ 12.345.678,87' -->
-<BaseCurrency :value="12345678.87654321" format="$i.iii,dd" />
-<!-- output: '$12.345.678,87' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,dd €" />
-<!-- output: '12.345.678,87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,dd€" />
-<!-- output: '12.345.678,87€' -->
-<BaseCurrency :value="12345678.87654321" format="i,iii.dd €" />
-<!-- output: '12,345,678.87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i iii.dd €" />
-<!-- output: '12 345 678.87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i iii - dd €" />
-<!-- output: '12 345 678 - 87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,dddddd €" />
-<!-- output: '12.345.678,876543 €' -->
-<BaseCurrency :value="12345678.87" format="i.iii,dddddd €" />
-<!-- output: '12.345.678,870000 €' -->
-<BaseCurrency :value="12345678" format="i.iii,dddddd €" />
-<!-- output: '12.345.678,000000 €' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii,dd €" />
-<!-- output: '12.345.678,87 €' -->
-<BaseCurrency :value="12345678.87654321" format="i.iii €" />
-<!-- output: '12.345.678 €' -->
+<template>
+  <BaseCurrency :value="12345678.87654321" />
+  <!-- output: '12.345.678,87' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i.iii,ddd? €" />
+  <!-- output: '12.345.678,876 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678" format="i.iii,ddd? €" />
+  <!-- output: '12.345.678 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="$ i.iii,dd" />
+  <!-- output: '$ 12.345.678,87' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="$i.iii,dd" />
+  <!-- output: '$12.345.678,87' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i.iii,dd €" />
+  <!-- output: '12.345.678,87 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i.iii,dd€" />
+  <!-- output: '12.345.678,87€' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i,iii.dd €" />
+  <!-- output: '12,345,678.87 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i iii.dd €" />
+  <!-- output: '12 345 678.87 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i iii - dd €" />
+  <!-- output: '12 345 678 - 87 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i.iii,dddddd €" />
+  <!-- output: '12.345.678,876543 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87" format="i.iii,dddddd €" />
+  <!-- output: '12.345.678,870000 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678" format="i.iii,dddddd €" />
+  <!-- output: '12.345.678,000000 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i.iii,dd €" />
+  <!-- output: '12.345.678,87 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
+```
+
+```vue
+<template>
+  <BaseCurrency :value="12345678.87654321" format="i.iii €" />
+  <!-- output: '12.345.678 €' -->
+</template>
+
+<script>
+  import { BaseCurrency } from '@empathyco/x-components/currency';
+
+  export default {
+    name: 'BaseCurrencyDemo',
+    components: {
+      BaseCurrency
+    }
+  };
+</script>
 ```
 </docs>

--- a/packages/x-components/src/components/currency/base-currency.vue
+++ b/packages/x-components/src/components/currency/base-currency.vue
@@ -64,8 +64,8 @@
      *
      * @public
      */
-    @Prop()
-    protected format?: string;
+    @Prop({ default: 'i.iii,dd' })
+    protected format!: string;
 
     /**
      * The injected format as string.
@@ -83,13 +83,9 @@
      * @internal
      */
     protected get renderedFormat(): string {
-      return (
-        this.format ??
-        this.injectedFormat ??
-        //TODO: add here logger
-        //eslint-disable-next-line no-console
-        console.warn('It is necessary to pass a prop or inject the format')
-      );
+      return 'format' in this.$options.propsData!
+        ? this.format
+        : this.injectedFormat ?? this.format;
     }
 
     /**
@@ -115,6 +111,8 @@ HTML element.
 ### Basic usage
 
 ```vue
+<BaseCurrency :value="12345678.87654321" />
+<!-- output: '12.345.678,87' -->
 <BaseCurrency :value="12345678.87654321" format="i.iii,ddd? €" />
 <!-- output: '12.345.678,876 €' -->
 <BaseCurrency :value="12345678" format="i.iii,ddd? €" />

--- a/packages/x-components/src/components/currency/base-currency.vue
+++ b/packages/x-components/src/components/currency/base-currency.vue
@@ -65,7 +65,7 @@
      * @public
      */
     @Prop()
-    protected format!: string;
+    protected format?: string;
 
     /**
      * The injected format as string.
@@ -115,7 +115,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -133,7 +133,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -151,7 +151,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -169,7 +169,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -187,7 +187,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -205,7 +205,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -223,7 +223,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -241,7 +241,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -259,7 +259,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -277,7 +277,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -295,7 +295,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -313,7 +313,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -331,7 +331,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -349,7 +349,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',
@@ -367,7 +367,7 @@ HTML element.
 </template>
 
 <script>
-  import { BaseCurrency } from '@empathyco/x-components/currency';
+  import { BaseCurrency } from '@empathyco/x-components';
 
   export default {
     name: 'BaseCurrencyDemo',

--- a/packages/x-components/src/components/result/base-result-previous-price.vue
+++ b/packages/x-components/src/components/result/base-result-previous-price.vue
@@ -72,7 +72,7 @@ props. `format` to select the currency format to be applied.
 </template>
 
 <script>
-  import { BaseResultPreviousPrice } from '@empathyco/x-components/result';
+  import { BaseResultPreviousPrice } from '@empathyco/x-components';
 
   export default {
     name: 'BaseResultPreviousPriceDemo',
@@ -93,7 +93,7 @@ props. `format` to select the currency format to be applied.
 </template>
 
 <script>
-  import { BaseResultPreviousPrice } from '@empathyco/x-components/result';
+  import { BaseResultPreviousPrice } from '@empathyco/x-components';
 
   export default {
     name: 'BaseResultPreviousPriceDemo',

--- a/packages/x-components/src/components/result/base-result-previous-price.vue
+++ b/packages/x-components/src/components/result/base-result-previous-price.vue
@@ -9,7 +9,7 @@
          @binding {result} result - Result data
     -->
     <slot :result="result">
-      <BaseCurrency :value="result.price.originalValue" :format="format" />
+      <BaseCurrency v-bind="{ value: result.price.originalValue, ...(format && { format }) }" />
     </slot>
   </div>
 </template>
@@ -46,7 +46,6 @@
      * - Decimal separator must be defined between the last 'i' and the first 'd'. It can be more
      * than one character.
      * - Set whatever you need around the integers and decimals marks.
-     * - Default mask: 'i.iii,dd' which returns '1.345,67'.
      *
      * @remarks The number of 'd', which is the maximum decimal length, MUST match with the length
      * of decimals provided from the adapter. Otherwise, when the component truncate the decimal
@@ -54,8 +53,8 @@
      *
      * @public
      */
-    @Prop({ default: 'i.iii,dd' })
-    protected format!: string;
+    @Prop()
+    protected format?: string;
   }
 </script>
 
@@ -68,7 +67,7 @@ This component shows the previous price formatted if it has discount. The compon
 props. `format` to select the currency format to be applied.
 
 ```vue
-<BaseResultPreviousPrice :value="result" :format="'i.iii,ddd €'" />
+<BaseResultPreviousPrice :result="result" :format="'i.iii,ddd €'" />
 ```
 
 ### Overriding default slot

--- a/packages/x-components/src/components/result/base-result-previous-price.vue
+++ b/packages/x-components/src/components/result/base-result-previous-price.vue
@@ -9,7 +9,7 @@
          @binding {result} result - Result data
     -->
     <slot :result="result">
-      <BaseCurrency v-bind="{ value: result.price.originalValue, ...(format && { format }) }" />
+      <BaseCurrency :value="result.price.originalValue" :format="format" />
     </slot>
   </div>
 </template>
@@ -67,14 +67,40 @@ This component shows the previous price formatted if it has discount. The compon
 props. `format` to select the currency format to be applied.
 
 ```vue
-<BaseResultPreviousPrice :result="result" :format="'i.iii,ddd €'" />
+<template>
+  <BaseResultPreviousPrice :result="result" :format="'i.iii,ddd €'" />
+</template>
+
+<script>
+  import { BaseResultPreviousPrice } from '@empathyco/x-components/result';
+
+  export default {
+    name: 'BaseResultPreviousPriceDemo',
+    components: {
+      BaseResultPreviousPrice
+    }
+  };
+</script>
 ```
 
 ### Overriding default slot
 
 ```vue
-<BaseResultPreviousPrice :result="result">
-  <span class="custom-base-result-previous-price">{{ result.price.originalValue }}</span>
-</BaseResultPreviousPrice>
+<template>
+  <BaseResultPreviousPrice :result="result">
+    <span class="custom-base-result-previous-price">{{ result.price.originalValue }}</span>
+  </BaseResultPreviousPrice>
+</template>
+
+<script>
+  import { BaseResultPreviousPrice } from '@empathyco/x-components/result';
+
+  export default {
+    name: 'BaseResultPreviousPriceDemo',
+    components: {
+      BaseResultPreviousPrice
+    }
+  };
+</script>
 ```
 </docs>


### PR DESCRIPTION
[EX-5649](https://searchbroker.atlassian.net/browse/EX-5649)

## Motivation and context
The `base-result-previous-price` was sending a format by default to the `base-currency` component, this format was taking priority over the injected format. Per the task, the priority order for the format to apply should be prop -> injected -> default. Given this, the decision was to move the default value of the format to `base-currency` and adjust the priorities.


## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Add `base-result-previous-price` to a result in a view, the default format is applied.
Pass a format for the prop. This should be the format applied.
Inject a different format to that result, the format of the prop should still apply.
Remove the prop format, the injected format should apply.
