### PR TITLE
feat(types): add autocomplete to `theme` function in `TailwindHelpers`

### DIFF
--- a/packages/x-tailwindcss/src/types.ts
+++ b/packages/x-tailwindcss/src/types.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, Dictionary } from '@empathyco/x-utils';
+import { DeepPartial, Dictionary, ExtractPath } from '@empathyco/x-utils';
 import { PluginAPI } from 'tailwindcss/types/config';
 import { Config } from 'tailwindcss';
 import { ReturnOfComponents } from './x-tailwind-plugin/components';
@@ -93,7 +93,12 @@ export type DynamicCssStylesOptions = Dictionary<{
  *
  * @public
  */
-export type TailwindHelpers = PluginAPI;
+export type TailwindHelpers = PluginAPI & {
+  theme: <TDefaultValue = Config['theme']>(
+    path?: ExtractPath<typeof Theme>,
+    defaultValue?: TDefaultValue
+  ) => TDefaultValue;
+};
 
 /**
  * Represents the return type of {@link PluginOptions.components}.


### PR DESCRIPTION
EX-7085

Adds autocomplete functionality to the `theme` function in `TailwindHelpers` so it is easier to use it. It doesn't restrict values, as those can be extended for customers and would result in errors when doing so.

Regarding modifying the `ExtractPath` type to allow `numeric` keys, it wasn't needed, as those keys can also be used as `strings`.

In order to use this autocomplete feature in `x-components`, you can't destructure the TailwindHelpers parameter.

For example, this allows autocompletion:
![image](https://user-images.githubusercontent.com/6247440/196644503-f9061a4e-4080-4926-9d96-f082b9065780.png)

But this doesn't:
![image](https://user-images.githubusercontent.com/6247440/196644614-faf23108-ca4d-4938-be5d-5e3af1f1c63e.png)


