### PR TITLE
feat(result): add variants support

### DIFF
--- a/packages/search-types/src/result/result.model.ts
+++ b/packages/search-types/src/result/result.model.ts
@@ -12,19 +12,28 @@ import { ResultRating } from './result-rating.model';
  */
 export interface Result extends NamedModel<'Result'>, Identifiable, Taggable {
   /** The type of the result: product, article, pack, etc... */
-  type: string;
+  type?: string;
   /** Images of the result. It should be the URLs. */
-  images: string[];
+  images?: string[];
   /** Result name. */
-  name: string;
+  name?: string;
   /** {@link ResultPrice | Result price}.  */
-  price: ResultPrice;
+  price?: ResultPrice;
   /** {@link ResultRating | Result rating}.  */
-  rating: ResultRating;
+  rating?: ResultRating;
   /** {@link ResultIdentifier | Result identifier}.  */
-  identifier: ResultIdentifier;
+  identifier?: ResultIdentifier;
   /** Result URL to redirect to PDP.  */
-  url: string;
+  url?: string;
   /** Flag if the results has been added to the wishlist or not. */
-  isWishlisted: boolean;
+  isWishlisted?: boolean;
+  /** {@link ResultVariant | Variants of the result}.  */
+  variants?: ResultVariant[];
 }
+
+/**
+ * A result variant.
+ *
+ * @public
+ */
+export interface ResultVariant extends Omit<Result, 'id' | 'modelName' | 'tagging'> {}

--- a/packages/x-components/src/components/__tests__/items-list.spec.ts
+++ b/packages/x-components/src/components/__tests__/items-list.spec.ts
@@ -83,7 +83,7 @@ describe('testing ItemsList component', () => {
     });
 
     expect(wrapper.find(getDataTestSelector('results-list-item')).text()).toBe(
-      `Result: ${resultsStub[0].name}`
+      `Result: ${resultsStub[0].name!}`
     );
 
     expect(wrapper.find(getDataTestSelector('banners-list-item')).text()).toBe(

--- a/packages/x-components/src/components/result/__tests__/base-result-current-price.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-current-price.spec.ts
@@ -90,7 +90,7 @@ describe('testing BaseCurrentPrice component', () => {
     });
 
     expect(wrapper.find(getDataTestSelector('override-default-slot')).exists()).toBe(true);
-    expect(wrapper.text()).toBe(mockedResult.price.value.toString());
+    expect(wrapper.text()).toBe(mockedResult.price!.value.toString());
   });
 });
 
@@ -99,8 +99,10 @@ interface RenderBaseCurrentPriceOptions {
   format?: string;
   /** The result with the price to display. */
   result?: Pick<Result, 'price'>;
-  /** The template to render. Receives the 'result', 'format' props and
-   * has registered a {@link BaseCurrency | BaseCurrency component}. */
+  /**
+   * The template to render. Receives the 'result', 'format' props and
+   * has registered a {@link BaseCurrency | BaseCurrency component}.
+   */
   template?: string;
 }
 

--- a/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
@@ -58,7 +58,7 @@ describe('testing BaseResultLink component', () => {
       template: `
         <BaseResultLink :result="result">
           <template #default="{ result }">
-            <img  data-test="result-link-image" src="${result.images[0]}"/>
+            <img data-test="result-link-image" src="${result.images![0]}"/>
             <span data-test="result-link-text">
               {{ result.name }}
             </span>
@@ -81,7 +81,7 @@ describe('testing BaseResultLink component', () => {
     ).toBeDefined();
     expect(
       customResultLinkWrapper.find(getDataTestSelector('result-link-image')).attributes('src')
-    ).toEqual(result.images[0]);
+    ).toEqual(result.images![0]);
     expect(customResultLinkWrapper.find(getDataTestSelector('result-link-text')).text()).toEqual(
       result.name
     );

--- a/packages/x-components/src/components/result/__tests__/base-result-previous-price.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-previous-price.spec.ts
@@ -85,7 +85,7 @@ describe('testing BaseResultPreviousPrice component', () => {
     });
 
     expect(wrapper.find(getDataTestSelector('override-default-slot')).exists()).toBe(true);
-    expect(wrapper.text()).toBe(mockedResult.price.originalValue.toString());
+    expect(wrapper.text()).toBe(mockedResult.price!.originalValue.toString());
   });
 });
 
@@ -94,7 +94,8 @@ interface RenderBasePreviousPriceOptions {
   format?: string;
   /** The result with the price to display. */
   result?: Pick<Result, 'price'>;
-  /** The template to render. Receives the 'result', 'format' prop and has registered a
+  /**
+   * The template to render. Receives the 'result', 'format' prop and has registered a
    * {@link BaseCurrency | BaseCurrency component}.
    */
   template?: string;

--- a/packages/x-components/src/components/result/base-result-current-price.vue
+++ b/packages/x-components/src/components/result/base-result-current-price.vue
@@ -64,7 +64,7 @@
      */
     protected get dynamicClasses(): VueCSSClasses {
       return {
-        'x-result-current-price--on-sale': this.result.price.hasDiscount
+        'x-result-current-price--on-sale': this.result.price?.hasDiscount ?? false
       };
     }
   }

--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -119,7 +119,7 @@
      * @internal
      */
     protected get imageSrc(): string {
-      if (this.hasEnteredView && this.result.images.length > 0) {
+      if (this.hasEnteredView && this.result.images?.length) {
         const image = this.result.images.find(image => !this.failedImages.includes(image));
         return image ?? '';
       }
@@ -174,7 +174,7 @@
      * @internal
      */
     protected get hasAllImagesFailed(): boolean {
-      return this.failedImages.length === this.result.images.length;
+      return this.failedImages.length === this.result.images?.length;
     }
 
     /**

--- a/packages/x-components/src/x-modules/identifier-results/components/__tests__/identifier-results.spec.ts
+++ b/packages/x-components/src/x-modules/identifier-results/components/__tests__/identifier-results.spec.ts
@@ -61,7 +61,7 @@ describe('testing IdentifierResult component', () => {
     const spanList = findAllByTestDataId(identifierResultsWrapper, 'identifier-result');
 
     identifierResults.forEach((result, index) => {
-      expect(spanList.at(index).text()).toEqual(result.identifier.value);
+      expect(spanList.at(index).text()).toEqual(result.identifier!.value);
     });
   });
 

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
@@ -57,14 +57,14 @@
      * @public
      */
     protected get highlightedQueryHTML(): string {
-      const identifierValue = this.result.identifier?.value;
+      const identifierValue = this.result.identifier?.value ?? '';
       if (identifierValue && this.identifierHighlightRegexp) {
         return identifierValue.replace(
           this.identifierHighlightRegexp,
           '<span class="x-identifier-result__matching-part">$1</span>'
         );
       }
-      return identifierValue ?? '';
+      return identifierValue;
     }
   }
 </script>

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
@@ -57,14 +57,14 @@
      * @public
      */
     protected get highlightedQueryHTML(): string {
-      const identifierValue = this.result.identifier.value;
+      const identifierValue = this.result.identifier?.value;
       if (identifierValue && this.identifierHighlightRegexp) {
         return identifierValue.replace(
           this.identifierHighlightRegexp,
           '<span class="x-identifier-result__matching-part">$1</span>'
         );
       }
-      return identifierValue;
+      return identifierValue ?? '';
     }
   }
 </script>

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-query-preview.spec.ts
@@ -92,7 +92,7 @@ describe('next query preview', () => {
     const wrappers = findTestDataById('result-name');
 
     resultsPreview!.items.forEach((result, index) => {
-      expect(wrappers.at(index).element).toHaveTextContent(result.name);
+      expect(wrappers.at(index).element).toHaveTextContent(result.name!);
     });
   });
 
@@ -122,7 +122,7 @@ describe('next query preview', () => {
     const resultsWrappers = findTestDataById('result-name');
 
     resultsPreview!.items.forEach((result, index) => {
-      expect(resultsWrappers.at(index).element).toHaveTextContent(result.name);
+      expect(resultsWrappers.at(index).element).toHaveTextContent(result.name!);
     });
   });
 
@@ -137,7 +137,7 @@ describe('next query preview', () => {
     const resultsWrapper = findTestDataById('result-content');
 
     resultsPreview!.items.forEach((result, index) => {
-      expect(resultsWrapper.at(index).element).toHaveTextContent(`${result.id} - ${result.name}`);
+      expect(resultsWrapper.at(index).element).toHaveTextContent(`${result.id} - ${result.name!}`);
     });
   });
 

--- a/packages/x-components/src/x-modules/search/components/__tests__/results-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/results-list.spec.ts
@@ -105,7 +105,7 @@ describe('testing Results list component', () => {
     expect(wrapper.classes('x-items-list')).toBe(true);
     expect(wrapper.find(getDataTestSelector('results-list-item')).exists()).toBe(true);
     expect(wrapper.find(getDataTestSelector('result-slot-overridden')).text()).toBe(
-      `Custom result: ${getResults()[0].name}`
+      `Custom result: ${getResults()[0].name!}`
     );
   });
 


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->
EX-6760

BREAKING CHANGE: `Result` model properties are optional, except `id`, `modelName`, and `tagging`. 

In order to support result variants:
- Now the `Result` properties are optional, except `id`, `modelName`, and `tagging`.
- A result variant can contain more variants.
- As result properties now are optional, I'm not defining a variant as a `Partial<Result>`, let me know if you feel it should be a partial result. 


## Motivation and context
- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: https://searchbroker.atlassian.net/browse/EX-6760

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:
