### PR TITLE
bugfix(url): normalize `+` characters into `%20` for spaces

### DIFF
--- a/packages/x-components/src/x-modules/url/components/__tests__/url-handler.spec.ts
+++ b/packages/x-components/src/x-modules/url/components/__tests__/url-handler.spec.ts
@@ -214,6 +214,23 @@ describe('testing UrlHandler component', () => {
     expect(urlSearchParams.get('store')).toEqual('111');
     expect(urlSearchParams.get('warehouse')).toBeNull();
   });
+
+  it('normalizes + characters into %20 for spaces when updating the url', () => {
+    const { emit } = renderUrlHandler({
+      template: '<UrlHandler store="store" />'
+    });
+    emit('PushableUrlStateChanged', {
+      ...initialUrlState,
+      query: 'lego city'
+    });
+    expect(window.location.href).toContain('query=lego%20city');
+
+    emit('ReplaceableUrlStateChanged', {
+      ...initialUrlState,
+      query: 'lego farm'
+    });
+    expect(window.location.href).toContain('query=lego%20farm');
+  });
 });
 
 interface UrlHandlerAPI {
@@ -229,7 +246,6 @@ interface UrlHandlerAPI {
    * @param urlParams - The URL params in format string: `query=lego&page=1&scroll=100`.
    */
   popstateUrlWithParams: (urlParams: string) => void;
-
   /**
    * Returns the current {@link URLSearchParams}.
    */

--- a/packages/x-components/src/x-modules/url/components/url-handler.vue
+++ b/packages/x-components/src/x-modules/url/components/url-handler.vue
@@ -285,7 +285,10 @@
         const url = new URL(window.location.href);
         this.deleteUrlParameters(url);
         this.setUrlParameters(url, newUrlParams);
-        if (url.href.replace(/\+/g, '%20') !== window.location.href) {
+
+        url.href = url.href.replace(/\+/g, '%20');
+
+        if (url.href !== window.location.href) {
           historyMethod({ ...window.history.state }, document.title, url.href);
         }
         this.url = url;


### PR DESCRIPTION
EX-5207

Normalize `+` characters into `%20` for spaces when updating the `url`

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

Add a new unit test case

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
