### PR TITLE
fix(url): URL now requires a query to store rest of fields.

### DIFF
--- a/packages/x-components/src/x-modules/url/components/__tests__/url-handler.spec.ts
+++ b/packages/x-components/src/x-modules/url/components/__tests__/url-handler.spec.ts
@@ -21,6 +21,7 @@ Object.defineProperty(window, 'performance', {
 /**
  * Renders the {@link UrlHandler} component, exposing a basic API for testing.
  *
+ * @param root0
  * @returns The API for testing the {@link UrlHandler} component.
  */
 function renderUrlHandler({
@@ -230,6 +231,20 @@ describe('testing UrlHandler component', () => {
       query: 'lego farm'
     });
     expect(window.location.href).toContain('query=lego%20farm');
+  });
+
+  it('ignores all parameters if query is not provided', () => {
+    const { emit } = renderUrlHandler();
+    emit('PushableUrlStateChanged', {
+      page: 2,
+      filter: ['dry-aged:2-months'],
+      sort: 'price desc',
+      tag: ['frisona'],
+      scroll: 'frisona-steak-1.5kg',
+      query: ''
+    });
+
+    expect(new URL(window.location.href).searchParams.toString()).toEqual('');
   });
 });
 

--- a/packages/x-components/src/x-modules/url/components/url-handler.vue
+++ b/packages/x-components/src/x-modules/url/components/url-handler.vue
@@ -300,7 +300,7 @@
      *
      * @param url - The URL to remove parameters from.
      * @internal
-     * **/
+     */
     protected deleteUrlParameters(url: URL): void {
       this.managedParamsNames.forEach(paramName =>
         url.searchParams.delete(this.getUrlKey(paramName))
@@ -318,8 +318,12 @@
      * important for SEO purposes.
      *
      * @internal
-     * **/
+     */
     protected setUrlParameters(url: URL, urlParams: UrlParams): void {
+      // Only when there is a query the rest of the parameters are valid.
+      if (!urlParams.query) {
+        return;
+      }
       const filteredParams = objectFilter(urlParams, paramName =>
         this.managedParamsNames.includes(paramName as string)
       );


### PR DESCRIPTION
EX-6134

This just prevents the url handler from storing any values when there is no query. This happens with the preselected filters PR.
