### PR TITLE
feat(next-queries): add `concatWhenNoMoreItems` prop

### DIFF
--- a/packages/x-components/src/components/decorators/injection.consts.ts
+++ b/packages/x-components/src/components/decorators/injection.consts.ts
@@ -17,6 +17,13 @@ export const LIST_ITEMS_KEY: XInjectKey<ListItem[] | undefined> = 'listItems';
 export const QUERY_KEY: XInjectKey<string | undefined> = 'query';
 
 /**
+ * It's used to identify the provided and injected `hasMoreItems`.
+ *
+ * @internal
+ */
+export const HAS_MORE_ITEMS_KEY: XInjectKey<boolean | undefined> = 'hasMoreItems';
+
+/**
  * It's used to identify the provided and injected `result`.
  *
  * @internal

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -226,7 +226,7 @@
               <ResultsList v-infinite-scroll:main-scroll>
                 <BannersList>
                   <PromotedsList>
-                    <NextQueriesList>
+                    <NextQueriesList :concat-when-no-more-items="false">
                       <BaseVariableColumnGrid :animation="resultsAnimation">
                         <template #result="{ item: result }">
                           <MainScrollItem :item="result">

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
@@ -336,9 +336,63 @@ describe('testing NextQueriesList component', () => {
       ]);
     });
   });
+
+  describe('when the offset is lower than the number of items', () => {
+    it('inserts next queries groups by default', () => {
+      const nextQueries = createNextQueries(
+        'steak',
+        'tomahawk' // This one should be ignored as there is no room for it.
+      );
+      const extraItems = createExtraItems(5);
+      const { getItemsRenderedText } = renderNextQueriesList({
+        nextQueries,
+        extraItems,
+        maxNextQueriesPerGroup: 1,
+        frequency: 48,
+        offset: 24
+      });
+
+      // 5 extra items + 1 group of NQs at index 5
+      expect(getItemsRenderedText()).toEqual([
+        extraItems[0].id,
+        extraItems[1].id,
+        extraItems[2].id,
+        extraItems[3].id,
+        extraItems[4].id,
+        ['steak'].join('')
+      ]);
+    });
+
+    it('does not insert next queries groups when `concatWhenNoMoreItems` is false', () => {
+      const nextQueries = createNextQueries('steak', 'tomahawk');
+      const extraItems = createExtraItems(5);
+      const { getItemsRenderedText } = renderNextQueriesList({
+        nextQueries,
+        extraItems,
+        concatWhenNoMoreItems: false,
+        maxNextQueriesPerGroup: 1,
+        frequency: 48,
+        offset: 24
+      });
+
+      // 5 extra items + no groups of NQs
+      expect(getItemsRenderedText()).toEqual([
+        extraItems[0].id,
+        extraItems[1].id,
+        extraItems[2].id,
+        extraItems[3].id,
+        extraItems[4].id
+      ]);
+    });
+  });
 });
 
 interface RenderNextQueriesListOptions {
+  /**
+    Determines if a group is added to the injected items list when the number
+   of items is smaller than the offset.
+   */
+  concatWhenNoMoreItems?: boolean;
   /** Extra components to be registered and rendered. */
   components?: Dictionary<VueConstructor | ComponentOptions<Vue>>;
   /** Extra items to be rendered. */

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
@@ -363,7 +363,7 @@ describe('testing NextQueriesList component', () => {
       ]);
     });
 
-    it('does not insert next queries groups when `concatWhenNoMoreItems` is false', () => {
+    it('does not insert next queries groups if `concatWhenNoMoreItems` is false', () => {
       const nextQueries = createNextQueries('steak', 'tomahawk');
       const extraItems = createExtraItems(5);
       const { getItemsRenderedText } = renderNextQueriesList({

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
@@ -389,8 +389,8 @@ describe('testing NextQueriesList component', () => {
 
 interface RenderNextQueriesListOptions {
   /**
-    Determines if a group is added to the injected items list when the number
-   of items is smaller than the offset.
+   * Determines if a group is added to the injected items list when the number
+   * of items is smaller than the offset.
    */
   concatWhenNoMoreItems?: boolean;
   /** Extra components to be registered and rendered. */

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -32,7 +32,7 @@
   import { NextQueriesGroup } from '../types';
   import { nextQueriesXModule } from '../x-module';
   import { XInject } from '../../../components/decorators/injection.decorators';
-  import { QUERY_KEY } from '../../../components/decorators/injection.consts';
+  import { HAS_MORE_ITEMS_KEY, QUERY_KEY } from '../../../components/decorators/injection.consts';
 
   /**
    * Component that inserts groups of next queries in different positions of the injected search
@@ -90,6 +90,15 @@
     public maxGroups!: number;
 
     /**
+     * Determines if a group is added to the injected items list when the number
+     * of items is smaller than the offset.
+     *
+     * @public
+     */
+    @Prop({ default: true })
+    public concatWhenNoMoreItems!: boolean;
+
+    /**
      * The state next queries.
      *
      * @internal
@@ -102,6 +111,12 @@
      */
     @XInject(QUERY_KEY)
     public injectedQuery!: string | undefined;
+
+    /**
+     * Indicates if there are more available results than the injected.
+     */
+    @XInject(HAS_MORE_ITEMS_KEY)
+    public hasMoreItems!: boolean;
 
     /**
      * The grouped next queries based on the given config.
@@ -135,6 +150,14 @@
       }
       if (this.nextQueriesAreOutdated) {
         return this.injectedListItems;
+      }
+      if (
+        this.concatWhenNoMoreItems &&
+        !this.hasMoreItems &&
+        this.injectedListItems.length &&
+        this.offset > this.injectedListItems.length
+      ) {
+        return [...this.injectedListItems].concat(this.nextQueriesGroups[0]);
       }
       return this.nextQueriesGroups.reduce(
         (items, nextQueriesGroup, index) => {

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -269,7 +269,7 @@ more groups will be inserted. Each one of this groups will have up to `6` next q
 ### Showing/hiding first next queries group when no more items
 
 By default, the first next query group will be inserted when the total number of results is smaller
-than the offset but this behavior can be disabled setting the `concatWhenNoMoreItems` to `false`.
+than the offset, but this behavior can be disabled setting the `concatWhenNoMoreItems` to `false`.
 
 ```vue live
 <template>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -157,7 +157,7 @@
         this.injectedListItems.length &&
         this.offset > this.injectedListItems.length
       ) {
-        return [...this.injectedListItems].concat(this.nextQueriesGroups[0]);
+        return this.injectedListItems.concat(this.nextQueriesGroups[0] ?? []);
       }
       return this.nextQueriesGroups.reduce(
         (items, nextQueriesGroup, index) => {
@@ -246,6 +246,42 @@ more groups will be inserted. Each one of this groups will have up to `6` next q
     <SearchInput />
     <ResultsList>
       <NextQueriesList :offset="48" :frequency="72" :maxNextQueriesPerGroup="6" :maxGroups="3" />
+    </ResultsList>
+  </div>
+</template>
+
+<script>
+  import { NextQueriesList } from '@empathyco/x-components/next-queries';
+  import { ResultsList } from '@empathyco/x-components/search';
+  import { SearchInput } from '@empathyco/x-components/search-box';
+
+  export default {
+    name: 'NextQueriesListDemo',
+    components: {
+      NextQueriesList,
+      ResultsList,
+      SearchInput
+    }
+  };
+</script>
+```
+
+### Showing/hiding first next queries group when no more items
+
+By default, the first next query group will be inserted when the total number of results is smaller
+than the offset but this behavior can be disabled setting the `concatWhenNoMoreItems` to `false`.
+
+```vue live
+<template>
+  <div>
+    <SearchInput />
+    <ResultsList>
+      <NextQueriesList
+        :offset="48"
+        :frequency="72"
+        :maxNextQueriesPerGroup="1"
+        :concatWhenNoMoreItems="false"
+      />
     </ResultsList>
   </div>
 </template>

--- a/packages/x-components/src/x-modules/search/components/__tests__/results-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/results-list.spec.ts
@@ -31,7 +31,7 @@ import { resetXSearchStateWith } from './utils';
 function renderResultsList({
   template = '<ResultsList />',
   results = getResultsStub(),
-  totalResults = results?.length,
+  totalResults = results.length,
   components
 }: RenderResultsListOptions = {}): RenderResultsListAPI {
   const localVue = createLocalVue();
@@ -214,7 +214,7 @@ describe('testing Results list component', () => {
     expect(childWrapper.text()).toBe('jacket');
   });
 
-  it('provides if there are more available results with the key `hasMoreItems`', () => {
+  it('provides a flag indicating if there are more results with the key `hasMoreItems`', () => {
     @Component({
       template: `
         <div></div>

--- a/packages/x-components/src/x-modules/search/components/results-list.vue
+++ b/packages/x-components/src/x-modules/search/components/results-list.vue
@@ -19,7 +19,11 @@
   import { Result } from '@empathyco/x-types';
   import Vue from 'vue';
   import { Component, Prop, Watch } from 'vue-property-decorator';
-  import { LIST_ITEMS_KEY, QUERY_KEY } from '../../../components/decorators/injection.consts';
+  import {
+    HAS_MORE_ITEMS_KEY,
+    LIST_ITEMS_KEY,
+    QUERY_KEY
+  } from '../../../components/decorators/injection.consts';
   import { XProvide } from '../../../components/decorators/injection.decorators';
   import { State } from '../../../components/decorators/store.decorators';
   import { NoElement } from '../../../components/no-element';
@@ -67,6 +71,23 @@
      */
     @XProvide(QUERY_KEY)
     public providedQuery = '';
+
+    /**
+     * Indicates if there are more available results that have not been injected.
+     *
+     * @returns Boolean.
+     * @public
+     */
+    @XProvide(HAS_MORE_ITEMS_KEY)
+    public get hasMoreItems(): boolean {
+      return this.items.length < this.totalResults;
+    }
+
+    /**
+     * The total number of results, taken from the state.
+     */
+    @State('search', 'totalResults')
+    public totalResults!: number;
 
     /**
      * The status of the search request, taken from the state.


### PR DESCRIPTION
EX-6840

I have disabled this behavior in the `Home.vue` as multiple e2e tests would be affected. 

In order to test it locally, the prop `concatWhenNoMoreItems`, passed to `NextQueriesList` in `Home.vue`, needs to be changed to `true` or removed (as its default value is `true`).

Then, you need to search for a term (i.e. `hats`) with less than `24` results as it is the default `offset` value defined in `NextQueriesList`. 


## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:




