### PR TITLE
fix(related-tags): Related tags are now kept when navigating back.

### DIFF
--- a/packages/x-components/src/x-modules/related-tags/store/actions/set-url-params.action.ts
+++ b/packages/x-components/src/x-modules/related-tags/store/actions/set-url-params.action.ts
@@ -32,6 +32,5 @@ export const setUrlParams: RelatedTagsXStoreModule['actions']['setUrlParams'] = 
   { query, tag }: UrlParams
 ) => {
   commit('setSelectedRelatedTags', createRelatedTags(tag, query));
-  commit('setRelatedTags', []);
   commit('setQuery', query);
 };

--- a/packages/x-components/tests/e2e/common/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/common/common-steps.spec.ts
@@ -202,3 +202,7 @@ Then(
       .should('have.property', key, value === 'default' ? '' : value);
   }
 );
+
+When('navigating back', () => {
+  cy.go(-1);
+});

--- a/packages/x-components/tests/e2e/related-tags.feature
+++ b/packages/x-components/tests/e2e/related-tags.feature
@@ -67,3 +67,19 @@ Feature: Related tags component
       | maxItemsToRequest | addToSearchBox | query | relatedTagItem | request                |
       | 9                 | false          | lego  | 2              | interceptedRelatedTags |
 
+  Scenario Outline: 4. Related tags are kept when navigating back
+    Given following config: requested items <maxItemsToRequest>, add to search-box <addToSearchBox>
+    And   start button is clicked
+    When  "<query>" is searched
+    Then related tags are displayed
+    Then related results have changed
+    When filter number 0 is clicked in facet "hierarchical_category"
+    Then related results have changed
+    When navigating back
+    Then related results have changed
+    Then related tags are displayed
+
+    Examples:
+      | maxItemsToRequest | addToSearchBox | query |
+      | 9                 | false          | lego  |
+

--- a/packages/x-components/tests/e2e/url/url.spec.ts
+++ b/packages/x-components/tests/e2e/url/url.spec.ts
@@ -1,10 +1,5 @@
 import { And, When } from 'cypress-cucumber-preprocessor/steps';
 
-// Scenario 2
-When('navigating back', () => {
-  cy.go(-1);
-});
-
 // Scenario 3
 When('clicking result in position {int}', (index: number) => {
   cy.getByDataTest('result-link').eq(index).click();


### PR DESCRIPTION
EX-6131

Before this PR:

1. Search for something with related tags
2. Select a filter
3. Navigate back
4. Related tags disappear

By just removing the `setRelatedTags` mutation call with an empty array, this works as expected, and if related tags are shared between different queries we should see them animate.

If someone complains about the user being able to select wrong related tags while they are loading between navigations, I would disable them so they are not clickable. However I see this as an edge use case.