### PR TITLE
bugfix(tagging): track click event on add to cart click

### DIFF
--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -190,7 +190,8 @@ export const taggingWiring = createWiring({
     storeClickedResultWire
   },
   UserClickedResultAddToCart: {
-    trackAddToCartWire
+    trackAddToCartWire,
+    trackResultClickedWire
   },
   UserClickedPDPAddToCart: {
     trackAddToCartFromSessionStorage

--- a/packages/x-components/tests/e2e/tagging.feature
+++ b/packages/x-components/tests/e2e/tagging.feature
@@ -76,4 +76,5 @@ Feature: Tagging component
     And   first result is clicked
     When  pdp add to cart button is clicked
     Then  add product to cart tagging request has been triggered
-    And   result click tagging request is triggered
+
+  # TODO: Add scenario checking tagging events when clicking addToCart in SERP

--- a/packages/x-components/tests/e2e/tagging.feature
+++ b/packages/x-components/tests/e2e/tagging.feature
@@ -26,7 +26,7 @@ Feature: Tagging component
     And   "lego" is searched
     And   first result is clicked
     Then  url matches "/products/"
-    And   query tagging request has been triggered
+    And   query tagging request is triggered
     And   result click tagging request is triggered
     And   result click tagging includes location "results"
 
@@ -37,7 +37,7 @@ Feature: Tagging component
     And   "lego" is searched
     And   first promoted is clicked
     Then  url matches "/promoted/"
-    And   query tagging request has been triggered
+    And   query tagging request is triggered
 
   Scenario: 5. Clicking a banner triggers the query tagging
     Given a results API with a banner
@@ -46,7 +46,7 @@ Feature: Tagging component
     And   "lego" is searched
     And   first banner is clicked
     Then  url matches "/banner/"
-    And   query tagging request has been triggered
+    And   query tagging request is triggered
 
   Scenario: 6. A redirection triggers query tagging
     Given a results API with a redirection
@@ -55,7 +55,7 @@ Feature: Tagging component
     And   "lego" is searched
     And   first redirection is clicked
     Then  url matches "/redirection/"
-    And   query tagging request has been triggered
+    And   query tagging request is triggered
 
   Scenario: 7. Infinite scrolling triggers query tagging
     Given a results API with 2 pages
@@ -65,7 +65,7 @@ Feature: Tagging component
     Then  results page number 1 is loaded
     When  scrolls down to next page
     Then  results page number 2 is loaded
-    And   query tagging request has been triggered
+    And   query tagging request is triggered
     And   second page query tagging request is triggered
 
   Scenario: 8. Tracking PDP add to cart
@@ -75,6 +75,6 @@ Feature: Tagging component
     And   "lego" is searched
     And   first result is clicked
     When  pdp add to cart button is clicked
-    Then  add product to cart tagging request has been triggered
+    Then  add product to cart tagging request is triggered
 
   # TODO: Add scenario checking tagging events when clicking addToCart in SERP

--- a/packages/x-components/tests/e2e/tagging.feature
+++ b/packages/x-components/tests/e2e/tagging.feature
@@ -76,3 +76,4 @@ Feature: Tagging component
     And   first result is clicked
     When  pdp add to cart button is clicked
     Then  add product to cart tagging request has been triggered
+    And   result click tagging request is triggered

--- a/packages/x-components/tests/e2e/tagging/tagging.spec.ts
+++ b/packages/x-components/tests/e2e/tagging/tagging.spec.ts
@@ -32,7 +32,7 @@ Then('query tagging request should be triggered', () => {
   cy.wait('@queryTagging').should('exist');
 });
 
-Then('query tagging request has been triggered', () => {
+Then('query tagging request is triggered', () => {
   cy.get('@queryTagging', { timeout: 0 }).should('exist');
 });
 
@@ -59,7 +59,7 @@ When('pdp add to cart button is clicked', () => {
   cy.getByDataTest('pdp-add-to-cart-button').click();
 });
 
-Then('add product to cart tagging request has been triggered', () => {
+Then('add product to cart tagging request is triggered', () => {
   cy.wait('@addToCartTagging').should('exist');
 });
 


### PR DESCRIPTION
EX-5898

We want to detect `addtocart` as an interaction of the user to improve `findability`, so we also need to track the `click` event when an add to cart button is clicked.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## How has this been tested?

Added new step in the add to cart tagging scenario.

## Checklist

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
