### PR TITLE
feat(components): add `BaseSwitch` component.

### DIFF
--- a/packages/x-components/src/components/__tests__/base-switch.spec.ts
+++ b/packages/x-components/src/components/__tests__/base-switch.spec.ts
@@ -37,7 +37,7 @@ describe('testing Switch component', () => {
 
   it('supports v-model syntax', async () => {
     const { wrapper } = renderBaseSwitch({
-      template: `<BaseSwitch :value="value" @change="value = !value" />`,
+      template: `<BaseSwitch v-model="value" />`,
       value: false
     });
     expect(wrapper.attributes('role')).toBe('switch');

--- a/packages/x-components/src/components/__tests__/base-switch.spec.ts
+++ b/packages/x-components/src/components/__tests__/base-switch.spec.ts
@@ -1,0 +1,69 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import BaseSwitch from '../base-switch.vue';
+
+function renderBaseSwitch({ template, value }: RenderBaseSwitchOptions): RenderBaseSwitchApi {
+  const wrapper = mount(
+    {
+      template,
+      data() {
+        return {
+          value
+        };
+      }
+    },
+    { components: { BaseSwitch } }
+  );
+
+  return {
+    wrapper
+  };
+}
+
+describe('testing Switch component', () => {
+  it('allows toggling the state', async () => {
+    const { wrapper } = renderBaseSwitch({
+      template: `<BaseSwitch :value="value" @change="value = !value" />`,
+      value: false
+    });
+
+    expect(wrapper.attributes('role')).toBe('switch');
+    expect(wrapper.attributes('aria-checked')).toBe('false');
+    expect(wrapper.classes('x-switch--is-selected')).toBe(false);
+
+    await wrapper.trigger('click');
+    expect(wrapper.attributes('aria-checked')).toBe('true');
+    expect(wrapper.classes('x-switch--is-selected')).toBe(true);
+  });
+
+  it('supports v-model syntax', async () => {
+    const { wrapper } = renderBaseSwitch({
+      template: `<BaseSwitch :value="value" @change="value = !value" />`,
+      value: false
+    });
+    expect(wrapper.attributes('role')).toBe('switch');
+    expect(wrapper.attributes('aria-checked')).toBe('false');
+    expect(wrapper.classes('x-switch--is-selected')).toBe(false);
+
+    await wrapper.trigger('click');
+    expect(wrapper.attributes('aria-checked')).toBe('true');
+    expect(wrapper.classes('x-switch--is-selected')).toBe(true);
+  });
+});
+
+interface RenderBaseSwitchOptions {
+  /**
+   * The template to render the switch with.
+   */
+  template: string;
+  /**
+   * The initial selected value of the switch.
+   */
+  value: boolean;
+}
+
+interface RenderBaseSwitchApi {
+  /**
+   * The wrapper testing component instance.
+   */
+  wrapper: Wrapper<Vue>;
+}

--- a/packages/x-components/src/components/base-switch.vue
+++ b/packages/x-components/src/components/base-switch.vue
@@ -13,11 +13,11 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { VueCSSClasses } from '../utils';
+  import { VueCSSClasses } from '../utils/types';
 
   /**
    * Basic switch component to handle boolean values. This component receives
-   * its selected state using a prop, and emits an event whenever the user
+   * its selected state using a prop, and emits a Vue event whenever the user
    * clicks it.
    *
    * @public
@@ -114,7 +114,7 @@ _Try clicking it to see how it changes its state_
 
 ```vue live
 <template>
-  <BaseSwitch :value="value" @change="value = !value" />
+  <BaseSwitch @change="value = !value" :value="value" />
 </template>
 
 <script>
@@ -134,7 +134,7 @@ _Try clicking it to see how it changes its state_
 </script>
 ```
 
-The switch component also supports v-model syntax to reduce to automatically handle its state
+The switch component also supports using the `v-model` directive, to automatically handle its state
 change:
 
 ```vue live

--- a/packages/x-components/src/components/base-switch.vue
+++ b/packages/x-components/src/components/base-switch.vue
@@ -19,6 +19,8 @@
    * Basic switch component to handle boolean values. This component receives
    * its selected state using a prop, and emits an event whenever the user
    * clicks it.
+   *
+   * @public
    */
   @Component({
     model: {

--- a/packages/x-components/src/components/base-switch.vue
+++ b/packages/x-components/src/components/base-switch.vue
@@ -60,21 +60,22 @@
 
 <style lang="scss" scoped>
   .x-switch {
-    --x-switch-height: var(--x-size-base-06);
+    --x-switch-height: var(--x-size-base-05);
+    --x-switch-width: calc(2 * (var(--x-switch-height)) + 2 * var(--x-switch-padding));
     --x-switch-background: var(--x-color-base-neutral-70);
     --x-switch-padding: var(--x-size-base-01);
-    box-sizing: border-box;
+    --x-switch-handle-size: calc(var(--x-switch-height));
+    box-sizing: content-box;
     height: var(--x-switch-height);
     padding: var(--x-switch-padding);
     border-radius: var(--x-size-border-radius-base-pill);
     background: var(--x-switch-background);
-    width: calc(2 * var(--x-switch-height));
+    width: var(--x-switch-width);
     border: none;
     transition: 0.25s ease-out background-color;
     cursor: pointer;
 
     &__handle {
-      --x-switch-handle-size: calc(var(--x-switch-height) - 2 * var(--x-switch-padding));
       background: var(--x-color-base-neutral-100);
       border-radius: 50%;
       height: var(--x-switch-handle-size);
@@ -84,16 +85,16 @@
     }
 
     &--is-selected {
-      --x-switch-translate-x: calc(100% + 2 * var(--x-switch-padding));
+      --x-switch-translate-x: calc(var(--x-switch-padding) + var(--x-switch-width) / 2);
       --x-switch-background: var(--x-color-base-neutral-10);
     }
 
     &--sm {
-      --x-switch-height: var(--x-size-base-05);
+      --x-switch-height: var(--x-size-base-04);
     }
 
     &--lg {
-      --x-switch-height: var(--x-size-base-07);
+      --x-switch-height: var(--x-size-base-06);
     }
   }
 </style>

--- a/packages/x-components/src/components/base-switch.vue
+++ b/packages/x-components/src/components/base-switch.vue
@@ -1,0 +1,158 @@
+<template>
+  <button
+    @click="toggle"
+    :aria-checked="value.toString()"
+    :class="cssClasses"
+    class="x-switch"
+    role="switch"
+  >
+    <div class="x-switch__handle" />
+  </button>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { VueCSSClasses } from '../utils';
+
+  /**
+   * Basic switch component to handle boolean values. This component receives
+   * its selected state using a prop, and emits an event whenever the user
+   * clicks it.
+   */
+  @Component({
+    model: {
+      event: 'change'
+    }
+  })
+  export default class BaseSwitch extends Vue {
+    /**
+     * The selected value of the switch.
+     *
+     * @public
+     */
+    @Prop({ required: true })
+    public value!: boolean;
+
+    /**
+     * Dynamic CSS classes to add to the switch component
+     * depending on its internal state.
+     *
+     * @returns A boolean dictionary with dynamic CSS classes.
+     * @internal
+     */
+    protected get cssClasses(): VueCSSClasses {
+      return {
+        'x-switch--is-selected': this.value
+      };
+    }
+
+    /**
+     * Emits a change event with the desired value of the switch.
+     *
+     * @internal
+     */
+    protected toggle(): void {
+      this.$emit('change', !this.value);
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .x-switch {
+    --x-switch-height: var(--x-size-base-06);
+    --x-switch-background: var(--x-color-base-neutral-70);
+    --x-switch-padding: var(--x-size-base-01);
+    box-sizing: border-box;
+    height: var(--x-switch-height);
+    padding: var(--x-switch-padding);
+    border-radius: var(--x-size-border-radius-base-pill);
+    background: var(--x-switch-background);
+    width: calc(2 * var(--x-switch-height));
+    border: none;
+    transition: 0.25s ease-out background-color;
+    cursor: pointer;
+
+    &__handle {
+      --x-switch-handle-size: calc(var(--x-switch-height) - 2 * var(--x-switch-padding));
+      background: var(--x-color-base-neutral-100);
+      border-radius: 50%;
+      height: var(--x-switch-handle-size);
+      width: var(--x-switch-handle-size);
+      transition: 0.25s ease-out transform;
+      transform: translateX(var(--x-switch-translate-x, 0%));
+    }
+
+    &--is-selected {
+      --x-switch-translate-x: calc(100% + 2 * var(--x-switch-padding));
+      --x-switch-background: var(--x-color-base-neutral-10);
+    }
+
+    &--sm {
+      --x-switch-height: var(--x-size-base-05);
+    }
+
+    &--lg {
+      --x-switch-height: var(--x-size-base-07);
+    }
+  }
+</style>
+
+<docs lang="mdx">
+## Events
+
+This component emits no events.
+
+## See it in action
+
+Here you have a basic example of how the switch is rendered.
+
+_Try clicking it to see how it changes its state_
+
+```vue live
+<template>
+  <BaseSwitch :value="value" @change="value = !value" />
+</template>
+
+<script>
+  import { BaseSwitch } from '@empathyco/x-components';
+
+  export default {
+    name: 'BaseSwitchDemo',
+    components: {
+      BaseSwitch
+    },
+    data() {
+      return {
+        value: false
+      };
+    }
+  };
+</script>
+```
+
+The switch component also supports v-model syntax to reduce to automatically handle its state
+change:
+
+```vue live
+<template>
+  <BaseSwitch v-model="value" />
+</template>
+
+<script>
+  import { BaseSwitch } from '@empathyco/x-components';
+
+  export default {
+    name: 'BaseSwitchDemo',
+    components: {
+      BaseSwitch
+    },
+    data() {
+      return {
+        value: false
+      };
+    }
+  };
+</script>
+```
+</docs>

--- a/packages/x-components/src/components/index.ts
+++ b/packages/x-components/src/components/index.ts
@@ -17,6 +17,7 @@ export { default as BaseEventButton } from './base-event-button.vue';
 export { default as BaseGrid } from './base-grid.vue';
 export { default as BaseKeyboardNavigation } from './base-keyboard-navigation.vue';
 export { default as BaseRating } from './base-rating.vue';
+export { default as BaseSwitch } from './base-switch.vue';
 export { default as BaseVariableColumnGrid } from './base-variable-column-grid.vue';
 export { default as GlobalXBus } from './global-x-bus.vue';
 export { default as ItemsList } from './items-list.vue';


### PR DESCRIPTION
EX-6004

Adds the `BaseSwitch` component.

- Does not handle its own selected state
- Supports v-model
- 3 sizes (default, sm and lg). This sizes use the closest token values
- Uses CSS variables internally to simplify styling size and background

To test it you can replace the checkbox control of the `Home.vue` **instant search** with the new switch component:

```html
      <li class="x-test-controls__item x-list__item">
        <label>
          search-input - instant
          <BaseSwitch v-model="controls.searchInput.instant" id="search-input-is-instant" />
        </label>
      </li>
```