### PR TITLE
chore: Change schemas naming.

### DIFF
--- a/packages/x-adapter-platform/src/mappers/requests/next-queries-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/next-queries-request.mapper.ts
@@ -1,10 +1,10 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { NextQueriesRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { nextQueriesRequestMutableSchema } from '../../schemas/requests/next-queries-request.schema';
+import { nextQueriesRequestSchema } from '../../schemas/requests/next-queries-request.schema';
 import { PlatformNextQueriesRequest } from '../../types/requests/next-queries-request.model';
 
 export const nextQueriesRequestMapper = schemaMapperFactory<
   NextQueriesRequest,
   PlatformNextQueriesRequest
->(nextQueriesRequestMutableSchema);
+>(nextQueriesRequestSchema);

--- a/packages/x-adapter-platform/src/mappers/requests/popular-searches-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/popular-searches-request.mapper.ts
@@ -1,11 +1,11 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { PopularSearchesRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { popularSearchesRequestMutableSchema } from '../../schemas/requests/popular-searches-request.schema';
+import { popularSearchesRequestSchema } from '../../schemas/requests/popular-searches-request.schema';
 // eslint-disable-next-line max-len
 import { PlatformPopularSearchesRequest } from '../../types/requests/popular-searches-request.model';
 
 export const popularSearchesRequestMapper = schemaMapperFactory<
   PopularSearchesRequest,
   PlatformPopularSearchesRequest
->(popularSearchesRequestMutableSchema);
+>(popularSearchesRequestSchema);

--- a/packages/x-adapter-platform/src/mappers/requests/query-suggestions-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/query-suggestions-request.mapper.ts
@@ -1,11 +1,11 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { QuerySuggestionsRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { querySuggestionsRequestMutableSchema } from '../../schemas/requests/query-suggestions-request.schema';
+import { querySuggestionsRequestSchema } from '../../schemas/requests/query-suggestions-request.schema';
 // eslint-disable-next-line max-len
 import { PlatformQuerySuggestionsRequest } from '../../types/requests/query-suggestions-request.model';
 
 export const querySuggestionsRequestMapper = schemaMapperFactory<
   QuerySuggestionsRequest,
   PlatformQuerySuggestionsRequest
->(querySuggestionsRequestMutableSchema);
+>(querySuggestionsRequestSchema);

--- a/packages/x-adapter-platform/src/mappers/requests/recommendations-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/recommendations-request.mapper.ts
@@ -1,11 +1,11 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { RecommendationsRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { recommendationsRequestMutableSchema } from '../../schemas/requests/recommendations-request.schema';
+import { recommendationsRequestSchema } from '../../schemas/requests/recommendations-request.schema';
 // eslint-disable-next-line max-len
 import { PlatformRecommendationsRequest } from '../../types/requests/recommendations-request.model';
 
 export const recommendationsRequestMapper = schemaMapperFactory<
   RecommendationsRequest,
   PlatformRecommendationsRequest
->(recommendationsRequestMutableSchema);
+>(recommendationsRequestSchema);

--- a/packages/x-adapter-platform/src/mappers/requests/related-tags-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/related-tags-request.mapper.ts
@@ -1,10 +1,10 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { RelatedTagsRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { relatedTagsRequestMutableSchema } from '../../schemas/requests/related-tags-request.schema';
+import { relatedTagsRequestSchema } from '../../schemas/requests/related-tags-request.schema';
 import { PlatformRelatedTagsRequest } from '../../types/requests/related-tags-request.model';
 
 export const relatedTagsRequestMapper = schemaMapperFactory<
   RelatedTagsRequest,
   PlatformRelatedTagsRequest
->(relatedTagsRequestMutableSchema);
+>(relatedTagsRequestSchema);

--- a/packages/x-adapter-platform/src/mappers/requests/search-request.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/requests/search-request.mapper.ts
@@ -1,8 +1,8 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { SearchRequest } from '@empathyco/x-types';
-import { searchRequestMutableSchema } from '../../schemas/requests/search-request.schema';
+import { searchRequestSchema } from '../../schemas/requests/search-request.schema';
 import { PlatformSearchRequest } from '../../types/requests/search-request.model';
 
 export const searchRequestMapper = schemaMapperFactory<SearchRequest, PlatformSearchRequest>(
-  searchRequestMutableSchema
+  searchRequestSchema
 );

--- a/packages/x-adapter-platform/src/mappers/responses/next-queries-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/responses/next-queries-response.mapper.ts
@@ -1,9 +1,9 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { NextQueriesResponse } from '@empathyco/x-types';
-import { nextQueriesResponseMutableSchema } from '../../schemas/responses';
+import { nextQueriesResponseSchema } from '../../schemas/responses';
 import { PlatformNextQueriesResponse } from '../../types/responses/next-queries-response.model';
 
 export const nextQueriesResponseMapper = schemaMapperFactory<
   PlatformNextQueriesResponse,
   NextQueriesResponse
->(nextQueriesResponseMutableSchema);
+>(nextQueriesResponseSchema);

--- a/packages/x-adapter-platform/src/mappers/responses/popular-searches-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/responses/popular-searches-response.mapper.ts
@@ -1,11 +1,11 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { PopularSearchesResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { popularSearchesResponseMutableSchema } from '../../schemas/responses/popular-searches-response.schema';
+import { popularSearchesResponseSchema } from '../../schemas/responses/popular-searches-response.schema';
 // eslint-disable-next-line max-len
 import { PlatformPopularSearchesResponse } from '../../types/responses/popular-searches-response.model';
 
 export const popularSearchesResponseMapper = schemaMapperFactory<
   PlatformPopularSearchesResponse,
   PopularSearchesResponse
->(popularSearchesResponseMutableSchema);
+>(popularSearchesResponseSchema);

--- a/packages/x-adapter-platform/src/mappers/responses/query-suggestions-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/responses/query-suggestions-response.mapper.ts
@@ -1,11 +1,11 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { QuerySuggestionsResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { querySuggestionsResponseMutableSchema } from '../../schemas/responses/query-suggestions-response.schema';
+import { querySuggestionsResponseSchema } from '../../schemas/responses/query-suggestions-response.schema';
 // eslint-disable-next-line max-len
 import { PlatformQuerySuggestionsResponse } from '../../types/responses/query-suggestions-response.model';
 
 export const querySuggestionsResponseMapper = schemaMapperFactory<
   PlatformQuerySuggestionsResponse,
   QuerySuggestionsResponse
->(querySuggestionsResponseMutableSchema);
+>(querySuggestionsResponseSchema);

--- a/packages/x-adapter-platform/src/mappers/responses/recommendations-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/responses/recommendations-response.mapper.ts
@@ -1,11 +1,11 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { RecommendationsResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { recommendationsResponseMutableSchema } from '../../schemas/responses/recommendations-response.schema';
+import { recommendationsResponseSchema } from '../../schemas/responses/recommendations-response.schema';
 // eslint-disable-next-line max-len
 import { PlatformRecommendationsResponse } from '../../types/responses/recommendations-response.model';
 
 export const recommendationsResponseMapper = schemaMapperFactory<
   PlatformRecommendationsResponse,
   RecommendationsResponse
->(recommendationsResponseMutableSchema);
+>(recommendationsResponseSchema);

--- a/packages/x-adapter-platform/src/mappers/responses/related-tags-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/responses/related-tags-response.mapper.ts
@@ -1,10 +1,10 @@
 import { schemaMapperFactory } from '@empathyco/x-adapter';
 import { RelatedTagsResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
-import { relatedTagsResponseMutableSchema } from '../../schemas/responses/related-tags-response.schema';
+import { relatedTagsResponseSchema } from '../../schemas/responses/related-tags-response.schema';
 import { PlatformRelatedTagsResponse } from '../../types/responses/related-tags-response.model';
 
 export const relatedTagsResponseMapper = schemaMapperFactory<
   PlatformRelatedTagsResponse,
   RelatedTagsResponse
->(relatedTagsResponseMutableSchema);
+>(relatedTagsResponseSchema);

--- a/packages/x-adapter-platform/src/mappers/responses/search-response.mapper.ts
+++ b/packages/x-adapter-platform/src/mappers/responses/search-response.mapper.ts
@@ -1,14 +1,14 @@
 import { schemaMapperFactory, combineMappers, MapperContext } from '@empathyco/x-adapter';
 import { SearchResponse, HierarchicalFacet, HierarchicalFilter } from '@empathyco/x-types';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
-import { searchResponseMutableSchema } from '../../schemas/responses/search-response.schema';
+import { searchResponseSchema } from '../../schemas/responses/search-response.schema';
 import {
   AdapterHierarchicalFacet,
   AdapterHierarchicalFilter
 } from '../../types/models/facet.model';
 
 export const searchResponseMapper = combineMappers(
-  schemaMapperFactory<PlatformSearchResponse, SearchResponse>(searchResponseMutableSchema),
+  schemaMapperFactory<PlatformSearchResponse, SearchResponse>(searchResponseSchema),
   searchResponseFacetsMapper
 );
 

--- a/packages/x-adapter-platform/src/schemas/index.ts
+++ b/packages/x-adapter-platform/src/schemas/index.ts
@@ -1,5 +1,4 @@
 export * from './facets';
-export * from './filters';
 export * from './models';
 export * from './requests';
 export * from './responses';

--- a/packages/x-adapter-platform/src/schemas/models/banner.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/banner.schema.ts
@@ -3,7 +3,7 @@ import { Banner } from '@empathyco/x-types';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformBanner } from '../../types/models/banner.model';
 
-export const bannerMutableSchema = createMutableSchema<Schema<PlatformBanner, Banner>>({
+export const bannerSchema = createMutableSchema<Schema<PlatformBanner, Banner>>({
   id: 'id',
   title: 'title',
   url: 'url',

--- a/packages/x-adapter-platform/src/schemas/models/facet.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/facet.schema.ts
@@ -2,17 +2,17 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import {
   EditableNumberRangeFacet,
   HierarchicalFacet,
-  HierarchicalFilter,
   NumberRangeFacet,
   SimpleFacet
 } from '@empathyco/x-types';
-import { numberFilterMutableSchema } from '../filters/number-filter.schema';
-import { simpleFilterMutableSchema } from '../filters/simple-filter.schema';
-import { PlatformFacet, PlatformHierarchicalFilter } from '../../types/models/facet.model';
+import { PlatformFacet } from '../../types/models/facet.model';
 import { getFacetConfig } from '../facets/utils';
 import { FacetsConfig } from '../facets/types';
+import { hierarchicalFilterSchema } from './filters/hierarchical-filter.schema';
+import { numberFilterSchema } from './filters/number-filter.schema';
+import { simpleFilterSchema } from './filters/simple-filter.schema';
 
-export const facetMutableSchema = createMutableSchema<
+export const facetSchema = createMutableSchema<
   Schema<
     PlatformFacet,
     HierarchicalFacet | NumberRangeFacet | SimpleFacet | EditableNumberRangeFacet
@@ -32,36 +32,17 @@ export const facetMutableSchema = createMutableSchema<
   }
 });
 
-export const hierarchicalFilterMutableSchema = createMutableSchema<
-  Schema<PlatformHierarchicalFilter, HierarchicalFilter>
->({
-  facetId: (_, $context) => $context?.facetId as string,
-  label: 'value',
-  id: 'filter',
-  totalResults: 'count',
-  parentId: (_, $context) => ($context?.parentId as string) ?? null,
-  selected: () => false,
-  modelName: () => 'HierarchicalFilter',
-  children: {
-    $path: 'children.values',
-    $subSchema: '$self',
-    $context: {
-      parentId: 'filter'
-    }
-  }
-});
-
 export const facetsConfig: FacetsConfig = {
   categoryPaths: {
     modelName: 'HierarchicalFacet',
-    schema: hierarchicalFilterMutableSchema
+    schema: hierarchicalFilterSchema
   },
   price: {
     modelName: 'NumberRangeFacet',
-    schema: numberFilterMutableSchema
+    schema: numberFilterSchema
   },
   default: {
     modelName: 'SimpleFacet',
-    schema: simpleFilterMutableSchema
+    schema: simpleFilterSchema
   }
 };

--- a/packages/x-adapter-platform/src/schemas/models/filters/hierarchical-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/filters/hierarchical-filter.schema.ts
@@ -1,0 +1,22 @@
+import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { HierarchicalFilter } from '@empathyco/x-types';
+import { PlatformHierarchicalFilter } from '../../../types/models/facet.model';
+
+export const hierarchicalFilterSchema = createMutableSchema<
+  Schema<PlatformHierarchicalFilter, HierarchicalFilter>
+>({
+  facetId: (_, $context) => $context?.facetId as string,
+  label: 'value',
+  id: 'filter',
+  totalResults: 'count',
+  parentId: (_, $context) => ($context?.parentId as string) ?? null,
+  selected: () => false,
+  modelName: () => 'HierarchicalFilter',
+  children: {
+    $path: 'children.values',
+    $subSchema: '$self',
+    $context: {
+      parentId: 'filter'
+    }
+  }
+});

--- a/packages/x-adapter-platform/src/schemas/models/filters/index.ts
+++ b/packages/x-adapter-platform/src/schemas/models/filters/index.ts
@@ -1,2 +1,3 @@
+export * from './hierarchical-filter.schema';
 export * from './number-filter.schema';
 export * from './simple-filter.schema';

--- a/packages/x-adapter-platform/src/schemas/models/filters/number-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/filters/number-filter.schema.ts
@@ -1,10 +1,8 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { NumberRangeFilter } from '@empathyco/x-types';
-import { PlatformFilter } from '../../types/models/facet.model';
+import { PlatformFilter } from '../../../types/models/facet.model';
 
-export const numberFilterMutableSchema = createMutableSchema<
-  Schema<PlatformFilter, NumberRangeFilter>
->({
+export const numberFilterSchema = createMutableSchema<Schema<PlatformFilter, NumberRangeFilter>>({
   id: 'filter',
   facetId: (_, $context) => $context?.facetId as string,
   label: 'value',

--- a/packages/x-adapter-platform/src/schemas/models/filters/simple-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/filters/simple-filter.schema.ts
@@ -1,8 +1,8 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { SimpleFilter } from '@empathyco/x-types';
-import { PlatformFilter } from '../../types/models/facet.model';
+import { PlatformFilter } from '../../../types/models/facet.model';
 
-export const simpleFilterMutableSchema = createMutableSchema<Schema<PlatformFilter, SimpleFilter>>({
+export const simpleFilterSchema = createMutableSchema<Schema<PlatformFilter, SimpleFilter>>({
   facetId: (_, $context) => $context?.facetId as string,
   label: 'value',
   id: 'filter',

--- a/packages/x-adapter-platform/src/schemas/models/index.ts
+++ b/packages/x-adapter-platform/src/schemas/models/index.ts
@@ -1,5 +1,6 @@
 export * from './banner.schema';
 export * from './facet.schema';
+export * from './filters';
 export * from './next-query.schema';
 export * from './related-tag.schema';
 export * from './promoted.schema';

--- a/packages/x-adapter-platform/src/schemas/models/next-query.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/next-query.schema.ts
@@ -2,7 +2,7 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { NextQuery } from '@empathyco/x-types';
 import { PlatformNextQuery } from '../../types/models/next-query.model';
 
-export const nextQueryMutableSchema = createMutableSchema<Schema<PlatformNextQuery, NextQuery>>({
+export const nextQuerySchema = createMutableSchema<Schema<PlatformNextQuery, NextQuery>>({
   query: 'query',
   results: () => [],
   facets: () => [],

--- a/packages/x-adapter-platform/src/schemas/models/promoted.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/promoted.schema.ts
@@ -3,7 +3,7 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { PlatformPromoted } from '../../types/models/promoted.model';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 
-export const promotedMutableSchema = createMutableSchema<Schema<PlatformPromoted, Promoted>>({
+export const promotedSchema = createMutableSchema<Schema<PlatformPromoted, Promoted>>({
   id: 'id',
   url: 'url',
   title: 'title',

--- a/packages/x-adapter-platform/src/schemas/models/redirection.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/redirection.schema.ts
@@ -3,9 +3,7 @@ import { Redirection } from '@empathyco/x-types';
 import { PlatformRedirection } from '../../types/models/redirection.model';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 
-export const redirectionMutableSchema = createMutableSchema<
-  Schema<PlatformRedirection, Redirection>
->({
+export const redirectionSchema = createMutableSchema<Schema<PlatformRedirection, Redirection>>({
   id: 'id',
   url: 'url',
   modelName: () => 'Redirection',

--- a/packages/x-adapter-platform/src/schemas/models/related-tag.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/related-tag.schema.ts
@@ -2,7 +2,7 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { RelatedTag } from '@empathyco/x-types';
 import { PlatformRelatedTag } from '../../types/models/related-tag.model';
 
-export const relatedTagMutableSchema = createMutableSchema<Schema<PlatformRelatedTag, RelatedTag>>({
+export const relatedTagSchema = createMutableSchema<Schema<PlatformRelatedTag, RelatedTag>>({
   query: 'query',
   tag: 'tag',
   modelName: () => 'RelatedTag',

--- a/packages/x-adapter-platform/src/schemas/models/suggestion.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/suggestion.schema.ts
@@ -2,7 +2,7 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { Suggestion } from '@empathyco/x-types';
 import { PlatformSuggestion } from '../../types/models/suggestion.model';
 
-export const suggestionMutableSchema = createMutableSchema<Schema<PlatformSuggestion, Suggestion>>({
+export const suggestionSchema = createMutableSchema<Schema<PlatformSuggestion, Suggestion>>({
   query: 'title_raw',
   key: 'title_raw',
   modelName: (_, $context) =>

--- a/packages/x-adapter-platform/src/schemas/requests/next-queries-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/next-queries-request.schema.ts
@@ -2,7 +2,7 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { NextQueriesRequest } from '@empathyco/x-types';
 import { PlatformNextQueriesRequest } from '../../types/requests/next-queries-request.model';
 
-export const nextQueriesRequestMutableSchema = createMutableSchema<
+export const nextQueriesRequestSchema = createMutableSchema<
   Schema<NextQueriesRequest, PlatformNextQueriesRequest>
 >({
   query: 'query',

--- a/packages/x-adapter-platform/src/schemas/requests/popular-searches-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/popular-searches-request.schema.ts
@@ -3,7 +3,7 @@ import { PopularSearchesRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformPopularSearchesRequest } from '../../types/requests/popular-searches-request.model';
 
-export const popularSearchesRequestMutableSchema = createMutableSchema<
+export const popularSearchesRequestSchema = createMutableSchema<
   Schema<PopularSearchesRequest, PlatformPopularSearchesRequest>
 >({
   start: 'start',

--- a/packages/x-adapter-platform/src/schemas/requests/query-suggestions-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/query-suggestions-request.schema.ts
@@ -3,7 +3,7 @@ import { QuerySuggestionsRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformQuerySuggestionsRequest } from '../../types/requests/query-suggestions-request.model';
 
-export const querySuggestionsRequestMutableSchema = createMutableSchema<
+export const querySuggestionsRequestSchema = createMutableSchema<
   Schema<QuerySuggestionsRequest, PlatformQuerySuggestionsRequest>
 >({
   query: 'query',

--- a/packages/x-adapter-platform/src/schemas/requests/recommendations-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/recommendations-request.schema.ts
@@ -3,7 +3,7 @@ import { RecommendationsRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformRecommendationsRequest } from '../../types/requests/recommendations-request.model';
 
-export const recommendationsRequestMutableSchema = createMutableSchema<
+export const recommendationsRequestSchema = createMutableSchema<
   Schema<RecommendationsRequest, PlatformRecommendationsRequest>
 >({
   start: 'start',

--- a/packages/x-adapter-platform/src/schemas/requests/related-tags-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/related-tags-request.schema.ts
@@ -2,7 +2,7 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { RelatedTagsRequest } from '@empathyco/x-types';
 import { PlatformRelatedTagsRequest } from '../../types/requests/related-tags-request.model';
 
-export const relatedTagsRequestMutableSchema = createMutableSchema<
+export const relatedTagsRequestSchema = createMutableSchema<
   Schema<RelatedTagsRequest, PlatformRelatedTagsRequest>
 >({
   query: 'query',

--- a/packages/x-adapter-platform/src/schemas/requests/search-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/search-request.schema.ts
@@ -3,7 +3,7 @@ import { reduce } from '@empathyco/x-utils';
 import { isHierarchicalFilter, SearchRequest } from '@empathyco/x-types';
 import { PlatformSearchRequest } from '../../types/requests/search-request.model';
 
-export const searchRequestMutableSchema = createMutableSchema<
+export const searchRequestSchema = createMutableSchema<
   Schema<SearchRequest, PlatformSearchRequest>
 >({
   query: 'query',

--- a/packages/x-adapter-platform/src/schemas/responses/next-queries-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/next-queries-response.schema.ts
@@ -1,13 +1,13 @@
 import { Schema, createMutableSchema } from '@empathyco/x-adapter';
 import { NextQueriesResponse } from '@empathyco/x-types';
 import { PlatformNextQueriesResponse } from '../../types/responses/next-queries-response.model';
-import { nextQueryMutableSchema } from '../models/next-query.schema';
+import { nextQuerySchema } from '../models/next-query.schema';
 
-export const nextQueriesResponseMutableSchema = createMutableSchema<
+export const nextQueriesResponseSchema = createMutableSchema<
   Schema<PlatformNextQueriesResponse, NextQueriesResponse>
 >({
   nextQueries: {
     $path: 'data.nextqueries',
-    $subSchema: nextQueryMutableSchema
+    $subSchema: nextQuerySchema
   }
 });

--- a/packages/x-adapter-platform/src/schemas/responses/popular-searches-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/popular-searches-response.schema.ts
@@ -2,13 +2,13 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { PopularSearchesResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformPopularSearchesResponse } from '../../types/responses/popular-searches-response.model';
-import { suggestionMutableSchema } from '../models/suggestion.schema';
+import { suggestionSchema } from '../models/suggestion.schema';
 
-export const popularSearchesResponseMutableSchema = createMutableSchema<
+export const popularSearchesResponseSchema = createMutableSchema<
   Schema<PlatformPopularSearchesResponse, PopularSearchesResponse>
 >({
   suggestions: {
     $path: 'topTrends.content',
-    $subSchema: suggestionMutableSchema
+    $subSchema: suggestionSchema
   }
 });

--- a/packages/x-adapter-platform/src/schemas/responses/query-suggestions-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/query-suggestions-response.schema.ts
@@ -2,13 +2,13 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { QuerySuggestionsResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformQuerySuggestionsResponse } from '../../types/responses/query-suggestions-response.model';
-import { suggestionMutableSchema } from '../models/suggestion.schema';
+import { suggestionSchema } from '../models/suggestion.schema';
 
-export const querySuggestionsResponseMutableSchema = createMutableSchema<
+export const querySuggestionsResponseSchema = createMutableSchema<
   Schema<PlatformQuerySuggestionsResponse, QuerySuggestionsResponse>
 >({
   suggestions: {
     $path: 'topTrends.content',
-    $subSchema: suggestionMutableSchema
+    $subSchema: suggestionSchema
   }
 });

--- a/packages/x-adapter-platform/src/schemas/responses/recommendations-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/recommendations-response.schema.ts
@@ -4,7 +4,7 @@ import { RecommendationsResponse } from '@empathyco/x-types';
 import { PlatformRecommendationsResponse } from '../../types/responses/recommendations-response.model';
 import { resultSchema } from '../models/result.schema';
 
-export const recommendationsResponseMutableSchema = createMutableSchema<
+export const recommendationsResponseSchema = createMutableSchema<
   Schema<PlatformRecommendationsResponse, RecommendationsResponse>
 >({
   results: {

--- a/packages/x-adapter-platform/src/schemas/responses/related-tags-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/related-tags-response.schema.ts
@@ -1,13 +1,13 @@
 import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { RelatedTagsResponse } from '@empathyco/x-types';
 import { PlatformRelatedTagsResponse } from '../../types/responses/related-tags-response.model';
-import { relatedTagMutableSchema } from '../models/related-tag.schema';
+import { relatedTagSchema } from '../models/related-tag.schema';
 
-export const relatedTagsResponseMutableSchema = createMutableSchema(<
+export const relatedTagsResponseSchema = createMutableSchema(<
   Schema<PlatformRelatedTagsResponse, RelatedTagsResponse>
 >{
   relatedTags: {
     $path: 'data.relatedtags',
-    $subSchema: relatedTagMutableSchema
+    $subSchema: relatedTagSchema
   }
 });

--- a/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
@@ -2,13 +2,13 @@ import { createMutableSchema, Schema } from '@empathyco/x-adapter';
 import { SearchResponse } from '@empathyco/x-types';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
-import { bannerMutableSchema } from '../models/banner.schema';
-import { facetMutableSchema } from '../models/facet.schema';
-import { promotedMutableSchema } from '../models/promoted.schema';
-import { redirectionMutableSchema } from '../models/redirection.schema';
+import { bannerSchema } from '../models/banner.schema';
+import { facetSchema } from '../models/facet.schema';
+import { promotedSchema } from '../models/promoted.schema';
+import { redirectionSchema } from '../models/redirection.schema';
 import { resultSchema } from '../models/result.schema';
 
-export const searchResponseMutableSchema = createMutableSchema<
+export const searchResponseSchema = createMutableSchema<
   Schema<PlatformSearchResponse, SearchResponse>
 >({
   results: {
@@ -17,21 +17,21 @@ export const searchResponseMutableSchema = createMutableSchema<
   },
   facets: {
     $path: 'catalog.facets',
-    $subSchema: facetMutableSchema
+    $subSchema: facetSchema
   },
   totalResults: 'catalog.numFound',
   spellcheck: 'catalog.spellchecked',
   banners: {
     $path: 'banner.content',
-    $subSchema: bannerMutableSchema
+    $subSchema: bannerSchema
   },
   promoteds: {
     $path: 'promoted.content',
-    $subSchema: promotedMutableSchema
+    $subSchema: promotedSchema
   },
   redirections: {
     $path: 'direct.content',
-    $subSchema: redirectionMutableSchema
+    $subSchema: redirectionSchema
   },
   queryTagging: ({ catalog }) => getTaggingInfoFromUrl(catalog?.tagging?.query)
 });


### PR DESCRIPTION
EX-6435

This PR does the following changes in `@empathyco/x-adapter-platform`:
1. Renaming all the schemas from `XXXXMutableSchema` to `XXXXSchema`. All the schemas here are mutable by default. No need to reiterate in naming
2. Moving `hierarchicalFilterSchema` to its own file like the others filters schemas.