### PR TITLE
fix: Make `Home` grid next queries use grid data rather than state data.

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -252,11 +252,10 @@
                                   <span class="x-font-weight--bold">"{{ $x.query.search }}"</span>
                                 </p>
                               </div>
-                              <NextQueries
-                                #suggestion="{ suggestion }"
+                              <BaseSuggestions
+                                #default="{ suggestion }"
                                 :suggestions="nextQueries"
                                 class="x-list--gap-06"
-                                :max-items-to-render="3"
                               >
                                 <NextQuery
                                   #default="{ suggestion: nextQuery }"
@@ -267,7 +266,7 @@
                                   <span class="x-flex-auto">{{ nextQuery.query }}</span>
                                   <ArrowRight class="x-icon--l" />
                                 </NextQuery>
-                              </NextQueries>
+                              </BaseSuggestions>
                             </div>
                             <SlidingNextQueryPreview
                               :suggestion="nextQueries[0]"

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -252,9 +252,9 @@
                                   <span class="x-font-weight--bold">"{{ $x.query.search }}"</span>
                                 </p>
                               </div>
-                              <BaseSuggestions
-                                #default="{ suggestion }"
+                              <NextQueries
                                 :suggestions="nextQueries"
+                                #suggestion="{ suggestion }"
                                 class="x-list--gap-06"
                               >
                                 <NextQuery
@@ -266,7 +266,7 @@
                                   <span class="x-flex-auto">{{ nextQuery.query }}</span>
                                   <ArrowRight class="x-icon--l" />
                                 </NextQuery>
-                              </BaseSuggestions>
+                              </NextQueries>
                             </div>
                             <SlidingNextQueryPreview
                               :suggestion="nextQueries[0]"
@@ -358,7 +358,6 @@
   import BaseResultImage from '../../components/result/base-result-image.vue';
   import SlidingPanel from '../../components/sliding-panel.vue';
   import SnippetCallbacks from '../../components/snippet-callbacks.vue';
-  import BaseSuggestions from '../../components/suggestions/base-suggestions.vue';
   import { infiniteScroll } from '../../directives/infinite-scroll/infinite-scroll';
   // eslint-disable-next-line max-len
   import RenderlessExtraParams from '../../x-modules/extra-params/components/renderless-extra-param.vue';
@@ -418,7 +417,6 @@
       BaseIdTogglePanelButton,
       BaseKeyboardNavigation,
       BaseResultImage,
-      BaseSuggestions,
       BaseVariableColumnGrid,
       CheckTiny,
       ChevronLeft,

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -1,6 +1,6 @@
 <template>
   <BaseSuggestions
-    :suggestions="nextQueries"
+    :suggestions="renderedNextQueries"
     data-test="next-queries"
     class="x-next-queries"
     :animation="animation"
@@ -64,7 +64,7 @@
      * @public
      */
     @Prop()
-    protected animation!: Vue;
+    public animation?: Vue;
 
     /**
      * Number of next queries to be rendered.
@@ -72,15 +72,7 @@
      * @public
      */
     @Prop()
-    protected maxItemsToRender?: number;
-
-    /**
-     * The list of next queries.
-     *
-     * @internal
-     */
-    @Getter('nextQueries', 'nextQueries')
-    public nextQueries!: NextQueryModel[];
+    public maxItemsToRender?: number;
 
     /**
      * Flag to indicate if the curated next queries should be displayed different.
@@ -88,7 +80,32 @@
      * @public
      */
     @Prop({ default: false, type: Boolean })
-    protected highlightCurated!: boolean;
+    public highlightCurated!: boolean;
+
+    /**
+     * NextQueries list to be used instead of state NextQueries.
+     *
+     * @public
+     */
+    @Prop()
+    public suggestions?: NextQueryModel[];
+
+    /**
+     * The list of next queries from the state.
+     *
+     * @internal
+     */
+    @Getter('nextQueries', 'nextQueries')
+    public stateNextQueries!: NextQueryModel[];
+
+    /**.
+     * The list of next queries finally rendered
+     *
+     * @internal
+     */
+    protected get renderedNextQueries(): NextQueryModel[] {
+      return this.suggestions ?? this.stateNextQueries;
+    }
   }
 </script>
 


### PR DESCRIPTION
EX-6955

Previously, the grid of the home view was rendering next queries from the state. Each next queries list contained the same queries. It should render the next queries coming from the grid `NextQueriesList` group. This component was also limiting to 3 rendered next queries, which was confusing with the default 4 next queries per group.
 This is easily solved by using the `BaseSuggestions` component rather than the `NextQueries` one, which didn't support passing the next queries to render.
