### PR TITLE
feat: Move `XAPI` from `window.X` to `window.InterfaceX`

### DIFF
--- a/packages/x-components/src/views/pdp.vue
+++ b/packages/x-components/src/views/pdp.vue
@@ -19,7 +19,7 @@
   })
   export default class Pdp extends Vue {
     addProductToCart(): void {
-      window.X?.addProductToCart();
+      window.InterfaceX?.addProductToCart();
     }
   }
 </script>

--- a/packages/x-components/src/x-installer/x-installer/__tests__/x-installer.spec.ts
+++ b/packages/x-components/src/x-installer/x-installer/__tests__/x-installer.spec.ts
@@ -58,17 +58,17 @@ describe('testing `XInstaller` utility', () => {
   });
 
   it('creates the public API in global scope by default', () => {
-    delete window.X;
+    delete window.InterfaceX;
     new XInstaller({ adapter, plugin, vue: createLocalVue() }).init(snippetConfig);
 
-    expect(window.X).toBeDefined();
-    delete window.X;
+    expect(window.InterfaceX).toBeDefined();
+    delete window.InterfaceX;
   });
 
   it('does not create the public API passing the api parameter to false', () => {
     new XInstaller({ adapter, plugin, api: false, vue: createLocalVue() }).init(snippetConfig);
 
-    expect(window.X).not.toBeDefined();
+    expect(window.InterfaceX).not.toBeDefined();
   });
 
   it('installs the XPlugin using the passed vue', () => {

--- a/packages/x-components/src/x-installer/x-installer/x-installer.ts
+++ b/packages/x-components/src/x-installer/x-installer/x-installer.ts
@@ -10,7 +10,7 @@ import { InitWrapper, InstallXOptions, VueConstructorPartialArgument } from './t
 
 declare global {
   interface Window {
-    X?: XAPI;
+    InterfaceX?: XAPI;
     initX?: (() => SnippetConfig) | SnippetConfig;
   }
 }
@@ -48,7 +48,7 @@ declare global {
  *            the Public API:
  *
  * ```
- *            window.X.init(snippetConfig)
+ *            window.InterfaceX.init(snippetConfig)
  * ```
  *
  *        2.3 When the script of the project build is loaded it searches for a global `initX`
@@ -125,7 +125,7 @@ export class XInstaller {
       this.api = api ?? new BaseXAPI();
       this.api.setInitCallback(this.init.bind(this));
       this.api.setSnippetConfigCallback(this.updateSnippetConfig.bind(this));
-      window.X = this.api;
+      window.InterfaceX = this.api;
     }
   }
 

--- a/packages/x-components/static-docs/build-search-ui/web-archetype-development-guide.md
+++ b/packages/x-components/static-docs/build-search-ui/web-archetype-development-guide.md
@@ -142,7 +142,7 @@ Since the X&nbsp;Archetype project operates as a layer and is designed to be int
 any kind of website regardless the chosen technology, the `XInstaller` utility and its
 `installXOptions` object are designed to install the xPlugin, adding the connection between the
 X&nbsp;Components and the search API and bootstrapping the entire application with powerful APIs
-that are available in the `window.X` object.
+that are available in the `window.InterfaceX` object.
 
 To configure the xPlugin, run this code:
 

--- a/packages/x-components/static-docs/build-search-ui/web-archetype-integration-guide.md
+++ b/packages/x-components/static-docs/build-search-ui/web-archetype-integration-guide.md
@@ -54,11 +54,11 @@ Automatic initialization is the easiest way to integrate the Interface&nbsp;X pr
 1. **Configure the JavaScript snippet** to define either an initialization object or a function.
 2. **Load and initialize** the Interface&nbsp;X script.
 
-#### Configuring the snippet  
+#### Configuring the snippet
 
-First, add the JavaScript snippet configuration to define multiple initialization options, i.e. the API to
-use, the language or currency to display, or even the tagging parameters to collect search-related
-data to generate conversational search features and analytics.
+First, add the JavaScript snippet configuration to define multiple initialization options, i.e. the
+API to use, the language or currency to display, or even the tagging parameters to collect
+search-related data to generate conversational search features and analytics.
 
 Depending on whether you are retrieving **static or dynamic configuration values** in your
 [snippet configuration](#snippet-configuration), you define an **object** or a **function** to
@@ -150,7 +150,7 @@ On-demand initialization allows you to control when Interface&nbsp;X is loaded.
 
 **Steps to initialize the project on demand**
 
-1. **Load** the Interface&nbsp;X script. 
+1. **Load** the Interface&nbsp;X script.
 2. **Initialize** Interface&nbsp;X.
 
 #### Loading the script
@@ -182,7 +182,7 @@ object to provide the initialization options:
 ```html
 <script src="https://x.empathy.co/my-store/app.js"></script>
 <script>
-  window.X.init({
+  window.InterfaceX.init({
     instance: 'my-store',
     env: 'live',
     scope: 'desktop',
@@ -262,7 +262,7 @@ shopping cart:
 ```html
 <script src="https://x.empathy.co/my-store/app.js"></script>
 <script>
-  window.X.init({
+  window.InterfaceX.init({
     instance: 'my-store',
     env: 'live',
     scope: 'desktop',


### PR DESCRIPTION
BREAKING-CHANGE: `XAPI` is now available now at `window.InterfaceX`.
EX-6645

Renames X to InterfaceX so it is less likely to collide with customer clients.
