### PR TITLE
Add search input hover events

### DIFF
--- a/packages/x-components/src/components/animations/animate-translate/animate-translate.style.scss
+++ b/packages/x-components/src/components/animations/animate-translate/animate-translate.style.scss
@@ -21,4 +21,34 @@
       transform: translateX(100%);
     }
   }
+
+  &--enter {
+    &#{$p}--top-to-bottom {
+      transform: translateY(-100%);
+    }
+    &#{$p}--bottom-to-top {
+      transform: translateY(100%);
+    }
+    &#{$p}--left-to-right {
+      transform: translateX(-100%);
+    }
+    &#{$p}--right-to-left {
+      transform: translateX(100%);
+    }
+  }
+
+  &--leave-to {
+    &#{$p}--top-to-bottom {
+      transform: translateY(100%);
+    }
+    &#{$p}--bottom-to-top {
+      transform: translateY(-100%);
+    }
+    &#{$p}--left-to-right {
+      transform: translateX(100%);
+    }
+    &#{$p}--right-to-left {
+      transform: translateX(-100%);
+    }
+  }
 }

--- a/packages/x-components/src/components/animations/create-directional-animation-factory.ts
+++ b/packages/x-components/src/components/animations/create-directional-animation-factory.ts
@@ -33,4 +33,12 @@ export function createDirectionalAnimationFactory(
   };
 }
 
-export type AnimationOrigin = 'top' | 'bottom' | 'left' | 'right';
+export type AnimationOrigin =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'top-to-bottom'
+  | 'bottom-to-top'
+  | 'left-to-right'
+  | 'right-to-left';

--- a/packages/x-components/src/x-modules/search-box/components/__tests__/search-input.spec.ts
+++ b/packages/x-components/src/x-modules/search-box/components/__tests__/search-input.spec.ts
@@ -73,6 +73,19 @@ describe('testing search input component', () => {
     expect(getXComponentXModuleName(mockedSearchInput.vm)).toEqual('searchBox');
   });
 
+  it('emits UserHoveredInSearchBox when it is hovered in', () => {
+    mockedSearchInput.vm.$x.on('UserHoveredInSearchBox').subscribe(listener);
+    mockedSearchInput.trigger('mouseenter');
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('emits UserHoveredOutSearchBox when it is hovered out', () => {
+    mockedSearchInput.vm.$x.on('UserHoveredOutSearchBox').subscribe(listener);
+    mockedSearchInput.trigger('mouseenter');
+    mockedSearchInput.trigger('mouseleave');
+    expect(listener).toHaveBeenCalled();
+  });
+
   it('emits UserFocusedSearchBox if input autofocus true', () => {
     const { wrapper } = mountNewSearchInput({ autofocus: true });
     wrapper.vm.$x.on('UserFocusedSearchBox').subscribe(listener);

--- a/packages/x-components/src/x-modules/search-box/components/search-input.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input.vue
@@ -1,6 +1,8 @@
 <template>
   <input
     ref="input"
+    @mouseenter="emitUserHoveredInSearchBox"
+    @mouseleave="emitUserHoveredOutSearchBox"
     @blur="emitUserBlurredSearchBox"
     @click="emitUserClickedSearchBox"
     @focus="emitUserFocusedSearchBox"
@@ -150,6 +152,24 @@
         target: this.$refs.input,
         feature: 'search_box'
       };
+    }
+
+    /**
+     * Emits event {@link SearchBoxXEvents.UserHoveredInSearchBox} when search box is hovered in.
+     *
+     * @internal
+     */
+    protected emitUserHoveredInSearchBox(): void {
+      this.$x.emit('UserHoveredInSearchBox', undefined, { target: this.$refs.input });
+    }
+
+    /**
+     * Emits event {@link SearchBoxXEvents.UserHoveredOutSearchBox} when search box is hovered out.
+     *
+     * @internal
+     */
+    protected emitUserHoveredOutSearchBox(): void {
+      this.$x.emit('UserHoveredOutSearchBox', undefined, { target: this.$refs.input });
     }
 
     /**

--- a/packages/x-components/src/x-modules/search-box/events.types.ts
+++ b/packages/x-components/src/x-modules/search-box/events.types.ts
@@ -7,67 +7,67 @@
 export interface SearchBoxXEvents {
   /**
    * The search-box query has changed
-   * Payload: The new search-box query.
+   * * Payload: The new search-box query.
    */
   SearchBoxQueryChanged: string;
   /**
    * The user hovered in the search-box.
-   * Payload: none.
+   * * Payload: none.
    */
   UserHoveredInSearchBox: void;
   /**
    * The user hovered out the search-box.
-   * Payload: none.
+   * * Payload: none.
    */
   UserHoveredOutSearchBox: void;
   /**
    * The user removed the focus from the search-box.
-   * Payload: none.
+   * * Payload: none.
    */
   UserBlurredSearchBox: void;
   /**
    * The user cleared the search-box query in any way, typing or pressing a button that clears it.
-   * Payload: none.
+   * * Payload: none.
    */
   /**
    * The user cleared the search-box query in any way, typing or pressing a button that clears it.
    * The payload is usually an empty string.
-   * Payload: string.
+   * * Payload: string.
    */
   UserClearedQuery: string;
   /**
    * The user clicked on the search-box input.
-   * Payload: none.
+   * * Payload: none.
    */
   UserClickedSearchBox: void;
   /**
    * The user focused the search-box
-   * Payload: none.
+   * * Payload: none.
    */
   UserFocusedSearchBox: void;
   /**
    * The user is typing/pasting a query
-   * Payload: the partial query that the user is typing.
+   * * Payload: the partial query that the user is typing.
    */
   UserIsTypingAQuery: string;
   /**
    * The user triggered the button that clears the search-box
-   * Payload: none.
+   * * Payload: none.
    */
   UserPressedClearSearchBoxButton: void;
   /**
    * The user pressed the enter key with the focus on the search-box
-   * Payload: the new query of the search-box.
+   * * Payload: the new query of the search-box.
    */
   UserPressedEnterKey: string;
   /**
    * The user pressed the search button
-   * Payload: The query to search.
+   * * Payload: The query to search.
    */
   UserPressedSearchButton: string;
   /**
    * The user voiced a query
-   * Payload: The spoken query.
+   * * Payload: The spoken query.
    */
   UserTalked: string;
 }

--- a/packages/x-components/src/x-modules/search-box/events.types.ts
+++ b/packages/x-components/src/x-modules/search-box/events.types.ts
@@ -7,57 +7,67 @@
 export interface SearchBoxXEvents {
   /**
    * The search-box query has changed
-   * * Payload: The new search-box query.
+   * Payload: The new search-box query.
    */
   SearchBoxQueryChanged: string;
   /**
+   * The user hovered in the search-box.
+   * Payload: none.
+   */
+  UserHoveredInSearchBox: void;
+  /**
+   * The user hovered out the search-box.
+   * Payload: none.
+   */
+  UserHoveredOutSearchBox: void;
+  /**
    * The user removed the focus from the search-box.
-   * * Payload: none.
+   * Payload: none.
    */
   UserBlurredSearchBox: void;
   /**
    * The user cleared the search-box query in any way, typing or pressing a button that clears it.
-   * * Payload: none.
+   * Payload: none.
    */
   /**
    * The user cleared the search-box query in any way, typing or pressing a button that clears it.
    * The payload is usually an empty string.
-   * * Payload: string.
+   * Payload: string.
    */
   UserClearedQuery: string;
   /**
    * The user clicked on the search-box input.
-   * * Payload: none.
+   * Payload: none.
    */
   UserClickedSearchBox: void;
   /**
    * The user focused the search-box
-   * * Payload: none.
+   * Payload: none.
    */
   UserFocusedSearchBox: void;
   /**
    * The user is typing/pasting a query
-   * * Payload: the partial query that the user is typing.
+   * Payload: the partial query that the user is typing.
    */
   UserIsTypingAQuery: string;
   /**
    * The user triggered the button that clears the search-box
-   * * Payload: none.
+   * Payload: none.
    */
   UserPressedClearSearchBoxButton: void;
   /**
    * The user pressed the enter key with the focus on the search-box
-   * * Payload: the new query of the search-box.
+   * Payload: the new query of the search-box.
    */
   UserPressedEnterKey: string;
   /**
    * The user pressed the search button
-   * * Payload: The query to search.
+   * Payload: The query to search.
    */
   UserPressedSearchButton: string;
   /**
    * The user voiced a query
-   * * Payload: The spoken query.
+   * Payload: The spoken query.
    */
   UserTalked: string;
 }


### PR DESCRIPTION
Related to https://github.com/empathyco/x/issues/385.

In order to implement the new SearchInputPlaceholder component the hover events (mouse enter & leave) must be emitted by the SearchInput so its state is available from any other element/component.

Note: The first approach for the SearchInputPlaceholder was to directly use its hover state but as it is conceived as a span placed in the same space than the input, that would generate conflicts between the mouse events from both elements depending on which one is placed on top of the other.

This PR is part of a specific issue and how it is used can be found [here](https://github.com/empathyco/x/pull/771/files#diff-4f94a892b7632521d53664a6cb2c3881f76f05e0bb615a6ffdf1ab29375c100aR118).
