### PR TITLE
fix: scrolling problems in single column aside layout

### DIFF
--- a/packages/x-components/src/components/layouts/single-column-layout.vue
+++ b/packages/x-components/src/components/layouts/single-column-layout.vue
@@ -175,7 +175,6 @@
     ::v-deep .x-layout__aside {
       grid-row: page;
       z-index: 3;
-      pointer-events: none;
 
       .x-modal__content {
         width: 100%;
@@ -186,7 +185,6 @@
 
     &__predictive ::v-deep,
     &__floating ::v-deep,
-    ::v-deep .x-layout__aside,
     .slot-helper ::v-deep {
       pointer-events: none;
 

--- a/packages/x-components/src/components/layouts/single-column-layout.vue
+++ b/packages/x-components/src/components/layouts/single-column-layout.vue
@@ -194,7 +194,7 @@
         pointer-events: all;
       }
 
-      .x-list {
+      > .x-list {
         pointer-events: none;
 
         > * {


### PR DESCRIPTION
It seems that the pointer events are not needed in the aside layout.
I have tested this in the archetype and the Kenay setup and all is working as it should.
This PR fixes the scroll bug of the selected filters in mobile view.
The pointer events are still needed in the predictive layer because it is being always rendered.

To test this:
- Open [this](https://x.staging.empathy.co/x-kenay/index.html?filter=currentPrice%3A200.0-400.0&filter=previousPrice%3A200.0-400.0&filter=height%3A45%2C6%20cm&query=sofa) link in staging in mobile view, the scroll of the selected filters should not be working.
- Make an `npm run install:local` with the new version of X Components in the Kenay setup.
  - With the same request, the scroll should be working now.

EX-6595