### PR TITLE
feat(x-adapter): Add `sendParamsInBody` option to `RequestOptions`

### DIFF
--- a/packages/x-adapter-platform/src/endpoint-adapters/tagging.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/tagging.endpoint-adapter.ts
@@ -1,9 +1,9 @@
-import { beaconHttpClient, endpointAdapterFactory, buildUrl } from '@empathyco/x-adapter';
+import { beaconHttpClient, endpointAdapterFactory } from '@empathyco/x-adapter';
 import { TaggingRequest } from '@empathyco/x-types';
 import { taggingRequestMapper } from '../mappers/requests/tagging-request.mapper';
 
 export const taggingEndpointAdapter = endpointAdapterFactory<TaggingRequest, void>({
-  endpoint: ({ url, params }) => buildUrl(url, params),
+  endpoint: ({ url }) => url,
   httpClient: beaconHttpClient,
   requestMapper: taggingRequestMapper
 });

--- a/packages/x-adapter-platform/src/mappers/requests/__tests__/tagging-request.mapper.spec.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/__tests__/tagging-request.mapper.spec.ts
@@ -20,6 +20,18 @@ describe('taggingRequestMapper tests', () => {
       }
     };
 
-    expect(taggingRequestMapper(internalRequest, {})).toStrictEqual({});
+    expect(taggingRequestMapper(internalRequest, {})).toStrictEqual({
+      filtered: 'false',
+      follow: false,
+      lang: 'en',
+      origin: 'search_box:none',
+      page: '1',
+      position: '1',
+      productId: '12345-U',
+      q: '12345',
+      scope: 'desktop',
+      spellcheck: 'false',
+      title: 'Xoxo Women Maroon Pure Georgette Solid Ready-to-wear Saree'
+    });
   });
 });

--- a/packages/x-adapter-platform/src/mappers/requests/tagging-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/tagging-request.mapper.ts
@@ -1,0 +1,7 @@
+import { Mapper } from '@empathyco/x-adapter';
+import { TaggingRequest } from '@empathyco/x-types';
+
+export const taggingRequestMapper: Mapper<TaggingRequest, any> = ({
+  url,
+  ...params
+}: TaggingRequest) => params;

--- a/packages/x-adapter-platform/src/mappers/requests/tagging-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/tagging-request.mapper.ts
@@ -1,7 +1,5 @@
 import { Mapper } from '@empathyco/x-adapter';
 import { TaggingRequest } from '@empathyco/x-types';
 
-export const taggingRequestMapper: Mapper<TaggingRequest, any> = ({
-  url,
-  ...params
-}: TaggingRequest) => params;
+export const taggingRequestMapper: Mapper<TaggingRequest, any> = ({ params }: TaggingRequest) =>
+  params;

--- a/packages/x-adapter-platform/src/mappers/requests/tagging-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/tagging-request.mapper.ts
@@ -1,7 +1,0 @@
-import { schemaMapperFactory } from '@empathyco/x-adapter';
-import { TaggingRequest } from '@empathyco/x-types';
-import { taggingRequestMutableSchema } from '../../schemas/requests/tagging-request.schema';
-
-export const taggingRequestMapper = schemaMapperFactory<TaggingRequest, any>(
-  taggingRequestMutableSchema
-);

--- a/packages/x-adapter-platform/src/schemas/requests/index.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/index.ts
@@ -5,4 +5,3 @@ export * from './query-suggestions-request.schema';
 export * from './related-tags-request.schema';
 export * from './recommendations-request.schema';
 export * from './search-request.schema';
-export * from './tagging-request.schema';

--- a/packages/x-adapter-platform/src/schemas/requests/tagging-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/tagging-request.schema.ts
@@ -1,4 +1,0 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
-import { TaggingRequest } from '@empathyco/x-types';
-
-export const taggingRequestMutableSchema = createMutableSchema<Schema<TaggingRequest, any>>({});

--- a/packages/x-adapter/src/http-clients/__tests__/beacon.http-client.spec.ts
+++ b/packages/x-adapter/src/http-clients/__tests__/beacon.http-client.spec.ts
@@ -44,4 +44,21 @@ describe('beaconHttpClient testing', () => {
       undefined
     );
   });
+
+  it('flats the received parameters', async () => {
+    await beaconHttpClient(endpoint, {
+      parameters: {
+        q: 'shirt',
+        filter: ['long sleeve', 'dotted', 'white'],
+        rows: 12,
+        extraParams: {
+          lang: 'en'
+        }
+      }
+    });
+    expect(mockedSendBeacon).toHaveBeenCalledTimes(1);
+    expect(mockedSendBeacon).toHaveBeenCalledWith(
+      `${endpoint}?q=shirt&filter=long+sleeve&filter=dotted&filter=white&rows=12&lang=en`
+    );
+  });
 });

--- a/packages/x-adapter/src/http-clients/__tests__/fetch.http-client.spec.ts
+++ b/packages/x-adapter/src/http-clients/__tests__/fetch.http-client.spec.ts
@@ -1,3 +1,4 @@
+import { flatObject } from '@empathyco/x-utils';
 import { koFetchMock, okFetchMock } from '../__mocks__/fetch.mock';
 import { HttpClient } from '../types';
 
@@ -106,16 +107,33 @@ describe('fetch httpClient testing', () => {
       }
     }).catch(error => expect(error.response.ok).toBeFalsy());
   });
+
+  it('send the data in the body if `sendParamsInBody` is true', async () => {
+    const parameters = {
+      q: 'shirt',
+      filter: ['long sleeve', 'dotted', 'white'],
+      rows: 12,
+      extraParams: {
+        lang: 'en'
+      }
+    };
+    await fetchHttpClient(endpoint, {
+      sendParamsInBody: true,
+      parameters
+    });
+    expectFetchCallWith(endpoint, { body: JSON.stringify(flatObject(parameters)) });
+  });
 });
 
 /**
  * Expects the `fetch` function to be called with the passed `URL`.
  *
  * @param url - The `URL` to check.
+ * @param options - The `options` to check.
  *
  * @internal
  */
-function expectFetchCallWith(url: string): void {
+function expectFetchCallWith(url: string, options = {}): void {
   expect(window.fetch as jest.Mock).toHaveBeenCalledTimes(1);
-  expect(window.fetch as jest.Mock).toHaveBeenCalledWith(url, expect.anything());
+  expect(window.fetch as jest.Mock).toHaveBeenCalledWith(url, expect.objectContaining(options));
 }

--- a/packages/x-adapter/src/http-clients/__tests__/fetch.http-client.spec.ts
+++ b/packages/x-adapter/src/http-clients/__tests__/fetch.http-client.spec.ts
@@ -1,4 +1,3 @@
-import { flatObject } from '@empathyco/x-utils';
 import { koFetchMock, okFetchMock } from '../__mocks__/fetch.mock';
 import { HttpClient } from '../types';
 
@@ -109,19 +108,25 @@ describe('fetch httpClient testing', () => {
   });
 
   it('send the data in the body if `sendParamsInBody` is true', async () => {
-    const parameters = {
-      q: 'shirt',
-      filter: ['long sleeve', 'dotted', 'white'],
-      rows: 12,
-      extraParams: {
-        lang: 'en'
-      }
-    };
     await fetchHttpClient(endpoint, {
       sendParamsInBody: true,
-      parameters
+      parameters: {
+        q: 'shirt',
+        filter: ['long sleeve', 'dotted', 'white'],
+        rows: 12,
+        extraParams: {
+          lang: 'en'
+        }
+      }
     });
-    expectFetchCallWith(endpoint, { body: JSON.stringify(flatObject(parameters)) });
+    expectFetchCallWith(endpoint, {
+      body: JSON.stringify({
+        q: 'shirt',
+        filter: ['long sleeve', 'dotted', 'white'],
+        rows: 12,
+        lang: 'en'
+      })
+    });
   });
 });
 
@@ -129,11 +134,12 @@ describe('fetch httpClient testing', () => {
  * Expects the `fetch` function to be called with the passed `URL`.
  *
  * @param url - The `URL` to check.
- * @param options - The `options` to check.
+ * @param options - An optional and partial `fetch` request init options to assert that fetch has
+ * been called with those parameters.
  *
  * @internal
  */
-function expectFetchCallWith(url: string, options = {}): void {
-  expect(window.fetch as jest.Mock).toHaveBeenCalledTimes(1);
-  expect(window.fetch as jest.Mock).toHaveBeenCalledWith(url, expect.objectContaining(options));
+function expectFetchCallWith(url: string, options: RequestInit = {}): void {
+  expect(window.fetch).toHaveBeenCalledTimes(1);
+  expect(window.fetch).toHaveBeenCalledWith(url, expect.objectContaining(options));
 }

--- a/packages/x-adapter/src/http-clients/__tests__/utils.spec.ts
+++ b/packages/x-adapter/src/http-clients/__tests__/utils.spec.ts
@@ -34,24 +34,17 @@ describe('http-client utils tests', () => {
   });
 
   describe('buildUrl tests', () => {
-    it('returns the href property from the built URL object flattening the objects', () => {
+    it('returns the href property from the built URL object', () => {
       const params = {
         str: 'string',
         num: 0,
         bool: false,
         arr: [1, 2],
         nil: null,
-        undef: undefined,
-        obj: {
-          str2: 'string2',
-          obj2: {
-            arr2: [1, 2]
-          }
-        }
+        undef: undefined
       };
       expect(buildUrl('https://api.empathy.co', params)).toBe(
-        'https://api.empathy.co/?' +
-          'str=string&num=0&bool=false&arr=1&arr=2&nil=null&str2=string2&arr2=1&arr2=2'
+        'https://api.empathy.co/?' + 'str=string&num=0&bool=false&arr=1&arr=2&nil=null'
       );
     });
   });

--- a/packages/x-adapter/src/http-clients/beacon.http-client.ts
+++ b/packages/x-adapter/src/http-clients/beacon.http-client.ts
@@ -1,3 +1,4 @@
+import { flatObject } from '@empathyco/x-utils';
 import { HttpClient } from './types';
 import { buildUrl } from './utils';
 
@@ -18,8 +19,11 @@ let hasAdBlocker: boolean | undefined = undefined;
  *
  * @public
  */
-export const beaconHttpClient: HttpClient = async (endpoint, { parameters, properties } = {}) => {
-  const url = buildUrl(endpoint, parameters);
+export const beaconHttpClient: HttpClient = async (
+  endpoint,
+  { parameters = {}, properties } = {}
+) => {
+  const url = buildUrl(endpoint, flatObject(parameters));
 
   if (hasAdBlocker === undefined) {
     try {

--- a/packages/x-adapter/src/http-clients/fetch.http-client.ts
+++ b/packages/x-adapter/src/http-clients/fetch.http-client.ts
@@ -1,11 +1,6 @@
-import { Dictionary } from '@empathyco/x-utils';
+import { Dictionary, flatObject } from '@empathyco/x-utils';
 import { HttpClient } from './types';
 import { buildUrl, toJson } from './utils';
-
-/**
- * Dictionary with the request id as key and an `AbortController` as value.
- */
-const requestAbortControllers: Dictionary<AbortController> = {};
 
 /**
  * The `fetchHttpClient()` function is a http client implementation using the `fetch` WebAPI.
@@ -19,11 +14,35 @@ const requestAbortControllers: Dictionary<AbortController> = {};
  */
 export const fetchHttpClient: HttpClient = (
   endpoint,
-  { id = endpoint, parameters, properties } = {}
+  { id = endpoint, parameters = {}, properties, sendParamsInBody = false } = {}
 ) => {
-  const url = buildUrl(endpoint, parameters);
+  const signal = abortAndGetNewAbortSignal(id);
+  const flatParameters = flatObject(parameters);
+  const url = sendParamsInBody ? endpoint : buildUrl(endpoint, flatParameters);
+  const bodyParameters = sendParamsInBody ? { body: JSON.stringify(flatParameters) } : {};
+
+  return fetch(url, {
+    ...properties,
+    ...bodyParameters,
+    signal
+  }).then(toJson);
+};
+
+/**
+ * Dictionary with the request id as key and an `AbortController` as value.
+ */
+const requestAbortControllers: Dictionary<AbortController> = {};
+
+/**
+ * Function that cancels previous request with the same `id` and returns a new `AbortSignal` for
+ * the new request.
+ *
+ * @param id - The identifier of the request to cancel and create a new `AbortSignal`.
+ *
+ * @returns The new `AbortSignal`.
+ */
+function abortAndGetNewAbortSignal(id: string): AbortSignal {
   requestAbortControllers[id]?.abort();
   requestAbortControllers[id] = new AbortController();
-
-  return fetch(url, { ...properties, signal: requestAbortControllers[id].signal }).then(toJson);
-};
+  return requestAbortControllers[id].signal;
+}

--- a/packages/x-adapter/src/http-clients/types.ts
+++ b/packages/x-adapter/src/http-clients/types.ts
@@ -24,6 +24,10 @@ export interface RequestOptions {
    */
   id?: string;
   /**
+   * A flag to send parameters in the body if true or in the url QueryString if false.
+   */
+  sendParamsInBody?: boolean;
+  /**
    * A list of parameters to send to the API.
    */
   parameters?: Dictionary<unknown>;

--- a/packages/x-adapter/src/http-clients/utils.ts
+++ b/packages/x-adapter/src/http-clients/utils.ts
@@ -1,4 +1,4 @@
-import { Dictionary, flatObject, forEach } from '@empathyco/x-utils';
+import { Dictionary, forEach } from '@empathyco/x-utils';
 import { RequestError } from './errors/request-error';
 
 /**
@@ -31,8 +31,7 @@ export function toJson(response: Response): Promise<any> {
  */
 export function buildUrl(endpoint: string, params: Dictionary<unknown> = {}): URL['href'] {
   const url = new URL(endpoint);
-  const flattenedParams = flatObject(params);
-  forEach(flattenedParams, (key, value) =>
+  forEach(params, (key, value) =>
     (Array.isArray(value) ? value : [value]).forEach(arrayItemValue =>
       url.searchParams.append(key, String(arrayItemValue))
     )


### PR DESCRIPTION
EX-6450


Add sendParamsInBody to the x-adapter RequestOptions

The idea is to send parameters in the body instead in the url of the request if this new sendParamsInBody option is true