### PR TITLE
feat: add 'my_history' as feature location

### DIFF
--- a/packages/x-components/src/types/origin.ts
+++ b/packages/x-components/src/types/origin.ts
@@ -56,6 +56,7 @@ export type ResultFeature =
  */
 export type FeatureLocation =
   | 'external'
+  | 'my_history'
   | 'no_query'
   | 'no_results'
   | 'none'


### PR DESCRIPTION
To test it, add this code in the predictive layer for example:

```
<LocationProvider location="my_history">
  <MyHistory />
</LocationProvider>
```

With this, if you click on a query in my history, the search request should have origin="predictive_layer:my_history"

EX-6527