### PR TITLE
feature/EX-6463-change-aspect-ratio

### DIFF
--- a/packages/x-components/src/design-system/components/picture/fixed-ratio.scss
+++ b/packages/x-components/src/design-system/components/picture/fixed-ratio.scss
@@ -1,5 +1,5 @@
 .x-picture--fixed-ratio.x-picture {
   // size
-  aspect-ratio: 1 / var(--x-number-aspect-ratio-picture);
+  aspect-ratio: var(--x-number-aspect-ratio-picture);
   width: 100%;
 }

--- a/packages/x-components/src/design-system/components/picture/fixed-ratio.scss
+++ b/packages/x-components/src/design-system/components/picture/fixed-ratio.scss
@@ -1,19 +1,5 @@
 .x-picture--fixed-ratio.x-picture {
-  // layout
-  position: relative;
-  height: 0;
-
   // size
-  padding-block-start: calc(var(--x-number-aspect-ratio-picture) * 100%);
-  padding-block-end: 0;
-  padding-inline-start: 0;
-  padding-inline-end: 0;
+  aspect-ratio: 1 / var(--x-number-aspect-ratio-picture);
   width: 100%;
-
-  .x-picture__image {
-    // layout
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
 }

--- a/packages/x-components/src/views/home/result.vue
+++ b/packages/x-components/src/views/home/result.vue
@@ -1,7 +1,11 @@
 <template>
   <article class="x-result" style="max-width: 300px; overflow: hidden">
     <BaseResultLink :result="result">
-      <BaseResultImage :result="result" class="x-result__picture x-picture--colored">
+      <BaseResultImage
+        :result="result"
+        class="x-result__picture x-picture--fixed-ratio"
+        :animation="crossFade"
+      >
         <template #placeholder>
           <div style="padding-top: 100%; background-color: lightgray"></div>
         </template>
@@ -32,6 +36,7 @@
   import BaseResultImage from '../../components/result/base-result-image.vue';
   import BaseResultLink from '../../components/result/base-result-link.vue';
   import BaseResultRating from '../../components/result/base-result-rating.vue';
+  import CrossFade from '../../components/animations/cross-fade.vue';
 
   @Component({
     components: {
@@ -43,6 +48,8 @@
   export default class ResultComponent extends Vue {
     @Prop()
     protected result!: Result;
+
+    protected crossFade = CrossFade;
   }
 </script>
 


### PR DESCRIPTION
Modifies the aspect ratio logic to use the modern CSS aspect-ratio property. This also prevents from creating unnecessary layers for the images in the view due to the `position: absolute` property. 
If we use `mix-blend-mode`, this will create another layer, that's why I also removed from the demo the `--colored` modifier.
From my own tests there is no performance improvement on either the paint or composite phases, at least for standard use cases (search & select an RT, search & select a suggestion...). I'd love to have more benchmarks here from different computers. What I did was simply record the performance, and in the bottom-up panel you should be able to see this.

![image](https://user-images.githubusercontent.com/68222542/181727353-c185abc1-d8fd-44ed-b146-9020b5c72098.png)

To see the layers you can use the `Layers` tool with different css properties to see how it affects. Right now you can see that images, results, and grid are on the same layer:

![image](https://user-images.githubusercontent.com/68222542/181727666-a0cd9ed9-cee7-49ad-943f-3c76158b8869.png)