### PR TITLE
chore: add `.parcel-cache` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .eslintcache
 .DS_Store
+.parcel-cache
 **/node_modules
 **/dist
 **/docs


### PR DESCRIPTION
This just removes the parcel cache generated from running the react-wrapper tests from the version controlled files