### PR TITLE
Feature/385 search box animated placeholder

### DIFF
--- a/packages/x-components/src/design-system/components/search-placeholder/default.scss
+++ b/packages/x-components/src/design-system/components/search-placeholder/default.scss
@@ -1,0 +1,42 @@
+.form-group{
+    position: relative;
+}
+.placeholder {
+    position: absolute;
+    left: 10px;
+    top: 12px;
+    opacity: 0;
+}
+    @keyframes fadeIn {
+        0% {
+            opacity: 0;
+        }
+
+        50% {
+            opacity: 1;
+        }
+
+        100% {
+            opacity: 0;
+        }
+    }
+
+    @keyframes slideIn {
+        0% {
+            transform: translateY(-30%);
+        }
+
+        50% {
+            transform: translateY(0);
+        }
+
+        100% {
+            transform: translateY(30%);
+        }
+    }
+
+    .visible{
+        opacity: 1;
+        animation: fadeIn 2s, slideIn 2s;
+        animation-iteration-count: infinite;
+    }

--- a/packages/x-components/src/views/Search.vue
+++ b/packages/x-components/src/views/Search.vue
@@ -3,15 +3,7 @@
     <header class="header">
       <div class="form-group">
         <SearchInput></SearchInput>
-        <SearchInputPlaceholder
-          :numberOfStrings="2"
-          :placeholdersArray="[
-            'Search for a product',
-            'Search for a category',
-            'Search for a brand',
-            'Search for a store'
-          ]"
-        />
+        <SearchInputPlaceholder />
         <ClearSearchInput>
           <CrossIcon />
         </ClearSearchInput>

--- a/packages/x-components/src/views/Search.vue
+++ b/packages/x-components/src/views/Search.vue
@@ -1,10 +1,21 @@
 <template>
   <div class="search">
     <header class="header">
-      <SearchInput />
-      <ClearSearchInput>
-        <CrossIcon />
-      </ClearSearchInput>
+      <div class="form-group">
+        <SearchInput></SearchInput>
+        <SearchInputPlaceholder
+          :numberOfStrings="2"
+          :placeholdersArray="[
+            'Search for a product',
+            'Search for a category',
+            'Search for a brand',
+            'Search for a store'
+          ]"
+        />
+        <ClearSearchInput>
+          <CrossIcon />
+        </ClearSearchInput>
+      </div>
     </header>
     <aside class="aside">
       <template v-if="hasFacets">
@@ -85,6 +96,8 @@
   import FiltersList from '../x-modules/facets/components/lists/filters-list.vue';
   import ClearSearchInput from '../x-modules/search-box/components/clear-search-input.vue';
   import SearchInput from '../x-modules/search-box/components/search-input.vue';
+  // eslint-disable-next-line max-len
+  import SearchInputPlaceholder from '../x-modules/search-box/components/search-input-placeholder.vue';
   import { searchXModule } from '../x-modules/search/x-module';
 
   XPlugin.registerXModule(searchXModule);
@@ -100,7 +113,8 @@
       FiltersList,
       Facets,
       ClearSearchInput,
-      SearchInput
+      SearchInput,
+      SearchInputPlaceholder
     }
   })
   export default class Search extends Vue {

--- a/packages/x-components/src/x-modules/search-box/components/search-input-placeholder.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input-placeholder.vue
@@ -1,0 +1,54 @@
+<template>
+  <label ref="placeholder" class="placeholder"></label>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { State } from '../../../components/decorators/store.decorators';
+  import { XOn } from '../../../components/decorators/bus.decorators';
+  import { xComponentMixin } from '../../../components/x-component.mixin';
+  import { searchBoxXModule } from '../x-module';
+  import SearchInput from './search-input.vue';
+  @Component({
+    components: { SearchInput },
+    mixins: [xComponentMixin(searchBoxXModule)]
+  })
+  export default class SearchInputPlaceholder extends Vue {
+    @State('searchBox', 'query')
+    public query!: string;
+
+    @Prop({ default: () => [''] })
+    protected placeholdersArray!: string[];
+
+    @Prop({ default: 1 })
+    protected numberOfStrings!: number;
+
+    protected get isQueryEmpty(): boolean {
+      return this.query.length === 0;
+    }
+
+    @XOn(['UserHoveringOverSearchBox'])
+    animatePlaceholder(): void {
+      if (this.isQueryEmpty) {
+        var array = this.placeholdersArray;
+        var element = this.$refs.placeholder as HTMLElement;
+        element.classList.add('visible');
+        for (let i = 0; i < array.length; i++) {
+          setTimeout(function () {
+            element.innerText = array[i];
+            if (i === array.length - 1) {
+              element.classList.remove('visible');
+            }
+          }, i * 2000);
+        }
+      }
+    }
+
+    @XOn(['UserFocusedSearchBox'])
+    stopAnimatingPlaceholder(): void {
+      var element = this.$refs.placeholder as HTMLElement;
+      element.classList.remove('visible');
+    }
+  }
+</script>

--- a/packages/x-components/src/x-modules/search-box/components/search-input-placeholder.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input-placeholder.vue
@@ -21,9 +21,6 @@
     @Prop({ default: () => [''] })
     protected placeholdersArray!: string[];
 
-    @Prop({ default: 1 })
-    protected numberOfStrings!: number;
-
     protected get isQueryEmpty(): boolean {
       return this.query.length === 0;
     }

--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -5,6 +5,8 @@
     @click="emitUserClickedSearchBox"
     @focus="emitUserFocusedSearchBox"
     @input="emitUserIsTypingAQueryEvents"
+    @mouseover="emitUserHoveringOverSearchBox"
+    @mouseout="emitUserHoveringOutOfSearchBox"
     @keydown.enter="emitUserPressedEnterKey"
     @keydown.up.down.prevent="emitUserPressedArrowKey"
     :maxlength="maxLength"
@@ -173,6 +175,13 @@
      */
     protected emitUserFocusedSearchBox(): void {
       this.$x.emit('UserFocusedSearchBox', undefined, { target: this.$refs.input });
+    }
+
+    protected emitUserHoveringOverSearchBox(): void {
+      this.$x.emit('UserHoveringOverSearchBox', undefined, { target: this.$refs.input });
+    }
+    protected emitUserHoveringOutOfSearchBox(): void {
+      this.$x.emit('UserHoveringOutOfSearchBox', undefined, { target: this.$refs.input });
     }
 
     /**

--- a/packages/x-components/src/x-modules/search-box/events.types.ts
+++ b/packages/x-components/src/x-modules/search-box/events.types.ts
@@ -7,57 +7,61 @@
 export interface SearchBoxXEvents {
   /**
    * The search-box query has changed
-   * * Payload: The new search-box query.
+   * Payload: The new search-box query.
    */
   SearchBoxQueryChanged: string;
   /**
    * The user removed the focus from the search-box.
-   * * Payload: none.
+   * Payload: none.
    */
   UserBlurredSearchBox: void;
   /**
    * The user cleared the search-box query in any way, typing or pressing a button that clears it.
-   * * Payload: none.
+   * Payload: none.
    */
   /**
    * The user cleared the search-box query in any way, typing or pressing a button that clears it.
    * The payload is usually an empty string.
-   * * Payload: string.
+   * Payload: string.
    */
   UserClearedQuery: string;
   /**
    * The user clicked on the search-box input.
-   * * Payload: none.
+   * Payload: none.
    */
   UserClickedSearchBox: void;
   /**
    * The user focused the search-box
-   * * Payload: none.
+   * Payload: none.
    */
   UserFocusedSearchBox: void;
   /**
    * The user is typing/pasting a query
-   * * Payload: the partial query that the user is typing.
+   * Payload: the partial query that the user is typing.
    */
+  UserHoveringOverSearchBox: void;
+
+  UserHoveringOutOfSearchBox: void;
+
   UserIsTypingAQuery: string;
   /**
    * The user triggered the button that clears the search-box
-   * * Payload: none.
+   * Payload: none.
    */
   UserPressedClearSearchBoxButton: void;
   /**
    * The user pressed the enter key with the focus on the search-box
-   * * Payload: the new query of the search-box.
+   * Payload: the new query of the search-box.
    */
   UserPressedEnterKey: string;
   /**
    * The user pressed the search button
-   * * Payload: The query to search.
+   * Payload: The query to search.
    */
   UserPressedSearchButton: string;
   /**
    * The user voiced a query
-   * * Payload: The spoken query.
+   * Payload: The spoken query.
    */
   UserTalked: string;
 }


### PR DESCRIPTION
**Purpose**
To have an animated placeholder showing different messages to inspire the shopper to type different types of queries.

## Motivation and context
The motivation for this issue is to bring a more welcoming experience to the user by providing an idea of the products being made available to the same.

A ```searchinputplaceholder``` component was made an the same can coexist with the already existant ```searchinput``` component.

A new emitter ```emitUserHoveringOverSearchBox``` was created for the hover on the ```searchinput``` component so that the animation can start on hover.
The animation stops when the user clicks on the input element or if the user stops hovering. Also if there is text in the placeholder, the animation won't trigger so that the text doesn't overlap the inputted text.


<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify: None
- [ ] Open issue: **[issue] (https://github.com/empathyco/x/issues/385)

## Type of change
New feature 

## What is the destination branch of this PR?
Main

## How has this been tested?
Testing has been performed in the development server by extensive usage
We tried different test scenarios by changing the number of placeholders in the prop

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
