### PR TITLE
feat: make adapter configurable in home view

### DIFF
--- a/packages/x-components/src/adapter/e2e-adapter.ts
+++ b/packages/x-components/src/adapter/e2e-adapter.ts
@@ -47,7 +47,8 @@ export const e2eAdapter: XComponentsAdapter = {
   tagging: endpointAdapterFactory({
     endpoint: ({ url }) => url,
     requestMapper: ({ params }) => params,
-    httpClient: mockedFetchHttpClient,
+    httpClient:
+      'Cypress' in window ? mockedFetchHttpClient : () => Promise.resolve({}) as Promise<any>,
     defaultRequestOptions: {
       properties: { keepalive: true }
     }

--- a/packages/x-components/src/adapter/e2e-adapter.ts
+++ b/packages/x-components/src/adapter/e2e-adapter.ts
@@ -1,5 +1,6 @@
 import { XComponentsAdapter } from '@empathyco/x-types';
 import { EndpointAdapter, endpointAdapterFactory, HttpClient } from '@empathyco/x-adapter';
+import { responses } from './mocked-responses';
 
 /**
  * Mock fetch httpClient.
@@ -27,7 +28,10 @@ export function mockEndpointAdapter<Request, Response>(
 ): EndpointAdapter<Request, Response> {
   return endpointAdapterFactory<Request, Response>({
     endpoint: `https://api.empathy.co/${path}`,
-    httpClient: mockedFetchHttpClient
+    httpClient:
+      'Cypress' in window
+        ? mockedFetchHttpClient
+        : () => Promise.resolve(responses[path as keyof typeof responses]) as Promise<any>
   });
 }
 

--- a/packages/x-components/src/adapter/e2e-adapter.ts
+++ b/packages/x-components/src/adapter/e2e-adapter.ts
@@ -1,6 +1,6 @@
 import { XComponentsAdapter } from '@empathyco/x-types';
 import { EndpointAdapter, endpointAdapterFactory, HttpClient } from '@empathyco/x-adapter';
-import { responses } from './mocked-responses';
+import { mockedResponses } from './mocked-responses';
 
 /**
  * Mock fetch httpClient.
@@ -31,7 +31,8 @@ export function mockEndpointAdapter<Request, Response>(
     httpClient:
       'Cypress' in window
         ? mockedFetchHttpClient
-        : () => Promise.resolve(responses[path as keyof typeof responses]) as Promise<any>
+        : () =>
+            Promise.resolve(mockedResponses[path as keyof typeof mockedResponses]) as Promise<any>
   });
 }
 

--- a/packages/x-components/src/adapter/mocked-responses.ts
+++ b/packages/x-components/src/adapter/mocked-responses.ts
@@ -1,0 +1,211 @@
+import { SearchResponse } from '@empathyco/x-types';
+import {
+  createHierarchicalFacetStub,
+  createNextQueryStub,
+  createNumberRangeFacetStub,
+  createPopularSearch,
+  createQuerySuggestion,
+  createResultStub,
+  createSimpleFacetStub,
+  getFacetsStub,
+  getRelatedTagsStub,
+  getResultsStub
+} from '../__stubs__/index';
+
+export const mockedApiUrl = 'https://api.empathy.co';
+
+export const getIdentifierResultsEndpoint = `${mockedApiUrl}/identifier-results`;
+export const getRecommendationsEndpoint = `${mockedApiUrl}/recommendations`;
+export const getQuerySuggestionsEndpoint = `${mockedApiUrl}/query-suggestions`;
+export const getRelatedTagsEndpoint = `${mockedApiUrl}/related-tags`;
+export const getPopularSearchesEndpoint = `${mockedApiUrl}/popular-searches`;
+
+export const getNextQueriesEndpoint = `${mockedApiUrl}/next-queries`;
+export const searchEndpoint = `${mockedApiUrl}/search`;
+export const trackEndpoint = `${mockedApiUrl}/track`;
+
+export const responses = {
+  'identifier-results': {
+    results: [
+      createResultStub('A0255072 - 9788467577112 - 160000', {
+        images: ['https://picsum.photos/seed/20/100/100']
+      }),
+      createResultStub('A0273378 - 9788467579543 - 166664', {
+        images: ['https://picsum.photos/seed/21/100/100']
+      }),
+      createResultStub('A0291017 - 9788467579536 - 166663', {
+        images: ['https://picsum.photos/seed/22/100/100']
+      }),
+      createResultStub('A0246951 - 8437006044851 - 4001', {
+        images: ['https://picsum.photos/seed/23/100/100']
+      })
+    ]
+  },
+  'next-queries': {
+    nextQueries: [
+      createNextQueryStub('lego'),
+      createNextQueryStub('camion'),
+      createNextQueryStub('marvel')
+    ]
+  },
+  'popular-searches': {
+    suggestions: [
+      createPopularSearch('playmobil'),
+      createPopularSearch('lego'),
+      createPopularSearch('mochila'),
+      createPopularSearch('barbie'),
+      createPopularSearch('dinosaurio')
+    ]
+  },
+  'query-suggestions': {
+    suggestions: [
+      createQuerySuggestion('lego'),
+      createQuerySuggestion('lego marvel'),
+      createQuerySuggestion('lego friends'),
+      createQuerySuggestion('lego star wars'),
+      createQuerySuggestion('lego city'),
+      createQuerySuggestion('lego harry potter')
+    ]
+  },
+  recommendations: {
+    results: [
+      createResultStub('Piscina 3 Anillos'),
+      createResultStub('Among Us Figura Acción'),
+      createResultStub('Barbie Sirenas Dreamtopia')
+    ]
+  },
+  search: createSearchResponse({
+    facets: [
+      createSimpleFacetStub('brand_facet', createSimpleFilter => [
+        createSimpleFilter('Juguetes deportivos', false, 3),
+        createSimpleFilter('Puzzles', false, 0),
+        createSimpleFilter('Construcción', false, 7),
+        createSimpleFilter('Construye', false, 6),
+        createSimpleFilter('Disfraces', false, 0)
+      ]),
+      createNumberRangeFacetStub('price_facet', createNumberRangeFilter => [
+        createNumberRangeFilter({ min: 0, max: 10 }, false),
+        createNumberRangeFilter({ min: 10, max: 20 }, false),
+        createNumberRangeFilter({ min: 20, max: 30 }, false),
+        createNumberRangeFilter({ min: 30, max: 40 }, false),
+        createNumberRangeFilter({ min: 40, max: 60 }, false),
+        createNumberRangeFilter({ min: 60, max: 100 }, false)
+      ]),
+      createNumberRangeFacetStub('age_facet', createNumberRangeFilter => [
+        createNumberRangeFilter({ min: 0, max: 1 }, false),
+        createNumberRangeFilter({ min: 1, max: 3 }, false),
+        createNumberRangeFilter({ min: 3, max: 6 }, false),
+        createNumberRangeFilter({ min: 6, max: 9 }, false),
+        createNumberRangeFilter({ min: 9, max: 12 }, false),
+        createNumberRangeFilter({ min: 12, max: 99 }, false)
+      ]),
+      createHierarchicalFacetStub('hierarchical_category', createFilter => [
+        createFilter('Vehículos y pistas', false, createFilter => [
+          createFilter('Radiocontrol', false)
+        ]),
+        createFilter('Juguetes electrónicos', false, createFilter => [
+          createFilter('Imagen y audio', false)
+        ]),
+        createFilter('Educativos', false, createFilter => [
+          createFilter('Juguetes educativos', false)
+        ]),
+        createFilter('Creativos', false, createFilter => [createFilter('Crea', false)]),
+        createFilter('Muñecas', false, createFilter => [
+          createFilter('Peluches', false),
+          createFilter('Ropa y accesorios', false),
+          createFilter('Playsets', false),
+          createFilter('Bebés', false),
+          createFilter('Carros', false)
+        ]),
+        createFilter('Construcción', false, createFilter => [createFilter('Construye', false)])
+      ])
+    ],
+    results: [
+      createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
+        images: ['https://picsum.photos/seed/1/100/100'],
+        price: {
+          hasDiscount: false,
+          originalValue: 59.99,
+          value: 59.99
+        }
+      }),
+      createResultStub('LEGO Duplo Classic Caja de Ladrillos - 1091', {
+        images: ['https://picsum.photos/seed/2/100/100'],
+        price: {
+          hasDiscount: false,
+          originalValue: 29.99,
+          value: 29.99
+        }
+      }),
+      createResultStub('LEGO City Coche Patrulla de Policía - 60239', {
+        images: ['https://picsum.photos/seed/3/100/100'],
+        price: {
+          hasDiscount: false,
+          originalValue: 11.99,
+          value: 11.99
+        }
+      }),
+      createResultStub('LEGO City Police Caja de Ladrillos - 60270', {
+        images: ['https://picsum.photos/seed/4/100/100'],
+        price: {
+          hasDiscount: false,
+          originalValue: 39.99,
+          value: 39.99
+        }
+      }),
+      createResultStub('LEGO Friends Parque para Cachorros - 41396', {
+        images: ['https://picsum.photos/seed/5/100/100'],
+        price: {
+          hasDiscount: false,
+          originalValue: 11.99,
+          value: 11.99
+        }
+      }),
+      createResultStub('LEGO Creator Ciberdrón - 31111', {
+        images: ['https://picsum.photos/seed/6/100/100'],
+        price: {
+          hasDiscount: false,
+          originalValue: 11.99,
+          value: 11.99
+        }
+      }),
+      createResultStub('LEGO Technic Dragster - 42103', {
+        images: ['https://picsum.photos/seed/7/100/100'],
+        price: {
+          hasDiscount: false,
+          originalValue: 22.99,
+          value: 22.99
+        }
+      })
+    ],
+    totalResults: 7
+  }),
+  'related-tags': {
+    relatedTags: getRelatedTagsStub()
+  }
+};
+
+/**
+ * Creates a search response.
+ *
+ * @param partial - Partial search response to override default fields.
+ *
+ * @returns A complete search response object.
+ */
+export function createSearchResponse(partial?: Partial<SearchResponse>): SearchResponse {
+  return {
+    banners: [],
+    promoteds: [],
+    facets: getFacetsStub(),
+    results: getResultsStub(),
+    redirections: [],
+    partialResults: [],
+    totalResults: 24,
+    queryTagging: {
+      url: `${trackEndpoint}/query`,
+      params: { page: 1 }
+    },
+    spellcheck: '',
+    ...partial
+  };
+}

--- a/packages/x-components/src/adapter/mocked-responses.ts
+++ b/packages/x-components/src/adapter/mocked-responses.ts
@@ -24,7 +24,7 @@ export const getNextQueriesEndpoint = `${mockedApiUrl}/next-queries`;
 export const searchEndpoint = `${mockedApiUrl}/search`;
 export const trackEndpoint = `${mockedApiUrl}/track`;
 
-export const responses = {
+export const mockedResponses = {
   'identifier-results': {
     results: [
       createResultStub('A0255072 - 9788467577112 - 160000', {

--- a/packages/x-components/src/views/adapter.ts
+++ b/packages/x-components/src/views/adapter.ts
@@ -1,0 +1,11 @@
+import { PlatformAdapter, platformAdapter } from '@empathyco/x-adapter-platform';
+import { e2eAdapter } from '../adapter/e2e-adapter';
+
+export const adapterConfig = {
+  e2e: false
+};
+
+export const adapter = new Proxy(platformAdapter, {
+  get: (obj: PlatformAdapter, prop: keyof PlatformAdapter) =>
+    adapterConfig.e2e ? e2eAdapter[prop] : obj[prop]
+});

--- a/packages/x-components/src/views/adapter.ts
+++ b/packages/x-components/src/views/adapter.ts
@@ -2,7 +2,7 @@ import { PlatformAdapter, platformAdapter } from '@empathyco/x-adapter-platform'
 import { e2eAdapter } from '../adapter/e2e-adapter';
 
 export const adapterConfig = {
-  e2e: false
+  e2e: 'Cypress' in window ? true : false
 };
 
 export const adapter = new Proxy(platformAdapter, {

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -1,7 +1,6 @@
-import { platformAdapter } from '@empathyco/x-adapter-platform';
 import { SnippetConfig } from '../x-installer/api/api.types';
 import { InstallXOptions } from '../x-installer/x-installer/types';
-import { e2eAdapter } from '../adapter/e2e-adapter';
+import { adapter } from './adapter';
 
 export const baseSnippetConfig: SnippetConfig = {
   instance: 'empathy',
@@ -9,8 +8,6 @@ export const baseSnippetConfig: SnippetConfig = {
   env: 'staging',
   scope: 'x-components-development'
 };
-
-const adapter = 'Cypress' in window ? e2eAdapter : platformAdapter;
 
 const xModulesURLConfig = JSON.parse(new URL(location.href).searchParams.get('xModules') ?? '{}');
 

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -8,16 +8,6 @@
     <OpenMainModal>Start</OpenMainModal>
     <h1 class="x-font-bold x-text-4xl x-text-primary-50 x-leading-[1.5]">Test controls</h1>
     <ul class="x-test-controls x-list x-list--gap-05">
-      <label for="searchInput.instant">
-        Use e2e adapter
-        <input
-          v-model="controls.adapter.useE2EAdapter"
-          @change="changeAdapter"
-          id="adapter.e2eAdapter"
-          type="checkbox"
-          data-test="adapter-e2e"
-        />
-      </label>
       <li class="x-test-controls__item x-list__item">
         <label for="searchInput.instant">
           search-input - instant
@@ -70,6 +60,18 @@
             id="historyQueries.maxItemsToRender"
             type="number"
             data-test="history-queries-max-to-render"
+          />
+        </label>
+      </li>
+      <li class="x-test-controls__item x-list__item">
+        <label for="adapter.e2eAdapter">
+          Use mocked adapter
+          <input
+            v-model="controls.adapter.useE2EAdapter"
+            @change="changeAdapter"
+            id="adapter.e2eAdapter"
+            type="checkbox"
+            data-test="adapter-e2e"
           />
         </label>
       </li>

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -68,7 +68,7 @@
           Use mocked adapter
           <input
             v-model="controls.adapter.useE2EAdapter"
-            @change="changeAdapter"
+            @change="toggleE2EAdapter"
             id="adapter.e2eAdapter"
             type="checkbox"
             data-test="adapter-e2e"
@@ -520,7 +520,7 @@
       }
     };
 
-    changeAdapter(): void {
+    toggleE2EAdapter(): void {
       adapterConfig.e2e = !adapterConfig.e2e;
     }
   }

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -8,6 +8,16 @@
     <OpenMainModal>Start</OpenMainModal>
     <h1 class="x-font-bold x-text-4xl x-text-primary-50 x-leading-[1.5]">Test controls</h1>
     <ul class="x-test-controls x-list x-list--gap-05">
+      <label for="searchInput.instant">
+        Use e2e adapter
+        <input
+          v-model="controls.adapter.useE2EAdapter"
+          @change="changeAdapter"
+          id="adapter.e2eAdapter"
+          type="checkbox"
+          data-test="adapter-e2e"
+        />
+      </label>
       <li class="x-test-controls__item x-list__item">
         <label for="searchInput.instant">
           search-input - instant
@@ -400,6 +410,7 @@
   import CloseMainModal from '../../components/modals/close-main-modal.vue';
   import BaseKeyboardNavigation from '../../components/base-keyboard-navigation.vue';
   import { XProvide } from '../../components/decorators/injection.decorators';
+  import { adapterConfig } from '../adapter';
   import Aside from './aside.vue';
   import PredictiveLayer from './predictive-layer.vue';
   import Result from './result.vue';
@@ -501,8 +512,15 @@
       },
       historyQueries: {
         maxItemsToRender: 5
+      },
+      adapter: {
+        useE2EAdapter: false
       }
     };
+
+    changeAdapter(): void {
+      adapterConfig.e2e = !adapterConfig.e2e;
+    }
   }
 </script>
 

--- a/packages/x-components/src/views/home/types.ts
+++ b/packages/x-components/src/views/home/types.ts
@@ -12,4 +12,7 @@ export interface HomeControls {
   historyQueries: {
     maxItemsToRender: number;
   };
+  adapter: {
+    useE2EAdapter: boolean;
+  };
 }

--- a/packages/x-components/tests/e2e/common/mocked-responses.spec.ts
+++ b/packages/x-components/tests/e2e/common/mocked-responses.spec.ts
@@ -28,7 +28,7 @@ import {
   getQuerySuggestionsEndpoint,
   getRecommendationsEndpoint,
   getRelatedTagsEndpoint,
-  responses,
+  mockedResponses,
   searchEndpoint,
   trackEndpoint
 } from '../../../src/adapter/mocked-responses';
@@ -44,7 +44,7 @@ Given('an ID results API', () => {
 
 Given('an ID results API with a known response', () => {
   cy.intercept(getIdentifierResultsEndpoint, req => {
-    req.reply(<IdentifierResultsResponse>responses['identifier-results']);
+    req.reply(<IdentifierResultsResponse>mockedResponses['identifier-results']);
   }).as('interceptedIDResults');
 });
 
@@ -67,7 +67,7 @@ Given('a next queries API', () => {
 
 Given('a next queries API with a known response', () => {
   cy.intercept(getNextQueriesEndpoint, req => {
-    req.reply(<NextQueriesResponse>responses['next-queries']);
+    req.reply(<NextQueriesResponse>mockedResponses['next-queries']);
   }).as('interceptedNextQueries');
 });
 
@@ -129,14 +129,14 @@ Given('a results API with partial results', () => {
 // Popular Searches
 Given('a popular searches API with a known response', () => {
   cy.intercept(getPopularSearchesEndpoint, req => {
-    req.reply(<PopularSearchesResponse>responses['popular-searches']);
+    req.reply(<PopularSearchesResponse>mockedResponses['popular-searches']);
   }).as('interceptedPopularSearches');
 });
 
 // Query Suggestions
 Given('a query suggestions API with a known response', () => {
   cy.intercept(getQuerySuggestionsEndpoint, req => {
-    req.reply(<QuerySuggestionsResponse>responses['query-suggestions']);
+    req.reply(<QuerySuggestionsResponse>mockedResponses['query-suggestions']);
   }).as('interceptedQuerySuggestions');
 });
 
@@ -151,14 +151,14 @@ Given('a query suggestions API with no query suggestions', () => {
 // Recommendations
 Given('a recommendations API with a known response', () => {
   cy.intercept(getRecommendationsEndpoint, req => {
-    req.reply(<RecommendationsResponse>responses.recommendations);
+    req.reply(<RecommendationsResponse>mockedResponses.recommendations);
   }).as('interceptedRecommendations');
 });
 
 // Related Tags
 Given('a related tags API', () => {
   cy.intercept(getRelatedTagsEndpoint, req => {
-    req.reply(<RelatedTagsResponse>responses['related-tags']);
+    req.reply(<RelatedTagsResponse>mockedResponses['related-tags']);
   });
 });
 
@@ -189,7 +189,7 @@ Given('a second related tags API with a known response', () => {
 // Results
 Given('a results API with a known response', () => {
   cy.intercept(searchEndpoint, req => {
-    req.reply(responses.search);
+    req.reply(mockedResponses.search);
   }).as('interceptedResults');
 });
 

--- a/packages/x-components/tests/e2e/common/mocked-responses.spec.ts
+++ b/packages/x-components/tests/e2e/common/mocked-responses.spec.ts
@@ -11,35 +11,27 @@ import {
 } from '@empathyco/x-types';
 import {
   createBannerStub,
-  createHierarchicalFacetStub,
-  createNextQueryStub,
-  createNumberRangeFacetStub,
-  createPopularSearch,
   createPromotedStub,
-  createQuerySuggestion,
   createRedirectionStub,
   createRelatedTagStub,
   createResultStub,
-  createSimpleFacetStub,
-  getFacetsStub,
   getNextQueriesStub,
   getPopularSearchesStub,
   getQuerySuggestionsStub,
-  getRelatedTagsStub,
   getResultsStub
 } from '../../../src/__stubs__/index';
-
-const mockedApiUrl = 'https://api.empathy.co';
-
-const getIdentifierResultsEndpoint = `${mockedApiUrl}/identifier-results`;
-const getRecommendationsEndpoint = `${mockedApiUrl}/recommendations`;
-const getQuerySuggestionsEndpoint = `${mockedApiUrl}/query-suggestions`;
-const getRelatedTagsEndpoint = `${mockedApiUrl}/related-tags`;
-const getPopularSearchesEndpoint = `${mockedApiUrl}/popular-searches`;
-
-const getNextQueriesEndpoint = `${mockedApiUrl}/next-queries`;
-const searchEndpoint = `${mockedApiUrl}/search`;
-const trackEndpoint = `${mockedApiUrl}/track`;
+import {
+  createSearchResponse,
+  getIdentifierResultsEndpoint,
+  getNextQueriesEndpoint,
+  getPopularSearchesEndpoint,
+  getQuerySuggestionsEndpoint,
+  getRecommendationsEndpoint,
+  getRelatedTagsEndpoint,
+  responses,
+  searchEndpoint,
+  trackEndpoint
+} from '../../../src/adapter/mocked-responses';
 
 // ID Results
 Given('an ID results API', () => {
@@ -52,22 +44,7 @@ Given('an ID results API', () => {
 
 Given('an ID results API with a known response', () => {
   cy.intercept(getIdentifierResultsEndpoint, req => {
-    req.reply(<IdentifierResultsResponse>{
-      results: [
-        createResultStub('A0255072 - 9788467577112 - 160000', {
-          images: ['https://picsum.photos/seed/20/100/100']
-        }),
-        createResultStub('A0273378 - 9788467579543 - 166664', {
-          images: ['https://picsum.photos/seed/21/100/100']
-        }),
-        createResultStub('A0291017 - 9788467579536 - 166663', {
-          images: ['https://picsum.photos/seed/22/100/100']
-        }),
-        createResultStub('A0246951 - 8437006044851 - 4001', {
-          images: ['https://picsum.photos/seed/23/100/100']
-        })
-      ]
-    });
+    req.reply(<IdentifierResultsResponse>responses['identifier-results']);
   }).as('interceptedIDResults');
 });
 
@@ -90,13 +67,7 @@ Given('a next queries API', () => {
 
 Given('a next queries API with a known response', () => {
   cy.intercept(getNextQueriesEndpoint, req => {
-    req.reply(<NextQueriesResponse>{
-      nextQueries: [
-        createNextQueryStub('lego'),
-        createNextQueryStub('camion'),
-        createNextQueryStub('marvel')
-      ]
-    });
+    req.reply(<NextQueriesResponse>responses['next-queries']);
   }).as('interceptedNextQueries');
 });
 
@@ -158,31 +129,14 @@ Given('a results API with partial results', () => {
 // Popular Searches
 Given('a popular searches API with a known response', () => {
   cy.intercept(getPopularSearchesEndpoint, req => {
-    req.reply(<PopularSearchesResponse>{
-      suggestions: [
-        createPopularSearch('playmobil'),
-        createPopularSearch('lego'),
-        createPopularSearch('mochila'),
-        createPopularSearch('barbie'),
-        createPopularSearch('dinosaurio')
-      ]
-    });
+    req.reply(<PopularSearchesResponse>responses['popular-searches']);
   }).as('interceptedPopularSearches');
 });
 
 // Query Suggestions
 Given('a query suggestions API with a known response', () => {
   cy.intercept(getQuerySuggestionsEndpoint, req => {
-    req.reply(<QuerySuggestionsResponse>{
-      suggestions: [
-        createQuerySuggestion('lego'),
-        createQuerySuggestion('lego marvel'),
-        createQuerySuggestion('lego friends'),
-        createQuerySuggestion('lego star wars'),
-        createQuerySuggestion('lego city'),
-        createQuerySuggestion('lego harry potter')
-      ]
-    });
+    req.reply(<QuerySuggestionsResponse>responses['query-suggestions']);
   }).as('interceptedQuerySuggestions');
 });
 
@@ -197,22 +151,14 @@ Given('a query suggestions API with no query suggestions', () => {
 // Recommendations
 Given('a recommendations API with a known response', () => {
   cy.intercept(getRecommendationsEndpoint, req => {
-    req.reply(<RecommendationsResponse>{
-      results: [
-        createResultStub('Piscina 3 Anillos'),
-        createResultStub('Among Us Figura Acción'),
-        createResultStub('Barbie Sirenas Dreamtopia')
-      ]
-    });
+    req.reply(<RecommendationsResponse>responses.recommendations);
   }).as('interceptedRecommendations');
 });
 
 // Related Tags
 Given('a related tags API', () => {
   cy.intercept(getRelatedTagsEndpoint, req => {
-    req.reply(<RelatedTagsResponse>{
-      relatedTags: getRelatedTagsStub()
-    });
+    req.reply(<RelatedTagsResponse>responses['related-tags']);
   });
 });
 
@@ -243,114 +189,7 @@ Given('a second related tags API with a known response', () => {
 // Results
 Given('a results API with a known response', () => {
   cy.intercept(searchEndpoint, req => {
-    req.reply(
-      createSearchResponse({
-        facets: [
-          createSimpleFacetStub('brand_facet', createSimpleFilter => [
-            createSimpleFilter('Juguetes deportivos', false, 3),
-            createSimpleFilter('Puzzles', false, 0),
-            createSimpleFilter('Construcción', false, 7),
-            createSimpleFilter('Construye', false, 6),
-            createSimpleFilter('Disfraces', false, 0)
-          ]),
-          createNumberRangeFacetStub('price_facet', createNumberRangeFilter => [
-            createNumberRangeFilter({ min: 0, max: 10 }, false),
-            createNumberRangeFilter({ min: 10, max: 20 }, false),
-            createNumberRangeFilter({ min: 20, max: 30 }, false),
-            createNumberRangeFilter({ min: 30, max: 40 }, false),
-            createNumberRangeFilter({ min: 40, max: 60 }, false),
-            createNumberRangeFilter({ min: 60, max: 100 }, false)
-          ]),
-          createNumberRangeFacetStub('age_facet', createNumberRangeFilter => [
-            createNumberRangeFilter({ min: 0, max: 1 }, false),
-            createNumberRangeFilter({ min: 1, max: 3 }, false),
-            createNumberRangeFilter({ min: 3, max: 6 }, false),
-            createNumberRangeFilter({ min: 6, max: 9 }, false),
-            createNumberRangeFilter({ min: 9, max: 12 }, false),
-            createNumberRangeFilter({ min: 12, max: 99 }, false)
-          ]),
-          createHierarchicalFacetStub('hierarchical_category', createFilter => [
-            createFilter('Vehículos y pistas', false, createFilter => [
-              createFilter('Radiocontrol', false)
-            ]),
-            createFilter('Juguetes electrónicos', false, createFilter => [
-              createFilter('Imagen y audio', false)
-            ]),
-            createFilter('Educativos', false, createFilter => [
-              createFilter('Juguetes educativos', false)
-            ]),
-            createFilter('Creativos', false, createFilter => [createFilter('Crea', false)]),
-            createFilter('Muñecas', false, createFilter => [
-              createFilter('Peluches', false),
-              createFilter('Ropa y accesorios', false),
-              createFilter('Playsets', false),
-              createFilter('Bebés', false),
-              createFilter('Carros', false)
-            ]),
-            createFilter('Construcción', false, createFilter => [createFilter('Construye', false)])
-          ])
-        ],
-        results: [
-          createResultStub('LEGO Super Mario Pack Inicial: Aventuras con Mario - 71360', {
-            images: ['https://picsum.photos/seed/1/100/100'],
-            price: {
-              hasDiscount: false,
-              originalValue: 59.99,
-              value: 59.99
-            }
-          }),
-          createResultStub('LEGO Duplo Classic Caja de Ladrillos - 1091', {
-            images: ['https://picsum.photos/seed/2/100/100'],
-            price: {
-              hasDiscount: false,
-              originalValue: 29.99,
-              value: 29.99
-            }
-          }),
-          createResultStub('LEGO City Coche Patrulla de Policía - 60239', {
-            images: ['https://picsum.photos/seed/3/100/100'],
-            price: {
-              hasDiscount: false,
-              originalValue: 11.99,
-              value: 11.99
-            }
-          }),
-          createResultStub('LEGO City Police Caja de Ladrillos - 60270', {
-            images: ['https://picsum.photos/seed/4/100/100'],
-            price: {
-              hasDiscount: false,
-              originalValue: 39.99,
-              value: 39.99
-            }
-          }),
-          createResultStub('LEGO Friends Parque para Cachorros - 41396', {
-            images: ['https://picsum.photos/seed/5/100/100'],
-            price: {
-              hasDiscount: false,
-              originalValue: 11.99,
-              value: 11.99
-            }
-          }),
-          createResultStub('LEGO Creator Ciberdrón - 31111', {
-            images: ['https://picsum.photos/seed/6/100/100'],
-            price: {
-              hasDiscount: false,
-              originalValue: 11.99,
-              value: 11.99
-            }
-          }),
-          createResultStub('LEGO Technic Dragster - 42103', {
-            images: ['https://picsum.photos/seed/7/100/100'],
-            price: {
-              hasDiscount: false,
-              originalValue: 22.99,
-              value: 22.99
-            }
-          })
-        ],
-        totalResults: 7
-      })
-    );
+    req.reply(responses.search);
   }).as('interceptedResults');
 });
 
@@ -489,30 +328,6 @@ Given('a results API with a redirection', () => {
 And('waiting for search request intercept', () => {
   cy.intercept('https://api.empathy.co/search').as('requestWithFilter');
 });
-
-/**
- * Creates a search response.
- *
- * @param partial - Partial search response to override default fields.
- * @returns A complete search response object.
- */
-function createSearchResponse(partial?: Partial<SearchResponse>): SearchResponse {
-  return {
-    banners: [],
-    promoteds: [],
-    facets: getFacetsStub(),
-    results: getResultsStub(),
-    redirections: [],
-    partialResults: [],
-    totalResults: 24,
-    queryTagging: {
-      url: `${trackEndpoint}/query`,
-      params: { page: 1 }
-    },
-    spellcheck: '',
-    ...partial
-  };
-}
 
 // Spellcheck
 Given('a results API response for a misspelled word', () => {


### PR DESCRIPTION
EX-7073

The `e2eAdapter` can't be used outside cypress directly. This adapter makes requests that cypress will intercept and resolve with mocked data. In order to workaround this issue, in this PR I prevent the `e2eAdapter` from using the [mockedFetchHttpClient](https://github.com/empathyco/x/blob/feature/EX-7072-make-adapter-configurable-in-home-view/packages/x-components/src/adapter/e2e-adapter.ts#L12) if we are not in a cypress environment and return the mocked data instead.

Note: if you see an error regarding the `SlidingQueryPreview` complaining about the missing location, this will be fixed in #746 