### PR TITLE
Bugfix/ex 6457 allow extending all transitions

### DIFF
--- a/packages/x-components/src/components/animations/animate-width.vue
+++ b/packages/x-components/src/components/animations/animate-width.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition v-on="$listeners" name="x-animate-width-">
+  <transition v-on="$listeners" name="x-animate-width-" v-bind="$attrs">
     <!-- @slot (Required) Transition content -->
     <slot />
   </transition>
@@ -14,7 +14,9 @@
    *
    * @public
    */
-  @Component
+  @Component({
+    inheritAttrs: true
+  })
   export default class AnimateWidth extends Vue {}
 </script>
 

--- a/packages/x-components/src/components/animations/animate-width.vue
+++ b/packages/x-components/src/components/animations/animate-width.vue
@@ -15,7 +15,7 @@
    * @public
    */
   @Component({
-    inheritAttrs: true
+    inheritAttrs: false
   })
   export default class AnimateWidth extends Vue {}
 </script>

--- a/packages/x-components/src/components/animations/collapse-height.vue
+++ b/packages/x-components/src/components/animations/collapse-height.vue
@@ -26,7 +26,7 @@
    */
   @Component({
     mixins: [createCollapseAnimationMixin('height')],
-    inheritAttrs: true
+    inheritAttrs: false
   })
   export default class CollapseHeight extends Vue {
     // TODO Add support for extending enter, after-enter and leave transitions

--- a/packages/x-components/src/components/animations/collapse-height.vue
+++ b/packages/x-components/src/components/animations/collapse-height.vue
@@ -37,7 +37,7 @@
   .x-collapse-height {
     &--enter-active,
     &--leave-active {
-      transition: height 5s ease-out;
+      transition: height 0.3s ease-out;
       overflow: hidden;
     }
   }

--- a/packages/x-components/src/components/animations/collapse-height.vue
+++ b/packages/x-components/src/components/animations/collapse-height.vue
@@ -6,6 +6,7 @@
     @leave="collapse"
     appear
     name="x-collapse-height-"
+    v-bind="$attrs"
   >
     <!-- @slot (Required) to add content to the transition -->
     <slot />
@@ -24,16 +25,19 @@
    * @public
    */
   @Component({
-    mixins: [createCollapseAnimationMixin('height')]
+    mixins: [createCollapseAnimationMixin('height')],
+    inheritAttrs: true
   })
-  export default class CollapseHeight extends Vue {}
+  export default class CollapseHeight extends Vue {
+    // TODO Add support for extending enter, after-enter and leave transitions
+  }
 </script>
 
 <style lang="scss" scoped>
   .x-collapse-height {
     &--enter-active,
     &--leave-active {
-      transition: height 0.3s ease-out;
+      transition: height 5s ease-out;
       overflow: hidden;
     }
   }

--- a/packages/x-components/src/components/animations/collapse-width.vue
+++ b/packages/x-components/src/components/animations/collapse-width.vue
@@ -26,7 +26,7 @@
    */
   @Component({
     mixins: [createCollapseAnimationMixin('width')],
-    inheritAttrs: true
+    inheritAttrs: false
   })
   export default class CollapseWidth extends Vue {
     // TODO Add support for extending enter, after-enter and leave transitions

--- a/packages/x-components/src/components/animations/collapse-width.vue
+++ b/packages/x-components/src/components/animations/collapse-width.vue
@@ -6,6 +6,7 @@
     @leave="collapse"
     appear
     name="x-collapse-width-"
+    v-bind="$attrs"
   >
     <!-- @slot (Required) to add content to the transition -->
     <slot />
@@ -26,7 +27,9 @@
   @Component({
     mixins: [createCollapseAnimationMixin('width')]
   })
-  export default class CollapseWidth extends Vue {}
+  export default class CollapseWidth extends Vue {
+    // TODO Add support for extending enter, after-enter and leave transitions
+  }
 </script>
 
 <style lang="scss" scoped>

--- a/packages/x-components/src/components/animations/collapse-width.vue
+++ b/packages/x-components/src/components/animations/collapse-width.vue
@@ -25,7 +25,8 @@
    * @public
    */
   @Component({
-    mixins: [createCollapseAnimationMixin('width')]
+    mixins: [createCollapseAnimationMixin('width')],
+    inheritAttrs: true
   })
   export default class CollapseWidth extends Vue {
     // TODO Add support for extending enter, after-enter and leave transitions

--- a/packages/x-components/src/components/animations/create-directional-animation-factory.ts
+++ b/packages/x-components/src/components/animations/create-directional-animation-factory.ts
@@ -15,7 +15,7 @@ export function createDirectionalAnimationFactory(
   return (animationOrigin = 'top') => {
     return Vue.extend({
       name: `transition-${animationName}-${animationOrigin}`,
-      inheritAttrs: true,
+      inheritAttrs: false,
       render(h) {
         return h(
           'transition',

--- a/packages/x-components/src/components/animations/create-directional-animation-factory.ts
+++ b/packages/x-components/src/components/animations/create-directional-animation-factory.ts
@@ -15,11 +15,16 @@ export function createDirectionalAnimationFactory(
   return (animationOrigin = 'top') => {
     return Vue.extend({
       name: `transition-${animationName}-${animationOrigin}`,
+      inheritAttrs: true,
       render(h) {
         return h(
           'transition',
           {
-            props: { name: `x-${animationName}--${animationOrigin} x-${animationName}-` }
+            props: {
+              name: `x-${animationName}--${animationOrigin} x-${animationName}-`,
+              ...this.$attrs
+            },
+            on: this.$listeners
           },
           this.$slots.default
         );

--- a/packages/x-components/src/components/animations/cross-fade.vue
+++ b/packages/x-components/src/components/animations/cross-fade.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition v-on="$listeners" appear name="x-cross-fade-" mode="in-out">
+  <transition v-on="$listeners" appear name="x-cross-fade-" mode="in-out" v-bind="$attrs">
     <!-- @slot (Required) to add content to the transition -->
     <slot />
   </transition>
@@ -15,7 +15,9 @@
    *
    * @public
    */
-  @Component
+  @Component({
+    inheritAttrs: false
+  })
   export default class CrossFade extends Vue {}
 </script>
 

--- a/packages/x-components/src/components/animations/fade-and-slide.vue
+++ b/packages/x-components/src/components/animations/fade-and-slide.vue
@@ -5,6 +5,7 @@
     appear
     name="x-fade-and-slide-"
     :tag="tag"
+    v-bind="$attrs"
   >
     <!-- @slot (Required) Transition-group content -->
     <slot />
@@ -21,7 +22,9 @@
    *
    * @public
    */
-  @Component
+  @Component({
+    inheritAttrs: false
+  })
   export default class FadeAndSlide extends Vue {
     /**
      * HTML Element that the transition-group children will be wrapped in.

--- a/packages/x-components/src/components/animations/fade.vue
+++ b/packages/x-components/src/components/animations/fade.vue
@@ -43,9 +43,28 @@ animate it. The animation just fades in/out the element by changing its opacity.
 
 Wrapping a component:
 
-```vue
-<Fade>
-  <ComponentOrElement v-if="open"/>
-</Fade>
+```vue live
+<template>
+  <div>
+    <button @click="shouldRender = !shouldRender">Toggle</button>
+    <Fade>
+      <p v-if="open">León is southern Spain</p>
+    </Fade>
+  </div>
+</template>
+<script>
+  import { Fade } from '@empathyco/x-components';
+  export default {
+    name: 'FadeAnimationDemo',
+    component: {
+      Fade
+    },
+    data() {
+      return {
+        shouldRender: false
+      };
+    }
+  };
+</script>
 ```
 </docs>

--- a/packages/x-components/src/components/animations/fade.vue
+++ b/packages/x-components/src/components/animations/fade.vue
@@ -48,7 +48,7 @@ Wrapping a component:
   <div>
     <button @click="shouldRender = !shouldRender">Toggle</button>
     <Fade>
-      <p v-if="open">León is southern Spain</p>
+      <p v-if="shouldRender">León is southern Spain</p>
     </Fade>
   </div>
 </template>

--- a/packages/x-components/src/components/animations/fade.vue
+++ b/packages/x-components/src/components/animations/fade.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition v-on="$listeners" appear name="x-cross-fade-" mode="in-out" v-bind="$attrs">
+  <transition v-on="$listeners" appear name="x-fade-" v-bind="$attrs">
     <!-- @slot (Required) to add content to the transition -->
     <slot />
   </transition>
@@ -10,26 +10,22 @@
   import { Component } from 'vue-property-decorator';
 
   /**
-   * Renders a transition wrapping the element passed in the default slot. The transition
-   * fades between the two toggled elements at the same time.
+   * Renders a transition wrapping the element passed in the default slot. The animation just fades
+   * in/out the element by changing its opacity.
    *
    * @public
    */
   @Component({
     inheritAttrs: false
   })
-  export default class CrossFade extends Vue {}
+  export default class Fade extends Vue {}
 </script>
 
 <style lang="scss" scoped>
-  .x-cross-fade {
+  .x-fade {
     &--enter-active,
     &--leave-active {
       transition: opacity 0.25s ease-in-out;
-    }
-
-    &--leave-active {
-      position: absolute;
     }
 
     &--leave-to,
@@ -42,14 +38,14 @@
 <docs lang="mdx">
 ## Example
 
-The `CrossFade` component is intended to be used as animation to wrap an element with v-if or v-show
-and animate it. The animation fades the new element into the previous one.
+The `Fade` component is intended to be used as animation to wrap an element with v-if or v-show and
+animate it. The animation just fades in/out the element by changing its opacity.
 
 Wrapping a component:
 
 ```vue
-<CrossFade>
+<Fade>
   <ComponentOrElement v-if="open"/>
-</CrossFade>
+</Fade>
 ```
 </docs>

--- a/packages/x-components/src/components/animations/index.ts
+++ b/packages/x-components/src/components/animations/index.ts
@@ -2,6 +2,7 @@ export { default as AnimateWidth } from './animate-width.vue';
 export { default as CollapseHeight } from './collapse-height.vue';
 export { default as CollapseWidth } from './collapse-width.vue';
 export { default as CrossFade } from './cross-fade.vue';
+export { default as Fade } from './fade.vue';
 export { default as FadeAndSlide } from './fade-and-slide.vue';
 export { default as StaggeredFadeAndSlide } from './staggered-fade-and-slide.vue';
 export { default as StaggeringTransitionGroup } from './staggering-transition-group.vue';

--- a/packages/x-components/src/components/animations/staggered-fade-and-slide.vue
+++ b/packages/x-components/src/components/animations/staggered-fade-and-slide.vue
@@ -1,10 +1,10 @@
 <template>
   <staggering-transition-group
     v-on="$listeners"
-    v-bind="$attrs"
     appear
     class="x-staggered-fade-and-slide"
     name="x-staggered-fade-and-slide-"
+    v-bind="$attrs"
   >
     <!-- @slot (Required) Transition-group content -->
     <slot />
@@ -23,7 +23,8 @@
    * @public
    */
   @Component({
-    components: { StaggeringTransitionGroup }
+    components: { StaggeringTransitionGroup },
+    inheritAttrs: false
   })
   export default class StaggeredFadeAndSlide extends Vue {}
 </script>

--- a/packages/x-components/src/components/modals/__tests__/base-modal.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-modal.spec.ts
@@ -27,8 +27,8 @@ function mountBaseModal({
 
   return {
     wrapper,
-    getModal() {
-      return wrapper.find(getDataTestSelector('modal'));
+    getModalContent() {
+      return wrapper.find(getDataTestSelector('modal-content'));
     },
     async setOpen(open) {
       await wrapper.setProps({ open });
@@ -49,12 +49,12 @@ function mountBaseModal({
 
 describe('testing Base Modal  component', () => {
   it('renders only when the open prop is set to true', async () => {
-    const { getModal, setOpen } = mountBaseModal();
+    const { getModalContent, setOpen } = mountBaseModal();
 
-    expect(getModal().exists()).toBe(false);
+    expect(getModalContent().exists()).toBe(false);
 
     await setOpen(true);
-    expect(getModal().exists()).toBe(true);
+    expect(getModalContent().exists()).toBe(true);
   });
 
   it("emits click:body event when clicking outside modal's content if it is opened", async () => {
@@ -102,7 +102,7 @@ interface MountBaseModalAPI {
   /** Fakes a click on the close button. */
   setOpen: (open: boolean) => Promise<void>;
   /** Retrieves the modal container wrapper. */
-  getModal: () => Wrapper<Vue>;
+  getModalContent: () => Wrapper<Vue>;
   /** Fakes a click on the modal close. */
   closeModal: () => Promise<void>;
   /** Fakes a focusin event in another HTMLElement of the body. */

--- a/packages/x-components/src/components/modals/base-modal.vue
+++ b/packages/x-components/src/components/modals/base-modal.vue
@@ -1,24 +1,37 @@
 <template>
-  <component :is="animation" @beforeEnter="showOverlay = false" @afterEnter="showOverlay = true">
-    <div v-if="open" class="x-modal" data-test="modal">
-      <div ref="modal" class="x-modal__content x-list" data-test="modal-content" role="dialog">
+  <div v-show="isWaitingForLeave || open" class="x-modal" data-test="modal">
+    <component
+      :is="animation"
+      @before-leave="isWaitingForLeave = true"
+      @after-leave="isWaitingForLeave = false"
+    >
+      <div
+        v-if="open"
+        ref="modal"
+        class="x-modal__content x-list"
+        data-test="modal-content"
+        role="dialog"
+      >
         <!-- @slot (Required) Modal container content -->
         <slot />
       </div>
+    </component>
+    <component :is="overlayAnimation">
       <div
+        v-if="open"
         @click="emitOverlayClicked"
         @keydown="emitOverlayClicked"
         class="x-modal__overlay"
-        :class="{ 'x-modal__overlay--is-visible': showOverlay }"
         data-test="modal-overlay"
       />
-    </div>
-  </component>
+    </component>
+  </div>
 </template>
 
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
+  import Fade from '../animations/fade.vue';
   import { NoElement } from '../no-element';
 
   /**
@@ -30,10 +43,17 @@
   @Component
   export default class BaseModal extends Vue {
     /**
-     * Animation to use for opening/closing the modal.
+     * Animation to use for opening/closing the modal. This animation only affects the content.
      */
     @Prop({ default: () => NoElement })
     public animation!: Vue | string;
+
+    /**
+     * Animation to use for the overlay (backdrop) part of the modal. By default, it uses
+     * a fade transition.
+     */
+    @Prop({ default: () => Fade })
+    public overlayAnimation!: Vue | string;
 
     /**
      * Determines if the modal is open or not.
@@ -45,8 +65,8 @@
     protected previousBodyOverflow = '';
     /** The previous value of the HTML element overflow style. */
     protected previousHTMLOverflow = '';
-    /** To animate the overlay opacity after and before the animation. */
-    protected showOverlay = true;
+    /** Boolean to delay the leave animation until it has completed. */
+    protected isWaitingForLeave = false;
 
     public $refs!: {
       modal: HTMLDivElement;
@@ -155,13 +175,11 @@
     position: fixed;
     top: 0;
     left: 0;
-
     display: flex;
     align-items: flex-start;
     justify-content: flex-start;
     width: 100%;
     height: 100%;
-
     z-index: 1;
 
     &__content {
@@ -171,14 +189,9 @@
     &__overlay {
       width: 100%;
       height: 100%;
-      position: fixed;
-      background-color: rgba(0, 0, 0, 0.7);
-      opacity: 0;
-
-      &--is-visible {
-        transition: opacity 0.3s ease-out;
-        opacity: 1;
-      }
+      position: absolute;
+      background-color: var(--x-modal-overlay-color, rgb(0, 0, 0));
+      opacity: var(--x-modal-overlay-opacity, 0.7);
     }
   }
 </style>


### PR DESCRIPTION
There were 2 issues before this PR:
- Directional animations (like translate) didn't support extra `$listeners`.
- There was a trick that relied on adding beforeLeave and afterLeave hooks to the transition component so we could delay the overlay animation, but this only worked for the leaving transition

Knowing that, this PR implements following changes:
* Normalises all animation components, so they can both receive extra listeners and props
* Fixes modal open/close logic so it can support independent animations for both the content and the overlay.
* Adds CSS variables for opacity and overlay color (so we can stop using `!important` in clients to override it.
* Adds a `Fade` animation, used by default for the overlay.
