### PR TITLE
fix: Remove `@empathyco/x-platform-adapter` dependency from library c…

### DIFF
--- a/packages/search-types/package.json
+++ b/packages/search-types/package.json
@@ -37,7 +37,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "tslib": "~2.3.0"
+    "tslib": "~2.3.0",
+    "@empathyco/x-adapter": "^8.0.0-alpha.1"
   },
   "devDependencies": {
     "@empathyco/x-jest-utils": "^1.4.0-alpha.4",

--- a/packages/search-types/src/index.ts
+++ b/packages/search-types/src/index.ts
@@ -15,3 +15,4 @@ export * from './sort.model';
 export * from './suggestion.model';
 export * from './tagging.model';
 export * from './user-info.model';
+export * from './x-components-adapter.model';

--- a/packages/search-types/src/x-components-adapter.model.ts
+++ b/packages/search-types/src/x-components-adapter.model.ts
@@ -1,0 +1,31 @@
+import { EndpointAdapter } from '@empathyco/x-adapter';
+import {
+  IdentifierResultsRequest,
+  NextQueriesRequest,
+  PopularSearchesRequest,
+  QuerySuggestionsRequest,
+  RecommendationsRequest,
+  RelatedTagsRequest,
+  SearchRequest,
+  TaggingRequest
+} from './request';
+import {
+  IdentifierResultsResponse,
+  NextQueriesResponse,
+  PopularSearchesResponse,
+  QuerySuggestionsResponse,
+  RecommendationsResponse,
+  RelatedTagsResponse,
+  SearchResponse
+} from './response';
+
+export interface XComponentsAdapter {
+  search: EndpointAdapter<SearchRequest, SearchResponse>;
+  popularSearches: EndpointAdapter<PopularSearchesRequest, PopularSearchesResponse>;
+  nextQueries: EndpointAdapter<NextQueriesRequest, NextQueriesResponse>;
+  recommendations: EndpointAdapter<RecommendationsRequest, RecommendationsResponse>;
+  querySuggestions: EndpointAdapter<QuerySuggestionsRequest, QuerySuggestionsResponse>;
+  relatedTags: EndpointAdapter<RelatedTagsRequest, RelatedTagsResponse>;
+  identifierResults: EndpointAdapter<IdentifierResultsRequest, IdentifierResultsResponse>;
+  tagging: EndpointAdapter<TaggingRequest, void>;
+}

--- a/packages/x-adapter-platform/src/mappers/__tests__/url.spec.ts
+++ b/packages/x-adapter-platform/src/mappers/__tests__/url.spec.ts
@@ -1,4 +1,4 @@
-import { extractUrlParameters, getTaggingInfoFromUrl } from '../url';
+import { extractUrlParameters, getTaggingInfoFromUrl } from '../url.util';
 
 describe('url utils methods tests', () => {
   describe('extractUrlParameters', () => {

--- a/packages/x-adapter-platform/src/mappers/__tests__/url.spec.ts
+++ b/packages/x-adapter-platform/src/mappers/__tests__/url.spec.ts
@@ -1,4 +1,4 @@
-import { extractUrlParameters, getTaggingInfoFromUrl } from '../url.util';
+import { extractUrlParameters, getTaggingInfoFromUrl } from '../url.utils';
 
 describe('url utils methods tests', () => {
   describe('extractUrlParameters', () => {

--- a/packages/x-adapter-platform/src/mappers/index.ts
+++ b/packages/x-adapter-platform/src/mappers/index.ts
@@ -1,2 +1,3 @@
 export * from './requests';
 export * from './responses';
+export * from './url.util';

--- a/packages/x-adapter-platform/src/mappers/index.ts
+++ b/packages/x-adapter-platform/src/mappers/index.ts
@@ -1,3 +1,3 @@
 export * from './requests';
 export * from './responses';
-export * from './url.util';
+export * from './url.utils';

--- a/packages/x-adapter-platform/src/mappers/url.util.ts
+++ b/packages/x-adapter-platform/src/mappers/url.util.ts
@@ -1,6 +1,24 @@
 import { TaggingRequest } from '@empathyco/x-types';
 
 /**
+ * Extracts the tagging info from a URL.
+ *
+ * @param taggingUrl - The url containing the tagging info.
+ *
+ * @returns The object with the tagging info.
+ */
+export function getTaggingInfoFromUrl(taggingUrl: string): TaggingRequest {
+  const { url, params } = extractUrlParameters(taggingUrl);
+  return {
+    url,
+    params: {
+      ...params,
+      follow: false
+    }
+  };
+}
+
+/**
  * Returns the base url path and an object with the query parameters.
  *
  * @param url - The url string to manipulate.
@@ -35,22 +53,4 @@ export function extractUrlParameters(url: string): {
       url
     };
   }
-}
-
-/**
- * Extracts the tagging info from an URL.
- *
- * @param taggingUrl - The url containing the tagging info.
- *
- * @returns The object with the tagging info.
- */
-export function getTaggingInfoFromUrl(taggingUrl: string): TaggingRequest {
-  const { url, params } = extractUrlParameters(taggingUrl);
-  return {
-    url,
-    params: {
-      ...params,
-      follow: false
-    }
-  };
 }

--- a/packages/x-adapter-platform/src/mappers/url.utils.ts
+++ b/packages/x-adapter-platform/src/mappers/url.utils.ts
@@ -48,7 +48,7 @@ export function extractUrlParameters(url: string): {
     };
   } catch (e) {
     //eslint-disable-next-line no-console
-    console.warn('Invalid url', url);
+    console.warn('Invalid url', url); // TODO Use Empathy's logger
     return {
       url
     };

--- a/packages/x-adapter-platform/src/schemas/models/banner.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/banner.schema.ts
@@ -1,6 +1,6 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { Banner } from '@empathyco/x-types';
-import { getTaggingInfoFromUrl } from '../../mappers/url.util';
+import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformBanner } from '../../types/models/banner.model';
 
 export const bannerMutableSchema = createMutableSchema<Schema<PlatformBanner, Banner>>({

--- a/packages/x-adapter-platform/src/schemas/models/banner.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/banner.schema.ts
@@ -1,6 +1,6 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { Banner } from '@empathyco/x-types';
-import { getTaggingInfoFromUrl } from '@empathyco/x-utils';
+import { getTaggingInfoFromUrl } from '../../mappers/url.util';
 import { PlatformBanner } from '../../types/models/banner.model';
 
 export const bannerMutableSchema = createMutableSchema<Schema<PlatformBanner, Banner>>({

--- a/packages/x-adapter-platform/src/schemas/models/promoted.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/promoted.schema.ts
@@ -1,7 +1,7 @@
 import { Promoted } from '@empathyco/x-types';
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { PlatformPromoted } from '../../types/models/promoted.model';
-import { getTaggingInfoFromUrl } from '../../mappers/url.util';
+import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 
 export const promotedMutableSchema = createMutableSchema<Schema<PlatformPromoted, Promoted>>({
   id: 'id',

--- a/packages/x-adapter-platform/src/schemas/models/promoted.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/promoted.schema.ts
@@ -1,7 +1,7 @@
 import { Promoted } from '@empathyco/x-types';
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
-import { getTaggingInfoFromUrl } from '@empathyco/x-utils';
 import { PlatformPromoted } from '../../types/models/promoted.model';
+import { getTaggingInfoFromUrl } from '../../mappers/url.util';
 
 export const promotedMutableSchema = createMutableSchema<Schema<PlatformPromoted, Promoted>>({
   id: 'id',

--- a/packages/x-adapter-platform/src/schemas/models/redirection.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/redirection.schema.ts
@@ -1,7 +1,7 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { Redirection } from '@empathyco/x-types';
 import { PlatformRedirection } from '../../types/models/redirection.model';
-import { getTaggingInfoFromUrl } from '../../mappers/url.util';
+import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 
 export const redirectionMutableSchema = createMutableSchema<
   Schema<PlatformRedirection, Redirection>

--- a/packages/x-adapter-platform/src/schemas/models/redirection.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/redirection.schema.ts
@@ -1,7 +1,7 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { Redirection } from '@empathyco/x-types';
-import { getTaggingInfoFromUrl } from '@empathyco/x-utils';
 import { PlatformRedirection } from '../../types/models/redirection.model';
+import { getTaggingInfoFromUrl } from '../../mappers/url.util';
 
 export const redirectionMutableSchema = createMutableSchema<
   Schema<PlatformRedirection, Redirection>

--- a/packages/x-adapter-platform/src/schemas/models/result.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/result.schema.ts
@@ -1,6 +1,6 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { Result } from '@empathyco/x-types';
-import { getTaggingInfoFromUrl } from '@empathyco/x-utils';
+import { getTaggingInfoFromUrl } from '../../mappers/url.util';
 import { PlatformResult } from '../../types/models/result.model';
 
 export const resultSchema = createMutableSchema<Schema<PlatformResult, Result>>({

--- a/packages/x-adapter-platform/src/schemas/models/result.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/result.schema.ts
@@ -1,6 +1,6 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { Result } from '@empathyco/x-types';
-import { getTaggingInfoFromUrl } from '../../mappers/url.util';
+import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformResult } from '../../types/models/result.model';
 
 export const resultSchema = createMutableSchema<Schema<PlatformResult, Result>>({

--- a/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
@@ -1,6 +1,6 @@
-import { Schema, createMutableSchema } from '@empathyco/x-adapter';
-import { getTaggingInfoFromUrl } from '@empathyco/x-utils';
+import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { SearchResponse } from '@empathyco/x-types';
+import { getTaggingInfoFromUrl } from '../../mappers/url.util';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
 import { bannerMutableSchema } from '../models/banner.schema';
 import { facetMutableSchema } from '../models/facet.schema';

--- a/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
@@ -1,6 +1,6 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { SearchResponse } from '@empathyco/x-types';
-import { getTaggingInfoFromUrl } from '../../mappers/url.util';
+import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
 import { bannerMutableSchema } from '../models/banner.schema';
 import { facetMutableSchema } from '../models/facet.schema';

--- a/packages/x-adapter-platform/src/types/platform-adapter.types.ts
+++ b/packages/x-adapter-platform/src/types/platform-adapter.types.ts
@@ -1,29 +1,30 @@
-import { Adapter, EndpointAdapter } from '@empathyco/x-adapter';
 import {
   IdentifierResultsRequest,
   IdentifierResultsResponse,
+  NextQueriesRequest,
+  NextQueriesResponse,
   PopularSearchesRequest,
   PopularSearchesResponse,
   QuerySuggestionsRequest,
-  NextQueriesRequest,
-  NextQueriesResponse,
   QuerySuggestionsResponse,
   RecommendationsRequest,
   RecommendationsResponse,
-  TaggingRequest,
-  RelatedTagsResponse,
   RelatedTagsRequest,
+  RelatedTagsResponse,
   SearchRequest,
-  SearchResponse
+  SearchResponse,
+  TaggingRequest,
+  XComponentsAdapter
 } from '@empathyco/x-types';
+import { ExtendableEndpointAdapter } from '@empathyco/x-adapter';
 
-export interface PlatformAdapter extends Adapter {
-  search: EndpointAdapter<SearchRequest, SearchResponse>;
-  popularSearches: EndpointAdapter<PopularSearchesRequest, PopularSearchesResponse>;
-  nextQueries: EndpointAdapter<NextQueriesRequest, NextQueriesResponse>;
-  recommendations: EndpointAdapter<RecommendationsRequest, RecommendationsResponse>;
-  querySuggestions: EndpointAdapter<QuerySuggestionsRequest, QuerySuggestionsResponse>;
-  relatedTags: EndpointAdapter<RelatedTagsRequest, RelatedTagsResponse>;
-  identifierResults: EndpointAdapter<IdentifierResultsRequest, IdentifierResultsResponse>;
-  tagging: EndpointAdapter<TaggingRequest, void>;
+export interface PlatformAdapter extends XComponentsAdapter {
+  search: ExtendableEndpointAdapter<SearchRequest, SearchResponse>;
+  popularSearches: ExtendableEndpointAdapter<PopularSearchesRequest, PopularSearchesResponse>;
+  nextQueries: ExtendableEndpointAdapter<NextQueriesRequest, NextQueriesResponse>;
+  recommendations: ExtendableEndpointAdapter<RecommendationsRequest, RecommendationsResponse>;
+  querySuggestions: ExtendableEndpointAdapter<QuerySuggestionsRequest, QuerySuggestionsResponse>;
+  relatedTags: ExtendableEndpointAdapter<RelatedTagsRequest, RelatedTagsResponse>;
+  identifierResults: ExtendableEndpointAdapter<IdentifierResultsRequest, IdentifierResultsResponse>;
+  tagging: ExtendableEndpointAdapter<TaggingRequest, void>;
 }

--- a/packages/x-adapter/src/endpoint-adapter/types.ts
+++ b/packages/x-adapter/src/endpoint-adapter/types.ts
@@ -2,13 +2,6 @@ import { HttpClient, RequestOptions } from '../http-clients/types';
 import { Mapper } from '../mappers/types';
 
 /**
- * A facade containing all the different {@link EndpointAdapter} methods.
- *
- * @public
- */
-export interface Adapter {}
-
-/**
  * Connects with a given API endpoint. Transforms the request object into something the API
  * can understand, makes the request, and transforms back the API response into the desired shape.
  *

--- a/packages/x-components/src/__tests__/adapter.dummy.ts
+++ b/packages/x-components/src/__tests__/adapter.dummy.ts
@@ -1,12 +1,12 @@
-import { PlatformAdapter } from '@empathyco/x-adapter-platform';
+import { XComponentsAdapter } from '@empathyco/x-types';
 
-export const SearchAdapterDummy: PlatformAdapter = {
-  identifierResults: jest.fn() as any,
-  nextQueries: jest.fn() as any,
-  popularSearches: jest.fn() as any,
-  querySuggestions: jest.fn() as any,
-  recommendations: jest.fn() as any,
-  relatedTags: jest.fn() as any,
-  search: jest.fn() as any,
-  tagging: jest.fn() as any
+export const SearchAdapterDummy: XComponentsAdapter = {
+  identifierResults: jest.fn(),
+  nextQueries: jest.fn(),
+  popularSearches: jest.fn(),
+  querySuggestions: jest.fn(),
+  recommendations: jest.fn(),
+  relatedTags: jest.fn(),
+  search: jest.fn(),
+  tagging: jest.fn()
 };

--- a/packages/x-components/src/__tests__/adapter.dummy.ts
+++ b/packages/x-components/src/__tests__/adapter.dummy.ts
@@ -1,6 +1,6 @@
 import { XComponentsAdapter } from '@empathyco/x-types';
 
-export const SearchAdapterDummy: XComponentsAdapter = {
+export const XComponentsAdapterDummy: XComponentsAdapter = {
   identifierResults: jest.fn(),
   nextQueries: jest.fn(),
   popularSearches: jest.fn(),

--- a/packages/x-components/src/__tests__/utils.ts
+++ b/packages/x-components/src/__tests__/utils.ts
@@ -3,8 +3,8 @@ import { DeepPartial, Dictionary } from '@empathyco/x-utils';
 import { createLocalVue } from '@vue/test-utils';
 import Vue from 'vue';
 import { Store } from 'vuex';
-import { PlatformAdapter } from '@empathyco/x-adapter-platform';
 import {
+  XComponentsAdapter,
   IdentifierResultsResponse,
   RecommendationsResponse,
   NextQueriesResponse,
@@ -25,9 +25,9 @@ import { SearchAdapterDummy } from './adapter.dummy';
 import Mock = jest.Mock;
 
 export type MockedSearchAdapter = {
-  [Method in keyof Required<PlatformAdapter>]: jest.Mock<
-    ReturnType<Required<PlatformAdapter>[Method]>,
-    Parameters<Required<PlatformAdapter>[Method]>
+  [Method in keyof Required<XComponentsAdapter>]: jest.Mock<
+    ReturnType<Required<XComponentsAdapter>[Method]>,
+    Parameters<Required<XComponentsAdapter>[Method]>
   >;
 };
 
@@ -121,12 +121,12 @@ export function getMockedAdapterFunction<T>(whatReturns: T): Mock<Promise<T>> {
 }
 
 /**
- * Mocks the {@link @empathyco/x-adapter-platform#PlatformAdapter | PlatformAdapter} features with
+ * Mocks the {@link @empathyco/x-types#XComponentsAdapter | XComponentsAdapter} features with
  * the features responses passes as parameter. Features responses are not passed through the
  * parameter will resolve the promise as empty.
  *
  * @param responseFeatures - The features responses available to be mocked.
- * @returns The {@link @empathyco/x-adapter-platform#PlatformAdapter | PlatformAdapter}
+ * @returns The {@link @empathyco/x-types#XComponentsAdapter | XComponentsAdapter}
  * with the features mocked.
  *
  * @internal

--- a/packages/x-components/src/__tests__/utils.ts
+++ b/packages/x-components/src/__tests__/utils.ts
@@ -21,10 +21,10 @@ import { MutationsDictionary } from '../store/mutations.types';
 import { RootXStoreState, XStoreModule } from '../store/store.types';
 import { cleanGettersProxyCache } from '../store/utils/getters-proxy.utils';
 import { ExtractState, XModule, XModuleName } from '../x-modules/x-modules.types';
-import { SearchAdapterDummy } from './adapter.dummy';
+import { XComponentsAdapterDummy } from './adapter.dummy';
 import Mock = jest.Mock;
 
-export type MockedSearchAdapter = {
+export type MockedXComponentsAdapter = {
   [Method in keyof Required<XComponentsAdapter>]: jest.Mock<
     ReturnType<Required<XComponentsAdapter>[Method]>,
     Parameters<Required<XComponentsAdapter>[Method]>
@@ -133,7 +133,7 @@ export function getMockedAdapterFunction<T>(whatReturns: T): Mock<Promise<T>> {
  */
 export function getMockedAdapter(
   responseFeatures?: Partial<MockedAdapterFeatures>
-): MockedSearchAdapter {
+): MockedXComponentsAdapter {
   return {
     /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
     identifierResults: getMockedAdapterFunction(responseFeatures?.identifierResults!),
@@ -167,8 +167,8 @@ function mergeStates<State extends Dictionary>(
  * Makes a clean install of the's the {@link XPlugin} into the passed Vue object.
  * This also resets the bus, and all the hardcoded dependencies of the XPlugin.
  *
- * @param options - The options for installing the {@link XPlugin}. The {@link SearchAdapterDummy}
- * is added by default.
+ * @param options - The options for installing the {@link XPlugin}. The
+ * {@link XComponentsAdapterDummy}  is added by default.
  * @param localVue - A clone of the Vue constructor to isolate tests.
  * If not provided, one will be created.
  * @returns An array containing the `xPlugin` singleton and the `localVue` and objects.
@@ -180,7 +180,7 @@ export function installNewXPlugin(
   XPlugin.resetInstance();
   const xPlugin = new XPlugin(new BaseXBus());
   const installOptions: XPluginOptions = {
-    adapter: SearchAdapterDummy,
+    adapter: XComponentsAdapterDummy,
     ...options
   };
   localVue.use(xPlugin, installOptions);

--- a/packages/x-components/src/adapter/e2e-adapter.ts
+++ b/packages/x-components/src/adapter/e2e-adapter.ts
@@ -13,14 +13,14 @@ import {
   QuerySuggestionsResponse,
   TaggingRequest,
   PopularSearchesRequest,
-  PopularSearchesResponse
+  PopularSearchesResponse,
+  XComponentsAdapter
 } from '@empathyco/x-types';
 import {
   endpointAdapterFactory,
   ExtendableEndpointAdapter,
   HttpClient
 } from '@empathyco/x-adapter';
-import { PlatformAdapter } from '@empathyco/x-adapter-platform';
 
 /**
  * Mock fetch httpClient.
@@ -76,7 +76,7 @@ export function mockEndpointAdapter<Request, Response>(
   return endpointAdapter;
 }
 
-export const e2eAdapter: PlatformAdapter = {
+export const e2eAdapter: XComponentsAdapter = {
   identifierResults: mockEndpointAdapter<IdentifierResultsRequest, IdentifierResultsResponse>(
     'identifier-results'
   ),

--- a/packages/x-components/src/plugins/__tests__/x-plugin-emitters.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-emitters.spec.ts
@@ -2,7 +2,7 @@ import { createLocalVue } from '@vue/test-utils';
 import { default as Vue, VueConstructor } from 'vue';
 import Vuex, { Store } from 'vuex';
 import { createWireFromFunction } from '../../wiring/wires.factory';
-import { SearchAdapterDummy } from '../../__tests__/adapter.dummy';
+import { XComponentsAdapterDummy } from '../../__tests__/adapter.dummy';
 import { createXModule } from '../../__tests__/utils';
 import { BaseXBus } from '../x-bus';
 import { XPlugin } from '../x-plugin';
@@ -66,7 +66,7 @@ describe('testing X Plugin emitters', () => {
   describe('install XPlugin overriding store emitters', () => {
     const newSearchBoxQueryChangedSelector = jest.fn();
     const pluginOptions: XPluginOptions = {
-      adapter: SearchAdapterDummy,
+      adapter: XComponentsAdapterDummy,
       __PRIVATE__xModules: {
         searchBox: {
           storeEmitters: {
@@ -118,7 +118,7 @@ describe('testing X Plugin emitters', () => {
     beforeEach(() => {
       XPlugin.registerXModule(xModule);
       localVue.use(plugin, {
-        adapter: SearchAdapterDummy,
+        adapter: XComponentsAdapterDummy,
         __PRIVATE__xModules: {
           searchBox: {
             storeEmitters: {
@@ -158,7 +158,7 @@ describe('testing X Plugin emitters', () => {
     // eslint-disable-next-line max-len
     it('should not execute wires with immediate `false` when the module is registered', async () => {
       const pluginOptions: XPluginOptions = {
-        adapter: SearchAdapterDummy,
+        adapter: XComponentsAdapterDummy,
         xModules: {
           searchBox: {
             wiring
@@ -187,7 +187,7 @@ describe('testing X Plugin emitters', () => {
 
     it('should execute wires with immediate `true` when the module is registered', async () => {
       const pluginOptions: XPluginOptions = {
-        adapter: SearchAdapterDummy,
+        adapter: XComponentsAdapterDummy,
         xModules: {
           searchBox: {
             wiring
@@ -226,7 +226,7 @@ describe('testing X Plugin emitters', () => {
         }
       };
       const pluginOptions: XPluginOptions = {
-        adapter: SearchAdapterDummy,
+        adapter: XComponentsAdapterDummy,
         xModules: {
           searchBox: {
             wiring

--- a/packages/x-components/src/plugins/__tests__/x-plugin.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin.spec.ts
@@ -7,7 +7,7 @@ import { createWireFromFunction, wireCommit } from '../../wiring/wires.factory';
 import { AnyWire } from '../../wiring/wiring.types';
 import { createWiring } from '../../wiring/wiring.utils';
 import { AnyXModule } from '../../x-modules/x-modules.types';
-import { SearchAdapterDummy } from '../../__tests__/adapter.dummy';
+import { XComponentsAdapterDummy } from '../../__tests__/adapter.dummy';
 import { installNewXPlugin } from '../../__tests__/utils';
 import { BaseXBus } from '../x-bus';
 import { XPlugin } from '../x-plugin';
@@ -94,14 +94,14 @@ describe('testing X Plugin', () => {
       XPlugin.registerXModule(xModule);
       expectDefaultModuleToBeNotRegistered();
 
-      installNewXPlugin({ store, adapter: SearchAdapterDummy });
+      installNewXPlugin({ store, adapter: XComponentsAdapterDummy });
       expectDefaultModuleToBeRegisteredOnce();
     });
 
     it('allows registering a initial x-module when installing', () => {
       installNewXPlugin({
         store,
-        adapter: SearchAdapterDummy,
+        adapter: XComponentsAdapterDummy,
         initialXModules: [xModule]
       });
 
@@ -109,7 +109,7 @@ describe('testing X Plugin', () => {
     });
 
     it('allows registering a x-module after installing', () => {
-      installNewXPlugin({ store, adapter: SearchAdapterDummy });
+      installNewXPlugin({ store, adapter: XComponentsAdapterDummy });
       XPlugin.registerXModule(xModule);
 
       expectDefaultModuleToBeRegisteredOnce();
@@ -117,7 +117,7 @@ describe('testing X Plugin', () => {
 
     it('does not re-register a module', () => {
       XPlugin.registerXModule(xModule);
-      installNewXPlugin({ store, adapter: SearchAdapterDummy });
+      installNewXPlugin({ store, adapter: XComponentsAdapterDummy });
       XPlugin.registerXModule(xModule);
 
       expectDefaultModuleToBeRegisteredOnce();
@@ -259,7 +259,7 @@ describe('testing X Plugin', () => {
           __PRIVATE__xModules: privateXModulesOptions,
           xModules: xModulesOptions,
           store,
-          adapter: SearchAdapterDummy
+          adapter: XComponentsAdapterDummy
         });
       });
 
@@ -275,7 +275,7 @@ describe('testing X Plugin', () => {
           __PRIVATE__xModules: privateXModulesOptions,
           xModules: xModulesOptions,
           store,
-          adapter: SearchAdapterDummy
+          adapter: XComponentsAdapterDummy
         });
         XPlugin.registerXModule(xModule);
       });
@@ -298,7 +298,7 @@ describe('testing X Plugin', () => {
           mutations: {}
         }
       };
-      installNewXPlugin({ store, adapter: SearchAdapterDummy });
+      installNewXPlugin({ store, adapter: XComponentsAdapterDummy });
       XPlugin.registerXModule(xModuleWithoutConfig);
 
       expect(store.state.x.searchBox.config).not.toBeDefined();
@@ -309,7 +309,7 @@ describe('testing X Plugin', () => {
     const newWire = jest.fn();
     const replacedWire = jest.fn();
     const pluginOptions: XPluginOptions = {
-      adapter: SearchAdapterDummy,
+      adapter: XComponentsAdapterDummy,
       xModules: {
         searchBox: {
           wiring: {
@@ -397,7 +397,7 @@ describe('testing X Plugin', () => {
         wiring,
         storeEmitters
       });
-      installNewXPlugin({ store, adapter: SearchAdapterDummy }, localVue);
+      installNewXPlugin({ store, adapter: XComponentsAdapterDummy }, localVue);
       component = shallowMount(
         {
           render(h) {

--- a/packages/x-components/src/plugins/x-plugin.ts
+++ b/packages/x-components/src/plugins/x-plugin.ts
@@ -413,8 +413,10 @@ export class XPlugin implements PluginObject<XPluginOptions> {
  * {@link XComponentAPI | X Component API }.
  *
  * @example
- * Minimal installation example. A search adapter is needed for the plugin to work, and connect to
- * the API.
+ * Minimal installation example. An API adapter is needed to connect the X Components with the
+ * suggestions, search, or tagging APIs. In this example we are using the default Empathy's platform
+ * adapter.
+ *
  * ```typescript
  *  import { platformAdapter } from '@empathyco/x-adapter-platform';
  *  Vue.use(xPlugin, { adapter: platformAdapter });

--- a/packages/x-components/src/plugins/x-plugin.ts
+++ b/packages/x-components/src/plugins/x-plugin.ts
@@ -2,7 +2,7 @@ import { deepMerge } from '@empathyco/x-deep-merge';
 import { forEach, Dictionary } from '@empathyco/x-utils';
 import { PluginObject, VueConstructor } from 'vue';
 import Vuex, { Module, Store } from 'vuex';
-import { PlatformAdapter } from '@empathyco/x-adapter-platform';
+import { XComponentsAdapter } from '@empathyco/x-types';
 import { FILTERS_REGISTRY } from '../filters/filters.registry';
 import { AnyXStoreModule, RootXStoreState } from '../store/store.types';
 import { cleanGettersProxyCache } from '../store/utils/getters-proxy.utils';
@@ -24,7 +24,7 @@ import { assertXPluginOptionsAreValid } from './x-plugin.utils';
  */
 export class XPlugin implements PluginObject<XPluginOptions> {
   /**
-   * {@link @empathyco/x-adapter-platform#PlatformAdapter | PlatformAdapter} Is the middleware
+   * {@link @empathyco/x-typesm#XComponentsAdapter | XComponentsAdapter} Is the middleware
    * between the components and our API where data can be mapped to client needs.
    * This property is only available after installing the plugin.
    *
@@ -32,7 +32,7 @@ export class XPlugin implements PluginObject<XPluginOptions> {
    * @throws If this property is accessed before calling `Vue.use(xPlugin)`.
    * @public
    */
-  public static get adapter(): PlatformAdapter {
+  public static get adapter(): XComponentsAdapter {
     return this.getInstance().adapter;
   }
 
@@ -101,7 +101,7 @@ export class XPlugin implements PluginObject<XPluginOptions> {
    *
    * @internal
    */
-  protected adapter!: PlatformAdapter;
+  protected adapter!: XComponentsAdapter;
 
   /**
    * Set of the already installed {@link XModule | XModules} to avoid re-registering them.

--- a/packages/x-components/src/plugins/x-plugin.types.ts
+++ b/packages/x-components/src/plugins/x-plugin.types.ts
@@ -7,11 +7,11 @@ import {
   Redirection,
   RelatedTag,
   Result,
-  Suggestion
+  Suggestion,
+  XComponentsAdapter
 } from '@empathyco/x-types';
 import { DeepPartial } from '@empathyco/x-utils';
 import { Store } from 'vuex';
-import { PlatformAdapter } from '@empathyco/x-adapter-platform';
 import { ActionsTree } from '../store/actions.types';
 import { GettersTree } from '../store/getters.types';
 import { MutationsTree } from '../store/mutations.types';
@@ -32,7 +32,7 @@ import { XBus } from './x-bus.types';
  */
 export interface XPluginOptions {
   /** The adapter transforms the request for the the search and tagging APIs and its responses. */
-  adapter: PlatformAdapter;
+  adapter: XComponentsAdapter;
   /**
    * A Vuex store to install the X module. If not passed a new one will be created and injected
    * into every component.

--- a/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
+++ b/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
@@ -1,5 +1,5 @@
 import { createLocalVue } from '@vue/test-utils';
-import { SearchAdapterDummy } from '../../../__tests__/adapter.dummy';
+import { XComponentsAdapterDummy } from '../../../__tests__/adapter.dummy';
 import { BaseXBus } from '../../../plugins/x-bus';
 import { XInstaller } from '../../x-installer/x-installer';
 import { SnippetConfig } from '../api.types';
@@ -54,7 +54,7 @@ describe('testing default X API', () => {
     });
 
     const { api, app } = await new XInstaller({
-      adapter: SearchAdapterDummy,
+      adapter: XComponentsAdapterDummy,
       api: defaultXAPI,
       app: installerApp
     }).init(snippetConfig);

--- a/packages/x-components/src/x-installer/x-installer/__tests__/x-installer.spec.ts
+++ b/packages/x-components/src/x-installer/x-installer/__tests__/x-installer.spec.ts
@@ -4,13 +4,13 @@ import VueRouter from 'vue-router';
 import { Store } from 'vuex';
 import { XPlugin } from '../../../plugins/x-plugin';
 import { PrivateXModulesOptions, XModulesOptions } from '../../../plugins/x-plugin.types';
-import { SearchAdapterDummy } from '../../../__tests__/adapter.dummy';
+import { XComponentsAdapterDummy } from '../../../__tests__/adapter.dummy';
 import { AnyXModule } from '../../../x-modules/x-modules.types';
 import { InitWrapper, InstallXOptions } from '../types';
 import { XInstaller } from '../x-installer';
 
 describe('testing `XInstaller` utility', () => {
-  const adapter = SearchAdapterDummy;
+  const adapter = XComponentsAdapterDummy;
   const xPluginMock = { install: jest.fn() };
   const plugin = xPluginMock as unknown as XPlugin;
   const store = {} as unknown as Store<any>;

--- a/packages/x-components/src/x-modules/tagging/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/tagging/store/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 import { TaggingRequest } from '@empathyco/x-types';
 import { getTaggingResponseStub } from '../../../../__stubs__/tagging-response-stubs.factory';
-import { SearchAdapterDummy } from '../../../../__tests__/adapter.dummy';
+import { XComponentsAdapterDummy } from '../../../../__tests__/adapter.dummy';
 import { installNewXPlugin } from '../../../../__tests__/utils';
 import { SafeStore } from '../../../../store/__tests__/utils';
 import { taggingXStoreModule } from '../module';
@@ -11,7 +11,7 @@ import { resetTaggingStateWith } from './utils';
 
 describe('testing tagging module actions', () => {
   const queryTagging = getTaggingResponseStub();
-  const adapter = SearchAdapterDummy;
+  const adapter = XComponentsAdapterDummy;
   const localVue = createLocalVue();
   localVue.config.productionTip = false; // Silent production console messages.
   localVue.use(Vuex);

--- a/packages/x-utils/package.json
+++ b/packages/x-utils/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@empathyco/x-get-safe-property-chain": "^1.3.0-alpha.3",
     "@empathyco/x-storage-service": "^2.0.0-alpha.2",
-    "@empathyco/x-types": "^10.0.0-alpha.25",
     "nanoid": "~3.1.31",
     "tslib": "~2.3.0"
   },

--- a/packages/x-utils/src/index.ts
+++ b/packages/x-utils/src/index.ts
@@ -2,4 +2,3 @@ export * from './object';
 export * from './typeguards';
 export * from './types';
 export * from './services';
-export * from './url';


### PR DESCRIPTION
- Removes `Adapter` type. This has no sense and it was complicated.
- Adds `XComponentsAdapter` type to `@empathyco/x-types`. Together with the rest of the request/responses info. `x-types` can be considered as a package where all the shared types needed mainly by x-components, and other packages are.
- Moves `getTaggingInfoFromUrl` to `@empathyco/x-platform-adapter`. This utility was previously in `@empathyco/x-utils`. Due to the refactor of the types it created a cyclic dependency.
- Makes `PlatformAdapter` extendable. 


