### PR TITLE
feat(search): make `banners` and `promoteds` optionals in `SearchResponse`

### DIFF
--- a/packages/search-adapter/src/empathy/__tests__/adapter/empathy-adapter-search.spec.ts
+++ b/packages/search-adapter/src/empathy/__tests__/adapter/empathy-adapter-search.spec.ts
@@ -6,7 +6,6 @@ import {
   ResultSchema,
   TaggingInfoSchema
 } from '@empathyco/x-types/schemas';
-import { SearchResponse } from '../../../types';
 import { SearchWithPartialsResponse } from '../../__fixtures__/responses/search-with-partials.response';
 import { SearchSimpleResponse } from '../../__fixtures__/responses/search.response';
 import { SpellcheckedResponse } from '../../__fixtures__/responses/spellchecked-search.response';
@@ -43,11 +42,14 @@ it('searches partials successfully', async () => {
 
   const response = await adapter.search(baseRequest);
 
-  expect(response.partialResults.length).toBeGreaterThan(0);
+  expect(response.partialResults!.length).toBeGreaterThan(0);
   expect(response.partialResults).toHaveLength(
     SearchWithPartialsResponse.content.suggestions.length
   );
-  expectEveryPartialResultToMatchSchema(response);
+
+  Object.values(response.partialResults!).forEach(partial => {
+    expect(partial.results).everyItemToMatch(ResultSchema);
+  });
 });
 
 it('search maps spellcheck successfully', async () => {
@@ -79,9 +81,3 @@ it('search maps redirections successfully', async () => {
   expect(response.redirections).toHaveLength(SearchSimpleResponse.direct.length);
   expect(response.redirections).everyItemToMatch(RedirectionSchema);
 });
-
-function expectEveryPartialResultToMatchSchema(response: SearchResponse) {
-  Object.values(response.partialResults).forEach(partial => {
-    expect(partial.results).everyItemToMatch(ResultSchema);
-  });
-}

--- a/packages/search-adapter/src/types/response.types.ts
+++ b/packages/search-adapter/src/types/response.types.ts
@@ -55,12 +55,12 @@ export interface TrackableShowResponse {
 export interface SearchResponse {
   banners?: Banner[];
   facets?: Facet[];
-  partialResults: PartialResult[];
+  partialResults?: PartialResult[];
   promoteds?: Promoted[];
   queryTagging: TaggingInfo;
-  redirections: Redirection[];
+  redirections?: Redirection[];
   results: Result[];
-  spellcheck: string;
+  spellcheck?: string;
   totalResults: number;
 }
 

--- a/packages/search-adapter/src/types/response.types.ts
+++ b/packages/search-adapter/src/types/response.types.ts
@@ -53,10 +53,10 @@ export interface TrackableShowResponse {
  * @public
  */
 export interface SearchResponse {
-  banners: Banner[];
+  banners?: Banner[];
   facets?: Facet[];
   partialResults: PartialResult[];
-  promoteds: Promoted[];
+  promoteds?: Promoted[];
   queryTagging: TaggingInfo;
   redirections: Redirection[];
   results: Result[];

--- a/packages/x-components/src/components/__tests__/base-grid.spec.ts
+++ b/packages/x-components/src/components/__tests__/base-grid.spec.ts
@@ -27,8 +27,8 @@ function renderBaseGridComponent({
 }: BaseGridRenderOptions = {}): BaseGridComponentAPI {
   const searchResponse = getSearchResponseStub();
   const defaultItems = [
-    ...searchResponse.banners,
-    ...searchResponse.promoteds,
+    ...searchResponse.banners!,
+    ...searchResponse.promoteds!,
     ...searchResponse.results,
     {
       modelName: 'NextQueriesGroup',

--- a/packages/x-components/src/components/__tests__/base-variable-column-grid.spec.ts
+++ b/packages/x-components/src/components/__tests__/base-variable-column-grid.spec.ts
@@ -7,8 +7,8 @@ import BaseVariableColumnGrid from '../base-variable-column-grid.vue';
 
 const searchResponse = getSearchResponseStub();
 const itemsStub = [
-  ...searchResponse.banners,
-  ...searchResponse.promoteds,
+  ...searchResponse.banners!,
+  ...searchResponse.promoteds!,
   ...searchResponse.results
 ];
 

--- a/packages/x-components/src/views/ResultApp.vue
+++ b/packages/x-components/src/views/ResultApp.vue
@@ -79,8 +79,8 @@
     private resultsStub = getResultsStub();
     private searchResponse = getSearchResponseStub();
     protected searchResponseStub = [
-      ...this.searchResponse.banners,
-      ...this.searchResponse.promoteds,
+      ...this.searchResponse.banners!,
+      ...this.searchResponse.promoteds!,
       ...this.searchResponse.results
     ];
     protected resultWithImages = this.resultsStub[0];

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -110,6 +110,30 @@ describe('testing search module actions', () => {
     });
 
     // eslint-disable-next-line max-len
+    it('should set banners and promoteds to their default values if they are not defined in the response', async () => {
+      resetSearchStateWith(store, {
+        query: 'lego'
+      });
+      adapter.search.mockResolvedValueOnce({
+        ...searchResponseStub,
+        banners: undefined,
+        promoteds: undefined
+      });
+
+      await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
+      expect(store.state.results).toEqual(resultsStub);
+      expect(store.state.facets).toEqual(facetsStub);
+      expect(store.state.banners).toEqual([]);
+      expect(store.state.promoteds).toEqual([]);
+      expect(store.state.spellcheckedQuery).toEqual('');
+      expect(store.state.redirections).toEqual(redirectionsStub);
+      expect(store.state.page).toEqual(1);
+      expect(store.state.config.pageSize).toEqual(24);
+      expect(store.state.status).toEqual('success');
+      expect(store.state.queryTagging).toEqual(searchResponseStub.queryTagging);
+    });
+
+    // eslint-disable-next-line max-len
     it('should clear results, facets, banners, promoteds, redirections and query tagging in the state if the query is empty', async () => {
       resetSearchStateWith(store, {
         results: resultsStub,

--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -109,24 +109,27 @@ describe('testing search module actions', () => {
       expect(store.state.queryTagging).toEqual(searchResponseStub.queryTagging);
     });
 
-    // eslint-disable-next-line max-len
-    it('should set banners and promoteds to their default values if they are not defined in the response', async () => {
+    it('should set undefined response values to their default values', async () => {
       resetSearchStateWith(store, {
         query: 'lego'
       });
       adapter.search.mockResolvedValueOnce({
         ...searchResponseStub,
         banners: undefined,
-        promoteds: undefined
+        partialResults: undefined,
+        promoteds: undefined,
+        redirections: undefined,
+        spellcheck: undefined
       });
 
       await store.dispatch('fetchAndSaveSearchResponse', store.getters.request);
       expect(store.state.results).toEqual(resultsStub);
       expect(store.state.facets).toEqual(facetsStub);
       expect(store.state.banners).toEqual([]);
+      expect(store.state.partialResults).toEqual([]);
       expect(store.state.promoteds).toEqual([]);
       expect(store.state.spellcheckedQuery).toEqual('');
-      expect(store.state.redirections).toEqual(redirectionsStub);
+      expect(store.state.redirections).toEqual([]);
       expect(store.state.page).toEqual(1);
       expect(store.state.config.pageSize).toEqual(24);
       expect(store.state.status).toEqual('success');

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -31,7 +31,7 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
       commit('setResults', results);
       commit('setBanners', banners ?? []);
       commit('setPromoteds', promoteds ?? []);
-      commit('setRedirections', redirections);
+      commit('setRedirections', redirections ?? []);
     }
 
     commit('setPartialResults', partialResults ?? []);

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -29,8 +29,8 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
       commit('appendResults', results);
     } else {
       commit('setResults', results);
-      commit('setBanners', banners);
-      commit('setPromoteds', promoteds);
+      commit('setBanners', banners ?? []);
+      commit('setPromoteds', promoteds ?? []);
       commit('setRedirections', redirections);
     }
 


### PR DESCRIPTION
EX-5976

The API has changed unexpectedly and when the searched query does not have any banner or promoted, they are not even defined in the response object (previously they were defined as []).

In order to avoid problems in the future or in case this is not rollbacked in the backend, we should make both banners and promoted optional.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update


## How has this been tested?

Added new unit test case.

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
