### PR TITLE
test/EX-6590-fix-exclude-filters-test

### DIFF
--- a/packages/x-components/src/views/home/aside.vue
+++ b/packages/x-components/src/views/home/aside.vue
@@ -97,7 +97,7 @@
                       :data-test="`${facet.label}-filter`"
                     >
                       {{ filter.label }}
-                      <span data-test="brand-filter-total-results">
+                      <span :data-test="`${facet.label}-filter-total-results`">
                         {{ filter.totalResults }}
                       </span>
                     </SimpleFilter>

--- a/packages/x-components/tests/e2e/exclude-filters/exclude-filters.spec.ts
+++ b/packages/x-components/tests/e2e/exclude-filters/exclude-filters.spec.ts
@@ -1,7 +1,7 @@
 import { And, Then } from 'cypress-cucumber-preprocessor/steps';
 
 Then('only filters with totalResults undefined or greater than 0 are shown in facet', () => {
-  cy.getByDataTest('brand-filter-total-results')
+  cy.getByDataTest('brand_facet-filter-total-results')
     .should('exist')
     .should($totalResultsElements => {
       $totalResultsElements.each((_, totalResults) => {


### PR DESCRIPTION
## Motivation and context
exclude-filters test was failing due to a duplicate data-test, as it was a generic data-test for any simple filter, causing 'In offer' and 'brand_facet' to have the same data-test. Cypress will find the first one (In offer) and continue with it as reference, causing the test to fail. 
This has been fixed setting the data-test as `:data-test="`${facet.label}-filter-total-results`"`

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

As usual, you can check the test separately by modifying `cypress.json`
 ` "testFiles": ["**/*.feature"],`

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
