### PR TITLE
feat(next-queries): add `maxItemsToRender` prop to `NextQueryPreview` component

### DIFF
--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-query-preview.spec.ts
@@ -18,8 +18,9 @@ import { resetXNextQueriesStateWith } from './utils';
 
 describe('next query preview', () => {
   function renderNextQueryPreview({
+    maxItemsToRender,
     suggestion = createNextQueryStub('milk'),
-    template = `<NextQueryPreview :suggestion="suggestion"/>`,
+    template = `<NextQueryPreview :maxItemsToRender="maxItemsToRender" :suggestion="suggestion" />`,
     resultsPreview = {
       query: suggestion.query,
       items: getResultsStub(4),
@@ -50,7 +51,7 @@ describe('next query preview', () => {
 
     const wrapper = mount(
       {
-        props: ['suggestion'],
+        props: ['maxItemsToRender', 'suggestion'],
         components: { NextQueryPreview },
         template
       },
@@ -58,6 +59,7 @@ describe('next query preview', () => {
         localVue,
         store,
         propsData: {
+          maxItemsToRender,
           suggestion
         }
       }
@@ -94,6 +96,15 @@ describe('next query preview', () => {
     resultsPreview!.items.forEach((result, index) => {
       expect(wrappers.at(index).element).toHaveTextContent(result.name);
     });
+  });
+
+  it('renders the specified number of items', () => {
+    const maxItemsToRender = 2;
+    const { findTestDataById } = renderNextQueryPreview({
+      maxItemsToRender
+    });
+
+    expect(findTestDataById('result-name')).toHaveLength(maxItemsToRender);
   });
 
   it('exposes the suggestion, the results and the totalResults in the default slot', () => {
@@ -151,6 +162,8 @@ describe('next query preview', () => {
 });
 
 interface RenderNextQueryPreviewOptions {
+  /** The maximum number of items to render. */
+  maxItemsToRender?: number;
   /** The initial next query to render. */
   suggestion?: NextQuery;
   /**

--- a/packages/x-components/src/x-modules/next-queries/components/next-query-preview.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-query-preview.vue
@@ -234,11 +234,11 @@ In this example, the suggestions has been limited to render a maximum of 4 items
   <NextQueryPreview
     :maxItemsToRender="maxItemsToRender"
     :suggestion="suggestion"
-    #result="{ result }"
+    #default="{ results }"
   >
-    <BaseGrid #default="{ item }">
-      <BaseResultLink :result="result">
-        <BaseResultImage :result="result" />
+    <BaseGrid #default="{ item }" :items="results">
+      <BaseResultLink :result="item">
+        <BaseResultImage :result="item" />
       </BaseResultLink>
     </BaseGrid>
   </NextQueryPreview>

--- a/packages/x-components/src/x-modules/next-queries/components/next-query-preview.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-query-preview.vue
@@ -60,6 +60,14 @@
     protected suggestion!: NextQuery;
 
     /**
+     * Number of suggestion results to be rendered.
+     *
+     * @public
+     */
+    @Prop()
+    protected maxItemsToRender?: number;
+
+    /**
      * The results preview of the next queries mounted.
      * It is a dictionary, indexed by the next query query.
      */
@@ -79,8 +87,15 @@
      *
      * @returns The results preview of the actual next query.
      */
-    public get suggestionResults(): PreviewResults {
-      return this.previewResults[this.suggestion.query];
+    public get suggestionResults(): PreviewResults | undefined {
+      const previewResults = this.previewResults[this.suggestion.query];
+
+      return previewResults
+        ? {
+            ...previewResults,
+            items: previewResults.items.slice(0, this.maxItemsToRender)
+          }
+        : undefined;
     }
   }
 </script>
@@ -199,6 +214,58 @@ In this example, the ID of the results will be rendered along with the name.
     },
     data() {
       return {
+        suggestion: {
+          modelName: 'NextQuery',
+          query: 'tshirt',
+          facets: []
+        }
+      };
+    }
+  };
+</script>
+```
+
+### Play with props
+
+In this example, the suggestions has been limited to render a maximum of 4 items.
+
+```vue
+<template>
+  <NextQueryPreview :suggestion="suggestion" #result="{ result }">
+    <BaseGrid
+      #default="{ item }"
+      :animation="gridAnimation"
+      :columns="maxItemsToRender"
+      class="x-padding--00"
+    >
+      <BaseResultLink :result="result">
+        <BaseResultImage :result="result" class="x-result__picture" />
+      </BaseResultLink>
+    </BaseGrid>
+  </NextQueryPreview>
+</template>
+
+<script>
+  import {
+    BaseGrid,
+    BaseResultImage,
+    BaseResultLink,
+    StaggeredFadeAndSlide
+  } from '@empathyco/x-components';
+  import { NextQueryPreview } from '@empathyco/x-components/next-queries';
+
+  export default {
+    name: 'NextQueryPreviewDemo',
+    components: {
+      BaseGrid,
+      BaseResultImage,
+      BaseResultLink,
+      NextQueryPreview,
+      StaggeredFadeAndSlide
+    },
+    data() {
+      return {
+        gridAnimation: StaggeredFadeAndSlide,
         suggestion: {
           modelName: 'NextQuery',
           query: 'tshirt',

--- a/packages/x-components/src/x-modules/next-queries/components/next-query-preview.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-query-preview.vue
@@ -231,27 +231,21 @@ In this example, the suggestions has been limited to render a maximum of 4 items
 
 ```vue
 <template>
-  <NextQueryPreview :suggestion="suggestion" #result="{ result }">
-    <BaseGrid
-      #default="{ item }"
-      :animation="gridAnimation"
-      :columns="maxItemsToRender"
-      class="x-padding--00"
-    >
+  <NextQueryPreview
+    :maxItemsToRender="maxItemsToRender"
+    :suggestion="suggestion"
+    #result="{ result }"
+  >
+    <BaseGrid #default="{ item }">
       <BaseResultLink :result="result">
-        <BaseResultImage :result="result" class="x-result__picture" />
+        <BaseResultImage :result="result" />
       </BaseResultLink>
     </BaseGrid>
   </NextQueryPreview>
 </template>
 
 <script>
-  import {
-    BaseGrid,
-    BaseResultImage,
-    BaseResultLink,
-    StaggeredFadeAndSlide
-  } from '@empathyco/x-components';
+  import { BaseGrid, BaseResultImage, BaseResultLink } from '@empathyco/x-components';
   import { NextQueryPreview } from '@empathyco/x-components/next-queries';
 
   export default {
@@ -260,12 +254,11 @@ In this example, the suggestions has been limited to render a maximum of 4 items
       BaseGrid,
       BaseResultImage,
       BaseResultLink,
-      NextQueryPreview,
-      StaggeredFadeAndSlide
+      NextQueryPreview
     },
     data() {
       return {
-        gridAnimation: StaggeredFadeAndSlide,
+        maxItemsToRender: 4,
         suggestion: {
           modelName: 'NextQuery',
           query: 'tshirt',


### PR DESCRIPTION
EX-6820

Add `maxItemsToRender` prop to `NextQueryPreview` component to limit the rendered number of items.
