### PR TITLE
feat: enforce npm version greater than 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
-      - name: Update npm
-        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
       - name: Update npm
-        run: sudo npm install -g npm@8
+        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 name: Check branch is releasable and release alpha on main branch update
 on: [push, pull_request]
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
   build:
+    runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
       - name: Update npm
@@ -20,9 +21,10 @@ jobs:
       - name: Run tests in all packages
         run: npm run test
       - name: Release alpha on non-release pushes to main branch
-        if: ${{ github.ref_name == 'main' && github.actor != 'support-empathy' && !startsWith(github.event.head_commit.message, 'chore(release):') }}
+        if:
+          ${{ github.ref_name == 'main' && github.actor != 'support-empathy' &&
+          !startsWith(github.event.head_commit.message, 'chore(release):') }}
         uses: ./.github/actions/release-alpha
         with:
           npm_token: ${{ secrets.NPM_TOKEN }}
           github_token: ${{ secrets.SUPPORT_TOKEN }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
+      - name: Update npm
+        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,10 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome91-ff89
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
+      - name: Update npm
+        run: npm install -g npm@8
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Update npm
         run: npm install -g npm@7
+      - name: log npm v
+        run: npm -v
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
+    container:
+      image: cypress/browsers:node14.19.0-chrome100-ff99-edge
+      options: --user root
     steps:
       - name: Update npm
         run: npm install -g npm@8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node14.19.0-chrome100-ff99-edge
-      options: --user root
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
       - name: Update npm
-        run: npm install -g npm@8
+        run: sudo npm install -g npm@8
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,8 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
-      - name: Update npm
-        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -26,7 +24,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.SUPPORT_TOKEN }}
-          commit-message: "chore(release): prepare stable release"
+          commit-message: 'chore(release): prepare stable release'
           committer: Interface X <x@empathy.co>
           title: Stable release
           body: Release preparation

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,7 +3,9 @@ on: [workflow_dispatch]
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
+    container:
+      image: cypress/browsers:node14.19.0-chrome100-ff99-edge
+      options: --user root
     steps:
       - name: Update npm
         run: npm install -g npm@8

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
+      - name: Update npm
+        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -24,7 +26,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.SUPPORT_TOKEN }}
-          commit-message: 'chore(release): prepare stable release'
+          commit-message: "chore(release): prepare stable release"
           committer: Interface X <x@empathy.co>
           title: Stable release
           body: Release preparation

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,12 +3,10 @@ on: [workflow_dispatch]
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node14.19.0-chrome100-ff99-edge
-      options: --user root
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
       - name: Update npm
-        run: npm install -g npm@8
+        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,8 +3,10 @@ on: [workflow_dispatch]
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome91-ff89
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
+      - name: Update npm
+        run: npm install -g npm@8
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,14 +1,16 @@
 name: Release a new version
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [ closed ]
+    branches: [ main ]
 jobs:
   release:
     if: github.event.pull_request.merged == true && github.head_ref == 'release'
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
+      - name: Update npm
+        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,16 +1,14 @@
 name: Release a new version
 on:
   pull_request:
-    types: [ closed ]
-    branches: [ main ]
+    types: [closed]
+    branches: [main]
 jobs:
   release:
     if: github.event.pull_request.merged == true && github.head_ref == 'release'
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
-      - name: Update npm
-        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,9 @@ jobs:
   release:
     if: github.event.pull_request.merged == true && github.head_ref == 'release'
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
+    container:
+      image: cypress/browsers:node14.19.0-chrome100-ff99-edge
+      options: --user root
     steps:
       - name: Update npm
         run: npm install -g npm@8

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,12 +7,10 @@ jobs:
   release:
     if: github.event.pull_request.merged == true && github.head_ref == 'release'
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node14.19.0-chrome100-ff99-edge
-      options: --user root
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
       - name: Update npm
-        run: npm install -g npm@8
+        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,8 +7,10 @@ jobs:
   release:
     if: github.event.pull_request.merged == true && github.head_ref == 'release'
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome91-ff89
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
+      - name: Update npm
+        run: npm install -g npm@8
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -3,12 +3,10 @@ on: [workflow_dispatch]
 jobs:
   release-alpha:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node14.19.0-chrome100-ff99-edge
-      options: --user root
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
       - name: Update npm
-        run: npm install -g npm@8
+        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -3,8 +3,10 @@ on: [workflow_dispatch]
 jobs:
   release-alpha:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome91-ff89
+    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
+      - name: Update npm
+        run: npm install -g npm@8
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -3,7 +3,9 @@ on: [workflow_dispatch]
 jobs:
   release-alpha:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.19.0-chrome100-ff99-edge
+    container:
+      image: cypress/browsers:node14.19.0-chrome100-ff99-edge
+      options: --user root
     steps:
       - name: Update npm
         run: npm install -g npm@8

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -5,8 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
-      - name: Update npm
-        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.19.0-chrome100-ff99-edge
     steps:
+      - name: Update npm
+        run: npm install -g npm@7
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "lint-staged": "~11.1.2",
     "prettier": "~2.3.2"
   },
+  "engines": {
+    "npm": ">=7.0.0"
+  },
   "prettier": "@empathyco/eslint-plugin-x/prettier-config",
   "lint-staged": {
     "*.{ts,tsx,vue}": [


### PR DESCRIPTION
EX-7036

To avoid accidentally modifying the package-lock, now we force users to use an npm version > 7, which includes the new package lock syntax. If you have an older npm version it will fail when installing.

We should do the same with node, but it is more complex, as some tests are failing in node16.
