### PR TITLE
feat: Add `rename` utility

### DIFF
--- a/packages/x-utils/src/__tests__/object.spec.ts
+++ b/packages/x-utils/src/__tests__/object.spec.ts
@@ -6,7 +6,8 @@ import {
   forEach,
   getNewAndUpdatedKeys,
   map,
-  reduce
+  reduce,
+  rename
 } from '../object';
 import { Dictionary } from '../types/utils.types';
 
@@ -560,6 +561,45 @@ describe('testing object utils', () => {
         k: null,
         l: obj.c.f.h.l
       });
+    });
+  });
+
+  describe('rename', () => {
+    const sampleObject = {
+      anString: 'string',
+      aNumber: 10,
+      anObject: {
+        notRenamedBoolean: true
+      }
+    };
+    it('allows using a prefix', () => {
+      const result = rename(sampleObject, { prefix: '_' });
+      expect(result._anString).toEqual(sampleObject.anString);
+      expect(result._aNumber).toEqual(sampleObject.aNumber);
+      expect(result._anObject).toEqual(sampleObject.anObject);
+      expect(result._anObject.notRenamedBoolean).toEqual(sampleObject.anObject.notRenamedBoolean);
+    });
+    it('allows using a suffix', () => {
+      const result = rename(sampleObject, { suffix: '_' });
+      expect(result.anString_).toEqual(sampleObject.anString);
+      expect(result.aNumber_).toEqual(sampleObject.aNumber);
+      expect(result.anObject_).toEqual(sampleObject.anObject);
+      expect(result.anObject_.notRenamedBoolean).toEqual(sampleObject.anObject.notRenamedBoolean);
+    });
+    it('allows using both prefix and a suffix', () => {
+      const result = rename(sampleObject, { prefix: '_', suffix: '_' });
+      expect(result._anString_).toEqual(sampleObject.anString);
+      expect(result._aNumber_).toEqual(sampleObject.aNumber);
+      expect(result._anObject_).toEqual(sampleObject.anObject);
+      expect(result._anObject_.notRenamedBoolean).toEqual(sampleObject.anObject.notRenamedBoolean);
+    });
+    it('excludes undefined properties', () => {
+      const result = rename(
+        { anString: 'string', anUndef: undefined },
+        { prefix: '_', suffix: '_' }
+      );
+      expect(result._anString_).toEqual(sampleObject.anString);
+      expect(result).not.toHaveProperty('_anUndef_');
     });
   });
 });

--- a/packages/x-utils/src/object.ts
+++ b/packages/x-utils/src/object.ts
@@ -200,6 +200,7 @@ export function every<ObjectType extends Dictionary>(
  *
  * @param object - The object to flatten.
  * @returns The flattened object.
+ * @public
  */
 export function flatObject(object: Dictionary): Dictionary {
   const flattenedObject: Dictionary = {};
@@ -211,4 +212,51 @@ export function flatObject(object: Dictionary): Dictionary {
     }
   });
   return flattenedObject;
+}
+
+/**
+ * Renames the keys of an object adding a prefix, a suffix, or both.
+ *
+ * @param object - The object to rename its keys.
+ * @param pattern - The options to rename with: a prefix and a suffix.
+ * @returns A new object with the keys renamed following the pattern.
+ * @public
+ */
+export function rename<
+  SomeObject extends Dictionary,
+  Prefix extends string = '',
+  Suffix extends string = ''
+>(
+  object: SomeObject,
+  { prefix, suffix }: RenameOptions<Prefix, Suffix>
+): Rename<SomeObject, Prefix, Suffix> {
+  return reduce(
+    object,
+    (renamed, key, value) => {
+      renamed[
+        `${prefix ?? ''}${key as string}${suffix ?? ''}` as keyof Rename<SomeObject, Prefix, Suffix>
+      ] = value;
+      return renamed;
+    },
+    {} as Rename<SomeObject, Prefix, Suffix>
+  );
+}
+
+/**
+ * Renames the keys of the given object prefixing and suffixing them.
+ *
+ * @public
+ */
+export type Rename<SomeObject, Prefix extends string, Suffix extends string> = {
+  [Key in keyof SomeObject as `${Prefix}${Key & string}${Suffix}`]: SomeObject[Key];
+};
+
+/**
+ * An optional prefix and suffix.
+ *
+ * @public
+ */
+interface RenameOptions<Prefix, Suffix> {
+  prefix?: Prefix;
+  suffix?: Suffix;
 }


### PR DESCRIPTION
EX-7103

Adds a rename utility, needed to ease the tailwind package object operations.
This utility for now prefixes and suffixes the first level of the given object keys. Using a mapper function would have been much more powerful, but that brings issues when typing the new object, as functions are much more complex.