### PR TITLE
fix: skip keys that are an object

### DIFF
--- a/packages/x-utils/src/__tests__/object.spec.ts
+++ b/packages/x-utils/src/__tests__/object.spec.ts
@@ -443,8 +443,8 @@ describe('testing object utils', () => {
     });
 
     it('returns an array with the keys that have different value', () => {
-      const newValue = { a: 2, b: 'fried potatoe', c: 'same value' };
-      const oldValue = { a: 1, b: 'potatoe', c: 'same value' };
+      const newValue = { a: 2, b: 'fried potatoe', c: 'same value', someObject: {} };
+      const oldValue = { a: 1, b: 'potatoe', c: 'same value', someObject: {} };
 
       expect(getNewAndUpdatedKeys(newValue, oldValue)).toEqual(['a', 'b']);
     });

--- a/packages/x-utils/src/object.ts
+++ b/packages/x-utils/src/object.ts
@@ -137,7 +137,9 @@ export function getNewAndUpdatedKeys<ObjectType extends Dictionary>(
     return [];
   }
 
-  return Object.keys(newValue).filter(key => !(key in oldValue) || newValue[key] !== oldValue[key]);
+  return Object.keys(newValue).filter(
+    key => !(key in oldValue) || (!isObject(newValue[key]) && newValue[key] !== oldValue[key])
+  );
 }
 
 /**


### PR DESCRIPTION
EX-6347