### PR TITLE
feat(utils): log request errors by default

### DIFF
--- a/packages/x-components/src/store/utils/fetch-and-save-action.utils.ts
+++ b/packages/x-components/src/store/utils/fetch-and-save-action.utils.ts
@@ -19,7 +19,8 @@ export function createFetchAndSaveActions<
 >({
   fetch,
   onSuccess,
-  onError,
+  // eslint-disable-next-line no-console
+  onError = console.error,
   onCancel
 }: FetchAndSaveHooks<Context, Request, Response>): FetchAndSaveActions<Context, Request> {
   let cancelPreviousRequest: undefined | (() => void);
@@ -60,7 +61,7 @@ export function createFetchAndSaveActions<
   function handleError(context: Context, error: unknown): void {
     if (error !== CancelSymbol) {
       context.commit('setStatus', 'error');
-      onError?.(error);
+      onError(error);
     }
   }
 
@@ -127,7 +128,7 @@ export interface FetchAndSaveHooks<
    *
    * @param error - The error that triggered this callback.
    */
-  onError?(error: unknown): void;
+  onError(error: unknown): void;
   /**
    * Synchronous callback executed when the request is cancelled. This can happen mainly for two
    * reasons:


### PR DESCRIPTION
EX-5981

While collaborating with @joseacabaneros we spotted that the request errors were silenced, making it hard to fix the issue. 

This happens because in the `createFetchAndSaveActions` we are catching all errors to check if they are a cancelation instead of a real error. 

My proposal is to use the `console.error` as the default of the `onError` hook. This way if you catch the error you will silence it. Otherwise it will be logged in the console.

To test this, simply try throwing an error in the result mapper that we have configured.