### PR TITLE
feat(facets): Add `FilterModify` by `FilterModelName`.

### DIFF
--- a/packages/x-components/src/main.ts
+++ b/packages/x-components/src/main.ts
@@ -8,8 +8,10 @@ import { FilterEntityFactory } from './x-modules/facets/entities/filter-entity.f
 import { SingleSelectModifier } from './x-modules/facets/entities/single-select.modifier';
 
 Vue.config.productionTip = false;
-['hierarchical_category', 'categories_facet', 'brand_facet', 'age_facet'].forEach(facetId =>
-  FilterEntityFactory.instance.registerFilterModifier(facetId, [SingleSelectModifier])
+FilterEntityFactory.instance.registerModifierByFacetId('age_facet', SingleSelectModifier);
+FilterEntityFactory.instance.registerModifierByFilterModelName(
+  'HierarchicalFilter',
+  SingleSelectModifier
 );
 
 new XInstaller({

--- a/packages/x-components/src/x-modules/facets/entities/__tests__/factory.spec.ts
+++ b/packages/x-components/src/x-modules/facets/entities/__tests__/factory.spec.ts
@@ -118,7 +118,7 @@ describe('testing filters entity factory', () => {
     });
     expect(getStoreEditableNumberRangeFilter(store, facetId).id).not.toBe(previousFilter.id);
 
-    // Deselecting a editable number range filter should  should keep it in the store with selected
+    // Deselecting a editable number range filter should keep it in the store with selected
     // to false and set the range values to null.
     previousFilter = getStoreEditableNumberRangeFilter(store, facetId);
     editableNumberRangeFilterEntity.deselect(previousFilter);
@@ -199,14 +199,14 @@ describe('testing filters entity factory', () => {
   });
 
   describe('testing modifiers', () => {
-    it('decorates entities of the given facet with modifiers', () => {
+    it('decorates entities of the given facet with modifiers by facet id', () => {
       const store = prepareFacetsStore();
       const factory = new FilterEntityFactory();
       const redColorFilter = createSimpleFilter('color', 'red');
       const blueColorFilter = createSimpleFilter('color', 'blue');
       const mediumSizeFilter = createSimpleFilter('size', 'm');
       const largeSizeFilter = createSimpleFilter('size', 'l');
-      factory.registerFilterModifier('color', [SingleSelectModifier]);
+      factory.registerModifierByFacetId('color', SingleSelectModifier);
       const colorEntity = factory.getFilterEntity(store, redColorFilter);
       const sizeEntity = factory.getFilterEntity(store, mediumSizeFilter);
 
@@ -217,7 +217,7 @@ describe('testing filters entity factory', () => {
       expect(isFilterSelected(store, redColorFilter.id)).toBe(false);
       expect(isFilterSelected(store, blueColorFilter.id)).toBe(true);
 
-      // Size entity shouldn not be decorated, therefore, its filters should be multiselectable.
+      // Size entity should not be decorated, therefore, its filters should be multiselectable.
       sizeEntity.select(mediumSizeFilter);
       sizeEntity.select(largeSizeFilter);
       colorEntity.select(redColorFilter);
@@ -226,6 +226,41 @@ describe('testing filters entity factory', () => {
       expect(isFilterSelected(store, blueColorFilter.id)).toBe(false);
       expect(isFilterSelected(store, mediumSizeFilter.id)).toBe(true);
       expect(isFilterSelected(store, largeSizeFilter.id)).toBe(true);
+    });
+
+    it('decorates entities of the given facet with modifiers by filter model name', () => {
+      const store = prepareFacetsStore();
+      const factory = new FilterEntityFactory();
+      const redColorFilter = createSimpleFilter('color', 'red');
+      const blueColorFilter = createSimpleFilter('color', 'blue');
+      const priceFilter10_20 = createNumberRangeFilter('price', { min: 10, max: 20 });
+      const priceFilter20_30 = createNumberRangeFilter('price', { min: 20, max: 30 });
+      const womanCategoryFilter = createHierarchicalFilter('category', 'woman');
+      const manCategoryFilter = createHierarchicalFilter('category', 'man');
+      factory.registerModifierByFilterModelName('SimpleFilter', SingleSelectModifier);
+      const colorEntity = factory.getFilterEntity(store, redColorFilter);
+      const priceEntity = factory.getFilterEntity(store, priceFilter10_20);
+      const categoryEntity = factory.getFilterEntity(store, womanCategoryFilter);
+
+      colorEntity.select(redColorFilter);
+      expect(isFilterSelected(store, redColorFilter.id)).toBe(true);
+
+      colorEntity.select(blueColorFilter);
+      expect(isFilterSelected(store, redColorFilter.id)).toBe(false);
+      expect(isFilterSelected(store, blueColorFilter.id)).toBe(true);
+
+      // The other Filters should not be decorated, therefore, its filters should be multiselectable
+      priceEntity.select(priceFilter10_20);
+      priceEntity.select(priceFilter20_30);
+      categoryEntity.select(womanCategoryFilter);
+      categoryEntity.select(manCategoryFilter);
+
+      expect(isFilterSelected(store, redColorFilter.id)).toBe(false);
+      expect(isFilterSelected(store, blueColorFilter.id)).toBe(true);
+      expect(isFilterSelected(store, priceFilter10_20.id)).toBe(true);
+      expect(isFilterSelected(store, priceFilter20_30.id)).toBe(true);
+      expect(isFilterSelected(store, womanCategoryFilter.id)).toBe(true);
+      expect(isFilterSelected(store, manCategoryFilter.id)).toBe(true);
     });
   });
 });

--- a/packages/x-components/src/x-modules/facets/service/__tests__/facets-service.spec.ts
+++ b/packages/x-components/src/x-modules/facets/service/__tests__/facets-service.spec.ts
@@ -569,7 +569,7 @@ describe('testing facets service', () => {
 
     it('sets a new Single Select facet with multiple selected values', () => {
       const filterEntityFactory = new FilterEntityFactory();
-      filterEntityFactory.registerFilterModifier('size', [SingleSelectModifier]);
+      filterEntityFactory.registerModifierByFacetId('size', SingleSelectModifier);
       const { service, getSelectedFilters } = prepareFacetsService(filterEntityFactory);
 
       const newSizeFacet = createSimpleFacetStub('size', createFilter => [
@@ -588,7 +588,7 @@ describe('testing facets service', () => {
 
     it('updates and sets facets with different configurations', () => {
       const filterEntityFactory = new FilterEntityFactory();
-      filterEntityFactory.registerFilterModifier('gender', [SingleSelectModifier]);
+      filterEntityFactory.registerModifierByFacetId('gender', SingleSelectModifier);
       const { service, getSelectedFilters } = prepareFacetsService(filterEntityFactory);
 
       const genderFacet = createSimpleFacetStub('gender', createFilter => [


### PR DESCRIPTION
BREAKING CHANGE: The method `registerFilterModifier` from `FilterEntityFactory` renamed to `registerModifierByFacetId`.
EX-6160

The intention of this PR is to add another option to register `FilterEntityModifier`s by `FilterModelName`.
The current way to register by Facet id is kept but renamed.

The use case is when you don't know the facets, therefore the facets ids, but you need to make single selectable the Hierarchical Filters, for example. This is a real case for Motive.