### PR TITLE
feat: add `extendableEndpointAdapterFactory`

### DIFF
--- a/packages/x-adapter/src/__tests__/endpoint-adapter.factory.spec.ts
+++ b/packages/x-adapter/src/__tests__/endpoint-adapter.factory.spec.ts
@@ -1,26 +1,18 @@
-import {
-  endpointAdapterFactory,
-  extendableEndpointAdapterFactory
-} from '../endpoint-adapter.factory';
+import { endpointAdapterFactory } from '../endpoint-adapter.factory';
 import { identityMapper } from '../mappers/identity.mapper';
-import {
-  EndpointAdapter,
-  EndpointAdapterOptions,
-  ExtendableEndpointAdapter
-} from '../types/adapter.types';
+import { EndpointAdapterOptions, ExtendableEndpointAdapter } from '../types/adapter.types';
 import { HttpClient, RequestOptions } from '../types/http-client.types';
 import { Mapper } from '../types/mapper.types';
 
 /**
- * Creates an {@link EndpointAdapter} using the {@link endpointAdapterFactory} with the given
- * {@link EndpointAdapterOptions}, exposing a basic API for testing.
+ * Creates an {@link ExtendableEndpointAdapter} using the {@link endpointAdapterFactory} with the
+ * given {@link EndpointAdapterOptions}, exposing a basic API for testing.
  *
  * @param options - The CreateEndpointAdapterFactoryOptions to create the API with.
  *
- * @returns The API for testing the {@link EndpointAdapter}.
+ * @returns The API for testing the {@link ExtendableEndpointAdapter}.
  */
-function createEndpointAdapterFactory<Request, Response>({
-  isExtendable = false,
+function createEndpointAdapterFactoryOptions<Request, Response>({
   options,
   rawResponse = {} as Response
 }: CreateEndpointAdapterFactoryOptions<Request, Response> = {}): CreateEndpointAdapterFactoryAPI<
@@ -38,10 +30,7 @@ function createEndpointAdapterFactory<Request, Response>({
     responseMapper: mockedResponseMapper,
     ...options
   };
-
-  const endpointAdapter = isExtendable
-    ? extendableEndpointAdapterFactory<Request, Response>(adapterOptions)
-    : endpointAdapterFactory<Request, Response>(adapterOptions);
+  const endpointAdapter = endpointAdapterFactory<Request, Response>(adapterOptions);
 
   return {
     endpointAdapter,
@@ -55,226 +44,220 @@ function createEndpointAdapterFactory<Request, Response>({
 describe('adapterFactory tests', () => {
   const request: TestRequest = { q: 'patata' };
 
-  describe('endpointAdapterFactory tests', () => {
-    it('should create an endpointAdapter with the given options', async () => {
-      const rawResponse: TestResponse = { query: 'patata' };
-      const {
-        endpointAdapter,
-        options,
-        mockedHttpClient,
-        mockedRequestMapper,
-        mockedResponseMapper
-      } = createEndpointAdapterFactory<TestRequest, TestResponse>({
-        rawResponse
-      });
-
-      expect(endpointAdapter).toBeDefined();
-
-      const response = await endpointAdapter(request);
-
-      expect(mockedRequestMapper).toHaveBeenCalledTimes(1);
-      expect(mockedHttpClient).toHaveBeenCalledTimes(1);
-      expect(mockedHttpClient).toHaveBeenCalledWith(options.endpoint, {
-        parameters: request
-      });
-      expect(mockedResponseMapper).toHaveBeenCalledTimes(1);
-      expect(response).toEqual(rawResponse);
+  it('should create an endpointAdapter with the given options', async () => {
+    const rawResponse: TestResponse = { query: 'patata' };
+    const {
+      endpointAdapter,
+      options,
+      mockedHttpClient,
+      mockedRequestMapper,
+      mockedResponseMapper
+    } = createEndpointAdapterFactoryOptions<TestRequest, TestResponse>({
+      rawResponse
     });
 
-    it('should use the raw request if no requestMapper is provided', async () => {
-      const { endpointAdapter, options, mockedHttpClient, mockedRequestMapper } =
-        createEndpointAdapterFactory<TestRequest, TestResponse>({
-          options: {
-            requestMapper: undefined
-          }
-        });
+    expect(endpointAdapter).toBeDefined();
+    expect(endpointAdapter).toHaveProperty('extends');
 
-      await endpointAdapter(request);
+    const response = await endpointAdapter(request);
 
-      expect(mockedRequestMapper).not.toHaveBeenCalled();
-      expect(mockedHttpClient).toHaveBeenCalledTimes(1);
-      expect(mockedHttpClient).toHaveBeenCalledWith(options.endpoint, {
-        parameters: request
-      });
+    expect(mockedRequestMapper).toHaveBeenCalledTimes(1);
+    expect(mockedHttpClient).toHaveBeenCalledTimes(1);
+    expect(mockedHttpClient).toHaveBeenCalledWith(options.endpoint, {
+      parameters: request
+    });
+    expect(mockedResponseMapper).toHaveBeenCalledTimes(1);
+    expect(response).toEqual(rawResponse);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should extend the endpointAdapter options with new ones, leaving the extended endpointAdapter untouched', async () => {
+    const {
+      endpointAdapter,
+      options,
+      mockedHttpClient,
+      mockedRequestMapper,
+      mockedResponseMapper
+    } = createEndpointAdapterFactoryOptions<TestRequest, TestResponse>();
+
+    const extendedEndpoint = 'https://api.empathy.co/extended';
+    const extendedRawResponse = { extendedQuery: 'patata', extendedHits: 10 };
+    const mockExtendedHttpClient = jest.fn(() => Promise.resolve(extendedRawResponse));
+    const mockExtendedRequestMapper = jest.fn(({ q, origin }: ExtendedTestRequest) => ({
+      extendedQuery: q,
+      extendedOrigin: origin
+    }));
+    const mockExtendedResponseMapper = jest.fn(
+      ({ extendedQuery, extendedHits }): ExtendedTestResponse => ({
+        query: extendedQuery,
+        hits: extendedHits
+      })
+    );
+
+    const extendedEndpointAdapter = endpointAdapter.extends<
+      ExtendedTestRequest,
+      ExtendedTestResponse
+    >({
+      endpoint: extendedEndpoint,
+      httpClient: mockExtendedHttpClient as HttpClient,
+      requestMapper: mockExtendedRequestMapper,
+      responseMapper: mockExtendedResponseMapper
     });
 
-    it('should return the raw response if no responseMapper is provided', async () => {
-      const rawResponse: TestResponse = { query: 'patata' };
-      const { endpointAdapter, mockedHttpClient, mockedResponseMapper } =
-        createEndpointAdapterFactory<TestRequest, TestResponse>({
-          options: {
-            responseMapper: undefined
-          },
-          rawResponse
-        });
+    const extendedRequest: ExtendedTestRequest = { q: 'patata', origin: 'extended' };
+    const extendedResponse = await extendedEndpointAdapter(extendedRequest);
+    const response = await endpointAdapter(request);
 
-      const response = await endpointAdapter(request);
-
-      expect(mockedHttpClient).toHaveBeenCalledTimes(1);
-      expect(mockedResponseMapper).not.toHaveBeenCalled();
-      expect(response).toEqual(rawResponse);
+    expect(mockedRequestMapper).toHaveBeenCalledTimes(1);
+    expect(mockedRequestMapper).toHaveBeenCalledWith(request, {
+      endpoint: options.endpoint
     });
 
-    describe('endpoint scenarios', () => {
-      it('should interpolate the endpoint using the request when it is a string', async () => {
-        const { endpointAdapter, mockedHttpClient } = createEndpointAdapterFactory<
-          TestRequest,
-          TestResponse
-        >({
-          options: {
-            endpoint: 'https://api{(-)env}.empathy.co/test'
-          }
-        });
+    expect(mockedHttpClient).toHaveBeenCalledTimes(1);
+    expect(mockedHttpClient).toHaveBeenCalledWith(options.endpoint, {
+      parameters: request
+    });
+    expect(mockedResponseMapper).toHaveBeenCalledTimes(1);
+    expect(mockedResponseMapper).toHaveBeenCalledWith(
+      {},
+      {
+        endpoint: options.endpoint,
+        requestParameters: request
+      }
+    );
+    expect(response).toEqual({});
 
-        await endpointAdapter({ ...request, env: 'test' });
+    const mappedExtendedRequest = {
+      extendedQuery: extendedRequest.q,
+      extendedOrigin: extendedRequest.origin
+    };
+    expect(mockExtendedRequestMapper).toHaveBeenCalledTimes(1);
+    expect(mockExtendedRequestMapper).toHaveBeenCalledWith(extendedRequest, {
+      endpoint: extendedEndpoint
+    });
+    expect(mockExtendedRequestMapper).toHaveReturnedWith(mappedExtendedRequest);
 
-        expect(mockedHttpClient).toHaveBeenCalledTimes(1);
-        expect(mockedHttpClient).toHaveBeenCalledWith(
-          'https://api-test.empathy.co/test',
-          expect.anything()
-        );
+    expect(mockExtendedHttpClient).toHaveBeenCalledTimes(1);
+    expect(mockExtendedHttpClient).toHaveBeenCalledWith(extendedEndpoint, {
+      parameters: mappedExtendedRequest
+    });
+
+    const extendedMappedResponse: ExtendedTestResponse = {
+      query: 'patata',
+      hits: 10
+    };
+    expect(mockExtendedResponseMapper).toHaveBeenCalledTimes(1);
+    expect(mockExtendedResponseMapper).toHaveBeenCalledWith(extendedRawResponse, {
+      endpoint: extendedEndpoint,
+      requestParameters: mappedExtendedRequest
+    });
+    expect(mockExtendedResponseMapper).toHaveReturnedWith(extendedMappedResponse);
+    expect(extendedResponse).toEqual(extendedMappedResponse);
+  });
+
+  it('should use the raw request if no requestMapper is provided', async () => {
+    const { endpointAdapter, options, mockedHttpClient, mockedRequestMapper } =
+      createEndpointAdapterFactoryOptions<TestRequest, TestResponse>({
+        options: {
+          requestMapper: undefined
+        }
       });
 
-      // eslint-disable-next-line max-len
-      it('should map the request to an endpoint when the provided endpoint is a function', async () => {
-        const endpoint: Mapper<TestRequest, string> = ({ env }) =>
-          env === 'test' ? 'api.internal.test.empathy.co/test' : 'api.empathy.co/test';
-        const { endpointAdapter, mockedHttpClient } = createEndpointAdapterFactory<
-          TestRequest,
-          TestResponse
-        >({
-          options: {
-            endpoint
-          }
-        });
+    await endpointAdapter(request);
 
-        await endpointAdapter({ ...request, env: 'test' });
-
-        expect(mockedHttpClient).toHaveBeenCalledTimes(1);
-        expect(mockedHttpClient).toHaveBeenCalledWith(
-          'api.internal.test.empathy.co/test',
-          expect.anything()
-        );
-      });
-
-      it('should use the requestOptions.endpoint if it is provided', async () => {
-        const { endpointAdapter, mockedHttpClient } = createEndpointAdapterFactory<
-          TestRequest,
-          TestResponse
-        >();
-        const requestOptions: RequestOptions = {
-          endpoint: 'https://api.empathy.co/staging'
-        };
-
-        await endpointAdapter(request, requestOptions);
-
-        expect(mockedHttpClient).toHaveBeenCalledTimes(1);
-        expect(mockedHttpClient).toHaveBeenCalledWith(requestOptions.endpoint, expect.anything());
-      });
+    expect(mockedRequestMapper).not.toHaveBeenCalled();
+    expect(mockedHttpClient).toHaveBeenCalledTimes(1);
+    expect(mockedHttpClient).toHaveBeenCalledWith(options.endpoint, {
+      parameters: request
     });
   });
 
-  describe('extendableEndpointAdapterFactory tests', () => {
-    // eslint-disable-next-line max-len
-    it('should extend the endpointAdapter options with new ones, leaving the extended endpointAdapter untouched', async () => {
-      const {
-        endpointAdapter,
-        options,
-        mockedHttpClient,
-        mockedRequestMapper,
-        mockedResponseMapper
-      } = createEndpointAdapterFactory({ isExtendable: true });
-
-      const extendedEndpoint = 'https://api.empathy.co/extended';
-      const extendedRawResponse = { extendedQuery: 'patata', extendedHits: 10 };
-      const mockExtendedHttpClient = jest.fn(() => Promise.resolve(extendedRawResponse));
-      const mockExtendedRequestMapper = jest.fn(({ q, origin }: ExtendedTestRequest) => ({
-        extendedQuery: q,
-        extendedOrigin: origin
-      }));
-      const mockExtendedResponseMapper = jest.fn(
-        ({ extendedQuery, extendedHits }): ExtendedTestResponse => ({
-          query: extendedQuery,
-          hits: extendedHits
-        })
-      );
-
-      const extendedEndpointAdapter = (
-        endpointAdapter as ExtendableEndpointAdapter<TestRequest, TestResponse>
-      ).extends<ExtendedTestRequest, ExtendedTestResponse>({
-        endpoint: extendedEndpoint,
-        httpClient: mockExtendedHttpClient as HttpClient,
-        requestMapper: mockExtendedRequestMapper,
-        responseMapper: mockExtendedResponseMapper
+  it('should return the raw response if no responseMapper is provided', async () => {
+    const rawResponse: TestResponse = { query: 'patata' };
+    const { endpointAdapter, mockedHttpClient, mockedResponseMapper } =
+      createEndpointAdapterFactoryOptions<TestRequest, TestResponse>({
+        options: {
+          responseMapper: undefined
+        },
+        rawResponse
       });
 
-      const extendedRequest: ExtendedTestRequest = { q: 'patata', origin: 'extended' };
-      const extendedResponse = await extendedEndpointAdapter(extendedRequest);
-      const response = await endpointAdapter(request);
+    const response = await endpointAdapter(request);
 
-      expect(mockedRequestMapper).toHaveBeenCalledTimes(1);
-      expect(mockedRequestMapper).toHaveBeenCalledWith(request, {
-        endpoint: options.endpoint
+    expect(mockedHttpClient).toHaveBeenCalledTimes(1);
+    expect(mockedResponseMapper).not.toHaveBeenCalled();
+    expect(response).toEqual(rawResponse);
+  });
+
+  describe('endpoint scenarios', () => {
+    it('should interpolate the endpoint using the request when it is a string', async () => {
+      const { endpointAdapter, mockedHttpClient } = createEndpointAdapterFactoryOptions<
+        TestRequest,
+        TestResponse
+      >({
+        options: {
+          endpoint: 'https://api{(-)env}.empathy.co/test'
+        }
       });
+
+      await endpointAdapter({ ...request, env: 'test' });
 
       expect(mockedHttpClient).toHaveBeenCalledTimes(1);
-      expect(mockedHttpClient).toHaveBeenCalledWith(options.endpoint, {
-        parameters: request
-      });
-      expect(mockedResponseMapper).toHaveBeenCalledTimes(1);
-      expect(mockedResponseMapper).toHaveBeenCalledWith(
-        {},
-        {
-          endpoint: options.endpoint,
-          requestParameters: request
-        }
+      expect(mockedHttpClient).toHaveBeenCalledWith(
+        'https://api-test.empathy.co/test',
+        expect.anything()
       );
-      expect(response).toEqual({});
+    });
 
-      const mappedExtendedRequest = {
-        extendedQuery: extendedRequest.q,
-        extendedOrigin: extendedRequest.origin
+    // eslint-disable-next-line max-len
+    it('should map the request to an endpoint when the provided endpoint is a function', async () => {
+      const endpoint: Mapper<TestRequest, string> = ({ env }) =>
+        env === 'test' ? 'api.internal.test.empathy.co/test' : 'api.empathy.co/test';
+      const { endpointAdapter, mockedHttpClient } = createEndpointAdapterFactoryOptions<
+        TestRequest,
+        TestResponse
+      >({
+        options: {
+          endpoint
+        }
+      });
+
+      await endpointAdapter({ ...request, env: 'test' });
+
+      expect(mockedHttpClient).toHaveBeenCalledTimes(1);
+      expect(mockedHttpClient).toHaveBeenCalledWith(
+        'api.internal.test.empathy.co/test',
+        expect.anything()
+      );
+    });
+
+    it('should use the requestOptions.endpoint if it is provided', async () => {
+      const { endpointAdapter, mockedHttpClient } = createEndpointAdapterFactoryOptions<
+        TestRequest,
+        TestResponse
+      >();
+      const requestOptions: RequestOptions = {
+        endpoint: 'https://api.empathy.co/staging'
       };
-      expect(mockExtendedRequestMapper).toHaveBeenCalledTimes(1);
-      expect(mockExtendedRequestMapper).toHaveBeenCalledWith(extendedRequest, {
-        endpoint: extendedEndpoint
-      });
-      expect(mockExtendedRequestMapper).toHaveReturnedWith(mappedExtendedRequest);
 
-      expect(mockExtendedHttpClient).toHaveBeenCalledTimes(1);
-      expect(mockExtendedHttpClient).toHaveBeenCalledWith(extendedEndpoint, {
-        parameters: mappedExtendedRequest
-      });
+      await endpointAdapter(request, requestOptions);
 
-      const extendedMappedResponse: ExtendedTestResponse = {
-        query: 'patata',
-        hits: 10
-      };
-      expect(mockExtendedResponseMapper).toHaveBeenCalledTimes(1);
-      expect(mockExtendedResponseMapper).toHaveBeenCalledWith(extendedRawResponse, {
-        endpoint: extendedEndpoint,
-        requestParameters: mappedExtendedRequest
-      });
-      expect(mockExtendedResponseMapper).toHaveReturnedWith(extendedMappedResponse);
-      expect(extendedResponse).toEqual(extendedMappedResponse);
+      expect(mockedHttpClient).toHaveBeenCalledTimes(1);
+      expect(mockedHttpClient).toHaveBeenCalledWith(requestOptions.endpoint, expect.anything());
     });
   });
 });
 
 interface CreateEndpointAdapterFactoryOptions<Request, Response> {
-  /** Flag to create either an {@link ExtendableEndpointAdapter} or {@link EndpointAdapter}. */
-  isExtendable?: boolean;
   /** The {@link EndpointAdapterOptions} passed to {@link endpointAdapterFactory} function. */
   options?: Partial<EndpointAdapterOptions<Request, Response>>;
-  /** The raw response of calling the {@link EndpointAdapter}. */
+  /** The raw response of calling the {@link ExtendableEndpointAdapter}. */
   rawResponse?: Response;
 }
 
 interface CreateEndpointAdapterFactoryAPI<Request, Response> {
-  /** The created {@link EndpointAdapter} or {@link ExtendableEndpointAdapter}. */
-  endpointAdapter:
-    | EndpointAdapter<Request, Response>
-    | ExtendableEndpointAdapter<Request, Response>;
+  /** The created {@link ExtendableEndpointAdapter} by the {@link endpointAdapterFactory}. */
+  endpointAdapter: ExtendableEndpointAdapter<Request, Response>;
   /** The options passed to {@link endpointAdapterFactory} function. */
   options: EndpointAdapterOptions<Request, Response>;
   /** The mocked {@link EndpointAdapterOptions.httpClient}. */

--- a/packages/x-adapter/src/endpoint-adapter.factory.ts
+++ b/packages/x-adapter/src/endpoint-adapter.factory.ts
@@ -4,7 +4,9 @@ import { identityMapper } from './mappers/identity.mapper';
 import {
   EndpointAdapter,
   EndpointAdapterFactory,
-  EndpointAdapterOptions
+  EndpointAdapterOptions,
+  ExtendableEndpointAdapter,
+  ExtendableEndpointAdapterFactory
 } from './types/adapter.types';
 import { Mapper } from './types/mapper.types';
 import { interpolate } from './utils/interpolate';
@@ -22,10 +24,7 @@ import { interpolate } from './utils/interpolate';
 export const endpointAdapterFactory: EndpointAdapterFactory = <Request, Response>(
   options: EndpointAdapterOptions<Request, Response>
 ) => {
-  const endpointAdapter: EndpointAdapter<Request, Response> = (
-    request,
-    { endpoint: requestEndpoint, ...requestOptions } = {}
-  ) => {
+  return ((request, { endpoint: requestEndpoint, ...requestOptions } = {}) => {
     const {
       endpoint: rawEndpoint,
       httpClient = fetchHttpClient,
@@ -41,7 +40,29 @@ export const endpointAdapterFactory: EndpointAdapterFactory = <Request, Response
       endpoint,
       deepMerge({}, defaultRequestOptions, requestOptions, { parameters: requestParameters })
     ).then(response => responseMapper(response, { endpoint, requestParameters }));
-  };
+  }) as EndpointAdapter<Request, Response>;
+};
+
+/**
+ * Factory to create {@link ExtendableEndpointAdapter | extendable endpoint adapters} with the given
+ * {@link EndpointAdapterOptions | options}.
+ *
+ * @param options - The {@link EndpointAdapterOptions | options} to create a new
+ * {@link ExtendableEndpointAdapter} with.
+ *
+ * @returns A brand new {@link ExtendableEndpointAdapter} object.
+ * @public
+ */
+export const extendableEndpointAdapterFactory: ExtendableEndpointAdapterFactory = <
+  Request,
+  Response
+>(
+  options: EndpointAdapterOptions<Request, Response>
+) => {
+  const endpointAdapter = endpointAdapterFactory(options) as ExtendableEndpointAdapter<
+    Request,
+    Response
+  >;
 
   endpointAdapter.extends = <NewRequest, NewResponse>(
     extendedOptions: Partial<EndpointAdapterOptions<NewRequest, NewResponse>>

--- a/packages/x-adapter/src/endpoint-adapter.factory.ts
+++ b/packages/x-adapter/src/endpoint-adapter.factory.ts
@@ -2,29 +2,30 @@ import { deepMerge } from '@empathyco/x-deep-merge';
 import { fetchHttpClient } from './http-clients/fetch.http-client';
 import { identityMapper } from './mappers/identity.mapper';
 import {
-  EndpointAdapter,
   EndpointAdapterFactory,
   EndpointAdapterOptions,
-  ExtendableEndpointAdapter,
-  ExtendableEndpointAdapterFactory
+  ExtendableEndpointAdapter
 } from './types/adapter.types';
 import { Mapper } from './types/mapper.types';
 import { interpolate } from './utils/interpolate';
 
 /**
- * Factory to create {@link EndpointAdapter | endpoint adapters} with the given
+ * Factory to create {@link ExtendableEndpointAdapter | endpoint adapters} with the given
  * {@link EndpointAdapterOptions | options}.
  *
  * @param options - The {@link EndpointAdapterOptions | options} to create a new
- * {@link EndpointAdapter} with.
+ * {@link ExtendableEndpointAdapter} with.
  *
- * @returns A brand new {@link EndpointAdapter} object.
+ * @returns A brand new {@link ExtendableEndpointAdapter} object.
  * @public
  */
 export const endpointAdapterFactory: EndpointAdapterFactory = <Request, Response>(
   options: EndpointAdapterOptions<Request, Response>
 ) => {
-  return ((request, { endpoint: requestEndpoint, ...requestOptions } = {}) => {
+  const endpointAdapter: ExtendableEndpointAdapter<Request, Response> = (
+    request,
+    { endpoint: requestEndpoint, ...requestOptions } = {}
+  ) => {
     const {
       endpoint: rawEndpoint,
       httpClient = fetchHttpClient,
@@ -40,29 +41,7 @@ export const endpointAdapterFactory: EndpointAdapterFactory = <Request, Response
       endpoint,
       deepMerge({}, defaultRequestOptions, requestOptions, { parameters: requestParameters })
     ).then(response => responseMapper(response, { endpoint, requestParameters }));
-  }) as EndpointAdapter<Request, Response>;
-};
-
-/**
- * Factory to create {@link ExtendableEndpointAdapter | extendable endpoint adapters} with the given
- * {@link EndpointAdapterOptions | options}.
- *
- * @param options - The {@link EndpointAdapterOptions | options} to create a new
- * {@link ExtendableEndpointAdapter} with.
- *
- * @returns A brand new {@link ExtendableEndpointAdapter} object.
- * @public
- */
-export const extendableEndpointAdapterFactory: ExtendableEndpointAdapterFactory = <
-  Request,
-  Response
->(
-  options: EndpointAdapterOptions<Request, Response>
-) => {
-  const endpointAdapter = endpointAdapterFactory(options) as ExtendableEndpointAdapter<
-    Request,
-    Response
-  >;
+  };
 
   endpointAdapter.extends = <NewRequest, NewResponse>(
     extendedOptions: Partial<EndpointAdapterOptions<NewRequest, NewResponse>>

--- a/packages/x-adapter/src/types/adapter.types.ts
+++ b/packages/x-adapter/src/types/adapter.types.ts
@@ -44,24 +44,13 @@ export interface ExtendableEndpointAdapter<Request, Response>
 }
 
 /**
- * Creates an {@link EndpointAdapter} with the given options.
- *
- * @param options - Options to create the endpoint adapter with.
- * @returns A brand-new {@link EndpointAdapter} instance.
- * @public
- */
-export type EndpointAdapterFactory = <Request, Response>(
-  options: EndpointAdapterOptions<Request, Response>
-) => EndpointAdapter<Request, Response>;
-
-/**
  * Creates an {@link ExtendableEndpointAdapter} with the given options.
  *
- * @param options - Options to create the extendable endpoint adapter with.
+ * @param options - Options to create the endpoint adapter with.
  * @returns A brand-new {@link ExtendableEndpointAdapter} instance.
  * @public
  */
-export type ExtendableEndpointAdapterFactory = <Request, Response>(
+export type EndpointAdapterFactory = <Request, Response>(
   options: EndpointAdapterOptions<Request, Response>
 ) => ExtendableEndpointAdapter<Request, Response>;
 

--- a/packages/x-adapter/src/types/adapter.types.ts
+++ b/packages/x-adapter/src/types/adapter.types.ts
@@ -37,6 +37,7 @@ export interface ExtendableEndpointAdapter<Request, Response>
    * {@link ExtendableEndpointAdapter} object.
    *
    * @param options - New options to extend the {@link ExtendableEndpointAdapter} with.
+   * @returns A new adapter created by merging the new and old options.
    */
   extends: <NewRequest = Request, NewResponse = Response>(
     options: Partial<EndpointAdapterOptions<NewRequest, NewResponse>>

--- a/packages/x-adapter/src/types/adapter.types.ts
+++ b/packages/x-adapter/src/types/adapter.types.ts
@@ -23,7 +23,15 @@ export interface EndpointAdapter<Request, Response> {
    * @returns A response promise.
    */
   (request: Request, options?: RequestOptions): Promise<Response>;
+}
 
+/**
+ * Adds extends functionality to an {@link EndpointAdapter}.
+ *
+ * @public
+ */
+export interface ExtendableEndpointAdapter<Request, Response>
+  extends EndpointAdapter<Request, Response> {
   /**
    * Extends the current adapter merging its options with the new ones creating a new
    * {@link EndpointAdapter} object.
@@ -38,13 +46,24 @@ export interface EndpointAdapter<Request, Response> {
 /**
  * Creates an {@link EndpointAdapter} with the given options.
  *
- * @param options - Options to create the adapter with.
+ * @param options - Options to create the endpoint adapter with.
  * @returns A brand-new {@link EndpointAdapter} instance.
  * @public
  */
 export type EndpointAdapterFactory = <Request, Response>(
   options: EndpointAdapterOptions<Request, Response>
 ) => EndpointAdapter<Request, Response>;
+
+/**
+ * Creates an {@link ExtendableEndpointAdapter} with the given options.
+ *
+ * @param options - Options to create the extendable endpoint adapter with.
+ * @returns A brand-new {@link ExtendableEndpointAdapter} instance.
+ * @public
+ */
+export type ExtendableEndpointAdapterFactory = <Request, Response>(
+  options: EndpointAdapterOptions<Request, Response>
+) => ExtendableEndpointAdapter<Request, Response>;
 
 /**
  * Options to create an adapter with.

--- a/packages/x-adapter/src/types/adapter.types.ts
+++ b/packages/x-adapter/src/types/adapter.types.ts
@@ -33,14 +33,14 @@ export interface EndpointAdapter<Request, Response> {
 export interface ExtendableEndpointAdapter<Request, Response>
   extends EndpointAdapter<Request, Response> {
   /**
-   * Extends the current adapter merging its options with the new ones creating a new
-   * {@link EndpointAdapter} object.
+   * Extends the endpoint adapter, merging its options with the new ones, creating a new
+   * {@link ExtendableEndpointAdapter} object.
    *
-   * @param options - New options to extend the {@link EndpointAdapter} with.
+   * @param options - New options to extend the {@link ExtendableEndpointAdapter} with.
    */
   extends: <NewRequest = Request, NewResponse = Response>(
     options: Partial<EndpointAdapterOptions<NewRequest, NewResponse>>
-  ) => EndpointAdapter<NewRequest, NewResponse>;
+  ) => ExtendableEndpointAdapter<NewRequest, NewResponse>;
 }
 
 /**


### PR DESCRIPTION
BREAKING-CHANGE: Split `EndpointAdapter` type into `EndpointAdapter` and `ExtendableEndpointAdapter`.

EX-6121

Allow creating `endpointAdapters` without having to implement the `extends` logic.