### PR TITLE
fix(facets): fix `SingleSelectModifier` handling for selecting hierar…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27802,7 +27802,7 @@
     },
     "packages/eslint-plugin-x": {
       "name": "@empathyco/eslint-plugin-x",
-      "version": "2.0.0-alpha.10",
+      "version": "2.0.0-alpha.11",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/x-components/src/x-modules/facets/entities/__tests__/single-select-modifier.spec.ts
+++ b/packages/x-components/src/x-modules/facets/entities/__tests__/single-select-modifier.spec.ts
@@ -91,6 +91,16 @@ describe('testing single select modifier', () => {
     expect(isFilterSelected(store, flavoredYogurtFilter.id)).toBe(true);
     expect(isFilterSelected(store, naturalOrganicFilter.id)).toBe(false);
 
+    // Select parent again: Previously we had a bug with re-selecting a filter like it happens when
+    // saving a search response. Doing so only kept hierarchical filters selected until the 2nd
+    // level #EX-6809
+    entity.select(dairyAndEggsFilter);
+    expect(isFilterSelected(store, dairyAndEggsFilter.id)).toBe(true);
+    expect(isFilterSelected(store, milkFilter.id)).toBe(false);
+    expect(isFilterSelected(store, yogurtFilter.id)).toBe(true);
+    expect(isFilterSelected(store, flavoredYogurtFilter.id)).toBe(true);
+    expect(isFilterSelected(store, naturalOrganicFilter.id)).toBe(false);
+
     // Select parent sibling
     entity.select(naturalOrganicFilter);
     expect(isFilterSelected(store, dairyAndEggsFilter.id)).toBe(false);

--- a/packages/x-components/src/x-modules/facets/entities/single-select.modifier.ts
+++ b/packages/x-components/src/x-modules/facets/entities/single-select.modifier.ts
@@ -89,9 +89,11 @@ export class SingleSelectModifier extends BaseFilterEntityModifier {
     filter: HierarchicalFilter,
     ids: Array<Filter['id']> = [filter.id]
   ): Array<Filter['id']> {
-    return filter?.children
-      ? filter?.children.flatMap(descendant =>
-          this.getDescendantsIds(descendant, [descendant.id, ...ids])
+    return filter?.children?.length
+      ? filter?.children.reduce(
+          (descentantIdsList, descendant) =>
+            this.getDescendantsIds(descendant, [descendant.id, ...ids]),
+          ids
         )
       : ids;
   }

--- a/packages/x-components/src/x-modules/facets/entities/single-select.modifier.ts
+++ b/packages/x-components/src/x-modules/facets/entities/single-select.modifier.ts
@@ -91,8 +91,8 @@ export class SingleSelectModifier extends BaseFilterEntityModifier {
   ): Array<Filter['id']> {
     return filter?.children?.length
       ? filter?.children.reduce(
-          (descentantIdsList, descendant) =>
-            this.getDescendantsIds(descendant, [descendant.id, ...ids]),
+          (descendantIdsList, descendant) =>
+            this.getDescendantsIds(descendant, [descendant.id, ...descendantIdsList]),
           ids
         )
       : ids;


### PR DESCRIPTION
Fixes the issue where selecting a 3rd level hierarchical filter caused it to be deselected when saving the search response. This happened because of the `SingleSelectModifier` retrieved wrongly the list of filter descendants for `HierarchicalFilter`s.