### PR TITLE
Add origin to Next Queries Preview

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -215,10 +215,11 @@
 
             <template v-if="!$x.query.searchBox">
               <h1 class="x-title1 x-margin--bottom-06">Brand Recommendations</h1>
-
-              <SlidingQueryPreview query="sunglasses" />
-              <SlidingQueryPreview query="handbag" />
-              <SlidingQueryPreview query="earrings" />
+              <LocationProvider location="no_results">
+                <SlidingQueryPreview query="sunglasses" />
+                <SlidingQueryPreview query="handbag" />
+                <SlidingQueryPreview query="earrings" />
+              </LocationProvider>
             </template>
 
             <!-- Results -->

--- a/packages/x-components/src/x-modules/next-queries/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/__tests__/actions.spec.ts
@@ -15,7 +15,6 @@ import {
   NextQueriesMutations,
   NextQueriesState
 } from '../types';
-import { XStoreModule } from '../../../../store/index';
 import { resetNextQueriesStateWith } from './utils';
 
 describe('testing next queries module actions', () => {
@@ -36,7 +35,7 @@ describe('testing next queries module actions', () => {
     NextQueriesGetters,
     NextQueriesMutations,
     NextQueriesActions
-  > = new Store(nextQueriesXStoreModule as XStoreModule<any, any, any, any>);
+  > = new Store(nextQueriesXStoreModule as any);
   installNewXPlugin({ adapter, store }, localVue);
 
   beforeEach(() => {

--- a/packages/x-components/src/x-modules/next-queries/store/actions/fetch-and-save-next-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/actions/fetch-and-save-next-query-preview.action.ts
@@ -8,7 +8,7 @@ export const fetchAndSaveNextQueryPreview: NextQueriesXStoreModule['actions']['f
         if (response) {
           commit('setResultsPreview', {
             [query]: {
-              query: query,
+              query,
               totalResults: response.totalResults,
               items: response.results
             }

--- a/packages/x-components/src/x-modules/next-queries/store/actions/fetch-and-save-next-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/actions/fetch-and-save-next-query-preview.action.ts
@@ -2,13 +2,13 @@ import { NextQueriesXStoreModule } from '../types';
 
 // eslint-disable-next-line max-len
 export const fetchAndSaveNextQueryPreview: NextQueriesXStoreModule['actions']['fetchAndSaveNextQueryPreview'] =
-  ({ dispatch, commit }, payload) => {
-    return dispatch('fetchNextQueryPreview', payload)
+  ({ dispatch, commit }, { query, location }) => {
+    return dispatch('fetchNextQueryPreview', { query, location })
       .then(response => {
         if (response) {
           commit('setResultsPreview', {
-            query: {
-              query: payload.query,
+            [query]: {
+              query: query,
               totalResults: response.totalResults,
               items: response.results
             }

--- a/packages/x-components/src/x-modules/next-queries/store/actions/fetch-and-save-next-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/actions/fetch-and-save-next-query-preview.action.ts
@@ -2,13 +2,13 @@ import { NextQueriesXStoreModule } from '../types';
 
 // eslint-disable-next-line max-len
 export const fetchAndSaveNextQueryPreview: NextQueriesXStoreModule['actions']['fetchAndSaveNextQueryPreview'] =
-  ({ dispatch, commit }, query) => {
-    return dispatch('fetchNextQueryPreview', query)
+  ({ dispatch, commit }, payload) => {
+    return dispatch('fetchNextQueryPreview', payload)
       .then(response => {
         if (response) {
           commit('setResultsPreview', {
-            [query]: {
-              query,
+            query: {
+              query: payload.query,
               totalResults: response.totalResults,
               items: response.results
             }

--- a/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
@@ -19,7 +19,7 @@ export const fetchNextQueryPreview: NextQueriesXStoreModule['actions']['fetchNex
   if (!query) {
     return null;
   }
-  const origin = createOrigin({ feature: 'next_query', location: location }) ?? undefined;
+  const origin = createOrigin({ feature: 'next_query', location }) ?? undefined;
 
   return XPlugin.adapter.search(
     {

--- a/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
@@ -26,7 +26,7 @@ export const fetchNextQueryPreview: NextQueriesXStoreModule['actions']['fetchNex
       query,
       rows: state.config.maxPreviewItemsToRequest,
       extraParams: state.params,
-      ...(origin && { origin })
+      origin
     },
     {
       id: `fetchNextQueryPreview-${query}`

--- a/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
@@ -19,7 +19,7 @@ export const fetchNextQueryPreview: NextQueriesXStoreModule['actions']['fetchNex
   if (!query) {
     return null;
   }
-  const origin = createOrigin({ feature: 'next_query', location: location });
+  const origin = createOrigin({ feature: 'next_query', location: location }) ?? undefined;
 
   return XPlugin.adapter.search(
     {

--- a/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
@@ -1,5 +1,6 @@
 import { NextQueriesXStoreModule } from '../types';
 import { XPlugin } from '../../../../plugins/x-plugin';
+import { createOrigin } from '../../../../utils/index';
 
 /**
  * Default implementation for the {@link NextQueriesActions.fetchNextQueryPreview}.
@@ -7,21 +8,25 @@ import { XPlugin } from '../../../../plugins/x-plugin';
  * @param state - The state of the store, used to retrieve the rows and the extraParams to be sent
  * in the request.
  * @param query - The next query to send in the request.
+ * @param location - The {@link FeatureLocation} to send in the request.
  * @returns A Promise of a SearchResponse when it fetches the results, `null` if the request was
  * not made.
  */
 export const fetchNextQueryPreview: NextQueriesXStoreModule['actions']['fetchNextQueryPreview'] = (
   { state },
-  query
+  { query, location }
 ) => {
   if (!query) {
     return null;
   }
+  const origin = createOrigin({ feature: 'next_query', location: location });
+
   return XPlugin.adapter.search(
     {
       query,
       rows: state.config.maxPreviewItemsToRequest,
-      extraParams: state.params
+      extraParams: state.params,
+      ...(origin && { origin })
     },
     {
       id: `fetchNextQueryPreview-${query}`

--- a/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/actions/fetch-next-query-preview.action.ts
@@ -1,6 +1,6 @@
 import { NextQueriesXStoreModule } from '../types';
 import { XPlugin } from '../../../../plugins/x-plugin';
-import { createOrigin } from '../../../../utils/index';
+import { createOrigin } from '../../../../utils/origin';
 
 /**
  * Default implementation for the {@link NextQueriesActions.fetchNextQueryPreview}.

--- a/packages/x-components/src/x-modules/next-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/types.ts
@@ -11,6 +11,7 @@ import { QueryMutations, QueryState } from '../../../store/utils/query.utils';
 import { StatusMutations, StatusState } from '../../../store/utils/status-store.utils';
 import { UrlParams } from '../../../types/url-params';
 import { NextQueriesConfig } from '../config.types';
+import { FeatureLocation } from '../../../types/index';
 
 /**
  * Next queries module state.
@@ -127,16 +128,22 @@ export interface NextQueriesActions {
    * Requests the results to preview a next query,
    * limited by {@link NextQueriesConfig.maxPreviewItemsToRequest}.
    *
-   * @param query - The next query to retrieve the results.
    * @returns A search response based on the next query.
+   * @param payload - The payload object containing the query and its location.
    */
-  fetchNextQueryPreview(query: string): SearchResponse | null;
+  fetchNextQueryPreview(payload: {
+    query: string;
+    location: FeatureLocation | undefined;
+  }): SearchResponse | null;
   /**
    * Requests the results to preview a next query and saves them in the state.
    *
-   * @param query - The next query to retrieve the results.
+   * @param payload - The payload object containing the query and its location.
    */
-  fetchAndSaveNextQueryPreview(query: string): void;
+  fetchAndSaveNextQueryPreview(payload: {
+    query: string;
+    location: FeatureLocation | undefined;
+  }): void;
 }
 
 /**

--- a/packages/x-components/src/x-modules/next-queries/wiring.ts
+++ b/packages/x-components/src/x-modules/next-queries/wiring.ts
@@ -6,7 +6,8 @@ import {
 import {
   NamespacedWireCommit,
   NamespacedWireCommitWithoutPayload,
-  NamespacedWireDispatch
+  NamespacedWireDispatch,
+  NamespacedWiringData
 } from '../../wiring/namespaced-wiring.types';
 import { createWiring } from '../../wiring/wiring.utils';
 
@@ -77,8 +78,15 @@ export const setQueryFromLastHistoryQueryWire = wireDispatch('setQueryFromLastHi
  *
  * @public
  */
-export const fetchAndSaveNextQueryPreviewWire = wireDispatch('fetchAndSaveNextQueryPreview');
-
+export const fetchAndSaveNextQueryPreviewWire = wireDispatch(
+  'fetchAndSaveNextQueryPreview',
+  ({ eventPayload: query, metadata: { location } }: NamespacedWiringData<'nextQueries'>) => {
+    return {
+      query,
+      location
+    };
+  }
+);
 /**
  * Resets the next query preview results.
  *


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->
[EX-6757](https://searchbroker.atlassian.net/browse/EX-6757)

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
- Modify `fetchAndSaveNextQueryPreviewWire` to send both the `query` and the `location` in the request.
- Update store `fetchAndSaveNextQueryPreview`and `fetchNextQueryPreview` actions & its types.
- Update tests.
- Create a test for an undefined location use case

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
Enable sending an `origin` for this feature to be tracked.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
