### PR TITLE
feat(search): add `updateResult` mutation

### DIFF
--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -111,6 +111,12 @@ export const searchXStoreModule: SearchXStoreModule = {
     },
     setQueryTagging(state, queryTagging) {
       state.queryTagging = queryTagging;
+    },
+    updateResult(state, result) {
+      const stateResult = state.results.find(stateResult => result.id === stateResult.id);
+      if (stateResult) {
+        Object.assign(stateResult, result);
+      }
     }
   },
   actions: {

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -96,6 +96,12 @@ export interface SearchMutations extends StatusMutations, QueryMutations {
    */
   appendResults(results: Result[]): void;
   /**
+   * Updates a result with new fields.
+   *
+   * @param result - A result containing at least an id, and the properties to modify.
+   */
+  updateResult(result: Partial<Result> & Pick<Result, 'id'>): void;
+  /**
    * Sets the banners of the module.
    *
    * @param banners - The new banners to save to the state.


### PR DESCRIPTION
EX-6894

Adds a mutation to update the result info.
