### PR TITLE
feat(facets): expose `clickEvents` as a `prop` in filters components using a `RenderlessFilter`

### DIFF
--- a/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
@@ -32,7 +32,7 @@
       </slot>
     </RenderlessFilter>
     <FiltersList
-      #default="{ filter: childFilter }"
+      v-slot="{ filter: childFilter }"
       :animation="childrenAnimation"
       :filters="renderedChildrenFilters"
       :parent-id="filter.id"
@@ -137,7 +137,6 @@
      * {@link @empathyco/x-types#HierarchicalFilter} as payload to the corresponding child filter.
      *
      * @param childFilter - The child filter.
-     *
      * @returns The events to emit when clicking a child.
      * @internal
      */
@@ -173,7 +172,6 @@
      * is empty it will return an empty array instead of inject the ones from the parent.
      *
      * @returns A list of filters.
-     *
      * @internal
      */
     protected get renderedChildrenFilters(): Filter[] {
@@ -220,6 +218,31 @@ to emit on click.
 <template>
   <HierarchicalFilter :filter="filter" />
 </template>
+
+<script>
+  import { HierarchicalFilter } from '@empathyco/x-components/facets';
+
+  export default {
+    name: 'HierarchicalFilterTest',
+    components: {
+      HierarchicalFilter
+    },
+    date() {
+      return {
+        filter: {
+          id: `categories:men`,
+          modelName: 'HierarchicalFilter',
+          label: `men`,
+          facetId: 'categories',
+          parentId: null,
+          totalResults: 10,
+          children: [],
+          selected: false
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Playing with props
@@ -230,6 +253,31 @@ Configuring the events to emit when the filter is clicked.
 <template>
   <HierarchicalFilter :clickEvents="{ UserClickedAHierarchicalFilter: filter }" :filter="filter" />
 </template>
+
+<script>
+  import { HierarchicalFilter } from '@empathyco/x-components/facets';
+
+  export default {
+    name: 'HierarchicalFilterTest',
+    components: {
+      HierarchicalFilter
+    },
+    date() {
+      return {
+        filter: {
+          id: `categories:men`,
+          modelName: 'HierarchicalFilter',
+          label: `men`,
+          facetId: 'categories',
+          parentId: null,
+          totalResults: 10,
+          children: [],
+          selected: false
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Customizing the default slot content
@@ -237,21 +285,75 @@ Configuring the events to emit when the filter is clicked.
 In this example, the child filters will also include the label and checkbox.
 
 ```vue
-<HierarchicalFilter :filter="filter" v-slot="{ filter, clickFilter, slotCSSClasses, isDisabled }">
-  <label :class="slotCSSClasses">
-    <input @change="clickFilter" :disabled="isDisabled">
-    {{ filter.label }}
-  </label>
-</HierarchicalFilter>
+<template>
+  <HierarchicalFilter :filter="filter" v-slot="{ filter, clickFilter, slotCSSClasses, isDisabled }">
+    <label :class="slotCSSClasses">
+      <input @change="clickFilter" :disabled="isDisabled" />
+      {{ filter.label }}
+    </label>
+  </HierarchicalFilter>
+</template>
+
+<script>
+  import { HierarchicalFilter } from '@empathyco/x-components/facets';
+
+  export default {
+    name: 'HierarchicalFilterTest',
+    components: {
+      HierarchicalFilter
+    },
+    date() {
+      return {
+        filter: {
+          id: `categories:men`,
+          modelName: 'HierarchicalFilter',
+          label: `men`,
+          facetId: 'categories',
+          parentId: null,
+          totalResults: 10,
+          children: [],
+          selected: false
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Customizing the label slot content
 
 ```vue
-<HierarchicalFilter :filter="filter">
-  <template #label :filter="filter">
-    <span class="custom-class">{{ filter.label }}</span>
-  </template>
-</HierarchicalFilter>
+<template>
+  <HierarchicalFilter :filter="filter">
+    <template #label :filter="filter">
+      <span class="custom-class">{{ filter.label }}</span>
+    </template>
+  </HierarchicalFilter>
+</template>
+
+<script>
+  import { HierarchicalFilter } from '@empathyco/x-components/facets';
+
+  export default {
+    name: 'HierarchicalFilterTest',
+    components: {
+      HierarchicalFilter
+    },
+    date() {
+      return {
+        filter: {
+          id: `categories:men`,
+          modelName: 'HierarchicalFilter',
+          label: `men`,
+          facetId: 'categories',
+          parentId: null,
+          totalResults: 10,
+          children: [],
+          selected: false
+        }
+      };
+    }
+  };
+</script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
@@ -106,7 +106,7 @@
     public clickEvents!: Partial<XEventsTypes>;
 
     /**
-     * The {@link clickEvents} to emit.
+     * The {@link XEventsTypes | events} to emit.
      *
      * @returns The events to emit when clicked.
      * @internal

--- a/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
@@ -144,9 +144,7 @@
     protected getChildFilterClickEvents(
       childFilter: HierarchicalFilterModel
     ): Partial<XEventsTypes> {
-      return Object.keys(this._clickEvents).reduce((clickEvents, event) => {
-        const payload = this._clickEvents[event as keyof XEventsTypes];
-
+      return Object.entries(this._clickEvents).reduce((clickEvents, [event, payload]) => {
         return {
           ...clickEvents,
           [event]:
@@ -198,21 +196,39 @@
 </script>
 
 <docs lang="mdx">
-## Examples
+## Events
+
+A list of events that the component will emit:
+
+- [`UserClickedAFilter`](x-components.xeventstypes.userclickedafilter.md): the event is emitted
+  after the user clicks the button, using the `filter` prop as its payload.
+- [`UserClickedAHierarchicalFilter`](x-components.xeventstypes.userclickedahierarchicalfilter.md):
+  the event is emitted after the user clicks the button, using the `filter` prop as its payload.
+  filter.
+
+## See it in action
 
 This component renders a button, which on clicked emits the `UserClickedAFilter` and
 `UserClickedAHierarchicalFilter` events. By default it renders the filter label as the button text.
 If the provided filter has children filters, this component will render them recursively. Changing
 the slot content will change it for all of the children.
 
-### Basic usage
+The `filter` prop is required. The `clickEvents` prop is optional and allows configuring the events
+to emit on click.
 
 ```vue
 <template>
-  <HierarchicalFilter
-    :filter="filter"
-    v-slot="{ filter: slotFilter, clickFilter, cssClasses, isDisabled }"
-  />
+  <HierarchicalFilter :filter="filter" />
+</template>
+```
+
+### Playing with props
+
+Configuring the events to emit when the filter is clicked.
+
+```vue
+<template>
+  <HierarchicalFilter :clickEvents="{ UserClickedAHierarchicalFilter: filter }" :filter="filter" />
 </template>
 ```
 
@@ -238,11 +254,4 @@ In this example, the child filters will also include the label and checkbox.
   </template>
 </HierarchicalFilter>
 ```
-
-## Events
-
-A list of events that the component will emit:
-
-- `UserClickedAHierarchicalFilter`: the event is emitted after the user clicks the button. The event
-  payload is the hierarchical filter.
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
@@ -119,7 +119,35 @@ The `filter` prop is required. The `clickEvents` prop is optional and allows con
 to emit on click.
 
 ```vue
-<NumberRangeFilter :filter="filter" />
+<template>
+  <NumberRangeFilter :filter="filter" />
+</template>
+
+<script>
+  import { NumberRangeFilter } from '@empathyco/x-components/facets';
+
+  export default {
+    name: 'NumberRangeFilterTest',
+    components: {
+      NumberRangeFilter
+    },
+    date() {
+      return {
+        filter: {
+          id: `price:1-10`,
+          modelName: 'NumberRangeFilter',
+          label: `From 1 to 10`,
+          facetId: 'price',
+          range: {
+            min: 1,
+            max: 10
+          },
+          selected: false
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Playing with props
@@ -127,15 +155,71 @@ to emit on click.
 Configuring the events to emit when the filter is clicked.
 
 ```vue
-<NumberRangeFilter :clickEvents="{ UserClickedANumberRangeFilter: filter }" :filter="filter" />
+<template>
+  <NumberRangeFilter :clickEvents="{ UserClickedANumberRangeFilter: filter }" :filter="filter" />
+</template>
+
+<script>
+  import { NumberRangeFilter } from '@empathyco/x-components/facets';
+
+  export default {
+    name: 'NumberRangeFilterTest',
+    components: {
+      NumberRangeFilter
+    },
+    date() {
+      return {
+        filter: {
+          id: `price:1-10`,
+          modelName: 'NumberRangeFilter',
+          label: `From 1 to 10`,
+          facetId: 'price',
+          range: {
+            min: 1,
+            max: 10
+          },
+          selected: false
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Customizing its contents
 
 ```vue
-<NumberRangeFilter :filter="filter" v-slot="{ filter }">
-  <img src="checkbox.png"/>
-  <span>{{ filter.label }}</span>
-</NumberRangeFilter>
+<template>
+  <NumberRangeFilter :filter="filter" v-slot="{ filter }">
+    <img src="checkbox.png" />
+    <span>{{ filter.label }}</span>
+  </NumberRangeFilter>
+</template>
+
+<script>
+  import { NumberRangeFilter } from '@empathyco/x-components/facets';
+
+  export default {
+    name: 'NumberRangeFilterTest',
+    components: {
+      NumberRangeFilter
+    },
+    date() {
+      return {
+        filter: {
+          id: `price:1-10`,
+          modelName: 'NumberRangeFilter',
+          label: `From 1 to 10`,
+          facetId: 'price',
+          range: {
+            min: 1,
+            max: 10
+          },
+          selected: false
+        }
+      };
+    }
+  };
+</script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
@@ -2,7 +2,7 @@
   <RenderlessFilter
     v-slot="{ filter, clickFilter, cssClasses, isDisabled }"
     :class="cssClasses"
-    :clickEvents="clickEvents"
+    :clickEvents="_clickEvents"
     :filter="filter"
     class="x-number-range-filter"
   >
@@ -66,15 +66,23 @@
     public filter!: NumberRangeFilterModel;
 
     /**
-     * Additional events to emit when the filter is clicked.
+     * Additional events, with their payload, to emit when the filter is clicked.
      *
-     * @returns A dictionary with the events to be emitted when the filter is clicked, and its
-     * payload.
+     * @public
+     */
+    @Prop()
+    public clickEvents?: Partial<XEventsTypes>;
+
+    /**
+     * The {@link clickEvents} to emit.
+     *
+     * @returns The events to emit when clicked.
      * @internal
      */
-    protected get clickEvents(): Partial<XEventsTypes> {
+    protected get _clickEvents(): Partial<XEventsTypes> {
       return {
-        UserClickedANumberRangeFilter: this.filter
+        UserClickedANumberRangeFilter: this.filter,
+        ...this.clickEvents
       };
     }
 

--- a/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
@@ -74,7 +74,7 @@
     public clickEvents?: Partial<XEventsTypes>;
 
     /**
-     * The {@link clickEvents} to emit.
+     * The {@link XEventsTypes | events} to emit.
      *
      * @returns The events to emit when clicked.
      * @internal

--- a/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
@@ -101,15 +101,33 @@
 </script>
 
 <docs lang="mdx">
-## Examples
+## Events
 
-This component renders a button, which on clicked emits the `UserClickedAFilter` and the
+This component emits the following events:
+
+- [`UserClickedAFilter`](x-components.xeventstypes.userclickedafilter.md): the event is emitted
+  after the user clicks the button, using the `filter` prop as its payload.
+- [`UserClickedANumberRangeFilter`](x-components.xeventstypes.userclickedanumberrangefilter.md): the
+  event is emitted after the user clicks the button, using the `filter` prop as its payload.
+
+## See it in action
+
+This component renders a button which, on clicked, emits the `UserClickedAFilter` and the
 `UserClickedANumberRangeFilter` events. By default, it renders the filter label as the button text.
 
-### Basic usage
+The `filter` prop is required. The `clickEvents` prop is optional and allows configuring the events
+to emit on click.
 
 ```vue
 <NumberRangeFilter :filter="filter" />
+```
+
+### Playing with props
+
+Configuring the events to emit when the filter is clicked.
+
+```vue
+<NumberRangeFilter :clickEvents="{ UserClickedANumberRangeFilter: filter }" :filter="filter" />
 ```
 
 ### Customizing its contents
@@ -120,11 +138,4 @@ This component renders a button, which on clicked emits the `UserClickedAFilter`
   <span>{{ filter.label }}</span>
 </NumberRangeFilter>
 ```
-
-## Events
-
-A list of events that the component will emit:
-
-- `UserClickedANumberRangeFilter`: the event is emitted after the user clicks the button. The event
-  payload is the number range filter.
 </docs>

--- a/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
@@ -2,7 +2,7 @@
   <RenderlessFilter
     v-slot="{ filter, clickFilter, cssClasses, isDisabled }"
     :class="cssClasses"
-    :clickEvents="clickEvents"
+    :clickEvents="_clickEvents"
     :filter="filter"
     class="x-simple-filter"
   >
@@ -66,15 +66,23 @@
     public filter!: SimpleFilterModel;
 
     /**
-     * Additional events to emit when the filter is clicked.
+     * Additional events, with their payload, to emit when the filter is clicked.
      *
-     * @returns A dictionary with the events to be emitted when the filter is clicked, and its
-     * payload.
+     * @public
+     */
+    @Prop()
+    public clickEvents?: Partial<XEventsTypes>;
+
+    /**
+     * The {@link clickEvents} to emit.
+     *
+     * @returns The events to emit when clicked.
      * @internal
      */
-    protected get clickEvents(): Partial<XEventsTypes> {
+    protected get _clickEvents(): Partial<XEventsTypes> {
       return {
-        UserClickedASimpleFilter: this.filter
+        UserClickedASimpleFilter: this.filter,
+        ...this.clickEvents
       };
     }
 

--- a/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
@@ -156,6 +156,29 @@ Configuring the events to emit when the filter is clicked.
 <template>
   <SimpleFilter :clickEvents="{ UserClickedASimpleFilter: filter }" :filter="filter" />
 </template>
+
+<script>
+  import { SimpleFilter } from '@empathyco/x-components/facets';
+
+  export default {
+    name: 'SimpleFilterTest',
+    components: {
+      SimpleFilter
+    },
+    data() {
+      return {
+        filter: {
+          modelName: 'SimpleFilter',
+          selected: false,
+          id: 'category:shirts',
+          value: 'category:shirts',
+          facetId: 'category',
+          totalResults: 10
+        }
+      };
+    }
+  };
+</script>
 ```
 
 ### Rendering an input

--- a/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
@@ -74,7 +74,7 @@
     public clickEvents?: Partial<XEventsTypes>;
 
     /**
-     * The {@link clickEvents} to emit.
+     * The {@link XEventsTypes | events} to emit.
      *
      * @returns The events to emit when clicked.
      * @internal

--- a/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/simple-filter.vue
@@ -101,13 +101,23 @@
 </script>
 
 <docs lang="mdx">
-## Examples
+## Events
+
+A list of events that the component will emit:
+
+- [`UserClickedAFilter`](x-components.xeventstypes.userclickedafilter.md): the event is emitted
+  after the user clicks the button, using the `filter` prop as its payload.
+- [`UserClickedASimpleFilter`[(x-components.xeventstypes.userclickedasimplefilter.md): the event is
+  emitted after the user clicks the button, using the `filter` prop as its payload.
+
+## See it in action
 
 This component renders a button, which on clicked emits the `UserClickedAFilter` and the
 `UserClickedASimpleFilter` events. By default, it renders a `button` with the `filter.label`
 property as text.
 
-### Basic usage
+The `filter` prop is required. The `clickEvents` prop is optional and allows configuring the events
+to emit on click.
 
 ```vue
 <template>
@@ -136,6 +146,16 @@ property as text.
     }
   };
 </script>
+```
+
+### Playing with props
+
+Configuring the events to emit when the filter is clicked.
+
+```vue
+<template>
+  <SimpleFilter :clickEvents="{ UserClickedASimpleFilter: filter }" :filter="filter" />
+</template>
 ```
 
 ### Rendering an input
@@ -218,11 +238,4 @@ receive the filter data.
   };
 </script>
 ```
-
-## Events
-
-A list of events that the component will emit:
-
-- `UserClickedASimpleFilter`: the event is emitted after the user clicks the button. The event
-  payload is the simple filter.
 </docs>


### PR DESCRIPTION
EX-5986

Exposed `@Prop() clickEvents` in filters component using a `RenderlessFilter` so the events emitted on clicked are configurable.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## How has this been tested?

Added new unit test cases.

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
