### PR TITLE
refactor(schema): remove undefined from return type of mapper factory

### DIFF
--- a/packages/x-adapter/src/__tests__/endpoint-adapter.factory.spec.ts
+++ b/packages/x-adapter/src/__tests__/endpoint-adapter.factory.spec.ts
@@ -231,17 +231,13 @@ describe('adapterFactory tests', () => {
       );
     });
 
-    it('should use the requestOptions.endpoint if no endpoint is provided', async () => {
+    it('should use the requestOptions.endpoint if it is provided', async () => {
       const { endpointAdapter, mockedHttpClient } = createEndpointAdapterFactoryOptions<
         TestRequest,
         TestResponse
-      >({
-        options: {
-          endpoint: undefined
-        }
-      });
+      >();
       const requestOptions: RequestOptions = {
-        endpoint: 'https://api.empathy.co/test'
+        endpoint: 'https://api.empathy.co/staging'
       };
 
       await endpointAdapter(request, requestOptions);

--- a/packages/x-adapter/src/endpoint-adapter.factory.ts
+++ b/packages/x-adapter/src/endpoint-adapter.factory.ts
@@ -37,10 +37,10 @@ export const endpointAdapterFactory: EndpointAdapterFactory = <Request, Response
     const endpoint = getEndpoint(rawEndpoint ?? requestEndpoint, request);
     const requestParameters = requestMapper(request, { endpoint });
 
-    return httpClient<Response>(
+    return httpClient(
       endpoint,
       deepMerge({}, defaultRequestOptions, requestOptions, { parameters: requestParameters })
-    ).then(response => responseMapper(response, { endpoint, requestParameters }));
+    ).then(response => responseMapper(response, { endpoint, requestParameters }) as Response);
   };
 
   endpointAdapter.extends = <NewRequest, NewResponse>(

--- a/packages/x-adapter/src/endpoint-adapter.factory.ts
+++ b/packages/x-adapter/src/endpoint-adapter.factory.ts
@@ -34,7 +34,7 @@ export const endpointAdapterFactory: EndpointAdapterFactory = <Request, Response
       defaultRequestOptions = {}
     }: EndpointAdapterOptions<Request, Response> = options;
 
-    const endpoint = getEndpoint(rawEndpoint ?? requestEndpoint, request);
+    const endpoint = getEndpoint(requestEndpoint ?? rawEndpoint, request);
     const requestParameters = requestMapper(request, { endpoint });
 
     return httpClient(

--- a/packages/x-adapter/src/endpoint-adapter.factory.ts
+++ b/packages/x-adapter/src/endpoint-adapter.factory.ts
@@ -32,7 +32,7 @@ export const endpointAdapterFactory: EndpointAdapterFactory = <Request, Response
       requestMapper = identityMapper,
       responseMapper = identityMapper,
       defaultRequestOptions = {}
-    } = options;
+    }: EndpointAdapterOptions<Request, Response> = options;
 
     const endpoint = getEndpoint(rawEndpoint ?? requestEndpoint, request);
     const requestParameters = requestMapper(request, { endpoint });
@@ -40,7 +40,7 @@ export const endpointAdapterFactory: EndpointAdapterFactory = <Request, Response
     return httpClient(
       endpoint,
       deepMerge({}, defaultRequestOptions, requestOptions, { parameters: requestParameters })
-    ).then(response => responseMapper(response, { endpoint, requestParameters }) as Response);
+    ).then(response => responseMapper(response, { endpoint, requestParameters }));
   };
 
   endpointAdapter.extends = <NewRequest, NewResponse>(

--- a/packages/x-adapter/src/mappers/schema-mapper.factory.ts
+++ b/packages/x-adapter/src/mappers/schema-mapper.factory.ts
@@ -17,8 +17,8 @@ import { createMutableSchema, isInternalMethod } from '../schemas/utils';
  */
 export function schemaMapperFactory<Source, Target>(
   schema: Schema<Source, Target>
-): Mapper<Source, Target | undefined> {
-  return function mapper(source: Source, context: MapperContext): Target | undefined {
+): Mapper<Source, Target> {
+  return function mapper(source: Source, context: MapperContext): Target {
     return mapSchema(source, schema, context);
   };
 }

--- a/packages/x-adapter/src/mappers/schema-mapper.factory.ts
+++ b/packages/x-adapter/src/mappers/schema-mapper.factory.ts
@@ -3,7 +3,7 @@ import { isFunction, isObject, reduce, isPath, isArray } from '@empathyco/x-util
 import { Schema, SubSchemaTransformer } from '../schemas/schemas.types';
 import { Mapper, MapperContext } from '../types/mapper.types';
 import { extractValue } from '../utils/extract-value';
-import { isInternalMethod } from '../schemas/utils';
+import { createMutableSchema, isInternalMethod } from '../schemas/utils';
 
 /**
  * The 'schemaMapperFactory' function creates a {@link Mapper | mapper function} for a given
@@ -39,9 +39,11 @@ function mapSchema<Source, Target>(
   source: Source,
   schema: Schema<Source, Target>,
   context: MapperContext
-): Target | undefined {
+): Target {
   if (!source) {
-    return undefined;
+    //eslint-disable-next-line no-console
+    console.warn('This schema cannot be applied', createMutableSchema(schema));
+    return undefined as any;
   }
   return reduce(
     schema,

--- a/packages/x-adapter/src/types/http-client.types.ts
+++ b/packages/x-adapter/src/types/http-client.types.ts
@@ -11,7 +11,7 @@ import { Dictionary } from '@empathyco/x-utils';
 export type HttpClient = <Response = unknown>(
   endpoint: string,
   options?: Omit<RequestOptions, 'endpoint'>
-) => Promise<Response>;
+) => Promise<Readonly<Response>>;
 
 /**
  * A record of options to make the request with.


### PR DESCRIPTION
Show a warning if a schema cannot be applied and remove union type with undefined from return type.

EX-5926 