### PR TITLE
fix: unnable to add breakpoints in vue components

### DIFF
--- a/packages/x-components/jest.config.js
+++ b/packages/x-components/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   transform: {
-    '^.+\\.vue$': '@vue/vue2-jest',
+    '^.+\\.vue$': require.resolve('./vue-preprocessor'),
     '^.+\\.scss$': 'jest-scss-transform'
   },
   testMatch: ['<rootDir>/src/**/*.spec.ts'],

--- a/packages/x-components/vue-preprocessor.js
+++ b/packages/x-components/vue-preprocessor.js
@@ -1,0 +1,12 @@
+const inner = require('@vue/vue2-jest');
+const convert = require('convert-source-map');
+
+module.exports = {
+  getCacheKey: inner.getCacheKey,
+
+  process(src, filename, config) {
+    const { code, map } = inner.process(src, filename, config);
+    const comment = convert.fromObject(map).toComment();
+    return `${code}\n\n${comment}`;
+  }
+};


### PR DESCRIPTION
We were investigating a little bit, we found this [workaround](https://github.com/vuejs/vue-jest/issues/448) but we should try to find another solution in the future (maybe we can try to find the problem in [vue-jest ](https://github.com/vuejs/vue-jest/tree/master/packages/vue2-jest)and create a pr)

The problem is related to the source maps, they are not linked with the source code.

EX-5325