### PR TITLE
fix(ci): add `support_token` when checking out repository 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Check branch is releasable and release alpha on main branch update
 on: [push, pull_request]
-concurrency:
+concurrency: 
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.SUPPORT_TOKEN }}
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          token: ${{ secrets.SUPPORT_TOKEN }}
           fetch-depth: 0
       - name: Install lerna and all packages
         run: npm ci

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          token: ${{ secrets.SUPPORT_TOKEN }}
           fetch-depth: 0
       - name: Install lerna and all packages
         run: npm ci

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.SUPPORT_TOKEN }}
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages


### PR DESCRIPTION
EX-6308

Given the `main` branch is write protected the `build` workflow will fail on `main` branch on the `release-alpha` step since it is not possible to push the release commit to main. See https://github.com/empathyco/x/runs/7991088722?check_suite_focus=true

<img width="820" alt="image" src="https://user-images.githubusercontent.com/7504736/186386975-9799a3ad-aede-415c-81fb-c88b77b69b03.png">

I'm adding this token back until we find a better solution.