### PR TITLE
chore(ci): review GitHub action tokens

### DIFF
--- a/.github/actions/release-alpha/action.yml
+++ b/.github/actions/release-alpha/action.yml
@@ -1,10 +1,10 @@
 name: Release alpha version
 description: Runs npm script to release alpha version and pushes tags to github
 inputs:
-  npm-token:
+  npm_token:
     description: Token to push code to npm
     required: true
-  github-token:
+  github_token:
     description: Token to push code to github
     required: true
 runs:
@@ -19,13 +19,13 @@ runs:
       run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
       shell: bash
       env:
-        NPM_TOKEN: ${{ inputs.npm-token }}
+        NPM_TOKEN: ${{ inputs.npm_token }}
     - name: Publish release
       run: npm run release:alpha
       shell: bash
     - name: Push tags
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ inputs.github-token }}
+        github_token: ${{ inputs.github_token }}
         branch: ${{ github.ref }}
         tags: true

--- a/.github/actions/release-alpha/action.yml
+++ b/.github/actions/release-alpha/action.yml
@@ -2,7 +2,10 @@ name: Release alpha version
 description: Runs npm script to release alpha version and pushes tags to github
 inputs:
   npm-token:
-    description: Token to push code with
+    description: Token to push code to npm
+    required: true
+  github-token:
+    description: Token to push code to github
     required: true
 runs:
   using: "composite"
@@ -20,6 +23,9 @@ runs:
     - name: Publish release
       run: npm run release:alpha
       shell: bash
-    - name: Push changes to GitHub
-      run: git push --follow-tags
-      shell: bash
+    - name: Push tags
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ inputs.github-token }}
+        branch: ${{ github.ref }}
+        tags: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,6 @@ jobs:
         if: ${{ github.ref_name == 'main' && github.actor != 'support-empathy' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
         uses: ./.github/actions/release-alpha
         with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.SUPPORT_TOKEN }}
+          npm_token: ${{ secrets.NPM_TOKEN }}
+          github_token: ${{ secrets.SUPPORT_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.SUPPORT_TOKEN }}
+          persist-credentials: false
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages
@@ -23,4 +23,5 @@ jobs:
         uses: ./.github/actions/release-alpha
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
+          github-token: ${{ secrets.SUPPORT_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.17.0-chrome91-ff89
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,7 +7,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.SUPPORT_TOKEN }}
           fetch-depth: 0
       - name: Install lerna and all packages
         run: npm ci

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.17.0-chrome91-ff89
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install lerna and all packages

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.SUPPORT_TOKEN }}
           fetch-depth: 0
       - name: Install lerna and all packages
         run: npm ci

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.17.0-chrome91-ff89
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -8,7 +8,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.SUPPORT_TOKEN }}
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -18,4 +18,5 @@ jobs:
       - name: Call release alpha action
         uses: ./.github/actions/release-alpha
         with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
+          npm_token: ${{ secrets.NPM_TOKEN }}
+          github_token: ${{ secrets.SUPPORT_TOKEN }}

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -5,9 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.17.0-chrome91-ff89
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install lerna and all packages
         run: npm ci
       - name: Run linter in all packages


### PR DESCRIPTION
EX-6308 

I have removed the `SUPPORT_TOKEN` from the `git checkout` step on the different workflows since it is not needed. In order to be able to push the alpha release commits to the write protected `main` branch I have configured the [github-push-action](https://github.com/ad-m/github-push-action). This action allows the `release-alpha` action to push to the main branch with the `SUPPORT_TOKEN` so it can bypass the write protection rule.

In case you want to take a look at a working example,  I have tested this configuration here: https://github.com/diegopf/gh-actions-playground. Feel free to fork and submit a silly PR there so we can test the external contributors issue.

I also took the chance to update the [github-checkout-action](https://github.com/actions/checkout) version.

An additional small change was to rename `npm-token` input for the `release-alpha` action to `npm_token` so we follow the same naming convention.