### PR TITLE
fix(base-modal): add prop to allow the modal to move the focus to an element within it on open

### DIFF
--- a/packages/x-components/src/components/modals/__tests__/base-modal.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-modal.spec.ts
@@ -96,8 +96,10 @@ describe('testing Base Modal  component', () => {
 
   it('changes the focus to the correct element when the modal opens', async () => {
     let { wrapper, setOpen, appendToBody } = mountBaseModal({
-      // eslint-disable-next-line max-len
-      defaultSlot: `<div><button data-test="expected-focus">First button</button><button>Second button</button></div>`,
+      defaultSlot: `<div>
+          <button data-test="expected-focus">First button</button>
+          <button>Second button</button>
+        </div>`,
       open: false
     });
 
@@ -109,8 +111,10 @@ describe('testing Base Modal  component', () => {
     );
 
     ({ wrapper, setOpen, appendToBody } = mountBaseModal({
-      // eslint-disable-next-line max-len
-      defaultSlot: `<div><button>First button</button><button tabindex="1" data-test="expected-focus">Second button</button></div>`,
+      defaultSlot: `<div>
+          <button>First button</button>
+          <button tabindex="1" data-test="expected-focus">Second button</button>
+        </div>`,
       open: false
     }));
 
@@ -122,9 +126,12 @@ describe('testing Base Modal  component', () => {
     );
   });
 
-  it("doesn't changes the focus if the focusOnOpen prop is false", async () => {
+  it("doesn't change the focus if the focusOnOpen prop is false", async () => {
     const { setOpen, appendToBody } = mountBaseModal({
-      defaultSlot: `<div><button>First button</button><button>Second button</button></div>`,
+      defaultSlot: `<div>
+          <button tabindex="1">First button</button>
+          <button>Second button</button>
+        </div>`,
       open: false,
       focusOnOpen: false
     });

--- a/packages/x-components/src/components/modals/__tests__/base-modal.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-modal.spec.ts
@@ -12,18 +12,23 @@ import BaseModal from '../base-modal.vue';
  */
 function mountBaseModal({
   defaultSlot = '<span data-test="default-slot">Modal</span>',
-  open = false
+  open = false,
+  focusOnOpen = true
 }: MountBaseModalOptions = {}): MountBaseModalAPI {
   const localVue = createLocalVue();
   const wrapper = mount(BaseModal, {
     localVue,
     propsData: {
-      open
+      open,
+      focusOnOpen
     },
     slots: {
       default: defaultSlot
     }
   });
+  const appendToBody = (): void => {
+    document.body.appendChild(wrapper.element);
+  };
 
   return {
     wrapper,
@@ -36,11 +41,12 @@ function mountBaseModal({
     async closeModal() {
       await wrapper.find(getDataTestSelector('modal-overlay'))?.trigger('click');
     },
+    appendToBody,
     async fakeFocusIn() {
       const buttonWrapper = mount({
         template: `<button>Button</button>`
       });
-      document.body.appendChild(wrapper.element);
+      appendToBody();
       document.body.appendChild(buttonWrapper.element);
       await buttonWrapper.trigger('focusin');
     }
@@ -87,6 +93,48 @@ describe('testing Base Modal  component', () => {
 
     expect(wrapper.find(getDataTestSelector('default-slot-overridden')).exists()).toBe(true);
   });
+
+  it('changes the focus to the correct element when the modal opens', async () => {
+    let { wrapper, setOpen, appendToBody } = mountBaseModal({
+      // eslint-disable-next-line max-len
+      defaultSlot: `<div><button data-test="expected-focus">First button</button><button>Second button</button></div>`,
+      open: false
+    });
+
+    appendToBody();
+    await setOpen(true);
+
+    expect(wrapper.find(getDataTestSelector('expected-focus')).element).toBe(
+      document.activeElement
+    );
+
+    ({ wrapper, setOpen, appendToBody } = mountBaseModal({
+      // eslint-disable-next-line max-len
+      defaultSlot: `<div><button>First button</button><button tabindex="1" data-test="expected-focus">Second button</button></div>`,
+      open: false
+    }));
+
+    appendToBody();
+    await setOpen(true);
+
+    expect(wrapper.find(getDataTestSelector('expected-focus')).element).toBe(
+      document.activeElement
+    );
+  });
+
+  it("doesn't changes the focus if the focusOnOpen prop is false", async () => {
+    const { setOpen, appendToBody } = mountBaseModal({
+      defaultSlot: `<div><button>First button</button><button>Second button</button></div>`,
+      open: false,
+      focusOnOpen: false
+    });
+
+    appendToBody();
+    const focusedElementBeforeOpen = document.activeElement;
+    await setOpen(true);
+
+    expect(focusedElementBeforeOpen).toBe(document.activeElement);
+  });
 });
 
 interface MountBaseModalOptions {
@@ -94,6 +142,8 @@ interface MountBaseModalOptions {
   defaultSlot?: string;
   /** Events that when emitted should open the modal. */
   open?: boolean;
+  /** Indicates if the focus changes to an element inside the modal when it opens. */
+  focusOnOpen?: boolean;
 }
 
 interface MountBaseModalAPI {
@@ -105,6 +155,8 @@ interface MountBaseModalAPI {
   getModalContent: () => Wrapper<Vue>;
   /** Fakes a click on the modal close. */
   closeModal: () => Promise<void>;
+  /** Appends the component's element the body. */
+  appendToBody: () => void;
   /** Fakes a focusin event in another HTMLElement of the body. */
   fakeFocusIn: () => Promise<void>;
 }

--- a/packages/x-components/src/components/modals/base-modal.vue
+++ b/packages/x-components/src/components/modals/base-modal.vue
@@ -33,6 +33,7 @@
   import { Component, Prop } from 'vue-property-decorator';
   import Fade from '../animations/fade.vue';
   import { NoElement } from '../no-element';
+  import { FOCUSABLE_SELECTORS } from '../../utils/focus';
 
   /**
    * Base component with no XPlugin dependencies that serves as a utility for constructing more
@@ -60,6 +61,13 @@
      */
     @Prop({ required: true })
     public open!: boolean;
+
+    /**
+     * Determines if the focused element changes to one inside the modal when it opens. Either the
+     * first element with a positive tabindex or just the first focusable element.
+     */
+    @Prop({ default: true })
+    public focusOnOpen!: boolean;
 
     /** The previous value of the body overflow style. */
     protected previousBodyOverflow = '';
@@ -92,6 +100,9 @@
         this.$on('hook:beforeDestroy', this.removeBodyListeners);
         this.$on('hook:beforeDestroy', this.enableScroll);
         /* eslint-enable @typescript-eslint/unbound-method */
+        if (this.focusOnOpen) {
+          this.setFocus();
+        }
       } else {
         this.enableScroll();
         this.removeBodyListeners();
@@ -166,6 +177,23 @@
       if (!this.$refs.modal.contains(event.target as HTMLElement)) {
         this.$emit('focusin:body', event);
       }
+    }
+
+    /**
+     * Sets the focused element to the first element either the first element with a positive
+     * tabindex or, if there isn't any, the first focusable element inside the modal.
+     *
+     * @internal
+     */
+    protected setFocus(): void {
+      const focusCandidates: HTMLElement[] = Array.from(
+        this.$refs.modal.querySelectorAll(FOCUSABLE_SELECTORS)
+      );
+
+      const elementToFocus =
+        focusCandidates.find(element => element.tabIndex) ?? focusCandidates[0];
+
+      elementToFocus?.focus();
     }
   }
 </script>

--- a/packages/x-components/src/services/directional-focus-navigation.service.ts
+++ b/packages/x-components/src/services/directional-focus-navigation.service.ts
@@ -1,3 +1,4 @@
+import { FOCUSABLE_SELECTORS } from '../utils/focus';
 import { ArrowKey } from '../utils/types';
 import {
   AbsoluteDistances,
@@ -82,8 +83,7 @@ export class DirectionalFocusNavigationService implements SpatialNavigation {
     /**
      * Comma separated focusable selectors to look up.
      */
-    // eslint-disable-next-line max-len
-    private readonly focusableSelectors: string = 'a, button, details, input, textarea, select, [tabindex]:not([tabindex="-1"])'
+    private readonly focusableSelectors = FOCUSABLE_SELECTORS
   ) {}
 
   /**

--- a/packages/x-components/src/utils/focus.ts
+++ b/packages/x-components/src/utils/focus.ts
@@ -1,5 +1,7 @@
 /**
  * Comma separated list of common focusable selectors.
+ *
+ * @public
  */
 /* eslint-disable max-len */
 export const FOCUSABLE_SELECTORS =

--- a/packages/x-components/src/utils/focus.ts
+++ b/packages/x-components/src/utils/focus.ts
@@ -1,0 +1,7 @@
+/**
+ * Comma separated list of common focusable selectors.
+ */
+/* eslint-disable max-len */
+export const FOCUSABLE_SELECTORS =
+  'a[href], button:not([disabled]), details, input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+/* eslint-enable max-len */

--- a/packages/x-components/src/utils/index.ts
+++ b/packages/x-components/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './clone';
 export * from './currency-formatter';
 export { debounce as debounceFunction } from './debounce';
 export * from './filters';
+export * from './focus';
 export * from './function';
 export * from './get-url-parameters';
 export * from './html';


### PR DESCRIPTION
EX-6755

## Motivation and context
When opening modals (namely the `MyHistory` one) the focus could still be behind the modal, which is weird.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
There are new unit tests for the new prop in the `base-modal` component.
