### PR TITLE
docs: clarify how to subscribe to any `XEvent`.

### DIFF
--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -321,6 +321,16 @@ For example, if you select the search input box, the message “focus” appears
 enter a search term, the message “typing” appears. If you press Enter after typing a search term,
 the message “enter” appears.
 
+<!-- prettier-ignore-start -->
+:::warning X Events are only emitted from the root X Component.
+At the moment, X Events are only emitted from the root X Component. This means that if you wrap
+the `SearchInput` with another component of another module like the `MainScroll`, you should add
+the listeners to the `MainScroll` instead of the `SearchInput`. If you need to subscribe to these
+events, it is recommended to use the [`GlobalXBus`](../common/x-components.global-x-bus.md)
+component instead.
+:::
+<!-- prettier-ignore-end -->
+
 _Type any term in the input field to try it out!_
 
 ```vue live

--- a/packages/x-components/static-docs/build-search-ui/web-how-to-use-x-components-guide.md
+++ b/packages/x-components/static-docs/build-search-ui/web-how-to-use-x-components-guide.md
@@ -162,3 +162,40 @@ Next, you want to configure the behavior of the `SearchInput` component. Here yo
   :autocompleteSuggestionsEvent="'NextQueriesChanged'"
 />
 ```
+
+**3. Listening to X Events**
+
+For advanced use cases you might need to subscribe to certain `XEvent`. The recommended way to do so
+is by using the `GlobalXBus` component.
+
+In this example you are subscribing to the `UserAcceptedAQuery` event. This event is emitted both by
+the `SearchInput` component and by the `QuerySuggestions` one.
+
+```vue live
+<template>
+  <div>
+    <GlobalXBus @UserAcceptedAQuery="logUserAcceptedAQuery" />
+    <SearchInput />
+    <QuerySuggestions />
+  </div>
+</template>
+<script>
+  import { GlobalXBus } from '@empathyco/x-components';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+  import { QuerySuggestions } from '@empathyco/x-components/query-suggestions';
+
+  export default {
+    name: 'Demo',
+    components: {
+      GlobalXBus,
+      SearchInput,
+      QuerySuggestions
+    },
+    methods: {
+      logUserAcceptedAQuery(query, metadata) {
+        console.log('UserAcceptedAQuery', query, metadata);
+      }
+    }
+  };
+</script>
+```


### PR DESCRIPTION
EX-6816

Clarifies how the XEvents emission works in X-Components. Suggests using GlobalXBus instead.
