### PR TITLE
feat: apply dynamic css mixin to sliding panel and column picker list buttons

### DIFF
--- a/packages/x-components/src/components/column-picker/__tests__/base-column-picker-list.spec.ts
+++ b/packages/x-components/src/components/column-picker/__tests__/base-column-picker-list.spec.ts
@@ -6,12 +6,13 @@ import BaseColumnPickerList from '../base-column-picker-list.vue';
 function renderBaseColumnPickerListComponent({
   columns,
   selectedColumns,
+  buttonClass,
   customItemSlot = `
     <template #default="{ column }">
       <p data-test="column-slot">{{ column }}</p>
     </template>`,
   template = `
-   <BaseColumnPickerList :columns="columns" v-model="selectedColumns">
+   <BaseColumnPickerList v-bind="$attrs" v-model="selectedColumns">
       ${customItemSlot ?? ''}
    </BaseColumnPickerList>`
 }: BaseColumnPickerListRenderOptions = {}): BaseColumnPickerListComponentAPI {
@@ -23,7 +24,6 @@ function renderBaseColumnPickerListComponent({
         components: {
           BaseColumnPickerList
         },
-        props: ['columns'],
         template,
         data() {
           return { selectedColumns: options.selectedColumns ?? selectedColumns };
@@ -31,7 +31,8 @@ function renderBaseColumnPickerListComponent({
       },
       {
         propsData: {
-          columns
+          columns,
+          buttonClass
         },
         localVue
       }
@@ -63,7 +64,7 @@ describe('testing Base Column Picker List', () => {
     const value = columns[index];
     const { wrapper } = renderBaseColumnPickerListComponent({
       columns,
-      template: `<BaseColumnPickerList :columns="columns" :value="${value}" />`
+      template: `<BaseColumnPickerList v-bind="$attrs" :value="${value}" />`
     });
     const listenerColumnPicker = jest.fn();
     wrapper.vm.$x.on('ColumnsNumberProvided', true).subscribe(listenerColumnPicker);
@@ -183,6 +184,17 @@ describe('testing Base Column Picker List', () => {
     expect(getSelectedItem(wrapper4)).toBe('0');
     expect(getSelectedItem(wrapper5)).toBe('0');
   });
+
+  it('allows adding CSS class to the buttons', () => {
+    const { wrapper } = renderBaseColumnPickerListComponent({
+      columns: [1, 3, 6],
+      buttonClass: 'x-background--accent'
+    });
+
+    wrapper.findAll('button').wrappers.forEach(button => {
+      expect(button.classes()).toContain('x-background--accent');
+    });
+  });
 });
 
 interface BaseColumnPickerListRenderOptions {
@@ -190,6 +202,8 @@ interface BaseColumnPickerListRenderOptions {
   columns?: number[];
   /** The custom element to be rendered. */
   customItemSlot?: string;
+  /** The CSS classes to add to the buttons. */
+  buttonClass?: string;
   /** The initial selected column value. */
   selectedColumns?: number;
   /** The template to be rendered. */

--- a/packages/x-components/src/components/column-picker/base-column-picker-list.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-list.vue
@@ -9,6 +9,7 @@
     >
       <BaseEventButton
         class="x-button column-picker-item__button"
+        :class="buttonClass"
         data-test="column-picker-button"
         :aria-selected="isSelected.toString()"
         :events="events"
@@ -27,19 +28,13 @@
   </ul>
 </template>
 
-<style lang="scss" scoped>
-  .x-column-picker-list {
-    display: flex;
-    list-style-type: none;
-  }
-</style>
-
 <script lang="ts">
   import { mixins } from 'vue-class-component';
   import { Component } from 'vue-property-decorator';
   import { VueCSSClasses } from '../../utils/types';
   import { XEventsTypes } from '../../wiring';
   import BaseEventButton from '../base-event-button.vue';
+  import { dynamicPropsMixin } from '../dynamic-props.mixin';
   import ColumnPickerMixin from './column-picker.mixin';
 
   interface ColumnPickerItem {
@@ -52,6 +47,9 @@
   /**
    * Column picker list component renders a list of buttons to choose the columns number.
    *
+   * Additionally, this component exposes the following props to modify the classes of the
+   * elements: `buttonClass`.
+   *
    * @remarks It extends {@link ColumnPickerMixin}.
    *
    * @public
@@ -59,7 +57,10 @@
   @Component({
     components: { BaseEventButton }
   })
-  export default class BaseColumnPickerList extends mixins(ColumnPickerMixin) {
+  export default class BaseColumnPickerList extends mixins(
+    ColumnPickerMixin,
+    dynamicPropsMixin(['buttonClass'])
+  ) {
     /**
      * Maps the column to an object containing: the `column` and `CSS classes`.
      *
@@ -86,6 +87,13 @@
     }
   }
 </script>
+
+<style lang="scss" scoped>
+  .x-column-picker-list {
+    display: flex;
+    list-style-type: none;
+  }
+</style>
 
 <docs lang="mdx">
 ## Examples
@@ -150,6 +158,28 @@ It is possible to override the column picker button content.
   <BaseColumnPickerList :columns="columns" #default="{ column, isSelected }">
     <span>{{ column }} {{ isSelected ? '🟢' : '' }}</span>
   </BaseColumnPickerList>
+</template>
+<script>
+  import { BaseColumnPickerList } from '@empathyco/xcomponents';
+
+  export default {
+    components: {
+      BaseColumnPickerList
+    },
+    data() {
+      return { columns: [2, 4, 6] };
+    }
+  };
+</script>
+```
+
+#### Customizing the buttons with classes
+
+The `buttonClass` prop can be used to add classes to the buttons.
+
+```vue
+<template>
+  <BaseColumnPickerList :columns="columns" buttonClass="x-button--round" />
 </template>
 <script>
   import { BaseColumnPickerList } from '@empathyco/xcomponents';

--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -40,7 +40,7 @@
   import { Debounce } from './decorators/debounce.decorators';
   import { dynamicPropsMixin } from './dynamic-props.mixin';
 
-  /**.
+  /**
    * This component allows for any other component or element inside it to be horizontally
    * navigable. It also implements customizable buttons as well as other minor customizations to its
    * general behavior.

--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -35,20 +35,23 @@
 </template>
 
 <script lang="ts">
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { Component, Mixins, Prop } from 'vue-property-decorator';
   import { VueCSSClasses } from '../utils/types';
   import { Debounce } from './decorators/debounce.decorators';
+  import { dynamicPropsMixin } from './dynamic-props.mixin';
 
-  /**
+  /**.
    * This component allows for any other component or element inside it to be horizontally
    * navigable. It also implements customizable buttons as well as other minor customizations to its
    * general behavior.
    *
+   * Additionally, this component exposes the following props to modify the classes of the
+   * elements: buttonClass
+   *
    * @public
    */
   @Component
-  export default class SlidingPanel extends Vue {
+  export default class SlidingPanel extends Mixins(dynamicPropsMixin(['buttonClass'])) {
     /**
      * Scroll factor that will dictate how much the scroll moves when pressing a navigation button.
      *
@@ -73,14 +76,6 @@
      */
     @Prop({ default: true })
     public resetOnContentChange!: boolean;
-
-    /**
-     * CSS classes to add to the buttons.
-     *
-     * @public
-     */
-    @Prop()
-    public buttonClass?: string;
 
     /**
      * Indicates if the scroll is at the start of the sliding panel.

--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -46,7 +46,7 @@
    * general behavior.
    *
    * Additionally, this component exposes the following props to modify the classes of the
-   * elements: buttonClass
+   * elements: `buttonClass`.
    *
    * @public
    */
@@ -368,6 +368,43 @@ just by swiping.
 ```vue
 <template>
   <SlidingPanel :showButtons="false">
+    <div class="item">Item 1</div>
+    <div class="item">Item 2</div>
+    <div class="item">Item 3</div>
+    <div class="item">Item 4</div>
+  </SlidingPanel>
+</template>
+
+<script>
+  import { SlidingPanel } from '@empathyco/x-components';
+
+  export default {
+    name: 'SlidingPanelDemo',
+    components: {
+      SlidingPanel
+    }
+  };
+</script>
+
+<style>
+  .x-sliding-panel {
+    width: 200px;
+  }
+
+  .item {
+    display: inline-block;
+    width: 100px;
+  }
+</style>
+```
+
+#### Customizing the buttons with classes
+
+The `buttonClass` prop can be used to add classes to the buttons.
+
+```vue
+<template>
+  <SlidingPanel buttonClass="x-button--round">
     <div class="item">Item 1</div>
     <div class="item">Item 2</div>
     <div class="item">Item 3</div>


### PR DESCRIPTION
The `base-dropdown` component is not being used in the `archetype`, so we can add the prop there when we need it.

EX-7224