### PR TITLE
ci: export webpack config from `x-archetype-utils`

### DIFF
--- a/packages/x-archetype-utils/src/build/webpack/webpack.config.ts
+++ b/packages/x-archetype-utils/src/build/webpack/webpack.config.ts
@@ -1,0 +1,42 @@
+/**.
+ * Self-made interface since Webpack does not provide a type for this object.
+ * Https://github.com/webpack/webpack/blob/main/declarations/WebpackOptions.d.ts#L463
+ *
+ * @internal
+ */
+interface webpackFilenameTemplateInfo {
+  identifier: string;
+  shortIdentifier: string;
+  resource: string;
+  resourcePath: string;
+  absoluteResourcePath: string;
+  allLoaders: string;
+  query: string;
+  moduleId: string;
+  hash: string;
+  namespace: string;
+}
+
+export const webpackConfig = {
+  transpileDependencies: ['@empathyco/x-components'],
+  configureWebpack: {
+    module: {
+      rules: [
+        {
+          test: /\.ts|js|vue$/,
+          enforce: 'pre',
+          use: ['source-map-loader']
+        }
+      ]
+    },
+    output: {
+      devtoolModuleFilenameTemplate: ({ resourcePath, hash, query }: webpackFilenameTemplateInfo) =>
+        resourcePath.match(/\.vue$/) &&
+        !query.match(/type=script/) &&
+        !query.match(/\?rollup-plugin-vue=script.ts/)
+          ? `webpack-generated:///${resourcePath}?${hash}`
+          : `sources://${resourcePath}`,
+      devtoolFallbackModuleFilenameTemplate: 'webpack:///[resource-path]?[hash]'
+    }
+  }
+};

--- a/packages/x-archetype-utils/src/index.ts
+++ b/packages/x-archetype-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './i18n/i18n.plugin';
 export * from './i18n/i18n.types';
+export * from './build/webpack/webpack.config';

--- a/packages/x-components/vue.config.js
+++ b/packages/x-components/vue.config.js
@@ -2,6 +2,18 @@ const glob = require('glob');
 
 module.exports = {
   configureWebpack: {
-    entry: [...glob.sync('src/design-system/**/*.scss').map(style => `./${style}`), './src/main.ts']
+    entry: [
+      ...glob.sync('src/design-system/**/*.scss').map(style => `./${style}`),
+      './src/main.ts'
+    ],
+    output: {
+      devtoolModuleFilenameTemplate: ({ resourcePath, hash, query }) =>
+        resourcePath.match(/\.vue$/) &&
+        !query.match(/type=script/) &&
+        !query.match(/\?rollup-plugin-vue=script.ts/)
+          ? `webpack-generated:///${resourcePath}?${hash}`
+          : `sources://${resourcePath}`,
+      devtoolFallbackModuleFilenameTemplate: 'webpack:///[resource-path]?[hash]'
+    }
   }
 };


### PR DESCRIPTION
EX-7221

After creating https://github.com/empathyco/x-archetype/pull/181 @tajespasarela suggested to move the webpack fix to the `x-archetype-utils` package.  This PR exports the whole configuration for webpack so we are able to update every customer setup easily.

Besides, I introduce the same fix for the `x-components` development build. See https://github.com/empathyco/x-archetype/pull/181 if you need more context.