### PR TITLE
feat(tagging): make `tagging` and `queryTagging` optional

### DIFF
--- a/packages/search-types/src/response/search-response.model.ts
+++ b/packages/search-types/src/response/search-response.model.ts
@@ -16,7 +16,7 @@ export interface SearchResponse {
   facets?: Facet[];
   partialResults?: PartialResult[];
   promoteds?: Promoted[];
-  queryTagging: TaggingRequest;
+  queryTagging?: TaggingRequest;
   redirections?: Redirection[];
   results: Result[];
   spellcheck?: string;

--- a/packages/search-types/src/tagging.model.ts
+++ b/packages/search-types/src/tagging.model.ts
@@ -7,7 +7,7 @@ import { TaggingRequest } from './request/tagging-request.model';
  */
 export interface Taggable {
   /** Tagging object containing the different taggable events. */
-  tagging: Tagging;
+  tagging?: Tagging;
 }
 
 /**

--- a/packages/x-components/src/x-modules/tagging/service/__tests__/pdp-add-to-cart.service.spec.ts
+++ b/packages/x-components/src/x-modules/tagging/service/__tests__/pdp-add-to-cart.service.spec.ts
@@ -137,7 +137,7 @@ describe('testing pdp add to cart', () => {
     service.trackAddToCart();
 
     expect(sessionGetItemSpy).toHaveBeenCalledWith(`add-to-cart-${productPathName}`);
-    expect(storeDispatchSpy).toHaveBeenCalledWith('x/tagging/track', result.tagging.add2cart);
+    expect(storeDispatchSpy).toHaveBeenCalledWith('x/tagging/track', result.tagging?.add2cart);
 
     commitTaggingConfig(store, { clickedResultStorageKey: 'id', clickedResultStorageTTLMs });
     service.storeResultClicked(result);
@@ -146,6 +146,14 @@ describe('testing pdp add to cart', () => {
     service.trackAddToCart(id);
 
     expect(sessionGetItemSpy).toHaveBeenCalledWith(`add-to-cart-${id}`);
-    expect(storeDispatchSpy).toHaveBeenCalledWith('x/tagging/track', result.tagging.add2cart);
+    expect(storeDispatchSpy).toHaveBeenCalledWith('x/tagging/track', result.tagging?.add2cart);
+  });
+
+  it('does not dispatch the add to track if result has no tagging', () => {
+    commitTaggingConfig(store, {});
+    service.storeResultClicked({ ...result, tagging: undefined });
+    service.trackAddToCart();
+
+    expect(storeDispatchSpy).not.toHaveBeenCalledWith('x/tagging/track', expect.anything());
   });
 });

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -1,4 +1,4 @@
-import { Result, TaggingRequest } from '@empathyco/x-types';
+import { Result, Tagging, TaggingRequest } from '@empathyco/x-types';
 import { DefaultSessionService } from '@empathyco/x-utils';
 import {
   namespacedWireCommit,
@@ -147,7 +147,7 @@ export const trackAddToCartWire = createTrackResultWire('add2cart');
  *
  * @internal
  */
-function createTrackResultWire(property: keyof Result['tagging']): Wire<Result> {
+function createTrackResultWire(property: keyof Tagging): Wire<Result> {
   return filter(
     wireDispatch('track', ({ eventPayload: { tagging }, metadata: { location } }) => {
       const taggingInfo: TaggingRequest = tagging[property];


### PR DESCRIPTION
BREAKING CHANGE: `tagging` property of `Taggable` and `queryTagging` property of `SearchResponse` are optional.

EX-7231

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: EX-7231

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [X] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
