### PR TITLE
Feature/ex 7049 debounce query preview requests

### DIFF
--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
@@ -274,7 +274,7 @@ describe('query preview', () => {
       // Emulates user is typing a new query
       await wrapper.setProps({ query: 'secall' }); // Timer relaunched
 
-      jest.advanceTimersByTime(1);
+      jest.advanceTimersByTime(249);
       expect(queryPreviewRequestChangedSpy).toHaveBeenCalledTimes(1);
 
       await wrapper.setProps({ query: 'secallona' }); // Timer relaunched
@@ -298,10 +298,11 @@ describe('query preview', () => {
         query: 'bull'
       });
 
-      jest.advanceTimersByTime(100);
+      jest.advanceTimersByTime(249);
       expect(queryPreviewRequestChangedSpy).toHaveBeenCalledTimes(0);
 
-      await wrapper.setProps({ debounceTimeMs: 100 }); // Timer relaunched
+      // Updating the debounce time aborts previous running timers
+      await wrapper.setProps({ debounceTimeMs: 100 });
       jest.advanceTimersByTime(99);
       expect(queryPreviewRequestChangedSpy).toHaveBeenCalledTimes(0);
 

--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
@@ -225,6 +225,12 @@ describe('query preview', () => {
 
     expect(wrapper.html()).toEqual('');
   });
+
+  describe('debounce', () => {
+    it('requests immediately when debounce is set to 0', () => {});
+    it('does not emit subsequent requests that happen in less than the debounce time', () => {});
+    it('updates the debounced request reactively when the prop value changes', () => {});
+  });
 });
 
 interface RenderQueryPreviewOptions {

--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
@@ -22,7 +22,12 @@ describe('query preview', () => {
     location,
     queryFeature,
     debounceTimeMs,
-    template = `<QueryPreview v-bind="$attrs" />`,
+    template = `<QueryPreview
+                  :debounceTimeMs="debounceTimeMs"
+                  :maxItemsToRender="maxItemsToRender"
+                  :query="query"
+                  :queryFeature="queryFeature"
+                />`,
     queryPreview = {
       request: {
         query
@@ -52,6 +57,7 @@ describe('query preview', () => {
 
     const wrapper = mount(
       {
+        props: ['debounceTimeMs', 'maxItemsToRender', 'query', 'queryFeature'],
         components: { QueryPreview },
         template,
         provide: {

--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
@@ -22,12 +22,7 @@ describe('query preview', () => {
     location,
     queryFeature,
     debounceTimeMs,
-    template = `<QueryPreview
-                  :debounceTimeMs="debounceTimeMs"
-                  :maxItemsToRender="maxItemsToRender"
-                  :query="query"
-                  :queryFeature="queryFeature"
-                />`,
+    template = `<QueryPreview v-bind="$attrs" />`,
     queryPreview = {
       request: {
         query
@@ -57,7 +52,6 @@ describe('query preview', () => {
 
     const wrapper = mount(
       {
-        props: ['debounceTimeMs', 'maxItemsToRender', 'query', 'queryFeature'],
         components: { QueryPreview },
         template,
         provide: {
@@ -176,7 +170,7 @@ describe('query preview', () => {
   it('exposes the query, the results and the totalResults in the default slot', () => {
     const template = `
       <QueryPreview
-          :query="query"
+          :query="$attrs.query"
           #default="{ results, query, totalResults}">
         <div>
           <span data-test="query-preview-query">{{ query }}</span>
@@ -207,7 +201,7 @@ describe('query preview', () => {
 
   it('allows changing the result content', () => {
     const template = `
-      <QueryPreview :query="query" #result="{ result }">
+      <QueryPreview :query="$attrs.query" #result="{ result }">
         <span data-test="result-content">{{result.id}} - {{result.name}}</span>
       </QueryPreview>
     `;
@@ -349,7 +343,7 @@ interface RenderQueryPreviewAPI {
   /** The Vue testing utils wrapper for the {@link QueryPreview} component. */
   wrapper: Wrapper<Vue>;
   /** A Jest spy set in the {@link XPlugin} `on` function. */
-  queryPreviewRequestChangedSpy?: jest.Mock<any, any>;
+  queryPreviewRequestChangedSpy?: jest.Mock;
   /** The query for which preview its results. */
   query: string;
   /** The results preview for the passed query. */

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -48,7 +48,6 @@
   import { createOrigin } from '../../../utils/origin';
   import { debounce } from '../../../utils/debounce';
   import { DebouncedFunction } from '../../../utils';
-  import { XEmit } from '../../../components';
 
   /**
    * Retrieves a preview of the results of a query and exposes them in the default slot,

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -48,6 +48,7 @@
   import { createOrigin } from '../../../utils/origin';
   import { debounce } from '../../../utils/debounce';
   import { DebouncedFunction } from '../../../utils';
+  import { XEmit } from '../../../components';
 
   /**
    * Retrieves a preview of the results of a query and exposes them in the default slot,
@@ -73,8 +74,8 @@
     })
     protected query!: string;
 
-    /**.
-     *  The origin property for the request
+    /**
+     * The origin property for the request.
      *
      * @public
      */
@@ -139,15 +140,15 @@
      * @internal
      */
     @Inject()
-    public location?: FeatureLocation;
+    protected location?: FeatureLocation;
 
     /**
      * The computed request object to be used to retrieve the query preview results.
      *
      * @returns The search request object.
-     * @public
+     * @internal
      */
-    public get queryPreviewRequest(): SearchRequest {
+    protected get queryPreviewRequest(): SearchRequest {
       const origin = createOrigin({
         feature: this.queryFeature,
         location: this.location
@@ -165,14 +166,19 @@
      * The debounce method to trigger the request after the debounceTimeMs defined.
      *
      * @returns The search request object.
-     * @public
+     * @internal
      */
-    public get emitQueryPreviewRequestChanged(): DebouncedFunction<[SearchRequest]> {
+    protected get emitQueryPreviewRequestChanged(): DebouncedFunction<[SearchRequest]> {
       return debounce(request => {
         this.$x.emit('QueryPreviewRequestChanged', request);
       }, this.debounceTimeMs);
     }
 
+    /**
+     * Initialises watcher to emit debounced requests, and first value for the requests.
+     *
+     * @internal
+     */
     protected created(): void {
       this.$watch(
         () => this.queryPreviewRequest,
@@ -184,6 +190,8 @@
     /**
      * Cancels the (remaining) requests when the component is destroyed
      * via the debounce.cancel() method.
+     *
+     * @internal
      */
     protected beforeDestroy(): void {
       this.emitQueryPreviewRequestChanged.cancel();
@@ -194,6 +202,7 @@
      *
      * @param _new - The new request.
      * @param old - The previous request.
+     * @internal
      */
     @Watch('emitQueryPreviewRequestChanged')
     protected cancelEmitPreviewRequestChanged(

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -138,7 +138,7 @@
      *
      * @internal
      */
-    @Inject()
+    @Inject({ default: undefined })
     protected location?: FeatureLocation;
 
     /**
@@ -197,10 +197,11 @@
     }
 
     /**
-     * Cancels the previous request when there is a new one.
+     * Cancels the previous request when the debounced function changes (e.g: the debounceTimeMs
+     * prop changes or there is a request in progress that cancels it).
      *
-     * @param _new - The new request.
-     * @param old - The previous request.
+     * @param _new - The new debounced function.
+     * @param old - The previous debounced function.
      * @internal
      */
     @Watch('emitQueryPreviewRequestChanged')

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -188,7 +188,7 @@
 
     /**
      * Cancels the (remaining) requests when the component is destroyed
-     * via the debounce.cancel() method.
+     * via the `debounce.cancel()` method.
      *
      * @internal
      */


### PR DESCRIPTION
[EX-7049](https://searchbroker.atlassian.net/browse/EX-7049)

Adds a debounce to the query preview requests. This makes the component usable for use cases such as search preview, where it would receive the input query, and trigger a small request as a preview.
