### PR TITLE
fix: hide overflow-y in the sliding panel

### DIFF
--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -255,7 +255,8 @@
       display: flex;
       flex: 100%;
       flex-flow: row nowrap;
-      overflow: auto;
+      overflow-x: auto;
+      overflow-y: hidden;
       scrollbar-width: none; // Firefox
       -ms-overflow-style: none; // IE
 


### PR DESCRIPTION
EX-7015