### PR TITLE
fix: Make Promoted and Banner position optional

### DIFF
--- a/packages/search-types/src/banner.model.ts
+++ b/packages/search-types/src/banner.model.ts
@@ -17,5 +17,5 @@ export interface Banner extends NamedModel<'Banner'>, Identifiable, Taggable {
   /** Banner image. */
   image: string;
   /** Banner position (= row) inside the grid. */
-  position: number;
+  position?: number;
 }

--- a/packages/search-types/src/promoted.model.ts
+++ b/packages/search-types/src/promoted.model.ts
@@ -16,5 +16,5 @@ export interface Promoted extends NamedModel<'Promoted'>, Identifiable, Taggable
   /** Promoted image. */
   image: string;
   /** Promoted position inside the grid. */
-  position: number;
+  position?: number;
 }

--- a/packages/search-types/src/schemas/banner.schema.ts
+++ b/packages/search-types/src/schemas/banner.schema.ts
@@ -16,5 +16,5 @@ export const BannerSchema: Banner = {
   modelName: expect.any(String),
   title: expect.any(String),
   url: expect.any(String),
-  position: expect.any(Number)
+  position: expect.undefinedOr(Number)
 };

--- a/packages/search-types/src/schemas/promoted.schema.ts
+++ b/packages/search-types/src/schemas/promoted.schema.ts
@@ -16,5 +16,5 @@ export const PromotedSchema: Promoted = {
   modelName: expect.any(String),
   title: expect.any(String),
   url: expect.any(String),
-  position: expect.any(Number)
+  position: expect.undefinedOr(Number)
 };

--- a/packages/x-adapter-platform/src/types/models/banner.model.ts
+++ b/packages/x-adapter-platform/src/types/models/banner.model.ts
@@ -8,7 +8,7 @@ export interface PlatformBanner {
   title: string;
   url: string;
   image_url: string;
-  position: number;
+  position?: number;
   tagging?: {
     query: string;
   };

--- a/packages/x-adapter-platform/src/types/models/promoted.model.ts
+++ b/packages/x-adapter-platform/src/types/models/promoted.model.ts
@@ -8,7 +8,7 @@ export interface PlatformPromoted {
   title: string;
   url: string;
   image_url: string;
-  position: number;
+  position?: number;
   tagging?: {
     query: string;
   };

--- a/packages/x-components/src/__stubs__/banners-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/banners-stubs.factory.ts
@@ -21,7 +21,7 @@ export function getBannersStub(): Banner[] {
  *
  * @internal
  */
-export function createBannerStub(identifier: string, position = 1): Banner {
+export function createBannerStub(identifier: string, position?: number): Banner {
   return {
     id: `xb-${identifier}`,
     title: `Banner ${identifier}`,

--- a/packages/x-components/src/__stubs__/promoteds-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/promoteds-stubs.factory.ts
@@ -21,7 +21,7 @@ export function getPromotedsStub(): Promoted[] {
  *
  * @internal
  */
-export function createPromotedStub(identifier: string, position = 1): Promoted {
+export function createPromotedStub(identifier: string, position?: number): Promoted {
   return {
     id: `xp-${identifier}`,
     title: `Promoted ${identifier}`,


### PR DESCRIPTION
[EX-7333](https://searchbroker.atlassian.net/browse/EX-7333)

Position optional on Promoteds and Banners to cover the APIs which don't implement that feature.

Related to [this](https://github.com/empathyco/x/commit/e7393fbce8d0767d3c762aa714fe94e162203a12).