### PR TITLE
feat(mappers): combine search response mappers to flatten hierarchical filters

### DIFF
--- a/packages/x-adapter-platform/src/__tests__/__fixtures__/platform-search.response.ts
+++ b/packages/x-adapter-platform/src/__tests__/__fixtures__/platform-search.response.ts
@@ -273,113 +273,94 @@ export const searchResponse = {
     {
       filters: [
         {
-          children: {
-            filters: [
-              {
-                facetId: 'categoryIds:78d9b7366__8a4e61a33',
-                id: 'categoryIds:78d9b7366__8a4e61a33',
-                label: 'Bottomwear',
-                modelName: 'HierarchicalFilter',
-                parentId: 'categoryPaths_78d9b7366',
-                selected: false,
-                totalResults: 637,
-                children: {
-                  id: 'categoryPaths_78d9b7366__8a4e61a33',
-                  label: 'categoryPaths_78d9b7366__8a4e61a33',
-                  modelName: 'HierarchicalFacet',
-                  filters: [
-                    {
-                      facetId: 'categoryIds:78d9b7366__8a4e61a33_aa',
-                      id: 'categoryIds:78d9b7366__8a4e61a33_aa',
-                      totalResults: 1,
-                      label: 'Added',
-                      selected: false,
-                      modelName: 'HierarchicalFilter',
-                      parentId: 'categoryPaths_78d9b7366__8a4e61a33',
-                      children: {
-                        filters: [
-                          {
-                            facetId: 'categoryIds:78d9b7366__8a4e61a33_aa_bb',
-                            id: 'categoryIds:78d9b7366__8a4e61a33_aa_bb',
-                            label: 'Added 2',
-                            modelName: 'HierarchicalFilter',
-                            parentId: 'categoryPaths_78d9b7366__8a4e61a33_aa',
-                            selected: false,
-                            totalResults: 1
-                          }
-                        ],
-                        id: 'categoryPaths_78d9b7366__8a4e61a33_aa',
-                        label: 'categoryPaths_78d9b7366__8a4e61a33_aa',
-                        modelName: 'HierarchicalFacet'
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                facetId: 'categoryIds:78d9b7366__e2f94a4ea',
-                id: 'categoryIds:78d9b7366__e2f94a4ea',
-                label: 'Topwear',
-                modelName: 'HierarchicalFilter',
-                parentId: 'categoryPaths_78d9b7366',
-                selected: false,
-                totalResults: 99
-              }
-            ],
-            id: 'categoryPaths_78d9b7366',
-            label: 'categoryPaths_78d9b7366',
-            modelName: 'HierarchicalFacet'
-          },
-          facetId: 'categoryIds:78d9b7366',
+          facetId: 'categoryPaths',
+          id: 'categoryIds:78d9b7366__8a4e61a33_aa_bb',
+          label: 'Added 2',
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:78d9b7366__8a4e61a33_aa',
+          selected: false,
+          totalResults: 1,
+          children: undefined
+        },
+        {
+          facetId: 'categoryPaths',
+          id: 'categoryIds:78d9b7366__8a4e61a33_aa',
+          totalResults: 1,
+          label: 'Added',
+          selected: false,
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:78d9b7366__8a4e61a33',
+          children: ['categoryIds:78d9b7366__8a4e61a33_aa_bb']
+        },
+        {
+          facetId: 'categoryPaths',
+          id: 'categoryIds:78d9b7366__8a4e61a33',
+          label: 'Bottomwear',
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:78d9b7366',
+          selected: false,
+          totalResults: 637,
+          children: ['categoryIds:78d9b7366__8a4e61a33_aa']
+        },
+        {
+          facetId: 'categoryPaths',
+          id: 'categoryIds:78d9b7366__e2f94a4ea',
+          label: 'Topwear',
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:78d9b7366',
+          selected: false,
+          totalResults: 99,
+          children: undefined
+        },
+        {
+          facetId: 'categoryPaths',
           id: 'categoryIds:78d9b7366',
           label: 'Apparel',
           modelName: 'HierarchicalFilter',
-          parentId: 'categoryPaths',
+          parentId: null,
           selected: false,
-          totalResults: 736
+          totalResults: 736,
+          children: ['categoryIds:78d9b7366__8a4e61a33', 'categoryIds:78d9b7366__e2f94a4ea']
         },
         {
-          facetId: 'categoryIds:b08648dbd',
+          facetId: 'categoryPaths',
           id: 'categoryIds:b08648dbd',
           label: 'Accessories',
           modelName: 'HierarchicalFilter',
-          parentId: 'categoryPaths',
+          parentId: null,
           selected: false,
-          totalResults: 43
+          totalResults: 43,
+          children: undefined
         },
         {
-          facetId: 'categoryIds:ffc61e1e9',
+          facetId: 'categoryPaths',
+          id: 'categoryIds:ffc61e1e9_aa',
+          label: 'Added',
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:ffc61e1e9',
+          selected: false,
+          totalResults: 1,
+          children: undefined
+        },
+        {
+          facetId: 'categoryPaths',
           id: 'categoryIds:ffc61e1e9',
           label: 'Personal Care',
           modelName: 'HierarchicalFilter',
-          parentId: 'categoryPaths',
+          parentId: null,
           selected: false,
           totalResults: 9,
-          children: {
-            filters: [
-              {
-                facetId: 'categoryIds:ffc61e1e9_aa',
-                id: 'categoryIds:ffc61e1e9_aa',
-                label: 'Added',
-                modelName: 'HierarchicalFilter',
-                parentId: 'categoryPaths_ffc61e1e9',
-                selected: false,
-                totalResults: 1
-              }
-            ],
-            id: 'categoryPaths_ffc61e1e9',
-            label: 'categoryPaths_ffc61e1e9',
-            modelName: 'HierarchicalFacet'
-          }
+          children: ['categoryIds:ffc61e1e9_aa']
         },
         {
-          facetId: 'categoryIds:e5eef62d8',
+          facetId: 'categoryPaths',
           id: 'categoryIds:e5eef62d8',
           label: 'Footwear',
           modelName: 'HierarchicalFilter',
-          parentId: 'categoryPaths',
+          parentId: null,
           selected: false,
-          totalResults: 6
+          totalResults: 6,
+          children: undefined
         }
       ],
       id: 'categoryPaths',
@@ -389,7 +370,7 @@ export const searchResponse = {
     {
       filters: [
         {
-          facetId: '10.0-20.0',
+          facetId: 'price',
           id: 'price:10.0-20.0',
           label: '10.0-20.0',
           modelName: 'NumberRangeFilter',
@@ -401,7 +382,7 @@ export const searchResponse = {
           totalResults: 97
         },
         {
-          facetId: '20.0-30.0',
+          facetId: 'price',
           id: 'price:20.0-30.0',
           label: '20.0-30.0',
           modelName: 'NumberRangeFilter',
@@ -413,7 +394,7 @@ export const searchResponse = {
           totalResults: 80
         },
         {
-          facetId: '30.0-40.0',
+          facetId: 'price',
           id: 'price:30.0-40.0',
           label: '30.0-40.0',
           modelName: 'NumberRangeFilter',
@@ -425,7 +406,7 @@ export const searchResponse = {
           totalResults: 85
         },
         {
-          facetId: '40.0-50.0',
+          facetId: 'price',
           id: 'price:40.0-50.0',
           label: '40.0-50.0',
           modelName: 'NumberRangeFilter',
@@ -437,7 +418,7 @@ export const searchResponse = {
           totalResults: 75
         },
         {
-          facetId: '50.0-60.0',
+          facetId: 'price',
           id: 'price:50.0-60.0',
           label: '50.0-60.0',
           modelName: 'NumberRangeFilter',
@@ -449,7 +430,7 @@ export const searchResponse = {
           totalResults: 88
         },
         {
-          facetId: '60.0-70.0',
+          facetId: 'price',
           id: 'price:60.0-70.0',
           label: '60.0-70.0',
           modelName: 'NumberRangeFilter',
@@ -461,7 +442,7 @@ export const searchResponse = {
           totalResults: 62
         },
         {
-          facetId: '70.0-80.0',
+          facetId: 'price',
           id: 'price:70.0-80.0',
           label: '70.0-80.0',
           modelName: 'NumberRangeFilter',
@@ -473,7 +454,7 @@ export const searchResponse = {
           totalResults: 84
         },
         {
-          facetId: '80.0-90.0',
+          facetId: 'price',
           id: 'price:80.0-90.0',
           label: '80.0-90.0',
           modelName: 'NumberRangeFilter',
@@ -485,7 +466,7 @@ export const searchResponse = {
           totalResults: 86
         },
         {
-          facetId: '90.0-100.0',
+          facetId: 'price',
           id: 'price:90.0-100.0',
           label: '90.0-100.0',
           modelName: 'NumberRangeFilter',
@@ -504,7 +485,7 @@ export const searchResponse = {
     {
       filters: [
         {
-          facetId: 'gender:men',
+          facetId: 'gender',
           id: 'gender:men',
           label: 'men',
           modelName: 'SimpleFilter',
@@ -512,7 +493,7 @@ export const searchResponse = {
           totalResults: 421
         },
         {
-          facetId: 'gender:women',
+          facetId: 'gender',
           id: 'gender:women',
           label: 'women',
           modelName: 'SimpleFilter',
@@ -520,7 +501,7 @@ export const searchResponse = {
           totalResults: 247
         },
         {
-          facetId: 'gender:boys',
+          facetId: 'gender',
           id: 'gender:boys',
           label: 'boys',
           modelName: 'SimpleFilter',
@@ -528,7 +509,7 @@ export const searchResponse = {
           totalResults: 35
         },
         {
-          facetId: 'gender:girls',
+          facetId: 'gender',
           id: 'gender:girls',
           label: 'girls',
           modelName: 'SimpleFilter',
@@ -536,7 +517,7 @@ export const searchResponse = {
           totalResults: 28
         },
         {
-          facetId: 'gender:unisex',
+          facetId: 'gender',
           id: 'gender:unisex',
           label: 'unisex',
           modelName: 'SimpleFilter',

--- a/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
+++ b/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
@@ -127,7 +127,7 @@ describe('platformAdapter tests', () => {
         modelName: 'NumberRangeFacet',
         filters: [
           {
-            facetId: '10.0-20.0',
+            facetId: 'price',
             id: 'price:10.0-20.0',
             label: '10.0-20.0',
             modelName: 'NumberRangeFilter',
@@ -139,7 +139,7 @@ describe('platformAdapter tests', () => {
             totalResults: 97
           },
           {
-            facetId: '20.0-30.0',
+            facetId: 'price',
             id: 'price:20.0-30.0',
             label: '20.0-30.0',
             modelName: 'NumberRangeFilter',

--- a/packages/x-adapter-platform/src/mappers/response/search-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/response/search-response.mapper.ts
@@ -2,7 +2,10 @@ import { schemaMapperFactory, combineMappers, MapperContext } from '@empathyco/x
 import { SearchResponse, HierarchicalFilter, HierarchicalFacet } from '@empathyco/x-types';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
 import { searchResponseMutableSchema } from '../../schemas/response/search-response.schema';
-import { AdapterHierarchicalFacet, AdapterHierarchicalFilter } from '../../types';
+import {
+  AdapterHierarchicalFacet,
+  AdapterHierarchicalFilter
+} from '../../types/responses/models/facet.model';
 
 export const searchResponseMapper = combineMappers(
   schemaMapperFactory<PlatformSearchResponse, SearchResponse>(searchResponseMutableSchema),

--- a/packages/x-adapter-platform/src/mappers/response/search-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/response/search-response.mapper.ts
@@ -1,8 +1,76 @@
-import { schemaMapperFactory } from '@empathyco/x-adapter-next';
-import { SearchResponse } from '@empathyco/x-types';
+import { schemaMapperFactory, combineMappers, MapperContext } from '@empathyco/x-adapter-next';
+import { SearchResponse, HierarchicalFilter, HierarchicalFacet } from '@empathyco/x-types';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
 import { searchResponseMutableSchema } from '../../schemas/response/search-response.schema';
+import { AdapterHierarchicalFacet, AdapterHierarchicalFilter } from '../../types';
 
-export const searchResponseMapper = schemaMapperFactory<PlatformSearchResponse, SearchResponse>(
-  searchResponseMutableSchema
+export const searchResponseMapper = combineMappers(
+  schemaMapperFactory<PlatformSearchResponse, SearchResponse>(searchResponseMutableSchema),
+  searchResponseFacetsMapper
 );
+
+/**
+ * Mapper to flatten hierarchical facet filters.
+ *
+ * @param from - The Platform search response.
+ * @param context - The context from the mapper.
+ * @returns The mapped facets.
+ */
+export function searchResponseFacetsMapper(
+  from: PlatformSearchResponse,
+  { to }: MapperContext
+): Partial<SearchResponse> {
+  const facets = (to as SearchResponse).facets?.map(facet =>
+    facet.modelName === 'HierarchicalFacet'
+      ? flattenHierarchicalFacet(facet as AdapterHierarchicalFacet)
+      : facet
+  );
+  return { facets };
+}
+
+/**
+ * Returns a hierarchical facet with its filters flattened.
+ *
+ * @param facet - The hierarchical facet.
+ * @returns The flattened hierarchical facet.
+ */
+function flattenHierarchicalFacet(facet: AdapterHierarchicalFacet): HierarchicalFacet {
+  const filters: HierarchicalFilter[] = [];
+
+  facet.filters.forEach(rawFilter => {
+    mapHierarchicalFilter(
+      rawFilter,
+      {
+        facetId: facet.id,
+        parentId: null
+      },
+      filters
+    );
+  });
+
+  return {
+    ...facet,
+    filters
+  };
+}
+
+/**
+ * Map recursively the hierarchical facet filters.
+ *
+ * @param rawFilter - The hierarchical filter to map.
+ * @param initialValues - The initial values for the filter.
+ * @param filters - The filters array to fill with the facet filters.
+ * @returns The filter id.
+ */
+function mapHierarchicalFilter(
+  rawFilter: AdapterHierarchicalFilter,
+  initialValues: Readonly<Partial<HierarchicalFilter>>,
+  filters: HierarchicalFilter[]
+): HierarchicalFilter['id'] {
+  const filter = { ...rawFilter, ...initialValues } as HierarchicalFilter;
+  filter.children = rawFilter.children?.filters?.map(rawFilterChild =>
+    mapHierarchicalFilter(rawFilterChild, { ...initialValues, parentId: filter.id }, filters)
+  );
+  filters.push(filter);
+  return filter.id;
+}

--- a/packages/x-adapter-platform/src/mappers/response/search-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/response/search-response.mapper.ts
@@ -59,11 +59,13 @@ function mapHierarchicalFilter(
   rawFilter: AdapterHierarchicalFilter,
   filters: HierarchicalFilter[]
 ): HierarchicalFilter[] {
-  const filter = { ...rawFilter } as HierarchicalFilter;
-  filter.children = rawFilter.children?.filters.map(rawFilterChild => {
-    mapHierarchicalFilter(rawFilterChild, filters);
-    return rawFilterChild.id;
-  });
+  const filter: HierarchicalFilter = {
+    ...rawFilter,
+    children: rawFilter.children?.filters.map(rawFilterChild => {
+      mapHierarchicalFilter(rawFilterChild, filters);
+      return rawFilterChild.id;
+    })
+  };
   filters.push(filter);
   return filters;
 }

--- a/packages/x-adapter-platform/src/schemas/response/models/facet.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facet.schema.ts
@@ -28,7 +28,6 @@ export const facetSchema: Schema<
     $path: 'values',
     $subSchema: ({ facet }) => getFacetConfig(facet).getSchema() as any,
     $context: {
-      parentId: 'facet',
       facetId: 'facet'
     }
   }
@@ -41,16 +40,14 @@ export const hierarchicalFilterSchema: Schema<PlatformHierarchicalFilter, Hierar
   label: 'value',
   id: 'filter',
   totalResults: 'count',
-  // eslint-disable-next-line @typescript-eslint/no-extra-parens
-  parentId: (_, $context) => ($context?.isChild ? ($context?.parentId as string) : null),
+  parentId: (_, $context) => ($context?.parentId as string) ?? null,
   selected: () => false,
   modelName: () => 'HierarchicalFilter',
   children: {
     $path: 'children',
     $subSchema: facetMutableSchema as any,
     $context: {
-      // TODO EX-6217 Replace with boolean value instead of using the value of `filter`
-      isChild: 'filter'
+      parentId: 'filter'
     }
   }
 };

--- a/packages/x-adapter-platform/src/schemas/response/models/facet.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facet.schema.ts
@@ -26,7 +26,7 @@ export const facetSchema: Schema<
   },
   filters: {
     $path: 'values',
-    $subSchema: ({ facet }) => getFacetConfig(facet).getSchema() as any,
+    $subSchema: ({ facet }) => getFacetConfig(facet).schema as any,
     $context: {
       facetId: 'facet'
     }
@@ -57,14 +57,14 @@ export const hierarchicalFilterMutableSchema = createMutableSchema(hierarchicalF
 export const facetsConfig: FacetsConfig = {
   categoryPaths: {
     modelName: 'HierarchicalFacet',
-    getSchema: () => hierarchicalFilterMutableSchema
+    schema: hierarchicalFilterMutableSchema
   },
   price: {
     modelName: 'NumberRangeFacet',
-    getSchema: () => numberFilterMutableSchema
+    schema: numberFilterMutableSchema
   },
   default: {
     modelName: 'SimpleFacet',
-    getSchema: () => simpleMutableFilterSchema
+    schema: simpleMutableFilterSchema
   }
 };

--- a/packages/x-adapter-platform/src/schemas/response/models/facet.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facet.schema.ts
@@ -12,7 +12,8 @@ import {
 } from '../../../types/responses/models/facet.model';
 import { getFacetConfig, getFacetId } from './facets/utils';
 import { FacetsConfig } from './facets';
-import { numberFilterMutableSchema, simpleMutableFilterSchema } from './filters';
+import { numberFilterMutableSchema } from './filters/number-filter.schema';
+import { simpleMutableFilterSchema } from './filters/simple-filter.schema';
 
 export const facetSchema: Schema<
   PlatformFacet,

--- a/packages/x-adapter-platform/src/schemas/response/models/facets/__tests__/utils.spec.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facets/__tests__/utils.spec.ts
@@ -1,0 +1,19 @@
+import { getFacetConfig, getFacetId } from '../utils';
+import { facetsConfig } from '../../facet.schema';
+
+describe('getFacetConfig', () => {
+  it('returns the config when the facet has its own config', () => {
+    expect(getFacetConfig('categoryPaths')).toStrictEqual(facetsConfig.categoryPaths);
+    expect(getFacetConfig('categoryPaths_78d9b7366')).toStrictEqual(facetsConfig.categoryPaths);
+  });
+  it("returns the default config when the facet doesn't have its own config", () => {
+    expect(getFacetConfig('gender')).toStrictEqual(facetsConfig.default);
+  });
+});
+
+describe('getFacetId', () => {
+  it('returns the facet id', () => {
+    expect(getFacetId('categoryPaths')).toEqual('categoryPaths');
+    expect(getFacetId('categoryPaths_78d9b7366')).toEqual('categoryPaths');
+  });
+});

--- a/packages/x-adapter-platform/src/schemas/response/models/facets/index.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facets/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './utils';

--- a/packages/x-adapter-platform/src/schemas/response/models/facets/types.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facets/types.ts
@@ -1,0 +1,12 @@
+import { FacetModelName } from '@empathyco/x-types';
+import { Schema } from '@empathyco/x-adapter-next';
+
+/**
+ * Facet configuration containing the model name and the schema.
+ */
+export type FacetConfig = { modelName: FacetModelName; getSchema: () => Schema };
+
+/**
+ * Dictionary grouping facets configurations.
+ */
+export type FacetsConfig = Record<string, FacetConfig>;

--- a/packages/x-adapter-platform/src/schemas/response/models/facets/types.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facets/types.ts
@@ -1,12 +1,17 @@
-import { FacetModelName } from '@empathyco/x-types';
+import { FacetModelName, Facet } from '@empathyco/x-types';
 import { Schema } from '@empathyco/x-adapter-next';
 
 /**
  * Facet configuration containing the model name and the schema.
  */
-export type FacetConfig = { modelName: FacetModelName; getSchema: () => Schema };
+export interface FacetConfig {
+  modelName: FacetModelName;
+  schema: Schema;
+}
 
 /**
  * Dictionary grouping facets configurations.
  */
-export type FacetsConfig = Record<string, FacetConfig>;
+export interface FacetsConfig {
+  [key: Facet['id']]: FacetConfig;
+}

--- a/packages/x-adapter-platform/src/schemas/response/models/facets/utils.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facets/utils.ts
@@ -19,5 +19,5 @@ export function getFacetId(facet: string): string {
  */
 export function getFacetConfig(facet: string): FacetConfig {
   const name = getFacetId(facet);
-  return facetsConfig[name] ? facetsConfig[name] : facetsConfig.default;
+  return facetsConfig[name] ?? facetsConfig.default;
 }

--- a/packages/x-adapter-platform/src/schemas/response/models/facets/utils.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facets/utils.ts
@@ -1,0 +1,23 @@
+import { facetsConfig } from '../facet.schema';
+import { FacetConfig } from './types';
+
+/**
+ * Returns the facet's config.
+ *
+ * @param facet - The facet to resolve the configuration.
+ * @returns The facet's config.
+ */
+export function getFacetConfig(facet: string): FacetConfig {
+  const name = facet.split('_')[0];
+  return facetsConfig[name] ? facetsConfig[name] : facetsConfig.default;
+}
+
+/**
+ * Returns the facet's id.
+ *
+ * @param facet - The facet to resolve the id.
+ * @returns The facet's id.
+ */
+export function getFacetId(facet: string): string {
+  return facet.includes('_') ? facet.split('_')[0] : facet;
+}

--- a/packages/x-adapter-platform/src/schemas/response/models/facets/utils.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/facets/utils.ts
@@ -2,17 +2,6 @@ import { facetsConfig } from '../facet.schema';
 import { FacetConfig } from './types';
 
 /**
- * Returns the facet's config.
- *
- * @param facet - The facet to resolve the configuration.
- * @returns The facet's config.
- */
-export function getFacetConfig(facet: string): FacetConfig {
-  const name = facet.split('_')[0];
-  return facetsConfig[name] ? facetsConfig[name] : facetsConfig.default;
-}
-
-/**
  * Returns the facet's id.
  *
  * @param facet - The facet to resolve the id.
@@ -20,4 +9,15 @@ export function getFacetConfig(facet: string): FacetConfig {
  */
 export function getFacetId(facet: string): string {
   return facet.includes('_') ? facet.split('_')[0] : facet;
+}
+
+/**
+ * Returns the facet's config.
+ *
+ * @param facet - The facet to resolve the configuration.
+ * @returns The facet's config.
+ */
+export function getFacetConfig(facet: string): FacetConfig {
+  const name = getFacetId(facet);
+  return facetsConfig[name] ? facetsConfig[name] : facetsConfig.default;
 }

--- a/packages/x-adapter-platform/src/schemas/response/models/filters/number-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/filters/number-filter.schema.ts
@@ -4,7 +4,7 @@ import { PlatformFilter } from '../../../../types/responses/models/facet.model';
 
 export const numberFilterSchema: Schema<PlatformFilter, NumberRangeFilter> = {
   id: 'filter',
-  facetId: 'id',
+  facetId: (_, $context) => $context?.facetId as string,
   label: 'value',
   totalResults: 'count',
   selected: () => false,

--- a/packages/x-adapter-platform/src/schemas/response/models/filters/simple-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/filters/simple-filter.schema.ts
@@ -3,7 +3,7 @@ import { SimpleFilter } from '@empathyco/x-types';
 import { PlatformFilter } from '../../../../types/responses/models/facet.model';
 
 export const simpleFilterSchema: Schema<PlatformFilter, SimpleFilter> = {
-  facetId: 'filter',
+  facetId: (_, $context) => $context?.facetId as string,
   label: 'value',
   id: 'filter',
   totalResults: 'count',

--- a/packages/x-adapter-platform/src/schemas/response/models/index.ts
+++ b/packages/x-adapter-platform/src/schemas/response/models/index.ts
@@ -1,6 +1,7 @@
 export * from './banner.schema';
 export * from './facet.schema';
 export * from './filters';
+export * from './facets';
 export * from './next-query.schema';
 export * from './promoted.schema';
 export * from './redirection.schema';

--- a/packages/x-adapter-platform/src/types/responses/models/facet.model.ts
+++ b/packages/x-adapter-platform/src/types/responses/models/facet.model.ts
@@ -3,6 +3,8 @@
  *
  * @public
  */
+import { Filter, Facet, BooleanFilter } from '@empathyco/x-types';
+
 export interface PlatformFacet {
   facet: string;
   values: PlatformFilter[];
@@ -27,4 +29,26 @@ export interface PlatformFilter {
  */
 export interface PlatformHierarchicalFilter extends PlatformFilter {
   children: PlatformFacet;
+}
+
+/**
+ * Hierarchical Facet model used when combining search response mappers.
+ */
+export interface AdapterHierarchicalFacet extends Facet {
+  /** Model name to indicate the facet type. */
+  modelName: 'HierarchicalFacet';
+  /** Filters available for the facet. */
+  filters: AdapterHierarchicalFilter[];
+}
+
+/**
+ * Hierarchical Filter model used when combining search response mappers.
+ */
+export interface AdapterHierarchicalFilter extends BooleanFilter {
+  /** Model name to indicate the filter type. */
+  modelName: 'HierarchicalFilter';
+  /** A unique id used to reference the parent filter or null if it hasn't. */
+  parentId: Filter['id'] | null;
+  /** Descendants filters id. */
+  children?: AdapterHierarchicalFacet;
 }

--- a/packages/x-adapter-platform/src/types/responses/models/facet.model.ts
+++ b/packages/x-adapter-platform/src/types/responses/models/facet.model.ts
@@ -1,10 +1,10 @@
+import { Filter, Facet, BooleanFilter } from '@empathyco/x-types';
+
 /**
  * Facet model for the `platform` API.
  *
  * @public
  */
-import { Filter, Facet, BooleanFilter } from '@empathyco/x-types';
-
 export interface PlatformFacet {
   facet: string;
   values: PlatformFilter[];
@@ -33,6 +33,8 @@ export interface PlatformHierarchicalFilter extends PlatformFilter {
 
 /**
  * Hierarchical Facet model used when combining search response mappers.
+ *
+ * @internal
  */
 export interface AdapterHierarchicalFacet extends Facet {
   /** Model name to indicate the facet type. */
@@ -43,6 +45,8 @@ export interface AdapterHierarchicalFacet extends Facet {
 
 /**
  * Hierarchical Filter model used when combining search response mappers.
+ *
+ * @internal
  */
 export interface AdapterHierarchicalFilter extends BooleanFilter {
   /** Model name to indicate the filter type. */


### PR DESCRIPTION
[EX-6205](https://searchbroker.atlassian.net/browse/EX-6205)

## Motivation and context

- [ ] Add a response mapper to flatten the filters of the hierarchical facets as expected by `x-components`.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

