### PR TITLE
fix: remove unnecessary token from github action allowing PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Check branch is releasable and release alpha on main branch update
 on: [push, pull_request]
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.SUPPORT_TOKEN }}
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,7 +7,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.SUPPORT_TOKEN }}
           fetch-depth: 0
       - name: Install lerna and all packages
         run: npm ci

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.SUPPORT_TOKEN }}
           fetch-depth: 0
       - name: Install lerna and all packages
         run: npm ci

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -8,7 +8,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.SUPPORT_TOKEN }}
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages


### PR DESCRIPTION
[EX-6308](https://searchbroker.atlassian.net/browse/EX-6307)

## Motivation and context
PRs from outside the project (specifically from forks) we're failing at the build step because they tried to access a token they didn't have access tot. This token isn't necessary for the workflow, so it has been removed.

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

Fork the repo and open a PR from the fork to main with the fix applied. The workflow should work.
