### PR TITLE
feat(base-modal): prevent content shift when hiding the scrollbar

### DIFF
--- a/packages/x-components/src/components/modals/base-modal.vue
+++ b/packages/x-components/src/components/modals/base-modal.vue
@@ -61,10 +61,10 @@
     @Prop({ required: true })
     public open!: boolean;
 
-    /** The previous value of the body overflow style. */
-    protected previousBodyOverflow = '';
-    /** The previous value of the HTML element overflow style. */
-    protected previousHTMLOverflow = '';
+    /** The previous value of the scrolling element overflow style. */
+    protected previousScrollingElementOverflow = '';
+    /** The previous value of the scrolling element scrollbar-gutter style. */
+    protected previousScrollingElementScrollbarGutter = '';
     /** Boolean to delay the leave animation until it has completed. */
     protected isWaitingForLeave = false;
 
@@ -108,9 +108,11 @@
      * @internal
      */
     protected disableScroll(): void {
-      this.previousBodyOverflow = document.body.style.overflow;
-      this.previousHTMLOverflow = document.documentElement.style.overflow;
-      document.body.style.overflow = document.documentElement.style.overflow = 'hidden';
+      const scrollingElement = document.scrollingElement as HTMLElement;
+      this.previousScrollingElementOverflow = scrollingElement.style.overflow;
+      this.previousScrollingElementScrollbarGutter = scrollingElement.style.scrollbarGutter;
+      scrollingElement.style.overflow = 'hidden';
+      scrollingElement.style.scrollbarGutter = 'stable';
     }
 
     /**
@@ -119,9 +121,9 @@
      * @internal
      */
     protected enableScroll(): void {
-      document.body.style.overflow = this.previousBodyOverflow;
-      document.documentElement.style.overflow = this.previousHTMLOverflow;
-      document.body.style.overflow = document.documentElement.style.overflow = '';
+      const scrollingElement = document.scrollingElement as HTMLElement;
+      scrollingElement.style.overflow = this.previousScrollingElementOverflow;
+      scrollingElement.style.scrollbarGutter = this.previousScrollingElementScrollbarGutter;
     }
 
     /**


### PR DESCRIPTION
## Motivation and context
Showing the layer hides the main scrollbar causing a content shift:

https://user-images.githubusercontent.com/194784/190706233-b7ac7614-0149-4d54-98ee-7c2e98916b89.mov

I haven't been able to test this PR, but the expected result is like this:

https://user-images.githubusercontent.com/194784/190706551-3043f46c-eea1-45ba-97e5-48d2eed326e1.mov


Also, there was a line that confuses me:
https://github.com/empathyco/x/blob/980f3e6628cfedad38f5f5ceeefbb24544b38cb6/packages/x-components/src/components/modals/base-modal.vue#L122-L124
The last line overrides all logic regarding `previousBodyOverflow` and `previousHTMLOverflow`.


<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
