### PR TITLE
feat(components): variants auto selection

### DIFF
--- a/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
@@ -47,13 +47,20 @@ const result = createResultStub('jacket', {
 
 const renderResultVariantsProvider = ({
   template = '<ResultVariantSelector/>',
-  result
+  result,
+  autoSelectDepth
 }: ResultVariantsProviderOptions): ResultVariantsProviderApi => {
   const [, localVue] = installNewXPlugin();
 
+  const eventsBusSpy = jest.spyOn(XPlugin.bus, 'emit');
+
   const wrapper = mount(
     {
-      template: `<ResultVariantsProvider :result="result" #default="{ result: newResult }">
+      template: `
+        <ResultVariantsProvider
+            :result="result"
+            :autoSelectDepth="autoSelectDepth"
+            #default="{ result: newResult }">
           ${template}
         </ResultVariantsProvider>`,
       components: {
@@ -65,7 +72,8 @@ const renderResultVariantsProvider = ({
       localVue,
       data() {
         return {
-          result
+          result,
+          autoSelectDepth
         };
       },
       scopedSlots: {
@@ -78,11 +86,15 @@ const renderResultVariantsProvider = ({
 
   return {
     wrapper: wrapper.findComponent(ResultVariantsProvider),
-    findSelectorLevelButtons: function (level: number): WrapperArray<Vue> {
+    findSelectorLevelWrappers: function (
+      level: number,
+      dataTestId = 'variant-button'
+    ): WrapperArray<Vue> {
       return findTestDataById(wrapper, 'variants-list')
         .at(level)
-        .findAll(getDataTestSelector('variant-button'));
-    }
+        .findAll(getDataTestSelector(dataTestId));
+    },
+    eventsBusSpy
   };
 };
 
@@ -97,7 +109,7 @@ describe('results with variants', () => {
   });
 
   it('merges the selected and parent variants data with the result', async () => {
-    const { wrapper, findSelectorLevelButtons } = renderResultVariantsProvider({
+    const { wrapper, findSelectorLevelWrappers } = renderResultVariantsProvider({
       template: `
         <div>
           <ResultVariantSelector #variant-content="{variant}">
@@ -110,10 +122,11 @@ describe('results with variants', () => {
           <span data-test="result-image" v-if="newResult.images">{{ newResult.images[0] }}</span>
         </div>
       `,
-      result
+      result,
+      autoSelectDepth: 0
     });
 
-    const firstLevelVariantButtons = findSelectorLevelButtons(0);
+    const firstLevelVariantButtons = findSelectorLevelWrappers(0);
 
     expect(wrapper.find(getDataTestSelector('result-name')).text()).toBe('jacket');
     expect(wrapper.find(getDataTestSelector('result-image')).text()).toBe('');
@@ -123,7 +136,7 @@ describe('results with variants', () => {
     expect(wrapper.find(getDataTestSelector('result-name')).text()).toBe('red jacket');
     expect(wrapper.find(getDataTestSelector('result-image')).text()).toBe('red-jacket-image');
 
-    const secondLevelVariantButtons = findSelectorLevelButtons(1);
+    const secondLevelVariantButtons = findSelectorLevelWrappers(1);
 
     await secondLevelVariantButtons.at(1).trigger('click');
 
@@ -150,7 +163,8 @@ describe('results with variants', () => {
           <span data-test="result-name">{{ newResult.name }}</span>
         </div>
       `,
-      result
+      result,
+      autoSelectDepth: 0
     });
 
     const button = wrapper.find(getDataTestSelector('variant-button'));
@@ -161,15 +175,17 @@ describe('results with variants', () => {
   });
 
   it('emits UserSelectedAResultVariant event when a variant is selected', async () => {
-    const { wrapper } = renderResultVariantsProvider({ result });
-    const eventsSpy = jest.spyOn(XPlugin.bus, 'emit');
+    const { wrapper, eventsBusSpy } = renderResultVariantsProvider({
+      result,
+      autoSelectDepth: 0
+    });
 
     const button = wrapper.find(getDataTestSelector('variant-button'));
 
     await button.trigger('click');
 
-    expect(eventsSpy).toHaveBeenCalledTimes(1);
-    expect(eventsSpy).toHaveBeenCalledWith(
+    expect(eventsBusSpy).toHaveBeenCalledTimes(1);
+    expect(eventsBusSpy).toHaveBeenCalledWith(
       'UserSelectedAResultVariant',
       {
         result,
@@ -178,6 +194,82 @@ describe('results with variants', () => {
       },
       expect.anything()
     );
+  });
+
+  it('selects the first variant of all levels by default', () => {
+    const { findSelectorLevelWrappers } = renderResultVariantsProvider({
+      template: `
+        <div>
+          <ResultVariantSelector :level="0"/>
+          <ResultVariantSelector :level="1"/>
+        </div>
+      `,
+      result
+    });
+
+    const firstVariant = findSelectorLevelWrappers(0, 'variant-item').at(0);
+    const secondSelectorFirstVariant = findSelectorLevelWrappers(1, 'variant-item').at(0);
+
+    expect(firstVariant.element.className).toContain('--is-selected');
+    expect(secondSelectorFirstVariant.element.className).toContain('--is-selected');
+  });
+
+  it('selects variants on init up to the level set in the autoSelectDepth prop', () => {
+    const { findSelectorLevelWrappers } = renderResultVariantsProvider({
+      template: `
+        <div>
+          <ResultVariantSelector :level="0"/>
+          <ResultVariantSelector :level="1"/>
+        </div>
+      `,
+      result,
+      autoSelectDepth: 1
+    });
+
+    const firstVariant = findSelectorLevelWrappers(0, 'variant-item').at(0);
+    const secondSelectorFirstVariant = findSelectorLevelWrappers(1, 'variant-item').at(0);
+
+    expect(firstVariant.element.className).toContain('--is-selected');
+    expect(secondSelectorFirstVariant.element.className).not.toContain('--is-selected');
+  });
+
+  it('wont select any variant by default if autoSelectDepth is 0', () => {
+    const { wrapper } = renderResultVariantsProvider({
+      result,
+      autoSelectDepth: 0
+    });
+
+    const firstVariant = wrapper.find(getDataTestSelector('variant-item'));
+
+    expect(firstVariant.element.className).not.toContain('--is-selected');
+  });
+
+  // eslint-disable-next-line max-len
+  it('does not emit the UserSelectedAResultVariant event when the variants are selected on init', () => {
+    const { eventsBusSpy } = renderResultVariantsProvider({ result });
+
+    expect(eventsBusSpy).not.toHaveBeenCalled();
+  });
+
+  it('reset the selected variants if the result changes', async () => {
+    const { wrapper } = renderResultVariantsProvider({
+      result,
+      autoSelectDepth: 0
+    });
+    const variantItem = wrapper.find(getDataTestSelector('variant-item'));
+    const variantButton = variantItem.find(getDataTestSelector('variant-button'));
+
+    await variantButton.trigger('click');
+
+    expect(variantItem.element.className).toContain('--is-selected');
+
+    await wrapper.setData({
+      result: createResultStub('tshirt', {
+        variants
+      })
+    });
+    //Resets even if the same variants are passed.
+    expect(variantItem.element.className).not.toContain('--is-selected');
   });
 
   describe('result variant selector', () => {
@@ -219,12 +311,12 @@ describe('results with variants', () => {
         </div>
       `;
 
-      const { findSelectorLevelButtons } = renderResultVariantsProvider({
+      const { findSelectorLevelWrappers } = renderResultVariantsProvider({
         template,
         result
       });
 
-      const firstLevelVariantButtons = findSelectorLevelButtons(0);
+      const firstLevelVariantButtons = findSelectorLevelWrappers(0);
 
       expect(firstLevelVariantButtons).toHaveLength(2);
       expect(firstLevelVariantButtons.at(0).text()).toBe('red jacket');
@@ -232,7 +324,7 @@ describe('results with variants', () => {
 
       await firstLevelVariantButtons.at(1).trigger('click');
 
-      const secondLevelVariantButtons = findSelectorLevelButtons(1);
+      const secondLevelVariantButtons = findSelectorLevelWrappers(1);
 
       expect(secondLevelVariantButtons).toHaveLength(2);
       expect(secondLevelVariantButtons.at(0).text()).toBe('blue jacket L');
@@ -240,7 +332,7 @@ describe('results with variants', () => {
 
       await secondLevelVariantButtons.at(0).trigger('click');
 
-      const thirdLevelVariantButtons = findSelectorLevelButtons(2);
+      const thirdLevelVariantButtons = findSelectorLevelWrappers(2);
 
       expect(thirdLevelVariantButtons).toHaveLength(3);
       expect(thirdLevelVariantButtons.at(0).text()).toBe('blue jacket L1');
@@ -354,6 +446,8 @@ interface ResultVariantsProviderOptions {
   result: Result | null;
   /** The template to render inside the provider's default slot. */
   template?: string;
+  /** Indicates the number of levels to auto select the first variants. */
+  autoSelectDepth?: number;
 }
 
 /**
@@ -368,5 +462,10 @@ interface ResultVariantsProviderApi {
    * @param level - The level of the variants.
    * @returns The wrappers of the buttons rendered for the given level.
    */
-  findSelectorLevelButtons: (level: number) => WrapperArray<Vue>;
+  findSelectorLevelWrappers: (level: number, dataTestId?: string) => WrapperArray<Vue>;
+  /**
+   * A Jest spy set in the {@link XPlugin} bus `emit` function,
+   * useful to test events emitted in the first lifecycle hooks of the component.
+   */
+  eventsBusSpy: jest.SpyInstance;
 }

--- a/packages/x-components/src/components/result/result-variants-provider.vue
+++ b/packages/x-components/src/components/result/result-variants-provider.vue
@@ -98,7 +98,7 @@
      * That includes doing the auto selection of the variants when the component is created
      * and when the result is changed.
      */
-    @Watch('result', { deep: true, immediate: true })
+    @Watch('result', { immediate: true })
     resetSelectedVariants(): void {
       this.selectedVariants = [];
       this.selectFirstVariants(this.result?.variants?.[0]);

--- a/packages/x-components/src/components/result/result-variants-provider.vue
+++ b/packages/x-components/src/components/result/result-variants-provider.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Vue, { VNode, CreateElement } from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { Component, Prop, Watch } from 'vue-property-decorator';
   import { Result, ResultVariant } from '@empathyco/x-types';
   import { XProvide } from '../decorators/injection.decorators';
   import {
@@ -31,6 +31,18 @@
     })
     @XProvide(RESULT_WITH_VARIANTS_KEY)
     public result!: Result;
+
+    /**
+     * The provider by default will auto select the first variants of all levels.
+     * This prop allows to limit the number of variants auto selected when the provider is created.
+     * Take into account that the depth will be the variants level + 1, so, setting autoSelectDepth
+     * to 0 will not select any variant, setting it to 1 will select only the first variant of the
+     * first level, and so on.
+     */
+    @Prop({
+      default: Number.POSITIVE_INFINITY
+    })
+    public autoSelectDepth!: number;
 
     /**
      * Array to keep track of the selected variants of the result.
@@ -82,6 +94,19 @@
     }
 
     /**
+     * Resets the selected variants when the result changes.
+     * That includes doing the auto selection of the variants when the component is created
+     * and when the result is changed.
+     */
+    @Watch('result', { deep: true, immediate: true })
+    resetSelectedVariants(): void {
+      this.selectedVariants = [];
+      if (this.result?.variants?.length) {
+        this.selectFirstVariants(this.result.variants[0]);
+      }
+    }
+
+    /**
      * Merges the original result with the selected variant.
      * The merge is done with all the selected variants of the array.
      *
@@ -101,6 +126,21 @@
       mergedResult.variants = this.result.variants;
       return mergedResult;
     }
+
+    /**
+     * Adds to the selectedVariants array the variants up to the autoSelectDepth level.
+     *
+     * @param variant - Variant to add to the array.
+     */
+    selectFirstVariants(variant: ResultVariant): void {
+      if (this.selectedVariants.length > this.autoSelectDepth - 1) {
+        return;
+      }
+      this.selectedVariants.push(variant);
+      if (variant.variants?.length) {
+        this.selectFirstVariants(variant.variants[0]);
+      }
+    }
   }
 </script>
 
@@ -117,9 +157,89 @@ This component is intended to be used in conjunction with the `ResultVariantSele
 
 The result exposed in the default slot will contain the data of the selected variant.
 
+By default, the first variants of all the levels will be selected when the component is rendered.
+
 ```vue
 <template>
   <ResultVariantsProvider :result="result" #default="{ result }">
+    <p>Result name: {{ result.name }}</p>
+
+    <h1>Select color</h1>
+    <ResultVariantSelector :level="0" #variant="{ variant, selectVariant }">
+      <button @click="selectVariant">{{ variant.name }}</button>
+    </ResultVariantSelector>
+
+    <h1>Select size</h1>
+    <ResultVariantSelector :level="1" #variant="{ variant, selectVariant }">
+      <button @click="selectVariant">{{ variant.name }}</button>
+    </ResultVariantSelector>
+  </ResultVariantsProvider>
+</template>
+
+<script>
+  import { ResultVariantsProvider, ResultVariantSelector } from '@empathyco/x-components';
+
+  export default {
+    name: 'ResultVariantsProviderDemo',
+    components: {
+      ResultVariantsProvider,
+      ResultVariantSelector
+    },
+    data() {
+      return {
+        result: {
+          id: 'jacket',
+          modelName: 'Result',
+          type: 'Product',
+          isWishlisted: false,
+          identifier: { value: 'jacket' },
+          images: [],
+          name: 'jacket',
+          price: { hasDiscount: false, originalValue: 10, value: 10 },
+          url: '/products/jacket',
+          variants: [
+            {
+              name: 'red',
+              variants: [
+                {
+                  name: 'red XL'
+                },
+                {
+                  name: 'red L'
+                }
+              ]
+            },
+            {
+              name: 'blue',
+              variants: [
+                {
+                  name: 'blue S'
+                },
+                {
+                  name: 'blue M'
+                },
+                {
+                  name: 'blue L'
+                }
+              ]
+            }
+          ]
+        }
+      };
+    }
+  };
+</script>
+```
+
+### Play with props
+
+In this example, the provider has been configured to not auto select any variant. Changing the
+`autoSelectDepth` prop sets the number of variant levels to auto select, being 0 no variants, 1 the
+first variant of the first level, and so on.
+
+```vue
+<template>
+  <ResultVariantsProvider :result="result" :autoSelectDepth="0" #default="{ result }">
     <p>Result name: {{ result.name }}</p>
 
     <h1>Select color</h1>

--- a/packages/x-components/src/components/result/result-variants-provider.vue
+++ b/packages/x-components/src/components/result/result-variants-provider.vue
@@ -101,9 +101,7 @@
     @Watch('result', { deep: true, immediate: true })
     resetSelectedVariants(): void {
       this.selectedVariants = [];
-      if (this.result?.variants?.length) {
-        this.selectFirstVariants(this.result.variants[0]);
-      }
+      this.selectFirstVariants(this.result?.variants?.[0]);
     }
 
     /**
@@ -132,13 +130,10 @@
      *
      * @param variant - Variant to add to the array.
      */
-    selectFirstVariants(variant: ResultVariant): void {
-      if (this.selectedVariants.length > this.autoSelectDepth - 1) {
-        return;
-      }
-      this.selectedVariants.push(variant);
-      if (variant.variants?.length) {
-        this.selectFirstVariants(variant.variants[0]);
+    selectFirstVariants(variant?: ResultVariant): void {
+      if (!!variant && this.selectedVariants.length <= this.autoSelectDepth - 1) {
+        this.selectedVariants.push(variant);
+        this.selectFirstVariants(variant.variants?.[0]);
       }
     }
   }


### PR DESCRIPTION
- auto select the first variant of all the levels by default
- add autoSelectDepth prop to limit the auto selection of variants when the provider is rendered

EX-6878
