### PR TITLE
fix(components):  `LayoutsMixin` properly checks if a `$scopedSlot` has content

### DIFF
--- a/packages/x-components/src/components/layouts/layouts.mixin.ts
+++ b/packages/x-components/src/components/layouts/layouts.mixin.ts
@@ -29,7 +29,7 @@ export default class LayoutsMixin extends Vue {
     return (
       (this.devMode ||
         slotNames.some(slotName =>
-          this.$slots[slotName]?.some(vNode => vNode.tag !== undefined)
+          this.$scopedSlots[slotName]?.(undefined)?.some(vNode => vNode.tag !== undefined)
         )) ??
       false
     );


### PR DESCRIPTION
EX-6681