### PR TITLE
feat(history-queries): disable `MyHistory` without confirmation when the history queries list is empty

### DIFF
--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/history-queries-switch.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/history-queries-switch.spec.ts
@@ -2,20 +2,25 @@ import { DeepPartial } from '@empathyco/x-utils';
 import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
+import { HistoryQuery } from '@empathyco/x-types';
 import { RootXStoreState } from '../../../../store/store.types';
 import { installNewXPlugin } from '../../../../__tests__/utils';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import { historyQueriesXModule } from '../../x-module';
 import HistoryQueriesSwitch from '../history-queries-switch.vue';
+import { createHistoryQueries } from '../../../../__stubs__/index';
 import { resetXHistoryQueriesStateWith } from './utils';
 
-function renderHistoryQueriesSwitch(): HistoryQueriesSwitchAPI {
+function renderHistoryQueriesSwitch({
+  historyQueries = createHistoryQueries('jacket', 'tshirt'),
+  isEnabled = false
+}: HistoryQueriesSwitchOptions = {}): HistoryQueriesSwitchAPI {
   const localVue = createLocalVue();
   localVue.use(Vuex);
 
   const store = new Store<DeepPartial<RootXStoreState>>({});
   installNewXPlugin({ store, initialXModules: [historyQueriesXModule] }, localVue);
-  resetXHistoryQueriesStateWith(store, { isEnabled: false });
+  resetXHistoryQueriesStateWith(store, { isEnabled, historyQueries });
 
   const wrapper = mount(HistoryQueriesSwitch, {
     localVue,
@@ -52,7 +57,30 @@ describe('testing HistoryQueriesSwitch component', () => {
 
     expect(disableListener).toHaveBeenCalledTimes(1);
   });
+
+  it('should emit confirm disable event if there are not history queries', () => {
+    const { wrapper } = renderHistoryQueriesSwitch({
+      historyQueries: [],
+      isEnabled: true
+    });
+    const listener = jest.fn();
+    wrapper.vm.$x.on('UserClickedConfirmDisableHistoryQueries').subscribe(listener);
+
+    wrapper.trigger('click');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
 });
+
+/**
+ * Test options for the {@link HistoryQueriesSwitch} component.
+ */
+interface HistoryQueriesSwitchOptions {
+  /** The History Queries to set in the state. */
+  historyQueries?: HistoryQuery[];
+  /** Initial state of the switch. */
+  isEnabled?: boolean;
+}
 
 /**
  * Test API for the {@link HistoryQueriesSwitch} component.

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/history-queries-switch.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/history-queries-switch.spec.ts
@@ -58,7 +58,7 @@ describe('testing HistoryQueriesSwitch component', () => {
     expect(disableListener).toHaveBeenCalledTimes(1);
   });
 
-  it('should emit confirm disable event if there are not history queries', () => {
+  it('should emit confirm disable event if there are not history queries', async () => {
     const { wrapper } = renderHistoryQueriesSwitch({
       historyQueries: [],
       isEnabled: true
@@ -68,7 +68,10 @@ describe('testing HistoryQueriesSwitch component', () => {
 
     wrapper.trigger('click');
 
+    await new Promise(resolve => setTimeout(resolve));
+
     expect(listener).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.$store.state.x.historyQueries.isEnabled).toBe(false);
   });
 });
 

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
@@ -75,7 +75,7 @@ A list of events that the component will emit:
   (x-components.historyqueriesxevents.userclickeddisablehistoryqueries.md): the event is emitted
   whenever the user clicks the switch when the history queries are enabled and the list of history
   queries is not empty.
-- [`UserClicedConfirmDisableHistoryQueries`]
+- [`UserClickedConfirmDisableHistoryQueries`]
   (x-components.historyqueriesxevents.userclickedconfirmdisablehistoryqueries.md): the event is
   emitted whenever the user clicks the switch when the history queries are enabled and the list of
   history queries is empty.

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
@@ -5,10 +5,12 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
+  import { HistoryQuery } from '@empathyco/x-types';
   import BaseSwitch from '../../../components/base-switch.vue';
   import { State } from '../../../components/decorators/store.decorators';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { historyQueriesXModule } from '../x-module';
+  import { isArrayEmpty } from '../../../utils/array';
 
   /**
    * History Queries Switch is a component to enable or disable the history queries.
@@ -30,13 +32,32 @@
     public isEnabled!: boolean;
 
     /**
+     * The history queries from the state.
+     */
+    @State('historyQueries', 'historyQueries')
+    public historyQueries!: HistoryQuery[];
+
+    /**
+     * Checks if there are history queries.
+     *
+     * @returns True if there are history queries; false otherwise.
+     */
+    protected get hasHistoryQueries(): boolean {
+      return !isArrayEmpty(this.historyQueries);
+    }
+
+    /**
      * Emits an event based on the switch state.
      *
      * @internal
      */
     protected toggle(): void {
       this.$x.emit(
-        this.isEnabled ? 'UserClickedDisableHistoryQueries' : 'UserClickedEnableHistoryQueries'
+        this.isEnabled
+          ? this.hasHistoryQueries
+            ? 'UserClickedDisableHistoryQueries'
+            : 'UserClickedConfirmDisableHistoryQueries'
+          : 'UserClickedEnableHistoryQueries'
       );
     }
   }
@@ -52,7 +73,12 @@ A list of events that the component will emit:
   whenever the user clicks the switch and the history queries are disabled.
 - [`UserClickedDisableHistoryQueries`]
   (x-components.historyqueriesxevents.userclickeddisablehistoryqueries.md): the event is emitted
-  whenever the user clicks the switch and the history queries are enabled.
+  whenever the user clicks the switch when the history queries are enabled and the list of history
+  queries is not empty.
+- [`UserClicedConfirmDisableHistoryQueries`]
+  (x-components.historyqueriesxevents.userclickedconfirmdisablehistoryqueries.md): the event is
+  emitted whenever the user clicks the switch when the history queries are enabled and the list of
+  history queries is empty.
 
 ## See it in action
 


### PR DESCRIPTION
EX-6696
