### PR TITLE
feat: Do not flatten body params in fetch http client.

### DIFF
--- a/packages/x-adapter/src/http-clients/__tests__/fetch.http-client.spec.ts
+++ b/packages/x-adapter/src/http-clients/__tests__/fetch.http-client.spec.ts
@@ -124,7 +124,9 @@ describe('fetch httpClient testing', () => {
         q: 'shirt',
         filter: ['long sleeve', 'dotted', 'white'],
         rows: 12,
-        lang: 'en'
+        extraParams: {
+          lang: 'en'
+        }
       })
     });
   });

--- a/packages/x-adapter/src/http-clients/fetch.http-client.ts
+++ b/packages/x-adapter/src/http-clients/fetch.http-client.ts
@@ -19,7 +19,7 @@ export const fetchHttpClient: HttpClient = (
   const signal = abortAndGetNewAbortSignal(id);
   const flatParameters = flatObject(parameters);
   const url = sendParamsInBody ? endpoint : buildUrl(endpoint, flatParameters);
-  const bodyParameters = sendParamsInBody ? { body: JSON.stringify(flatParameters) } : {};
+  const bodyParameters = sendParamsInBody ? { body: JSON.stringify(parameters) } : {};
 
   return fetch(url, {
     ...properties,


### PR DESCRIPTION
MOTPRD-7732

This PR modifies the fetch HTTP client to not flatten the parameters object when it is sent in the body of the request.
