### PR TITLE
build: fix publish

### DIFF
--- a/packages/tailwindcss-x/package.json
+++ b/packages/tailwindcss-x/package.json
@@ -46,7 +46,6 @@
     "vite": "~2.9.0"
   },
   "publishConfig": {
-    "access": "public",
-    "directory": "dist"
+    "access": "public"
   }
 }


### PR DESCRIPTION
EX-5939

Tailwind package was trying to be published from the `tailwindcss-x/dist` directory, check [this error for more info](https://github.com/empathyco/x/runs/6112249204?check_suite_focus=true#step:7:145), which doesn't have a valid `package.json`. Now it is published from the `tailwindcss-x` folder.
