### PR TITLE
feat(components): make `BaseIdModalClose` rendering configurable

### DIFF
--- a/packages/x-components/src/components/modals/__tests__/base-id-modal-close.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-id-modal-close.spec.ts
@@ -55,6 +55,30 @@ describe('testing Close Button component', () => {
 
     expect(wrapper.text()).toEqual('Close');
   });
+
+  // eslint-disable-next-line max-len
+  it('renders custom content replacing the default exposing the function that closes the modal', async () => {
+    const { wrapper, click, modalId } = renderBaseIdModalClose({
+      template: `<BaseIdModalClose modalId="modal" v-bind="$attrs">
+                    <template #closer-element="{ closeModal }">
+                      <div>
+                        Close <span data-test="custom-close-modal" @click="closeModal">HERE</span>
+                      </div>
+                    </template>
+                  </BaseIdModalClose>`
+    });
+
+    const listener = jest.fn();
+    wrapper.vm.$x.on('UserClickedCloseModal').subscribe(listener);
+
+    await click();
+
+    expect(listener).toHaveBeenCalledTimes(0);
+
+    wrapper.find('[data-test="custom-close-modal"]').trigger('click');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(modalId);
+  });
 });
 
 interface RenderBaseIdModalCloseOptions {

--- a/packages/x-components/src/components/modals/__tests__/base-id-modal-close.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-id-modal-close.spec.ts
@@ -60,7 +60,7 @@ describe('testing Close Button component', () => {
   it('renders custom content replacing the default exposing the function that closes the modal', async () => {
     const { wrapper, click, modalId } = renderBaseIdModalClose({
       template: `<BaseIdModalClose modalId="modal" v-bind="$attrs">
-                    <template #closer-element="{ closeModal }">
+                    <template #closing-element="{ closeModal }">
                       <div>
                         Close <span data-test="custom-close-modal" @click="closeModal">HERE</span>
                       </div>

--- a/packages/x-components/src/components/modals/base-id-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-id-modal-close.vue
@@ -1,36 +1,44 @@
 <template>
-  <BaseEventButton
-    v-on="$listeners"
-    :events="events"
-    class="x-button x-events-modal-id-close-button"
-    data-test="close-modal-id"
-  >
-    <!-- @slot (Required) Button content with a text, an icon or both -->
-    <slot />
-  </BaseEventButton>
+  <NoElement v-on="$listeners" data-test="close-modal-id">
+    <!--
+      @slot closer-element. It's the element that will trigger the modal closing. It's a
+      button by default.
+        @binding {Function} closeModal - The function to close the modal.
+    -->
+    <slot :closeModal="emitCloseModalEvent" name="closer-element">
+      <BaseEventButton
+        v-on="$listeners"
+        :events="{ UserClickedCloseModal: modalId }"
+        class="x-button x-events-modal-id-close-button"
+      >
+        <slot />
+      </BaseEventButton>
+    </slot>
+  </NoElement>
 </template>
 
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop } from 'vue-property-decorator';
-  import { XEventsTypes } from '../../wiring/events.types';
   import BaseEventButton from '../base-event-button.vue';
+  import { NoElement } from '../no-element';
 
   /**
-   * Component containing an event button that emits {@link XEventsTypes.UserClickedCloseModal} when
-   * clicked with the modalId as payload. It has a default slot to customize its contents.
+   * Component that allows to close a modal by emitting {@link XEventsTypes.UserClickedCloseModal}.
+   * It's fully customizable as it exposes the closing event but by default it renders a
+   * customizable button.
    *
    * @public
    */
   @Component({
-    components: { BaseEventButton }
+    components: { BaseEventButton, NoElement }
   })
   export default class BaseIdModalClose extends Vue {
     @Prop({ required: true })
     protected modalId!: string;
 
-    protected get events(): Partial<XEventsTypes> {
-      return { UserClickedCloseModal: this.modalId };
+    protected emitCloseModalEvent(): void {
+      this.$x.emit('UserClickedCloseModal', this.modalId, { target: this.$el as HTMLElement });
     }
   }
 </script>
@@ -39,17 +47,47 @@
 ## Examples
 
 Component containing an event button that emits `UserClickedCloseModal` when clicked with the
-modalId as payload. It has a default slot to customize its contents.
+modalId as payload. It has a default slot to customize its contents and can also be fully
+customized, replacing the default button with any other element.
 
 ### Basic example
 
-The component renders whatever is passed to it in the default slot and closing the modal with
-modalId `my-modal`.
+The component renders whatever is passed to it in the default slot inside the button and closes the
+modal with modalId `my-modal`.
 
 ```vue
 <template>
   <BaseIdModalClose modalId="my-modal">
     <img src="./close-button-icon.svg" />
+  </BaseIdModalClose>
+</template>
+
+<script>
+  import { BaseIdModalClose } from '@empathyco/x-components';
+
+  export default {
+    name: 'BaseIdModalCloseTest',
+    components: {
+      BaseIdModalClose
+    }
+  };
+</script>
+```
+
+### Replacing the default button
+
+The component renders whatever element is passed, replacing the default button and exposing the
+function to close the modal with modalId `my-modal`.
+
+```vue
+<template>
+  <BaseIdModalClose modalId="my-modal">
+    <template #closer-element="{ closeModal }">
+      <ul>
+        <li @click="closeModal">Close here</li>
+        <li>Not here</li>
+      </ul>
+    </template>
   </BaseIdModalClose>
 </template>
 

--- a/packages/x-components/src/components/modals/base-id-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-id-modal-close.vue
@@ -1,7 +1,7 @@
 <template>
   <NoElement v-on="$listeners" data-test="close-modal-id">
     <!--
-      @slot closer-element. It's the element that will trigger the modal closing. It's a
+      @slot closing-element. It's the element that will trigger the modal closing. It's a
       button by default.
         @binding {Function} closeModal - The function to close the modal.
     -->

--- a/packages/x-components/src/components/modals/base-id-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-id-modal-close.vue
@@ -5,14 +5,10 @@
       button by default.
         @binding {Function} closeModal - The function to close the modal.
     -->
-    <slot :closeModal="emitCloseModalEvent" name="closer-element">
-      <BaseEventButton
-        v-on="$listeners"
-        :events="{ UserClickedCloseModal: modalId }"
-        class="x-button x-events-modal-id-close-button"
-      >
+    <slot :closeModal="emitCloseModalEvent" name="closing-element">
+      <button @click="emitCloseModalEvent" class="x-button x-events-modal-id-close-button">
         <slot />
-      </BaseEventButton>
+      </button>
     </slot>
   </NoElement>
 </template>

--- a/packages/x-components/src/components/modals/base-id-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-id-modal-close.vue
@@ -78,7 +78,7 @@ function to close the modal with modalId `my-modal`.
 ```vue
 <template>
   <BaseIdModalClose modalId="my-modal">
-    <template #closer-element="{ closeModal }">
+    <template #closing-element="{ closeModal }">
       <ul>
         <li @click="closeModal">Close here</li>
         <li>Not here</li>


### PR DESCRIPTION
[EX-6726](https://searchbroker.atlassian.net/browse/EX-6726)

## Motivation and context
Some cases required closing modals from different parts of the code by elements that weren't always simple buttons. The old `BaseIdModalClose` didn't allow that so we're changing it to make it more configurable and maintain retro compatibility.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

Create a new element to close an id modal by using `BaseIdModalClose` and override the slot content. Check that everything is working.
Also, a new test for this functionality was created.
