### PR TITLE
feat: Create highlight component for suggestions

### DIFF
--- a/packages/x-components/src/components/highlight/highlight.vue
+++ b/packages/x-components/src/components/highlight/highlight.vue
@@ -1,0 +1,52 @@
+<template>
+  <span
+    v-html="queryHTML"
+    v-bind="{ toHighlight, queryHTML }"
+    :aria-label="toHighlight"
+    class="x-suggestion__query"
+  />
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { normalizeString } from '../../utils/normalize';
+  import { sanitize } from '../../utils/sanitize';
+
+  @Component
+  export default class Highlight extends Vue {
+    @Prop({ required: true })
+    protected toHighlight!: string;
+
+    @Prop({ required: true })
+    protected highlight!: string;
+
+    protected get hasMatchingQuery(): boolean {
+      return !!this.toHighlight && normalizeString(this.toHighlight).includes(this.toHighlight);
+    }
+
+    protected get queryHTML(): string {
+      if (this.hasMatchingQuery) {
+        const matcherIndex = normalizeString(this.highlight).indexOf(this.toHighlight);
+
+        const [beginning, matching, end] = this.splitAt(
+          this.toHighlight,
+          matcherIndex,
+          this.toHighlight.length
+        );
+
+        const attrsMatching = 'data-test="matching-part" class="x-suggestion__matching-part"';
+        return `${beginning}<span ${attrsMatching}>${matching}</span>${end}`;
+      }
+
+      return sanitize(this.toHighlight);
+    }
+
+    protected splitAt(label: string, start: number, skip: number): [string, string, string] {
+      const startPart = label.substr(0, start);
+      const matchingPart = label.substr(start, skip);
+      const endPart = label.substr(start + skip);
+      return [sanitize(startPart), sanitize(matchingPart), sanitize(endPart)];
+    }
+  }
+</script>

--- a/packages/x-components/src/components/highlight/index.ts
+++ b/packages/x-components/src/components/highlight/index.ts
@@ -1,0 +1,1 @@
+export { default as Highlight } from './highlight.vue';


### PR DESCRIPTION
**Purpose**
Create a new Highlight component to be in charge of highlighting the part of a suggestions that matches the current query in the search box.

## Motivation and context
Extract the highlight logic from the [BaseSuggestion](https://github.com/empathyco/x/blob/main/packages/x-components/src/components/suggestions/base-suggestion.vue) component.

The methods needed for the highlight funcionality were extracted from the [BaseSuggestion](https://github.com/empathyco/x/blob/main/packages/x-components/src/components/suggestions/base-suggestion.vue) and moved into a ```Highlight``` component

- [ ] Dependencies. If any, specify: None
- [ ] Open issue: **[issue] (https://github.com/empathyco/x/issues/381)

## Type of change
New feature 

## What is the destination branch of this PR?
Main

## How has this been tested?
The component codebase was tested from a static analysis point of view since we couldn't find the highlight functionality in the UI itself.

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
