### PR TITLE
feat(queries-preview): add wiring and actions

### DIFF
--- a/packages/x-components/src/x-modules/queries-preview/config.types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/config.types.ts
@@ -1,0 +1,11 @@
+/**
+ * Configuration options for the {@link QueriesPreviewXModule}.
+ *
+ * @public
+ */
+export interface QueriesPreviewConfig {
+  /**
+   * Maximum number of items to request.
+   */
+  maxItemsToRequest: number;
+}

--- a/packages/x-components/src/x-modules/queries-preview/events.types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/events.types.ts
@@ -11,7 +11,7 @@ export interface QueriesPreviewXEvents {
    * Any property of the queries preview request has changed.
    * Payload: The new {@link @empathyco/x-types#SearchRequest | request}.
    */
-  QueryPreviewRequestChange: SearchRequest;
+  QueryPreviewRequestChanged: SearchRequest;
   /**
    * The component that shows a Query preview has been unmounted.
    * Payload: The query whose preview has been removed.

--- a/packages/x-components/src/x-modules/queries-preview/events.types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/events.types.ts
@@ -8,7 +8,7 @@ import { SearchRequest } from '@empathyco/x-types';
  */
 export interface QueriesPreviewXEvents {
   /**
-   * Query preview request have been changed.
+   * Any property of the queries preview request has changed.
    * Payload: The new {@link @empathyco/x-types#SearchRequest | request}.
    */
   QueryPreviewRequestChange: SearchRequest;

--- a/packages/x-components/src/x-modules/queries-preview/events.types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/events.types.ts
@@ -1,7 +1,20 @@
+import { SearchRequest } from '@empathyco/x-types';
+
 /**
  * Dictionary of the events of QueriesPreview XModule, where each key is the event name, and the
  * value is the event payload type or `void` if it has no payload.
  *
  * @public
  */
-export interface QueriesPreviewXEvents {}
+export interface QueriesPreviewXEvents {
+  /**
+   * Query preview request have been changed.
+   * Payload: The new {@link @empathyco/x-types#SearchRequest | request}.
+   */
+  QueryPreviewRequestChange: SearchRequest;
+  /**
+   * The component that shows a Query preview has been unmounted.
+   * Payload: The query whose preview has been removed.
+   */
+  QueryPreviewRemoved: string;
+}

--- a/packages/x-components/src/x-modules/queries-preview/index.ts
+++ b/packages/x-components/src/x-modules/queries-preview/index.ts
@@ -1,3 +1,4 @@
+export * from './config.types';
 export * from './events.types';
 export * from './store';
 export * from './x-module';

--- a/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
@@ -65,10 +65,10 @@ describe('testing queries preview module actions', () => {
       const query = 'tshirt';
       const request = getQueryPreviewRequest(query);
 
-      const promise = store.dispatch('fetchAndSaveQueryPreview', request);
+      await store.dispatch('fetchAndSaveQueryPreview', request);
       await promise;
 
-      const expectedResults = {
+      const expectedResults:  QueryPreviewItem = {
         totalResults: mockedSearchResponse.totalResults,
         results: mockedSearchResponse.results,
         query,

--- a/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
@@ -9,7 +9,8 @@ import {
   QueriesPreviewState,
   QueriesPreviewGetters,
   QueriesPreviewMutations,
-  QueriesPreviewActions
+  QueriesPreviewActions,
+  QueryPreviewItem
 } from '../types';
 
 describe('testing queries preview module actions', () => {
@@ -66,9 +67,8 @@ describe('testing queries preview module actions', () => {
       const request = getQueryPreviewRequest(query);
 
       await store.dispatch('fetchAndSaveQueryPreview', request);
-      await promise;
 
-      const expectedResults:  QueryPreviewItem = {
+      const expectedResults: QueryPreviewItem = {
         totalResults: mockedSearchResponse.totalResults,
         results: mockedSearchResponse.results,
         query,

--- a/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
@@ -1,0 +1,106 @@
+import Vuex, { Store } from 'vuex';
+import { createLocalVue } from '@vue/test-utils';
+import { SearchRequest } from '@empathyco/x-types';
+import { getSearchResponseStub } from '../../../../__stubs__/search-response-stubs.factory';
+import { getMockedAdapter, installNewXPlugin } from '../../../../__tests__/utils';
+import { SafeStore } from '../../../../store/__tests__/utils';
+import { queriesPreviewXStoreModule } from '../module';
+import {
+  QueriesPreviewState,
+  QueriesPreviewGetters,
+  QueriesPreviewMutations,
+  QueriesPreviewActions
+} from '../types';
+
+describe('testing queries preview module actions', () => {
+  const mockedSearchResponse = getSearchResponseStub();
+  const getQueryPreviewRequest = (query: string): SearchRequest => ({
+    query,
+    rows: 3,
+    extraParams: {
+      extraParam: 'extra param'
+    }
+  });
+
+  const adapter = getMockedAdapter({
+    search: mockedSearchResponse
+  });
+
+  const localVue = createLocalVue();
+  localVue.config.productionTip = false; // Silent production console messages.
+  localVue.use(Vuex);
+
+  const store: SafeStore<
+    QueriesPreviewState,
+    QueriesPreviewGetters,
+    QueriesPreviewMutations,
+    QueriesPreviewActions
+  > = new Store(queriesPreviewXStoreModule as any);
+  installNewXPlugin({ adapter, store }, localVue);
+
+  describe('fetchQueryPreview', () => {
+    it('should make a search request with a unique id', async () => {
+      const request = getQueryPreviewRequest('sandals');
+      await store.dispatch('fetchQueryPreview', request);
+
+      expect(adapter.search).toHaveBeenCalledWith(request, {
+        id: 'fetchQueryPreview-sandals'
+      });
+    });
+
+    it('should return the search response', async () => {
+      const request = getQueryPreviewRequest('sandals');
+      const results = await store.dispatch('fetchQueryPreview', request);
+      expect(results).toEqual(mockedSearchResponse);
+    });
+
+    it('should return `null` if the query is empty', async () => {
+      const request = getQueryPreviewRequest('');
+      expect(await store.dispatch('fetchQueryPreview', request)).toBeNull();
+    });
+  });
+
+  describe('fetchAndSaveQueryPreview', () => {
+    it('should request and store query preview results in the state', async () => {
+      const query = 'tshirt';
+      const request = getQueryPreviewRequest(query);
+
+      const promise = store.dispatch('fetchAndSaveQueryPreview', request);
+      await promise;
+
+      const expectedResults = {
+        totalResults: mockedSearchResponse.totalResults,
+        results: mockedSearchResponse.results,
+        query,
+        status: 'success',
+        request: {
+          extraParams: {
+            extraParam: 'extra param'
+          },
+          query: 'tshirt',
+          rows: 3
+        }
+      };
+      const stateResults = store.state.queriesPreview;
+
+      expect(query in stateResults).toBeTruthy();
+      expect(stateResults[query]).toEqual(expectedResults);
+    });
+
+    it('should send multiple requests if the queries are different', async () => {
+      const firstRequest = store.dispatch(
+        'fetchAndSaveQueryPreview',
+        getQueryPreviewRequest('milk')
+      );
+      const secondRequest = store.dispatch(
+        'fetchAndSaveQueryPreview',
+        getQueryPreviewRequest('cookies')
+      );
+
+      await Promise.all([firstRequest, secondRequest]);
+
+      expect('milk' in store.state.queriesPreview).toBeTruthy();
+      expect('cookies' in store.state.queriesPreview).toBeTruthy();
+    });
+  });
+});

--- a/packages/x-components/src/x-modules/queries-preview/store/__tests__/utils.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/__tests__/utils.ts
@@ -1,0 +1,21 @@
+import { DeepPartial } from '@empathyco/x-utils';
+import { Store } from 'vuex';
+import { resetStoreModuleState } from '../../../../__tests__/utils';
+import { queriesPreviewXStoreModule } from '../module';
+import { QueriesPreviewState } from '../types';
+
+/**
+ * Reset queries preview module state with its original state and the partial state passes as
+ * parameter.
+ *
+ * @param store - Queries preview store state.
+ * @param state - Partial queries preview store state to be replaced.
+ *
+ * @internal
+ */
+export function resetQueriesPreviewStateWith(
+  store: Store<QueriesPreviewState>,
+  state?: DeepPartial<QueriesPreviewState>
+): void {
+  resetStoreModuleState<QueriesPreviewState>(store, queriesPreviewXStoreModule.state(), state);
+}

--- a/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
@@ -7,6 +7,8 @@ import { QueriesPreviewXStoreModule } from '../types';
  * provided by Vuex.
  * @param request - The query preview request to make.
  * @returns A Promise of a SearchResponse when it fetches the results.
+ *
+ * @public
  */
 // eslint-disable-next-line max-len
 export const fetchAndSaveQueryPreview: QueriesPreviewXStoreModule['actions']['fetchAndSaveQueryPreview'] =

--- a/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
@@ -14,19 +14,23 @@ import { QueriesPreviewXStoreModule } from '../types';
 export const fetchAndSaveQueryPreview: QueriesPreviewXStoreModule['actions']['fetchAndSaveQueryPreview'] =
   ({ dispatch, commit }, request) => {
     const { query } = request;
+    if (!query) {
+      return;
+    }
+    commit('setQueryPreview', {
+      request,
+      results: [],
+      status: 'loading',
+      totalResults: 0
+    });
     return dispatch('fetchQueryPreview', request)
       .then(response => {
-        if (response) {
-          commit('setQueriesPreview', {
-            [query]: {
-              query,
-              request,
-              results: response.results,
-              status: 'success',
-              totalResults: response.totalResults
-            }
-          });
-        }
+        commit('setQueryPreview', {
+          request,
+          results: response?.results ?? [],
+          status: 'success',
+          totalResults: response?.totalResults ?? 0
+        });
       })
       .catch(error => {
         // eslint-disable-next-line no-console

--- a/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
@@ -1,0 +1,34 @@
+import { QueriesPreviewXStoreModule } from '../types';
+
+/**
+ * Default implementation for the {@link QueriesPreviewActions.fetchAndSaveQueryPreview}.
+ *
+ * @param _context - The {@link https://vuex.vuejs.org/guide/actions.html | context} of the actions,
+ * provided by Vuex.
+ * @param request - The query preview request to make.
+ * @returns A Promise of a SearchResponse when it fetches the results.
+ */
+// eslint-disable-next-line max-len
+export const fetchAndSaveQueryPreview: QueriesPreviewXStoreModule['actions']['fetchAndSaveQueryPreview'] =
+  ({ dispatch, commit }, request) => {
+    const { query } = request;
+    return dispatch('fetchQueryPreview', request)
+      .then(response => {
+        if (response) {
+          commit('setQueriesPreview', {
+            [query]: {
+              query,
+              request,
+              results: response.results,
+              status: 'success',
+              totalResults: response.totalResults
+            }
+          });
+        }
+      })
+      .catch(error => {
+        // eslint-disable-next-line no-console
+        console.error(error);
+        commit('setStatus', { query, status: 'error' });
+      });
+  };

--- a/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-query-preview.action.ts
@@ -12,14 +12,13 @@ import { QueriesPreviewXStoreModule } from '../types';
  * @public
  */
 export const fetchQueryPreview: QueriesPreviewXStoreModule['actions']['fetchQueryPreview'] = (
-  { commit },
+  _context,
   request
 ) => {
   const { query } = request;
   if (!query) {
     return null;
   }
-  commit('setStatus', { query, status: 'loading' });
   return XPlugin.adapter.search(request, {
     id: `fetchQueryPreview-${query}`
   });

--- a/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-query-preview.action.ts
@@ -8,6 +8,8 @@ import { QueriesPreviewXStoreModule } from '../types';
  * provided by Vuex.
  * @param request - The query preview request to make.
  * @returns A Promise of a SearchResponse when it fetches the results.
+ *
+ * @public
  */
 export const fetchQueryPreview: QueriesPreviewXStoreModule['actions']['fetchQueryPreview'] = (
   { commit },

--- a/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-query-preview.action.ts
@@ -1,0 +1,24 @@
+import { XPlugin } from '../../../../plugins/x-plugin';
+import { QueriesPreviewXStoreModule } from '../types';
+
+/**
+ * Default implementation for the {@link QueriesPreviewActions.fetchQueryPreview}.
+ *
+ * @param _context - The {@link https://vuex.vuejs.org/guide/actions.html | context} of the actions,
+ * provided by Vuex.
+ * @param request - The query preview request to make.
+ * @returns A Promise of a SearchResponse when it fetches the results.
+ */
+export const fetchQueryPreview: QueriesPreviewXStoreModule['actions']['fetchQueryPreview'] = (
+  { commit },
+  request
+) => {
+  const { query } = request;
+  if (!query) {
+    return null;
+  }
+  commit('setStatus', { query, status: 'loading' });
+  return XPlugin.adapter.search(request, {
+    id: `fetchQueryPreview-${query}`
+  });
+};

--- a/packages/x-components/src/x-modules/queries-preview/store/index.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/index.ts
@@ -1,3 +1,5 @@
+export * from './actions/fetch-query-preview.action';
+export * from './actions/fetch-and-save-query-preview.action';
 export * from './emitters';
 export * from './module';
 export * from './types';

--- a/packages/x-components/src/x-modules/queries-preview/store/module.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/module.ts
@@ -24,11 +24,11 @@ export const queriesPreviewXStoreModule: QueriesPreviewXStoreModule = {
     setParams(state, params) {
       state.params = params;
     },
-    setQueriesPreview(state, queriesPreview) {
-      state.queriesPreview = { ...state.queriesPreview, ...queriesPreview };
+    setQueryPreview(state, queryPreview) {
+      Vue.set(state.queriesPreview, queryPreview.request.query, queryPreview);
     },
     setStatus(state, { query, status }) {
-      state.queriesPreview[query] = { ...state.queriesPreview[query], status };
+      state.queriesPreview[query].status = status;
     }
   },
   actions: {

--- a/packages/x-components/src/x-modules/queries-preview/store/module.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/module.ts
@@ -1,13 +1,38 @@
+import Vue from 'vue';
 import { QueriesPreviewXStoreModule } from './types';
+import { fetchQueryPreview } from './actions/fetch-query-preview.action';
+import { fetchAndSaveQueryPreview } from './actions/fetch-and-save-query-preview.action';
 
 /**
- * {@link XStoreModule} For the queries-preview module.
+ * {@link XStoreModule} For the `queries-preview` module.
  *
  * @internal
  */
 export const queriesPreviewXStoreModule: QueriesPreviewXStoreModule = {
-  state: () => ({}),
+  state: () => ({
+    config: {
+      maxItemsToRequest: 24
+    },
+    queriesPreview: {},
+    params: {}
+  }),
   getters: {},
-  mutations: {},
-  actions: {}
+  mutations: {
+    clearQueryPreview(state, query) {
+      Vue.delete(state.queriesPreview, query);
+    },
+    setParams(state, params) {
+      state.params = params;
+    },
+    setQueriesPreview(state, queriesPreview) {
+      state.queriesPreview = { ...state.queriesPreview, ...queriesPreview };
+    },
+    setStatus(state, { query, status }) {
+      state.queriesPreview[query] = { ...state.queriesPreview[query], status };
+    }
+  },
+  actions: {
+    fetchQueryPreview,
+    fetchAndSaveQueryPreview
+  }
 };

--- a/packages/x-components/src/x-modules/queries-preview/store/types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/types.ts
@@ -2,7 +2,6 @@ import { Result, SearchRequest, SearchResponse } from '@empathyco/x-types';
 import { Dictionary } from '@empathyco/x-utils';
 import { XActionContext } from '../../../store/actions.types';
 import { XStoreModule } from '../../../store/store.types';
-import { QueryState } from '../../../store/utils/query.utils';
 import { RequestStatus, StatusState } from '../../../store/utils/status-store.utils';
 import { QueriesPreviewConfig } from '../config.types';
 
@@ -11,12 +10,12 @@ import { QueriesPreviewConfig } from '../config.types';
  *
  * @public
  */
-export interface QueryPreviewItem extends QueryState, StatusState {
+export interface QueryPreviewItem extends StatusState {
   /**
    * Request object to retrieve the query preview using the search adapter, or null if there is
    * no valid data to conform a valid request.
    */
-  request: SearchRequest | null;
+  request: SearchRequest;
   /** Results of the query preview request. */
   results: Result[];
   /** The total number of results for the search query. */
@@ -65,10 +64,9 @@ export interface QueriesPreviewMutations {
   /**
    * Adds a new entry to the queries preview's dictionary.
    *
-   * @param queriesPreview - Object containing the preview query,
-   * the totalResults and the results to add.
+   * @param queryPreview - The query preview item to add.
    */
-  setQueriesPreview(queriesPreview: Dictionary<QueryPreviewItem>): void;
+  setQueryPreview(queryPreview: QueryPreviewItem): void;
   /**
    * Sets the status of a query preview request.
    *

--- a/packages/x-components/src/x-modules/queries-preview/store/types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/types.ts
@@ -1,6 +1,7 @@
 import { Result, SearchRequest, SearchResponse } from '@empathyco/x-types';
 import { Dictionary } from '@empathyco/x-utils';
-import { XActionContext, XStoreModule } from '../../../store';
+import { XActionContext } from '../../../store/actions.types';
+import { XStoreModule } from '../../../store/store.types';
 import { QueryState } from '../../../store/utils/query.utils';
 import { RequestStatus, StatusState } from '../../../store/utils/status-store.utils';
 import { QueriesPreviewConfig } from '../config.types';

--- a/packages/x-components/src/x-modules/queries-preview/store/types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/types.ts
@@ -1,11 +1,40 @@
-import { XActionContext, XStoreModule } from '../../../store/index';
+import { Result, SearchRequest, SearchResponse } from '@empathyco/x-types';
+import { Dictionary } from '@empathyco/x-utils';
+import { XActionContext, XStoreModule } from '../../../store';
+import { QueryState } from '../../../store/utils/query.utils';
+import { RequestStatus, StatusState } from '../../../store/utils/status-store.utils';
+import { QueriesPreviewConfig } from '../config.types';
 
 /**
  * QueriesPreview store state.
  *
  * @public
  */
-export interface QueriesPreviewState {}
+export interface QueryPreviewItem extends QueryState, StatusState {
+  /**
+   * Request object to retrieve the query preview using the search adapter, or null if there is
+   * no valid data to conform a valid request.
+   */
+  request: SearchRequest | null;
+  /** Results of the query preview request. */
+  results: Result[];
+  /** The total number of results for the search query. */
+  totalResults: number;
+}
+
+/**
+ * QueriesPreview store state.
+ *
+ * @public
+ */
+export interface QueriesPreviewState {
+  /* The request and results */
+  queriesPreview: Dictionary<QueryPreviewItem>;
+  /** The configuration of the queries preview module. */
+  config: QueriesPreviewConfig;
+  /** The extra params property of the state. */
+  params: Dictionary<unknown>;
+}
 
 /**
  * QueriesPreview store getters.
@@ -19,14 +48,55 @@ export interface QueriesPreviewGetters {}
  *
  * @public
  */
-export interface QueriesPreviewMutations {}
+export interface QueriesPreviewMutations {
+  /**
+   * Removes a query preview entry from the queries preview's dictionary.
+   *
+   * @param query - Query whose entry will be removed.
+   */
+  clearQueryPreview(query: string): void;
+  /**
+   * Sets the extra params of the module.
+   *
+   * @param params - The new extra params.
+   */
+  setParams(params: Dictionary<unknown>): void;
+  /**
+   * Adds a new entry to the queries preview's dictionary.
+   *
+   * @param queriesPreview - Object containing the preview query,
+   * the totalResults and the results to add.
+   */
+  setQueriesPreview(queriesPreview: Dictionary<QueryPreviewItem>): void;
+  /**
+   * Sets the status of a query preview request.
+   *
+   * @param payload - Object containing the query and the status of a query preview item.
+   */
+  setStatus(payload: QueryPreviewStatusPayload): void;
+}
 
 /**
  * QueriesPreview store actions.
  *
  * @public
  */
-export interface QueriesPreviewActions {}
+export interface QueriesPreviewActions {
+  /**
+   * Requests the results for a query preview,
+   * limited by {@link QueriesPreviewConfig.maxItemsToRequest}.
+   *
+   * @param request - The request object to retrieve the query preview.
+   * @returns A search response based on the query.
+   */
+  fetchQueryPreview(request: SearchRequest): SearchResponse | null;
+  /**
+   * Requests the results for a query preview and saves them in the state.
+   *
+   * @param request - The request object to retrieve the query preview.
+   */
+  fetchAndSaveQueryPreview(request: SearchRequest): void;
+}
 
 /**
  * QueriesPreview type safe store module.
@@ -51,3 +121,19 @@ export type QueriesPreviewActionContext = XActionContext<
   QueriesPreviewMutations,
   QueriesPreviewActions
 >;
+
+/**
+ * Payload to use in the `setStatus` mutation.
+ *
+ * @public
+ */
+export interface QueryPreviewStatusPayload {
+  /**
+   * The query whose request status to modify.
+   */
+  query: string;
+  /**
+   * The new request status.
+   */
+  status: RequestStatus;
+}

--- a/packages/x-components/src/x-modules/queries-preview/wiring.ts
+++ b/packages/x-components/src/x-modules/queries-preview/wiring.ts
@@ -1,8 +1,64 @@
+import {
+  namespacedWireCommit,
+  namespacedWireDispatch
+} from '../../wiring/namespaced-wires.factory';
+import { NamespacedWireCommit, NamespacedWireDispatch } from '../../wiring/namespaced-wiring.types';
 import { createWiring } from '../../wiring/wiring.utils';
+
+/**
+ * `queriesPreview` {@link XModuleName | XModule name}.
+ *
+ * @internal
+ */
+const moduleName = 'queriesPreview';
+
+/**
+ * WireCommit for {@link QueriesPreviewXModule}.
+ *
+ * @internal
+ */
+const wireCommit: NamespacedWireCommit<typeof moduleName> = namespacedWireCommit(moduleName);
+
+/**
+ * WireDispatch for {@link QueriesPreviewXModule}.
+ *
+ * @internal
+ */
+const wireDispatch: NamespacedWireDispatch<typeof moduleName> = namespacedWireDispatch(moduleName);
+
+/**
+ * Requests and stores the query preview results.
+ *
+ * @public
+ */
+export const fetchAndSaveQueryPreviewWire = wireDispatch('fetchAndSaveQueryPreview');
+
+/**
+ * Clears a query preview from queries preview module.
+ *
+ * @public
+ */
+export const clearQueryPreview = wireCommit('clearQueryPreview');
+/**
+ * Sets the queries preview state `params`.
+ *
+ * @public
+ */
+export const setQueriesPreviewExtraParams = wireCommit('setParams');
 
 /**
  * Wiring configuration for the {@link QueriesPreviewXModule | queriesPreview module}.
  *
  * @internal
  */
-export const queriesPreviewWiring = createWiring({});
+export const queriesPreviewWiring = createWiring({
+  QueryPreviewRequestChange: {
+    fetchAndSaveQueryPreviewWire
+  },
+  QueryPreviewRemoved: {
+    clearQueryPreview
+  },
+  ExtraParamsChanged: {
+    setQueriesPreviewExtraParams
+  }
+});

--- a/packages/x-components/src/x-modules/queries-preview/wiring.ts
+++ b/packages/x-components/src/x-modules/queries-preview/wiring.ts
@@ -17,7 +17,7 @@ const moduleName = 'queriesPreview';
  *
  * @internal
  */
-const wireCommit: NamespacedWireCommit<typeof moduleName> = namespacedWireCommit(moduleName);
+const wireCommit = namespacedWireCommit(moduleName);
 
 /**
  * WireDispatch for {@link QueriesPreviewXModule}.

--- a/packages/x-components/src/x-modules/queries-preview/wiring.ts
+++ b/packages/x-components/src/x-modules/queries-preview/wiring.ts
@@ -2,7 +2,6 @@ import {
   namespacedWireCommit,
   namespacedWireDispatch
 } from '../../wiring/namespaced-wires.factory';
-import { NamespacedWireCommit, NamespacedWireDispatch } from '../../wiring/namespaced-wiring.types';
 import { createWiring } from '../../wiring/wiring.utils';
 
 /**
@@ -24,7 +23,7 @@ const wireCommit = namespacedWireCommit(moduleName);
  *
  * @internal
  */
-const wireDispatch: NamespacedWireDispatch<typeof moduleName> = namespacedWireDispatch(moduleName);
+const wireDispatch = namespacedWireDispatch(moduleName);
 
 /**
  * Requests and stores the query preview results.
@@ -38,13 +37,14 @@ export const fetchAndSaveQueryPreviewWire = wireDispatch('fetchAndSaveQueryPrevi
  *
  * @public
  */
-export const clearQueryPreview = wireCommit('clearQueryPreview');
+
+export const clearQueryPreviewWire = wireCommit('clearQueryPreview');
 /**
  * Sets the queries preview state `params`.
  *
  * @public
  */
-export const setQueriesPreviewExtraParams = wireCommit('setParams');
+export const setQueriesPreviewExtraParamsWire = wireCommit('setParams');
 
 /**
  * Wiring configuration for the {@link QueriesPreviewXModule | queriesPreview module}.
@@ -52,13 +52,13 @@ export const setQueriesPreviewExtraParams = wireCommit('setParams');
  * @internal
  */
 export const queriesPreviewWiring = createWiring({
-  QueryPreviewRequestChange: {
+  QueryPreviewRequestChanged: {
     fetchAndSaveQueryPreviewWire
   },
   QueryPreviewRemoved: {
-    clearQueryPreview
+    clearQueryPreviewWire
   },
   ExtraParamsChanged: {
-    setQueriesPreviewExtraParams
+    setQueriesPreviewExtraParamsWire
   }
 });


### PR DESCRIPTION
[EX-6844](https://searchbroker.atlassian.net/browse/EX-6844)

## Motivation and context
Added wiring and actions to the `queries-preview` module.

- The module's state now stores a dictionary of `QueryPreviewItems`, where each item contains, mainly, the results of a specific query and the request used for the search.


- `fetchQueryPreview` and `fetchAndSaveQueryPreview` actions have been added in order to perform the request and save the results, and the request, used for the search.

#### Events
- Whenever the `QueryPreviewRequestChange` is emitted, a search will be performed with the passed request.
> The component described by [EX-6845](https://searchbroker.atlassian.net/browse/EX-6845) will be in charge of emitting this event if the `extraParams` change.

- `QueryPreviewRemoved` event will remove the entry of a specific query from the `queriesPreview` dictionary.


## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

