### PR TITLE
ci: add cache in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,33 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+            ~/.cache/Cypress
+          key: node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            node-modules-
+      - name: Cache eslint
+        id: cache-eslint
+        uses: actions/cache@v3
+        with:
+          path: |
+            .eslintcache
+          key: eslint-${{github.sha}}
+          restore-keys: |
+            eslint-
       - name: Install lerna and all packages
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
+      - name: Build
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        run: npm run build
       - name: Run linter in all packages
+        if: steps.cache-eslint.outputs.cache-hit != 'true'
         run: npm run lint
       - name: Run tests in all packages
         run: npm run test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      # Using lerna, it is recommended to cache the whole node_modules folder https://github.com/actions/cache/blob/main/examples.md#node---lerna
+      # but this is not the standard, normally, only the node_modules/.cache should be cached. Also, as cypress image is used, node is already
+      # preinstalled, the expected action `setup-node` is not used.
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#about-caching-workflow-dependencies
       - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,21 +19,20 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v3
         with:
-          path: |
-            **/node_modules
-            ~/.cache/Cypress
+          path: '**/node_modules'
           key: node-modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            node-modules-
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-cache
       - name: Cache eslint
         id: cache-eslint
         uses: actions/cache@v3
         with:
-          path: |
-            .eslintcache
+          path: .eslintcache
           key: eslint-${{github.sha}}
-          restore-keys: |
-            eslint-
       - name: Install lerna and all packages
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
@@ -41,7 +40,6 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit == 'true'
         run: npm run build
       - name: Run linter in all packages
-        if: steps.cache-eslint.outputs.cache-hit != 'true'
         run: npm run lint
       - name: Run tests in all packages
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "lerna bootstrap --hoist && npm run build",
     "postci": "lerna bootstrap --hoist --ci && npm run build",
     "build": "lerna run build",
-    "lint": "eslint packages --ext .ts,.tsx,.vue --quiet",
+    "lint": "eslint packages --ext .ts,.tsx,.vue --quiet --cache",
     "lint:fix": "eslint packages --ext .ts,.tsx,.vue --fix",
     "test": "lerna run test --parallel",
     "serve": "lerna run serve --parallel",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "lerna bootstrap --hoist && npm run build",
     "postci": "lerna bootstrap --hoist --ci && npm run build",
     "build": "lerna run build",
-    "lint": "eslint packages --ext .ts,.tsx,.vue --quiet --cache",
+    "lint": "eslint packages --ext .ts,.tsx,.vue --quiet --cache --cache-strategy content",
     "lint:fix": "eslint packages --ext .ts,.tsx,.vue --fix",
     "test": "lerna run test --parallel",
     "serve": "lerna run serve --parallel",


### PR DESCRIPTION
# Pull request template

Some steps in the CI can use a cache, like install and lint steps.

## Motivation and context

This PR is done because right now our CI is really slow, with the cache enabled for the install and the eslint steps, we are able to reduce 4-5min the time of the actions. 

[Github actions cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)

I read this post: [Speed your CI](https://jongleberry.medium.com/speed-up-your-ci-and-dx-with-node-modules-cache-ac8df82b7bb0). It said that maybe its better to cache `node_module/.cache`instead of the whole `node_modules` but I am not sure. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?

- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

After updating the changes, you can check the different times between the 2 actions. The first time that you upload the code, it took:
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/6597815/198899327-058c0bb3-fac0-4933-9886-27f6f3c3c589.png">

 if you relaunch the same action, the time will be decreased by 4-5 min (it changes between relaunch)
 
 
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/6597815/198900529-9f7d67e2-f9c5-4635-8df8-af9f8dceec61.png">


Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [X] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [X] I have **commented** my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [X] My changes generate **no new warnings**.
- [X] I have added **tests** that prove my fix is effective or that my feature works.
- [X] New and existing **unit tests pass locally** with my changes.
