### PR TITLE
feat(mappers): allow passing raw values to `subSchema.$context` pros using functions

### DIFF
--- a/packages/x-adapter/src/mappers/__tests__/schema-mapper.factory.spec.ts
+++ b/packages/x-adapter/src/mappers/__tests__/schema-mapper.factory.spec.ts
@@ -259,7 +259,8 @@ describe('schemaMapperFactory tests', () => {
     const filterSchema: Schema<Filter, TargetFilter> = {
       filterId: 'id',
       value: 'value',
-      parentId: (_, $context) => $context?.parentId as string
+      // eslint-disable-next-line @typescript-eslint/no-extra-parens
+      parentId: (_, $context) => ($context?.isChild ? ($context?.parentId as string) : '')
     };
 
     const facetSchema: Schema<Facet, TargetFacet> = {
@@ -268,32 +269,32 @@ describe('schemaMapperFactory tests', () => {
         $path: 'children',
         $subSchema: filterSchema,
         $context: {
-          parentId: 'facet'
+          parentId: 'facet',
+          isChild: () => true
         }
       }
     };
 
     const source: Facet = {
-      facet: 'parentFacet',
+      facet: 'category',
       children: [
         {
-          id: 'filter',
-          value: 'filterValue'
+          id: 'category:man',
+          value: 'man'
         }
       ]
     };
 
-    const target: TargetFacet = {
-      id: 'parentFacet',
+    const mapper = schemaMapperFactory(facetSchema);
+    expect(mapper(source, { requestParameters: { addNumFound: 2 } })).toStrictEqual<TargetFacet>({
+      id: 'category',
       filters: [
         {
-          filterId: 'filter',
-          value: 'filterValue',
-          parentId: 'parentFacet'
+          filterId: 'category:man',
+          value: 'man',
+          parentId: 'category'
         }
       ]
-    };
-    const mapper = schemaMapperFactory(facetSchema);
-    expect(mapper(source, { requestParameters: { addNumFound: 2 } })).toStrictEqual(target);
+    });
   });
 });

--- a/packages/x-adapter/src/mappers/__tests__/schema-mapper.factory.spec.ts
+++ b/packages/x-adapter/src/mappers/__tests__/schema-mapper.factory.spec.ts
@@ -237,6 +237,7 @@ describe('schemaMapperFactory tests', () => {
   it('should resolve the context from the source', () => {
     interface Facet {
       facet: string;
+      isParent: boolean;
       children: Filter[];
     }
 
@@ -260,7 +261,7 @@ describe('schemaMapperFactory tests', () => {
       filterId: 'id',
       value: 'value',
       // eslint-disable-next-line @typescript-eslint/no-extra-parens
-      parentId: (_, $context) => ($context?.isChild ? ($context?.parentId as string) : '')
+      parentId: (_, $context) => ($context?.hasParent ? ($context?.parentId as string) : '')
     };
 
     const facetSchema: Schema<Facet, TargetFacet> = {
@@ -270,13 +271,14 @@ describe('schemaMapperFactory tests', () => {
         $subSchema: filterSchema,
         $context: {
           parentId: 'facet',
-          isChild: () => true
+          hasParent: ({ isParent }: Facet) => isParent
         }
       }
     };
 
     const source: Facet = {
       facet: 'category',
+      isParent: true,
       children: [
         {
           id: 'category:man',

--- a/packages/x-adapter/src/mappers/schema-mapper.factory.ts
+++ b/packages/x-adapter/src/mappers/schema-mapper.factory.ts
@@ -111,7 +111,9 @@ function applySubSchemaTransformer<Source, Target>(
       if (['requestParameters', 'endpoint', 'to'].includes(key)) {
         return;
       }
-      extendedContext[key] = extractValue(source, value as ExtractPath<typeof source>);
+      extendedContext[key] = isFunction(value)
+        ? value()
+        : extractValue(source, value as ExtractPath<typeof source>);
     });
   }
 

--- a/packages/x-adapter/src/mappers/schema-mapper.factory.ts
+++ b/packages/x-adapter/src/mappers/schema-mapper.factory.ts
@@ -112,7 +112,7 @@ function applySubSchemaTransformer<Source, Target>(
         return;
       }
       extendedContext[key] = isFunction(value)
-        ? value()
+        ? value(source)
         : extractValue(source, value as ExtractPath<typeof source>);
     });
   }


### PR DESCRIPTION
EX-6217

## Motivation and context
applySubsSchemaTransformer implementation allows $context props to only be source property paths. We also need to be able to pass normal values (a number, boolean, string, etc). In order to make things easier, we will only allow these normal values to be passed through functions.## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## How has this been tested?
Refactored unit test case adding this functionality.

## Checklist:
- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
