### PR TITLE
feat(ci): add option to synchronise only the  `static-docs`

### DIFF
--- a/.github/workflows/edocs-synchronization.yml
+++ b/.github/workflows/edocs-synchronization.yml
@@ -1,5 +1,13 @@
 name: Synchronize with eDocs
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      content:
+        type: choice
+        description: Content to be synchronized
+        options: 
+        - static
+        - all
 jobs:
   connect-with-edocs:
     runs-on: ubuntu-latest
@@ -20,7 +28,8 @@ jobs:
           curl --request POST \
           -u empathyco:${GITHUB_TOKEN} \
           --header 'content-type: application/json' \
-          --url https://api.github.com/repos/empathyco/docs-empathy-documentation/actions/workflows/14218449/dispatches \
+          --url https://api.github.com/repos/empathyco/docs-empathy-documentation/actions/workflows/${{ github.event.inputs.content == 'static' && '26816599' || '14218449' }}/dispatches \
           --data '{"ref": "main",  "inputs": {"branchName": "${{ env.BRANCH_NAME }}", "version": "${{ steps.package-version.outputs.current-version }}"}}'
         env:
           GITHUB_TOKEN: ${{ secrets.SUPPORT_TOKEN }}
+          


### PR DESCRIPTION
EX-6255

Added input parameter with two choices to select `all` or `static` and synchronize all the documentation or  just the static. It can be seen working here in [this fork](https://github.com/herrardo/x)

![image](https://user-images.githubusercontent.com/4663897/171008512-df3558d3-00ee-4447-ba4b-2541724dcd4d.png)


# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
The purpose of the change is to provide a way to only sync the `static-docs` folder instead of all the generated docs. For that a new choice input param has been added to the workflow. Depending on the param two different actions would be called in the [docs-empathy-documentation](https://github.com/empathyco/docs-empathy-documentation/) repository

### Just for info purposes
Regular workflow to sync all docs: https://github.com/empathyco/docs-empathy-documentation/blob/main/.github/workflows/trigger_synchronize_x.yml

Workflow to sync only static docs: https://github.com/empathyco/docs-empathy-documentation/blob/main/.github/workflows/trigger_synchronize_x_static.yml

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

When there are new changes in the static docs, and we call the action to synchronize the documentation with eDocs portal, all the generated files from Vue components are also generated, so the tech writers have to do a sanity check over every existing component. This PR will allow them to only deploy static documents and save time on checking components out of scope.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: EX-6525

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
