### PR TITLE
[FEATURE]: Add support to React.context to the ReactWrapper #190

### DIFF
--- a/packages/react-wrapper/package.json
+++ b/packages/react-wrapper/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "styled-components": "^5.3.5",
     "tslib": "~2.3.0",
     "vue": "^2.6.0"
   },
@@ -47,6 +48,7 @@
     "eslint-plugin-react": "~7.20.0",
     "jest": "~27.3.1",
     "parcel": "~2.0.1",
+    "process": "^0.11.10",
     "start-server-and-test": "~1.11.5",
     "ts-jest": "~27.0.7",
     "typescript": "~4.6.2"

--- a/packages/react-wrapper/src/react-wrapper.types.ts
+++ b/packages/react-wrapper/src/react-wrapper.types.ts
@@ -31,6 +31,10 @@ export interface ReactWrapperProps {
    */
   className?: string;
   /**
+   * React context to pass to vue component where it is stored in a provider
+   */
+  context?: any
+  /**
    * Any other prop is passed down to the Vue component.
    */
   [key: string]: any;

--- a/packages/react-wrapper/src/vue-creator.ts
+++ b/packages/react-wrapper/src/vue-creator.ts
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import Vue, { computed } from 'vue';
 import { ReactWrapper } from './react-wrapper';
 import {
   ReactNodeWithoutRenderProps,
@@ -8,6 +8,7 @@ import {
 } from './react-wrapper.types';
 import { VueChildrenWrapper } from './vue-children-wrapper';
 import { getVueComponentProps, isScopedSlot } from './vue-creator.utils';
+
 
 /**
  * Stores the Vue constructor extending its interface with the methods required to map React
@@ -92,12 +93,16 @@ export const VueExtended = Vue.extend({
  * @returns The Vue constructor with the extended methods.
  */
 export function createVueInstance(reactWrapper: ReactWrapper): Vue {
+  const reactProps = reactWrapper.props;
   return new VueExtended({
-    data: getVueComponentProps(reactWrapper.props),
+    data: getVueComponentProps(reactProps), // props contain context
+    provide() {
+      // use computed() to make context reactive
+      return { context: computed(() => this.context) }
+    },
     render(h) {
-      const reactProps = reactWrapper.props;
       const { children, scopedSlots } = this.mapSlots(reactProps);
-
+      
       return h(
         reactProps.component,
         {

--- a/packages/react-wrapper/tests/demo/contexts/user-context.tsx
+++ b/packages/react-wrapper/tests/demo/contexts/user-context.tsx
@@ -1,0 +1,27 @@
+import React, { ReactElement, createContext, useState, useEffect } from "react";
+
+const UserContext = createContext();
+
+const UserContextProvider = ({ children }) : ReactElement => {
+  const [user, setUser] = useState(null);
+
+  // fetch a user from a stub API
+  useEffect(() => {
+    const fetchUser = () => {
+      fetch("https://randomuser.me/api/")
+        .then((res) => res.json())
+        .then((res) => setUser(res.results[0]))
+        .catch((err) => console.error(err));
+    };
+
+    fetchUser();
+  }, []);
+
+  return (
+    <UserContext.Provider value={[user, setUser]}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export { UserContext, UserContextProvider };

--- a/packages/react-wrapper/tests/demo/demo.tsx
+++ b/packages/react-wrapper/tests/demo/demo.tsx
@@ -2,10 +2,13 @@ import React, { ReactElement } from 'react';
 import ReactDOM from 'react-dom';
 import { SlotsComponentsView } from './views/slots-components.view';
 import { SlotsView } from './views/slots.view';
+import { ReactContextDemoView } from './views/react-context-demo.view';
+import { UserContextProvider } from './contexts/user-context';
 
 const views = {
   slots: SlotsView,
-  slotsComponents: SlotsComponentsView
+  slotsComponents: SlotsComponentsView,
+  contextDemo: ReactContextDemoView
 };
 
 const url = new URL(location.href);
@@ -14,7 +17,12 @@ const viewName = url.searchParams.get('view') ?? 'default';
 function App(): ReactElement {
   if (viewName in views) {
     const RouteComponent = views[viewName as keyof typeof views];
-    return <RouteComponent />;
+
+    return (
+      <UserContextProvider>
+        <RouteComponent />
+      </UserContextProvider>
+    );
   }
   return <AvailableRoutes />;
 }

--- a/packages/react-wrapper/tests/demo/stubs/react-user-context.stub.tsx
+++ b/packages/react-wrapper/tests/demo/stubs/react-user-context.stub.tsx
@@ -1,0 +1,67 @@
+import React, { ReactElement, useContext, useState } from 'react'
+import { ReactWrapper } from '../../../src'
+import { VueUserContext } from './vue-user-context'
+import { UserContext } from '../contexts/user-context';
+import styled from 'styled-components'
+
+const Container = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  max-width: 1000px;
+  margin: 0 auto;
+  background-color: beige;
+  padding: 2rem;
+  
+`
+
+const Column = styled.div`
+  min-width: 400px;
+  
+`
+
+export function ReactUserContext({...props}): ReactElement {
+
+  const [ userContext, setUserContext ] = useContext(UserContext);
+  const [ textBoxState, setTextBoxState ] = useState('')
+
+  const context = {
+    user: {
+      userContext,
+      setUserContext
+    }
+  }
+
+  function handleTextBoxChange(event) {
+    const { value } = event.target
+    setTextBoxState(value)
+  }
+  function updateContextFromReact() {
+    setUserContext({
+      ...userContext,
+      name: {
+        first: textBoxState,
+        last: userContext.name.last
+      }
+    })
+  }
+
+  const slots = {}
+  return (
+    <Container>
+      <Column>
+        <h1>React User Context</h1>
+        { userContext && 
+          <p>Username: {userContext.name.first} {userContext.name.last}</p>
+        }
+        <input onChange={handleTextBoxChange} value={textBoxState} type="text" />
+        <button onClick={updateContextFromReact}>
+          Update First Name from inside React
+        </button>
+      </Column>
+      <Column>
+        <ReactWrapper component={VueUserContext as any} context={context} {...slots} {...props} />
+      </Column>     
+    </Container>
+  )
+}

--- a/packages/react-wrapper/tests/demo/stubs/vue-user-context.ts
+++ b/packages/react-wrapper/tests/demo/stubs/vue-user-context.ts
@@ -1,0 +1,68 @@
+import { defineComponent } from '../../../src/vue-creator.utils'
+
+
+export const VueUserContext = defineComponent({
+  inject: ['context'],
+  data() {
+    return {
+      textBoxState: ''
+    }
+  },
+  render(h) {
+    const { user: { 
+        userContext, 
+        setUserContext
+      }
+    } = this.context || {}
+
+    const getUsername = () => {
+      return userContext ? [userContext.name.first, userContext.name.last].join(' ') : 'Loading...'
+    }
+    return h(
+      'div',
+      {},
+      [
+        h(
+          'h1',
+          {},
+          'Vue User Context'),
+        h(
+          'p',
+          {},
+          `Username: ${ getUsername() }`
+          ),
+        h(
+          'input',
+          {
+            attrs: {
+              type: 'text'
+            },
+            on: {
+              change: (event) => {
+                this.textBoxState = event.target.value
+              }
+            },
+          },
+          []
+        ),
+        h(
+          'button',
+          {
+            on: {
+              click: () => {
+                setUserContext({
+                  ...userContext,
+                  name: {
+                    first: this.textBoxState,
+                    last: userContext.name.last
+                  }
+                })
+              }
+            }
+          },
+          'Update First Name from inside Vue'
+        )
+      ]
+    )
+  }
+})

--- a/packages/react-wrapper/tests/demo/views/react-context-demo.view.tsx
+++ b/packages/react-wrapper/tests/demo/views/react-context-demo.view.tsx
@@ -1,0 +1,11 @@
+import React, { ReactElement } from 'react';
+import { ReactUserContext} from '../stubs/react-user-context.stub';
+
+export function ReactContextDemoView(): ReactElement {
+
+  return (
+    <div>
+      <ReactUserContext/>
+    </div>
+  )
+}


### PR DESCRIPTION
Hi guys 
I saw this issue open and decided to give it a try..

I am sure there are some more elegant ways to do this, but to open the conversation I propose here a simple solution. If you have suggestions how to improve, I am happy to take them..

---

I pass a 'context' prop to the ReactWrapper. This prop is fed by a context consumer, which makes it reactive. It also contains a setter to update the context. 

In the VueCreator, I add a provider that makes the context prop globally accessible in the part of the dom tree controlled by the vue instance. 

To read and write the context, any Vue child component can then inject the context value and setter into its scope and use them.

I added a demo page localhost:1234/?view=contextDemo

---

What do you think? 



