### PR TITLE
ci: silent jest and eslint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "lerna bootstrap --hoist && npm run build",
     "postci": "lerna bootstrap --hoist --ci && npm run build",
     "build": "lerna run build",
-    "lint": "eslint packages --ext .ts,.tsx,.vue",
+    "lint": "eslint packages --ext .ts,.tsx,.vue --quiet",
     "lint:fix": "eslint packages --ext .ts,.tsx,.vue --fix",
     "test": "lerna run test --parallel",
     "serve": "lerna run serve --parallel",

--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -48,7 +48,7 @@
     "gen:component-docs": "vue-docgen",
     "postbuild": "npm pack ./dist",
     "prepublishOnly": "npm run build",
-    "test:unit": "jest && npm run test:unit-cypress",
+    "test:unit": "cross-env NODE_ENV=production jest && npm run test:unit-cypress",
     "test:unit-jest": "jest",
     "test:unit-cypress": "cypress run-ct",
     "test:unit-coverage": "jest --coverage",

--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -48,7 +48,7 @@
     "gen:component-docs": "vue-docgen",
     "postbuild": "npm pack ./dist",
     "prepublishOnly": "npm run build",
-    "test:unit": "cross-env NODE_ENV=production jest && npm run test:unit-cypress",
+    "test:unit": "jest --silent && npm run test:unit-cypress",
     "test:unit-jest": "jest",
     "test:unit-cypress": "cypress run-ct",
     "test:unit-coverage": "jest --coverage",


### PR DESCRIPTION
Avoids jest from printing console statements (only our logs and in jest for the CI). This should avoid noise and speed up the tests as logging is suprisingly expensive. 