### PR TITLE
feat: disable `@typescript-eslint/no-extra-parens` rule

### DIFF
--- a/packages/eslint-plugin-x/lib/configs/ts.js
+++ b/packages/eslint-plugin-x/lib/configs/ts.js
@@ -14,7 +14,7 @@ const syntaxRules = {
   '@typescript-eslint/no-empty-function': ['error', { allow: ['protected-constructors'] }],
   '@typescript-eslint/no-empty-interface': 'off',
   '@typescript-eslint/no-explicit-any': 'off',
-  '@typescript-eslint/no-extra-parens': ['error', 'all', { nestedBinaryExpressions: false }],
+  '@typescript-eslint/no-extra-parens': 'off',
   '@typescript-eslint/no-non-null-assertion': 'off',
   '@typescript-eslint/no-unused-expressions': ['error'],
   '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],

--- a/packages/react-wrapper/src/__tests__/stubs/react-toggle-component.tsx
+++ b/packages/react-wrapper/src/__tests__/stubs/react-toggle-component.tsx
@@ -27,12 +27,9 @@ export class ReactToggleComponent extends React.Component<
   render(): ReactNode {
     return (
       <section>
-        {
-          // eslint-disable-next-line @typescript-eslint/no-extra-parens
-          this.state.renderVueComponent && (
-            <ReactWrapper component={VueDestroyed} count={this.state.clicksCount} />
-          )
-        }
+        {this.state.renderVueComponent && (
+          <ReactWrapper component={VueDestroyed} count={this.state.clicksCount} />
+        )}
       </section>
     );
   }

--- a/packages/storage-service/src/browser-storage-service.ts
+++ b/packages/storage-service/src/browser-storage-service.ts
@@ -87,7 +87,6 @@ export class BrowserStorageService implements StorageService {
 
   protected createExpirableItem(item: any, ttlInMs?: number): any {
     return {
-      // eslint-disable-next-line @typescript-eslint/no-extra-parens
       ...(!!ttlInMs && { ttl: ttlInMs + this.currentTimestamp() }),
       value: item
     };

--- a/packages/x-adapter/src/http-clients/utils.ts
+++ b/packages/x-adapter/src/http-clients/utils.ts
@@ -13,7 +13,6 @@ import { RequestError } from './errors/request-error';
  */
 export function toJson(response: Response): Promise<any> {
   if (response.ok) {
-    // eslint-disable-next-line @typescript-eslint/no-extra-parens
     return response.text().then(text => (text ? JSON.parse(text) : {}));
   } else {
     throw new RequestError('Request failed', response);

--- a/packages/x-adapter/src/mappers/__tests__/schema-mapper.factory.spec.ts
+++ b/packages/x-adapter/src/mappers/__tests__/schema-mapper.factory.spec.ts
@@ -72,7 +72,6 @@ describe('schemaMapperFactory tests', () => {
       hits: 5
     };
     const schema: Schema<Source, Target> = {
-      // eslint-disable-next-line @typescript-eslint/no-extra-parens
       query: ({ q }, context) => (context?.endpoint?.match(/search/gi) ? q : ''),
       hits: 'rows'
     };
@@ -260,7 +259,6 @@ describe('schemaMapperFactory tests', () => {
     const filterSchema: Schema<Filter, TargetFilter> = {
       filterId: 'id',
       value: 'value',
-      // eslint-disable-next-line @typescript-eslint/no-extra-parens
       parentId: (_, $context) => ($context?.hasParent ? ($context?.parentId as string) : '')
     };
 

--- a/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/fetch-and-save-search-response.action.ts
@@ -37,7 +37,6 @@ function enrichRequest(request: InternalSearchRequest, state: SearchState): Sear
 
   return {
     ...restRequest,
-    // eslint-disable-next-line @typescript-eslint/no-extra-parens
     ...(origin && { origin }),
     start,
     rows: pageSize * page - start


### PR DESCRIPTION
EX-6996

We have Prettier to take care of code style. This rule was conflicting with Prettier, and adds no value.
