### PR TITLE
fix(schemas): flatten hierarchical filters

### DIFF
--- a/packages/x-adapter-platform/src/__tests__/__fixtures__/search.response.ts
+++ b/packages/x-adapter-platform/src/__tests__/__fixtures__/search.response.ts
@@ -273,113 +273,94 @@ export const searchResponse = {
     {
       filters: [
         {
-          children: {
-            filters: [
-              {
-                facetId: 'categoryIds:78d9b7366__8a4e61a33',
-                id: 'categoryIds:78d9b7366__8a4e61a33',
-                label: 'Bottomwear',
-                modelName: 'HierarchicalFilter',
-                parentId: 'categoryPaths_78d9b7366',
-                selected: false,
-                totalResults: 637,
-                children: {
-                  id: 'categoryPaths_78d9b7366__8a4e61a33',
-                  label: 'categoryPaths_78d9b7366__8a4e61a33',
-                  modelName: 'HierarchicalFacet',
-                  filters: [
-                    {
-                      facetId: 'categoryIds:78d9b7366__8a4e61a33_aa',
-                      id: 'categoryIds:78d9b7366__8a4e61a33_aa',
-                      totalResults: 1,
-                      label: 'Added',
-                      selected: false,
-                      modelName: 'HierarchicalFilter',
-                      parentId: 'categoryPaths_78d9b7366__8a4e61a33',
-                      children: {
-                        filters: [
-                          {
-                            facetId: 'categoryIds:78d9b7366__8a4e61a33_aa_bb',
-                            id: 'categoryIds:78d9b7366__8a4e61a33_aa_bb',
-                            label: 'Added 2',
-                            modelName: 'HierarchicalFilter',
-                            parentId: 'categoryPaths_78d9b7366__8a4e61a33_aa',
-                            selected: false,
-                            totalResults: 1
-                          }
-                        ],
-                        id: 'categoryPaths_78d9b7366__8a4e61a33_aa',
-                        label: 'categoryPaths_78d9b7366__8a4e61a33_aa',
-                        modelName: 'HierarchicalFacet'
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                facetId: 'categoryIds:78d9b7366__e2f94a4ea',
-                id: 'categoryIds:78d9b7366__e2f94a4ea',
-                label: 'Topwear',
-                modelName: 'HierarchicalFilter',
-                parentId: 'categoryPaths_78d9b7366',
-                selected: false,
-                totalResults: 99
-              }
-            ],
-            id: 'categoryPaths_78d9b7366',
-            label: 'categoryPaths_78d9b7366',
-            modelName: 'HierarchicalFacet'
-          },
-          facetId: 'categoryIds:78d9b7366',
+          facetId: 'categoryPaths',
+          id: 'categoryIds:78d9b7366__8a4e61a33_aa_bb',
+          label: 'Added 2',
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:78d9b7366__8a4e61a33_aa',
+          selected: false,
+          totalResults: 1,
+          children: undefined
+        },
+        {
+          facetId: 'categoryPaths',
+          id: 'categoryIds:78d9b7366__8a4e61a33_aa',
+          totalResults: 1,
+          label: 'Added',
+          selected: false,
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:78d9b7366__8a4e61a33',
+          children: ['categoryIds:78d9b7366__8a4e61a33_aa_bb']
+        },
+        {
+          facetId: 'categoryPaths',
+          id: 'categoryIds:78d9b7366__8a4e61a33',
+          label: 'Bottomwear',
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:78d9b7366',
+          selected: false,
+          totalResults: 637,
+          children: ['categoryIds:78d9b7366__8a4e61a33_aa']
+        },
+        {
+          facetId: 'categoryPaths',
+          id: 'categoryIds:78d9b7366__e2f94a4ea',
+          label: 'Topwear',
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:78d9b7366',
+          selected: false,
+          totalResults: 99,
+          children: undefined
+        },
+        {
+          facetId: 'categoryPaths',
           id: 'categoryIds:78d9b7366',
           label: 'Apparel',
           modelName: 'HierarchicalFilter',
-          parentId: 'categoryPaths',
+          parentId: null,
           selected: false,
-          totalResults: 736
+          totalResults: 736,
+          children: ['categoryIds:78d9b7366__8a4e61a33', 'categoryIds:78d9b7366__e2f94a4ea']
         },
         {
-          facetId: 'categoryIds:b08648dbd',
+          facetId: 'categoryPaths',
           id: 'categoryIds:b08648dbd',
           label: 'Accessories',
           modelName: 'HierarchicalFilter',
-          parentId: 'categoryPaths',
+          parentId: null,
           selected: false,
-          totalResults: 43
+          totalResults: 43,
+          children: undefined
         },
         {
-          facetId: 'categoryIds:ffc61e1e9',
+          facetId: 'categoryPaths',
+          id: 'categoryIds:ffc61e1e9_aa',
+          label: 'Added',
+          modelName: 'HierarchicalFilter',
+          parentId: 'categoryIds:ffc61e1e9',
+          selected: false,
+          totalResults: 1,
+          children: undefined
+        },
+        {
+          facetId: 'categoryPaths',
           id: 'categoryIds:ffc61e1e9',
           label: 'Personal Care',
           modelName: 'HierarchicalFilter',
-          parentId: 'categoryPaths',
+          parentId: null,
           selected: false,
           totalResults: 9,
-          children: {
-            filters: [
-              {
-                facetId: 'categoryIds:ffc61e1e9_aa',
-                id: 'categoryIds:ffc61e1e9_aa',
-                label: 'Added',
-                modelName: 'HierarchicalFilter',
-                parentId: 'categoryPaths_ffc61e1e9',
-                selected: false,
-                totalResults: 1
-              }
-            ],
-            id: 'categoryPaths_ffc61e1e9',
-            label: 'categoryPaths_ffc61e1e9',
-            modelName: 'HierarchicalFacet'
-          }
+          children: ['categoryIds:ffc61e1e9_aa']
         },
         {
-          facetId: 'categoryIds:e5eef62d8',
+          facetId: 'categoryPaths',
           id: 'categoryIds:e5eef62d8',
           label: 'Footwear',
           modelName: 'HierarchicalFilter',
-          parentId: 'categoryPaths',
+          parentId: null,
           selected: false,
-          totalResults: 6
+          totalResults: 6,
+          children: undefined
         }
       ],
       id: 'categoryPaths',
@@ -389,7 +370,7 @@ export const searchResponse = {
     {
       filters: [
         {
-          facetId: '10.0-20.0',
+          facetId: 'price',
           id: 'price:10.0-20.0',
           label: '10.0-20.0',
           modelName: 'NumberRangeFilter',
@@ -401,7 +382,7 @@ export const searchResponse = {
           totalResults: 97
         },
         {
-          facetId: '20.0-30.0',
+          facetId: 'price',
           id: 'price:20.0-30.0',
           label: '20.0-30.0',
           modelName: 'NumberRangeFilter',
@@ -413,7 +394,7 @@ export const searchResponse = {
           totalResults: 80
         },
         {
-          facetId: '30.0-40.0',
+          facetId: 'price',
           id: 'price:30.0-40.0',
           label: '30.0-40.0',
           modelName: 'NumberRangeFilter',
@@ -425,7 +406,7 @@ export const searchResponse = {
           totalResults: 85
         },
         {
-          facetId: '40.0-50.0',
+          facetId: 'price',
           id: 'price:40.0-50.0',
           label: '40.0-50.0',
           modelName: 'NumberRangeFilter',
@@ -437,7 +418,7 @@ export const searchResponse = {
           totalResults: 75
         },
         {
-          facetId: '50.0-60.0',
+          facetId: 'price',
           id: 'price:50.0-60.0',
           label: '50.0-60.0',
           modelName: 'NumberRangeFilter',
@@ -449,7 +430,7 @@ export const searchResponse = {
           totalResults: 88
         },
         {
-          facetId: '60.0-70.0',
+          facetId: 'price',
           id: 'price:60.0-70.0',
           label: '60.0-70.0',
           modelName: 'NumberRangeFilter',
@@ -461,7 +442,7 @@ export const searchResponse = {
           totalResults: 62
         },
         {
-          facetId: '70.0-80.0',
+          facetId: 'price',
           id: 'price:70.0-80.0',
           label: '70.0-80.0',
           modelName: 'NumberRangeFilter',
@@ -473,7 +454,7 @@ export const searchResponse = {
           totalResults: 84
         },
         {
-          facetId: '80.0-90.0',
+          facetId: 'price',
           id: 'price:80.0-90.0',
           label: '80.0-90.0',
           modelName: 'NumberRangeFilter',
@@ -485,7 +466,7 @@ export const searchResponse = {
           totalResults: 86
         },
         {
-          facetId: '90.0-100.0',
+          facetId: 'price',
           id: 'price:90.0-100.0',
           label: '90.0-100.0',
           modelName: 'NumberRangeFilter',
@@ -504,7 +485,7 @@ export const searchResponse = {
     {
       filters: [
         {
-          facetId: 'gender:men',
+          facetId: 'gender',
           id: 'gender:men',
           label: 'men',
           modelName: 'SimpleFilter',
@@ -512,7 +493,7 @@ export const searchResponse = {
           totalResults: 421
         },
         {
-          facetId: 'gender:women',
+          facetId: 'gender',
           id: 'gender:women',
           label: 'women',
           modelName: 'SimpleFilter',
@@ -520,7 +501,7 @@ export const searchResponse = {
           totalResults: 247
         },
         {
-          facetId: 'gender:boys',
+          facetId: 'gender',
           id: 'gender:boys',
           label: 'boys',
           modelName: 'SimpleFilter',
@@ -528,7 +509,7 @@ export const searchResponse = {
           totalResults: 35
         },
         {
-          facetId: 'gender:girls',
+          facetId: 'gender',
           id: 'gender:girls',
           label: 'girls',
           modelName: 'SimpleFilter',
@@ -536,7 +517,7 @@ export const searchResponse = {
           totalResults: 28
         },
         {
-          facetId: 'gender:unisex',
+          facetId: 'gender',
           id: 'gender:unisex',
           label: 'unisex',
           modelName: 'SimpleFilter',

--- a/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
+++ b/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
@@ -125,7 +125,7 @@ describe('platformAdapter tests', () => {
         modelName: 'NumberRangeFacet',
         filters: [
           {
-            facetId: '10.0-20.0',
+            facetId: 'price',
             id: 'price:10.0-20.0',
             label: '10.0-20.0',
             modelName: 'NumberRangeFilter',
@@ -137,7 +137,7 @@ describe('platformAdapter tests', () => {
             totalResults: 97
           },
           {
-            facetId: '20.0-30.0',
+            facetId: 'price',
             id: 'price:20.0-30.0',
             label: '20.0-30.0',
             modelName: 'NumberRangeFilter',

--- a/packages/x-adapter-platform/src/mappers/responses/search-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/responses/search-response.mapper.ts
@@ -1,8 +1,71 @@
-import { schemaMapperFactory } from '@empathyco/x-adapter-next';
-import { SearchResponse } from '@empathyco/x-types';
+import { schemaMapperFactory, combineMappers, MapperContext } from '@empathyco/x-adapter-next';
+import { SearchResponse, HierarchicalFacet, HierarchicalFilter } from '@empathyco/x-types';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
 import { searchResponseMutableSchema } from '../../schemas/responses/search-response.schema';
+import {
+  AdapterHierarchicalFacet,
+  AdapterHierarchicalFilter
+} from '../../types/models/facet.model';
 
-export const searchResponseMapper = schemaMapperFactory<PlatformSearchResponse, SearchResponse>(
-  searchResponseMutableSchema
+export const searchResponseMapper = combineMappers(
+  schemaMapperFactory<PlatformSearchResponse, SearchResponse>(searchResponseMutableSchema),
+  searchResponseFacetsMapper
 );
+
+/**
+ * Mapper to flatten hierarchical facet filters.
+ *
+ * @param from - The Platform search response.
+ * @param context - The context from the mapper.
+ * @returns The mapped facets.
+ */
+export function searchResponseFacetsMapper(
+  from: PlatformSearchResponse,
+  { mappedValue }: MapperContext
+): Partial<SearchResponse> {
+  const facets = (mappedValue as SearchResponse).facets?.map(facet =>
+    facet.modelName === 'HierarchicalFacet'
+      ? flattenHierarchicalFacet(facet as AdapterHierarchicalFacet)
+      : facet
+  );
+  return { facets };
+}
+
+/**
+ * Returns a hierarchical facet with its filters flattened.
+ *
+ * @param facet - The hierarchical facet.
+ * @returns The flattened hierarchical facet.
+ */
+function flattenHierarchicalFacet(facet: AdapterHierarchicalFacet): HierarchicalFacet {
+  const filters = facet.filters.reduce((flattenedFilters, filter) => {
+    return mapHierarchicalFilter(filter, flattenedFilters);
+  }, [] as HierarchicalFilter[]);
+
+  return {
+    ...facet,
+    filters
+  };
+}
+
+/**
+ * Map recursively the hierarchical facet filters.
+ *
+ * @param rawFilter - The hierarchical filter to map.
+ * @param filters - The filters array to fill with the facet filters.
+ * @returns The filter id.
+ */
+function mapHierarchicalFilter(
+  rawFilter: AdapterHierarchicalFilter,
+  filters: HierarchicalFilter[]
+): HierarchicalFilter[] {
+  const filter: HierarchicalFilter = {
+    ...rawFilter,
+    children: rawFilter.children?.map(rawFilterChild => {
+      mapHierarchicalFilter(rawFilterChild, filters);
+      return rawFilterChild.id;
+    })
+  };
+  filters.push(filter);
+  return filters;
+}

--- a/packages/x-adapter-platform/src/schemas/facets/__tests__/utils.spec.ts
+++ b/packages/x-adapter-platform/src/schemas/facets/__tests__/utils.spec.ts
@@ -1,0 +1,11 @@
+import { getFacetConfig } from '../utils';
+import { facetsConfig } from '../../models/facet.schema';
+
+describe('getFacetConfig', () => {
+  it('returns the config when the facet has its own config', () => {
+    expect(getFacetConfig('categoryPaths')).toStrictEqual(facetsConfig.categoryPaths);
+  });
+  it("returns the default config when the facet doesn't have its own config", () => {
+    expect(getFacetConfig('gender')).toStrictEqual(facetsConfig.default);
+  });
+});

--- a/packages/x-adapter-platform/src/schemas/facets/index.ts
+++ b/packages/x-adapter-platform/src/schemas/facets/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './utils';

--- a/packages/x-adapter-platform/src/schemas/facets/types.ts
+++ b/packages/x-adapter-platform/src/schemas/facets/types.ts
@@ -1,0 +1,17 @@
+import { FacetModelName, Facet } from '@empathyco/x-types';
+import { Schema } from '@empathyco/x-adapter-next';
+
+/**
+ * Facet configuration containing the model name and the schema.
+ */
+export interface FacetConfig {
+  modelName: FacetModelName;
+  schema: Schema;
+}
+
+/**
+ * Dictionary grouping facets configurations.
+ */
+export interface FacetsConfig {
+  [key: Facet['id']]: FacetConfig;
+}

--- a/packages/x-adapter-platform/src/schemas/facets/utils.ts
+++ b/packages/x-adapter-platform/src/schemas/facets/utils.ts
@@ -1,0 +1,12 @@
+import { facetsConfig } from '../models/facet.schema';
+import { FacetConfig } from './types';
+
+/**
+ * Returns the facet's config.
+ *
+ * @param facet - The facet to resolve the configuration.
+ * @returns The facet's config.
+ */
+export function getFacetConfig(facet: string): FacetConfig {
+  return facetsConfig[facet] ?? facetsConfig.default;
+}

--- a/packages/x-adapter-platform/src/schemas/filters/number-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/filters/number-filter.schema.ts
@@ -6,7 +6,7 @@ export const numberFilterMutableSchema = createMutableSchema<
   Schema<PlatformFilter, NumberRangeFilter>
 >({
   id: 'filter',
-  facetId: 'id',
+  facetId: (_, $context) => $context?.facetId as string,
   label: 'value',
   totalResults: 'count',
   selected: () => false,

--- a/packages/x-adapter-platform/src/schemas/filters/simple-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/filters/simple-filter.schema.ts
@@ -3,7 +3,7 @@ import { SimpleFilter } from '@empathyco/x-types';
 import { PlatformFilter } from '../../types/models/facet.model';
 
 export const simpleFilterMutableSchema = createMutableSchema<Schema<PlatformFilter, SimpleFilter>>({
-  facetId: 'filter',
+  facetId: (_, $context) => $context?.facetId as string,
   label: 'value',
   id: 'filter',
   totalResults: 'count',

--- a/packages/x-adapter-platform/src/schemas/index.ts
+++ b/packages/x-adapter-platform/src/schemas/index.ts
@@ -1,3 +1,4 @@
+export * from './facets';
 export * from './filters';
 export * from './models';
 export * from './requests';

--- a/packages/x-adapter-platform/src/types/models/facet.model.ts
+++ b/packages/x-adapter-platform/src/types/models/facet.model.ts
@@ -1,3 +1,5 @@
+import { BooleanFilter, Facet, Filter } from '@empathyco/x-types';
+
 /**
  * Facet model for the `platform` API.
  *
@@ -27,4 +29,30 @@ export interface PlatformFilter {
  */
 export interface PlatformHierarchicalFilter extends PlatformFilter {
   children: PlatformFacet;
+}
+
+/**
+ * Hierarchical Facet model used when combining search response mappers.
+ *
+ * @internal
+ */
+export interface AdapterHierarchicalFacet extends Facet {
+  /** Model name to indicate the facet type. */
+  modelName: 'HierarchicalFacet';
+  /** Filters available for the facet. */
+  filters: AdapterHierarchicalFilter[];
+}
+
+/**
+ * Hierarchical Filter model used when combining search response mappers.
+ *
+ * @internal
+ */
+export interface AdapterHierarchicalFilter extends BooleanFilter {
+  /** Model name to indicate the filter type. */
+  modelName: 'HierarchicalFilter';
+  /** A unique id used to reference the parent filter or null if it hasn't. */
+  parentId: Filter['id'] | null;
+  /** Descendants filters. */
+  children?: AdapterHierarchicalFilter[];
 }


### PR DESCRIPTION
[EX-6205](https://searchbroker.atlassian.net/browse/EX-6205)

## Motivation and context

- [ ] Add a response mapper to flatten the filters of the hierarchical facets as expected by `x-components`.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

