### PR TITLE
feat: add `queriesPreview` option to snippet config

### DIFF
--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -115,6 +115,22 @@ export interface SnippetConfig {
   productId?: string;
   /** The filters to be applied on the first request. */
   filters?: string[];
+  /** List of queries to preview. */
+  queriesPreview?: QueryPreview[];
   /** Any extra param to send in all backend calls. */
-  [extra: string]: any;
+  [extra: string]: unknown;
+}
+
+/**
+ * Information to render a query preview with.
+ *
+ * @public
+ */
+export interface QueryPreview {
+  /** The query to search for. */
+  query: string;
+  /** An optional title for the container. */
+  title?: string;
+  /** Any other additional information to render the preview with. */
+  [extra: string]: unknown;
 }

--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -62,7 +62,9 @@
         'consent',
         'documentDirection',
         'currency',
-        'filters'
+        'filters',
+        'isSpa',
+        'queriesPreview'
       ]
     })
     protected excludedExtraParams!: Array<keyof SnippetConfig>;
@@ -77,10 +79,9 @@
     @Watch('snippetConfig', { deep: true, immediate: true })
     syncExtraParams(snippetConfig: SnippetConfig): void {
       forEach({ ...this.values, ...snippetConfig }, (name, value) => {
-        if (this.excludedExtraParams.includes(name)) {
-          return;
+        if (!this.excludedExtraParams.includes(name)) {
+          this.$set(this.extraParams, name, value);
         }
-        this.$set(this.extraParams, name, value);
       });
     }
   }


### PR DESCRIPTION
EX-6849

Modifies the `SnippetConfig` types and the `SnippetConfigExtraParams` to support adding a list of queries to preview.
