### PR TITLE
fix(translations): Fix '\r' issue on csv-to-json script

### DIFF
--- a/packages/x-translations/src/csv-to-json.ts
+++ b/packages/x-translations/src/csv-to-json.ts
@@ -30,7 +30,7 @@ function generateJSONFile(sourcePath: string): JSON {
  * @returns A JSON object with the contents of the CSV file.
  */
 function transformToJson(csv: string): JSON {
-  const [header, ...rows] = csv.trim().split(/\r\n|\n/);
+  const [header, ...rows] = csv.trim().split(/\r?\n|\r/);
   const [, ...columns] = header.split(';');
 
   return rows.reduce<JSON>(toMessagesObject(columns), {});

--- a/packages/x-translations/src/csv-to-json.ts
+++ b/packages/x-translations/src/csv-to-json.ts
@@ -30,7 +30,7 @@ function generateJSONFile(sourcePath: string): JSON {
  * @returns A JSON object with the contents of the CSV file.
  */
 function transformToJson(csv: string): JSON {
-  const [header, ...rows] = csv.trim().split('\n');
+  const [header, ...rows] = csv.trim().split(/\r\n|\n/);
   const [, ...columns] = header.split(';');
 
   return rows.reduce<JSON>(toMessagesObject(columns), {});


### PR DESCRIPTION
[EX-6631](https://searchbroker.atlassian.net/browse/EX-6631)

## Motivation and context

After the Kenay and Izas setups we found some issues with the `csv-to-json` scripts. 
The first issue was extra `"` on some messages. In this case, the issue didn't come from the script but from the CSV provided by the customers.
The second one was the script inserting `\r` in some points of the JSON and in messages that should be empty. This was caused by the format of the exports of the "Numbers" program. Instead of ending the CSV line with just `\n` it ends them with `\r\n`

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

Grab the example CSV file `it.messages.csv` from the task and use the script on it (I changed the source file from the script's test to do so). Test the result with and without the change of the PR applied.
