### PR TITLE
Add directional origins for translate animations

### DIFF
--- a/packages/x-components/src/components/animations/animate-translate/animate-translate.style.scss
+++ b/packages/x-components/src/components/animations/animate-translate/animate-translate.style.scss
@@ -21,4 +21,34 @@
       transform: translateX(100%);
     }
   }
+
+  &--enter {
+    &#{$p}--top-to-bottom {
+      transform: translateY(-100%);
+    }
+    &#{$p}--bottom-to-top {
+      transform: translateY(100%);
+    }
+    &#{$p}--left-to-right {
+      transform: translateX(-100%);
+    }
+    &#{$p}--right-to-left {
+      transform: translateX(100%);
+    }
+  }
+
+  &--leave-to {
+    &#{$p}--top-to-bottom {
+      transform: translateY(100%);
+    }
+    &#{$p}--bottom-to-top {
+      transform: translateY(-100%);
+    }
+    &#{$p}--left-to-right {
+      transform: translateX(100%);
+    }
+    &#{$p}--right-to-left {
+      transform: translateX(-100%);
+    }
+  }
 }

--- a/packages/x-components/src/components/animations/create-directional-animation-factory.ts
+++ b/packages/x-components/src/components/animations/create-directional-animation-factory.ts
@@ -33,4 +33,12 @@ export function createDirectionalAnimationFactory(
   };
 }
 
-export type AnimationOrigin = 'top' | 'bottom' | 'left' | 'right';
+export type AnimationOrigin =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'top-to-bottom'
+  | 'bottom-to-top'
+  | 'left-to-right'
+  | 'right-to-left';


### PR DESCRIPTION
Related to https://github.com/empathyco/x/issues/385.

Translate animations must be extended to support a different direction for enter and leave so the following case is achievable (search input placeholder animation):

https://user-images.githubusercontent.com/72568818/195307148-8a0b52cb-6736-48f6-bf51-caf427c56cc7.mov


This PR is part of a specific issue and how it is used can be found [here](https://github.com/empathyco/x/pull/771/files#diff-4f94a892b7632521d53664a6cb2c3881f76f05e0bb615a6ffdf1ab29375c100aR48).
