### PR TITLE
build(dependencies): fix Vue & Vuex versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,15 +79,15 @@
         "tslint": "~5.16.0",
         "typescript": "~4.6.2",
         "vite": "~2.9.0",
-        "vue": "^2.6.0",
+        "vue": "~2.6.14",
         "vue-class-component": "~7.1.0",
         "vue-docgen-cli": "~4.13.1",
         "vue-global-events": "~1.2.1",
         "vue-property-decorator": "~8.3.0",
         "vue-router": "~3.4.3",
         "vue-runtime-helpers": "~1.1.2",
-        "vue-template-compiler": "^2.6.0",
-        "vuex": "^3.0.0"
+        "vue-template-compiler": "~2.6.14",
+        "vuex": "~3.6.2"
       },
       "devDependencies": {
         "@empathyco/eslint-plugin-x": "file:packages/eslint-plugin-x",

--- a/packages/react-wrapper/package.json
+++ b/packages/react-wrapper/package.json
@@ -34,10 +34,12 @@
     "test:e2e:ci": "start-server-and-test serve http://localhost:1234 cypress:run"
   },
   "dependencies": {
+    "tslib": "~2.3.0"
+  },
+  "peerDependencies": {
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "tslib": "~2.3.0",
-    "vue": "^2.6.0"
+    "vue": "~2.6.0"
   },
   "devDependencies": {
     "@types/jest": "~27.0.3",
@@ -49,7 +51,10 @@
     "parcel": "~2.0.1",
     "start-server-and-test": "~1.11.5",
     "ts-jest": "~27.0.7",
-    "typescript": "~4.6.2"
+    "typescript": "~4.6.2",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
+    "vue": "~2.6.14"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/x-components/build/rollup.config.ts
+++ b/packages/x-components/build/rollup.config.ts
@@ -21,7 +21,9 @@ import { generateEntryFiles } from './rollup-plugins/x-components.rollup-plugin'
 const rootDir = path.resolve(__dirname, '../');
 const buildPath = path.join(rootDir, 'dist');
 
-const dependencies = new Set(Object.keys(packageJSON.dependencies));
+const dependencies = new Set(
+  Object.keys(packageJSON.dependencies).concat(Object.keys(packageJSON.peerDependencies))
+);
 const jsOutputDirectory = path.join(buildPath, 'js');
 const typesOutputDirectory = path.join(buildPath, 'types');
 const cssOutputDirectory = path.join(buildPath, 'design-system');

--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -69,11 +69,13 @@
     "@types/resize-observer-browser": "~0.1.5",
     "rxjs": "~7.4.0",
     "tslib": "~2.3.0",
-    "vue": "^2.6.0",
     "vue-class-component": "~7.1.0",
     "vue-global-events": "~1.2.1",
     "vue-property-decorator": "~8.3.0",
-    "vue-runtime-helpers": "~1.1.2",
+    "vue-runtime-helpers": "~1.1.2"
+  },
+  "peerDependencies": {
+    "vue": "~2.6.0",
     "vuex": "^3.0.0"
   },
   "devDependencies": {
@@ -121,9 +123,11 @@
     "ts-jest": "~27.0.7",
     "ts-node": "~8.9.1",
     "typescript": "~4.6.2",
+    "vue": "~2.6.14",
+    "vuex": "~3.6.2",
     "vue-docgen-cli": "~4.13.1",
     "vue-router": "~3.4.3",
-    "vue-template-compiler": "^2.6.0"
+    "vue-template-compiler": "~2.6.14"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
EX-6918

The recent Vue 2.7 release breaks some things. Until we fix them, X-Components is only compatible with the 2.6.x version. To avoid accidental updates, we are setting `Vue` and `Vuex` as `peerDependencies` (we want to make sure we use the version installed by the user project), and setting them also as `devDependencies` with minor versions for our local development.