### PR TITLE
fix: Initial immediate requests now wait for the extra params to be p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27900,7 +27900,7 @@
     },
     "packages/eslint-plugin-x": {
       "name": "@empathyco/eslint-plugin-x",
-      "version": "2.0.0-alpha.13",
+      "version": "2.0.0-alpha.14",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/x-components/src/plugins/__tests__/x-plugin-emitters.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-emitters.spec.ts
@@ -156,7 +156,7 @@ describe('testing X Plugin emitters', () => {
     };
 
     // eslint-disable-next-line max-len
-    it('should not execute wires with immediate `false` when the module is registered', async () => {
+    it('should not execute wires with immediate `false` when the module is registered', () => {
       const pluginOptions: XPluginOptions = {
         adapter: XComponentsAdapterDummy,
         xModules: {
@@ -180,12 +180,12 @@ describe('testing X Plugin emitters', () => {
 
       /* Emitters relies on Vue watcher that are async. We need to wait a cycle before testing if
          they have emitted or not. */
-      await Promise.resolve();
+      jest.runAllTimers();
 
       expect(testWire).not.toHaveBeenCalled();
     });
 
-    it('should execute wires with immediate `true` when the module is registered', async () => {
+    it('should execute wires with immediate `true` when the module is registered', () => {
       const pluginOptions: XPluginOptions = {
         adapter: XComponentsAdapterDummy,
         xModules: {
@@ -211,7 +211,7 @@ describe('testing X Plugin emitters', () => {
 
       /* Emitters relies on Vue watcher that are async. We need to wait a cycle before testing if
        they have emitted or not. */
-      await Promise.resolve();
+      jest.advanceTimersByTime(0);
 
       expect(testWire).toHaveBeenCalled();
     });

--- a/packages/x-components/src/plugins/x-emitters.ts
+++ b/packages/x-components/src/plugins/x-emitters.ts
@@ -30,26 +30,18 @@ export function registerStoreEmitters(
       event
     );
 
-    const emit = (
-      value: XEventPayload<typeof event>,
-      oldValue?: XEventPayload<typeof event>
-    ): void => {
-      bus.emit(event, value, { moduleName: name, oldValue });
-    };
     const watcherSelector = (): XEventPayload<typeof event> =>
       selector(store.state.x[name], safeGettersProxy);
     const debouncedEffect = debounceWatcherEffect(event, (newValue, oldValue) => {
       if (filter(newValue, oldValue)) {
-        emit(newValue, oldValue);
+        bus.emit(event, newValue, { moduleName: name, oldValue });
       }
     });
 
     store.watch(watcherSelector, debouncedEffect, options);
 
     if (immediate) {
-      Promise.resolve().then(() => {
-        emit(watcherSelector());
-      });
+      debouncedEffect(watcherSelector());
     }
   });
 }

--- a/packages/x-components/src/plugins/x-emitters.ts
+++ b/packages/x-components/src/plugins/x-emitters.ts
@@ -32,16 +32,16 @@ export function registerStoreEmitters(
 
     const watcherSelector = (): XEventPayload<typeof event> =>
       selector(store.state.x[name], safeGettersProxy);
-    const debouncedEffect = debounceWatcherEffect(event, (newValue, oldValue) => {
+    const emit = debounceWatcherEffect(event, (newValue, oldValue) => {
       if (filter(newValue, oldValue)) {
         bus.emit(event, newValue, { moduleName: name, oldValue });
       }
     });
 
-    store.watch(watcherSelector, debouncedEffect, options);
+    store.watch(watcherSelector, emit, options);
 
     if (immediate) {
-      debouncedEffect(watcherSelector());
+      emit(watcherSelector());
     }
   });
 }

--- a/packages/x-components/tests/e2e/common/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/common/common-steps.spec.ts
@@ -254,6 +254,14 @@ Then(
   }
 );
 
+Then('search request contains sort parameter with value {string}', (value: string) => {
+  cy.wait('@interceptedResults')
+    .its('request.body')
+    .should((body: string) => {
+      expect(JSON.parse(body)).to.have.property('sort', value === 'default' ? '' : value);
+    });
+});
+
 Then(
   'search request contains extra parameter {string} with value {string}',
   (key: string, value: string) => {

--- a/packages/x-components/tests/e2e/common/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/common/common-steps.spec.ts
@@ -249,7 +249,7 @@ Then(
     cy.wait('@interceptedResults')
       .its('request.body')
       .should((body: string) => {
-        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+        expect(JSON.parse(body)).to.have.property(key, value);
       });
   }
 );

--- a/packages/x-components/tests/e2e/common/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/common/common-steps.spec.ts
@@ -264,6 +264,28 @@ Then(
   }
 );
 
+Then(
+  'recommendations request contains extra parameter {string} with value {string}',
+  (key: string, value: string) => {
+    cy.wait('@interceptedRecommendations')
+      .its('request.body')
+      .then(JSON.parse)
+      .its('extraParams')
+      .should('have.property', key, value);
+  }
+);
+
+Then(
+  'popular searches request contains extra parameter {string} with value {string}',
+  (key: string, value: string) => {
+    cy.wait('@interceptedPopularSearches')
+      .its('request.body')
+      .then(JSON.parse)
+      .its('extraParams')
+      .should('have.property', key, value);
+  }
+);
+
 When('the page is reloaded', () => {
   cy.reload();
 });

--- a/packages/x-components/tests/e2e/common/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/common/common-steps.spec.ts
@@ -257,11 +257,9 @@ Then(
 Then(
   'search request contains extra parameter {string} with value {string}',
   (key: string, value: string) => {
-    cy.wait('@interceptedResults')
-      .its('request.body')
-      .should((body: string) => {
-        expect(JSON.parse(body).extraParams).to.have.property(key, value);
-      });
+    cy.wait('@interceptedResults').should(intercept => {
+      expect(JSON.parse(intercept.request.body).extraParams).to.have.property(key, value);
+    });
   }
 );
 
@@ -280,6 +278,39 @@ Then(
   'popular searches request contains extra parameter {string} with value {string}',
   (key: string, value: string) => {
     cy.wait('@interceptedPopularSearches')
+      .its('request.body')
+      .should((body: string) => {
+        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+      });
+  }
+);
+
+Then(
+  'next queries request contains extra parameter {string} with value {string}',
+  (key: string, value: string) => {
+    cy.wait('@interceptedNextQueries')
+      .its('request.body')
+      .should((body: string) => {
+        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+      });
+  }
+);
+
+Then(
+  'related tags request contains extra parameter {string} with value {string}',
+  (key: string, value: string) => {
+    cy.wait('@interceptedRelatedTags')
+      .its('request.body')
+      .should((body: string) => {
+        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+      });
+  }
+);
+
+Then(
+  'query suggestions request contains extra parameter {string} with value {string}',
+  (key: string, value: string) => {
+    cy.wait('@interceptedQuerySuggestions')
       .its('request.body')
       .should((body: string) => {
         expect(JSON.parse(body).extraParams).to.have.property(key, value);

--- a/packages/x-components/tests/e2e/common/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/common/common-steps.spec.ts
@@ -257,9 +257,11 @@ Then(
 Then(
   'search request contains extra parameter {string} with value {string}',
   (key: string, value: string) => {
-    cy.wait('@interceptedResults').should(intercept => {
-      expect(JSON.parse(intercept.request.body).extraParams).to.have.property(key, value);
-    });
+    cy.wait('@interceptedResults')
+      .its('request.body')
+      .should((body: string) => {
+        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+      });
   }
 );
 

--- a/packages/x-components/tests/e2e/common/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/common/common-steps.spec.ts
@@ -248,8 +248,9 @@ Then(
   (key: string, value: string) => {
     cy.wait('@interceptedResults')
       .its('request.body')
-      .then(JSON.parse)
-      .should('have.property', key, value === 'default' ? '' : value);
+      .should((body: string) => {
+        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+      });
   }
 );
 
@@ -258,9 +259,9 @@ Then(
   (key: string, value: string) => {
     cy.wait('@interceptedResults')
       .its('request.body')
-      .then(JSON.parse)
-      .its('extraParams')
-      .should('have.property', key, value);
+      .should((body: string) => {
+        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+      });
   }
 );
 
@@ -269,9 +270,9 @@ Then(
   (key: string, value: string) => {
     cy.wait('@interceptedRecommendations')
       .its('request.body')
-      .then(JSON.parse)
-      .its('extraParams')
-      .should('have.property', key, value);
+      .should((body: string) => {
+        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+      });
   }
 );
 
@@ -280,9 +281,9 @@ Then(
   (key: string, value: string) => {
     cy.wait('@interceptedPopularSearches')
       .its('request.body')
-      .then(JSON.parse)
-      .its('extraParams')
-      .should('have.property', key, value);
+      .should((body: string) => {
+        expect(JSON.parse(body).extraParams).to.have.property(key, value);
+      });
   }
 );
 

--- a/packages/x-components/tests/e2e/extra-params.feature
+++ b/packages/x-components/tests/e2e/extra-params.feature
@@ -2,26 +2,25 @@ Feature: Extra-params component
 
   Background:
     Given a next queries API
-    And   a results API
+    And   a results API with a known response
     And   a query suggestions API
-    And   a popular searches API
+    And   a popular searches API with a known response
     And   a related tags API
     And   a recommendations API with a known response
+    And   a tracking API
     And   no special config for layout view
     And   start button is clicked
 
   Scenario Outline: 1. Search request includes extra-params from Snippet Config
-    Given a results API with a known response
     When  "<query>" is searched
     And   search request contains extra parameter "<ExtraParamName>" with value "<ExtraParamValue>"
     And   related results are displayed
 
     Examples:
-      | query | ExtraParamName    | ExtraParamValue |
-      | lego  | store             | Portugal        |
+      | query | ExtraParamName | ExtraParamValue |
+      | lego  | store          | Portugal        |
 
   Scenario Outline: 2. Search request includes renderless extra-param
-    Given a results API with a known response
     When  "<query>" is searched
     Then  search request contains extra parameter "<RenderlessExtraParamName>" with value "<InitialExtraParamValue>"
     And   related results are displayed
@@ -31,3 +30,18 @@ Feature: Extra-params component
     Examples:
       | query | RenderlessExtraParamName | InitialExtraParamValue | RenderlessExtraParamValue |
       | lego  | store                    | Portugal               | Spain                     |
+
+  Scenario Outline: 3. Immediate requests includes correct extra-params
+    Then  recommendations request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
+    And   popular searches request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
+    When  "<query>" is searched
+    And   store is changed to "<NewExtraParamValue>"
+    Then  recommendations request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   popular searches request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   the page is reloaded
+    Then  recommendations request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   popular searches request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+
+    Examples:
+      | query | ExtraParamName | InitialExtraParamValue | NewExtraParamValue |
+      | lego  | store          | Portugal               | Spain              |

--- a/packages/x-components/tests/e2e/extra-params.feature
+++ b/packages/x-components/tests/e2e/extra-params.feature
@@ -11,27 +11,18 @@ Feature: Extra-params component
     And   no special config for layout view
     And   start button is clicked
 
-  Scenario Outline: 1. Search request includes extra-params from Snippet Config
+  Scenario Outline: 1. Search request includes extra-params
     When  "<query>" is searched
-    And   search request contains extra parameter "<ExtraParamName>" with value "<ExtraParamValue>"
+    Then  search request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
     And   related results are displayed
+    When  store is changed to "<NewExtraParamValue>"
+    Then  search request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
 
     Examples:
-      | query | ExtraParamName | ExtraParamValue |
-      | lego  | store          | Portugal        |
+      | query | ExtraParamName | InitialExtraParamValue | NewExtraParamValue |
+      | lego  | store          | Portugal               | Spain              |
 
-  Scenario Outline: 2. Search request includes renderless extra-param
-    When  "<query>" is searched
-    Then  search request contains extra parameter "<RenderlessExtraParamName>" with value "<InitialExtraParamValue>"
-    And   related results are displayed
-    When  store is changed to "<RenderlessExtraParamValue>"
-    Then  search request contains extra parameter "<RenderlessExtraParamName>" with value "<RenderlessExtraParamValue>"
-
-    Examples:
-      | query | RenderlessExtraParamName | InitialExtraParamValue | RenderlessExtraParamValue |
-      | lego  | store                    | Portugal               | Spain                     |
-
-  Scenario Outline: 3. Immediate requests includes correct extra-params
+  Scenario Outline: 2. Immediate requests includes correct extra-params
     Then  recommendations request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
     And   popular searches request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
     When  "<query>" is searched

--- a/packages/x-components/tests/e2e/extra-params.feature
+++ b/packages/x-components/tests/e2e/extra-params.feature
@@ -1,37 +1,40 @@
 Feature: Extra-params component
 
   Background:
-    Given a next queries API
+    Given a next queries API with a known response
     And   a results API with a known response
-    And   a query suggestions API
+    And   a query suggestions API with a known response
     And   a popular searches API with a known response
-    And   a related tags API
+    And   a related tags API with a known response
     And   a recommendations API with a known response
     And   a tracking API
     And   no special config for layout view
     And   start button is clicked
 
   Scenario Outline: 1. Search request includes extra-params
+    Then  popular searches request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
+    And   recommendations request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
+    # This is the initial query preview request for the no-search carousels
+    And   search request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
     When  "<query>" is searched
-    Then  search request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
-    And   related results are displayed
+    Then  query suggestions request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
+    And   search request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
+    And   next queries request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
+    And   related tags request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
     When  store is changed to "<NewExtraParamValue>"
-    Then  search request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
-
-    Examples:
-      | query | ExtraParamName | InitialExtraParamValue | NewExtraParamValue |
-      | lego  | store          | Portugal               | Spain              |
-
-  Scenario Outline: 2. Immediate requests includes correct extra-params
-    Then  recommendations request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
-    And   popular searches request contains extra parameter "<ExtraParamName>" with value "<InitialExtraParamValue>"
-    When  "<query>" is searched
-    And   store is changed to "<NewExtraParamValue>"
-    Then  recommendations request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
-    And   popular searches request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
-    And   the page is reloaded
-    Then  recommendations request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
-    And   popular searches request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    Then  popular searches request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   query suggestions request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   recommendations request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   search request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   next queries request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   related tags request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    When  the page is reloaded
+    Then  popular searches request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   query suggestions request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   recommendations request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   search request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   next queries request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
+    And   related tags request contains extra parameter "<ExtraParamName>" with value "<NewExtraParamValue>"
 
     Examples:
       | query | ExtraParamName | InitialExtraParamValue | NewExtraParamValue |

--- a/packages/x-components/tests/e2e/sort.feature
+++ b/packages/x-components/tests/e2e/sort.feature
@@ -14,14 +14,14 @@ Feature: Search sort components
   Scenario Outline: 1. Search sort list and dropdown order the results
     Given a results API with a known response
     When  "<query>" is searched
-    Then  search request contains parameter "sort" with value "<defaultSort>"
+    Then  search request contains sort parameter with value "<defaultSort>"
     Then  related results are displayed
     When  sort option "<sortOption2>" is selected from the sort dropdown
-    Then  search request contains parameter "sort" with value "<sortOption2>"
+    Then  search request contains sort parameter with value "<sortOption2>"
     When  sort option "<sortOption1>" is selected from the sort dropdown
-    Then  search request contains parameter "sort" with value "<sortOption1>"
+    Then  search request contains sort parameter with value "<sortOption1>"
     When  sort option "<defaultSort>" is selected from the sort dropdown
-    Then  search request contains parameter "sort" with value "<defaultSort>"
+    Then  search request contains sort parameter with value "<defaultSort>"
 
     Examples:
       | query | sortOption1   | sortOption2    | defaultSort |


### PR DESCRIPTION
…rovided.

EX-6977

Prevents initial request (Popular searches and recommendations) to be fired before the extra params have been loaded in all modules.

The issue was that we were using a `Promise.resolve` (microtask queue) for the `immediate` emitters instead of the debounced emit function, which may delay the emission (and cancel previous attempts) to try to group as maximum changes as possible  in one emission by using the macrotask queue (`setTimeout`).
