### PR TITLE
Feature/Not show Empathize with no content

### DIFF
--- a/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
+++ b/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
@@ -1,53 +1,104 @@
-import { mount } from '@vue/test-utils';
+import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import BaseEventButton from '../../../../components/base-event-button.vue';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
 import Empathize from '../empathize.vue';
+import { empathizeXModule } from '../../x-module';
+import { XPlugin } from '../../../../plugins/index';
+import { XEvent } from '../../../../wiring/index';
 
 describe('testing empathize component', () => {
-  let localVue: typeof Vue;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  function renderEmpathize({
+    eventsToOpenEmpathize,
+    eventsToCloseEmpathize,
+    template = `<Empathize
+                  :events-to-open-empathize="['TestOpenEvent']"
+                  :events-to-close-empathize="['TestCloseEvent']"
+                >
+                  <template #default>
+                    <span data-test="empathize-content">Empathize</span>
+                  </template>
+                </Empathize>`,
+    eventToSpy
+  }: RenderEmpathizeOptions = {}): RenderEmpathizeAPI {
+    const [, localVue] = installNewXPlugin();
+    XPlugin.registerXModule(empathizeXModule);
 
-  beforeEach(() => {
-    [, localVue] = installNewXPlugin({});
-  });
+    let eventSpy;
+    if (eventToSpy) {
+      eventSpy = jest.fn();
+      XPlugin.bus.on(eventToSpy).subscribe(eventSpy);
+    }
+
+    const wrapper = mount(
+      {
+        props: ['eventsToOpenEmpathize', 'eventsToCloseEmpathize'],
+        components: { Empathize, BaseEventButton },
+        template
+      },
+      {
+        localVue,
+        propsData: {
+          eventsToOpenEmpathize,
+          eventsToCloseEmpathize
+        }
+      }
+    ).findComponent(Empathize);
+
+    return {
+      wrapper,
+      eventSpy
+    };
+  }
 
   it('is an XComponent which has an XModule', () => {
-    const empathize = mount(Empathize, { localVue });
-    expect(isXComponent(empathize.vm)).toEqual(true);
-    expect(getXComponentXModuleName(empathize.vm)).toEqual('empathize');
+    const { wrapper } = renderEmpathize();
+    expect(isXComponent(wrapper.vm)).toEqual(true);
+    expect(getXComponentXModuleName(wrapper.vm)).toEqual('empathize');
   });
 
   it('listens to UserOpenedEmpathize and UserClosedEmpathize by default', async () => {
-    const component = {
-      template: `
-        <Empathize :events-to-open-empathize="['TestOpenEvent']"
-                   :events-to-close-empathize="['TestCloseEvent']">
-          <template #default>
-            <span data-test="empathize-content">Empathize</span>
-          </template>
-        </Empathize>
-      `,
-      components: {
-        BaseEventButton,
-        Empathize
-      },
-      localVue
-    };
-    const componentWrapper = mount(component, {
-      localVue
-    });
+    const { wrapper } = renderEmpathize();
 
-    componentWrapper.vm.$x.emit('TestOpenEvent' as any);
+    wrapper.vm.$x.emit('TestOpenEvent' as any);
     await new Promise(resolve => setTimeout(resolve));
     // await localVue.nextTick();
-    expect(componentWrapper.find('.x-empathize').exists()).toBe(true);
-    expect(componentWrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(true);
+    expect(wrapper.find('.x-empathize').exists()).toBe(true);
+    expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(true);
 
-    componentWrapper.vm.$x.emit('TestCloseEvent' as any);
+    wrapper.vm.$x.emit('TestCloseEvent' as any);
     await new Promise(resolve => setTimeout(resolve));
     // await localVue.nextTick();
-    expect(componentWrapper.find('.x-empathize').exists()).toBe(false);
-    expect(componentWrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(false);
+    expect(wrapper.find('.x-empathize').exists()).toBe(false);
+    expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(false);
   });
 });
+
+interface RenderEmpathizeOptions {
+  /**
+   * Array of {@link XEvent | xEvents} to open the empathize.
+   */
+  eventsToOpenEmpathize: XEvent[];
+  /**
+   * Array of {@link XEvent | xEvents} to close the empathize.
+   */
+  eventsToCloseEmpathize: XEvent[];
+  /**
+   * The template to render {@link Empathize} component.
+   */
+  template?: string;
+  /**
+   * An event to spy on.
+   */
+  eventToSpy?: XEvent;
+}
+
+interface RenderEmpathizeAPI {
+  /** The Vue testing utils wrapper for the {@link Empathize} component. */
+  wrapper: Wrapper<Vue>;
+  /** A Jest spy set in the {@link XPlugin} `on` function. */
+  eventSpy?: jest.Mock;
+}

--- a/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
+++ b/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
@@ -22,6 +22,9 @@ describe('testing empathize component', () => {
     const [, localVue] = installNewXPlugin();
     XPlugin.registerXModule(empathizeXModule);
 
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+
     const wrapper = mount(
       {
         components: { Empathize },
@@ -29,6 +32,7 @@ describe('testing empathize component', () => {
       },
       {
         localVue,
+        attachTo: parent,
         propsData: {
           eventsToOpenEmpathize,
           eventsToCloseEmpathize
@@ -69,19 +73,19 @@ describe('testing empathize component', () => {
 
     // Both should exist and be visible
     expect(wrapper.find('.x-empathize').exists()).toBe(true);
-    expect(wrapper.find('.x-empathize').isVisible()).toBe(true);
+    expect(wrapper.find('.x-empathize').element).toBeVisible();
     expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(true);
-    expect(wrapper.find(getDataTestSelector('empathize-content')).isVisible()).toBe(true);
+    expect(wrapper.find(getDataTestSelector('empathize-content')).element).toBeVisible();
 
     wrapper.vm.$x.emit('UserClosedEmpathize');
     jest.runAllTimers();
     await wrapper.vm.$nextTick();
 
-    // Both should exist, as v-show doesn't remove the elements in the DOM, but not be visible
+    // Both should exist, as v-show doesn't remove the elements in the DOM, and not be visible
     expect(wrapper.find('.x-empathize').exists()).toBe(true);
-    expect(wrapper.find('.x-empathize').isVisible()).toBe(false);
+    expect(wrapper.find('.x-empathize').element).not.toBeVisible();
     expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(true);
-    expect(wrapper.find(getDataTestSelector('empathize-content')).isVisible()).toBe(false);
+    expect(wrapper.find(getDataTestSelector('empathize-content')).element).not.toBeVisible();
   });
 });
 

--- a/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
+++ b/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
@@ -7,6 +7,8 @@ import { empathizeXModule } from '../../x-module';
 import { XPlugin } from '../../../../plugins/index';
 import { XEvent } from '../../../../wiring/index';
 
+jest.useFakeTimers();
+
 describe('testing empathize component', () => {
   function renderEmpathize({
     eventsToOpenEmpathize = ['UserClickedSearchBox'],
@@ -50,7 +52,10 @@ describe('testing empathize component', () => {
     const { wrapper } = renderEmpathize({ template });
 
     wrapper.vm.$x.emit('UserClickedSearchBox');
+    // Fast-forward until all timers have been executed
+    jest.runAllTimers();
     await wrapper.vm.$nextTick();
+
     expect(wrapper.find('.x-empathize').exists()).toBe(true);
     expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(false);
   });
@@ -58,26 +63,25 @@ describe('testing empathize component', () => {
   it('listens to UserOpenedEmpathize and UserClosedEmpathize by default', async () => {
     const { wrapper } = renderEmpathize();
 
-    wrapper.vm.$x.emit('UserFocusedSearchBox');
+    wrapper.vm.$x.emit('UserClickedSearchBox');
+    jest.runAllTimers();
     await wrapper.vm.$nextTick();
 
+    // Both should exist and be visible
     expect(wrapper.find('.x-empathize').exists()).toBe(true);
+    expect(wrapper.find('.x-empathize').isVisible()).toBe(true);
     expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(true);
-    // FAILS, IT SHOULD EXIST AND BE VISIBLE
-    // expect(wrapper.find('.x-empathize').isVisible()).toBe(true);
-    // expect(wrapper.find(getDataTestSelector('empathize-content')).isVisible()).toBe(true);
-
-    // WRONG, IT SHOULD NOT PASS
-    // expect(wrapper.element.style.display).toEqual('none');
-    // expect(wrapper.attributes().style).toBe('display:none');
+    expect(wrapper.find(getDataTestSelector('empathize-content')).isVisible()).toBe(true);
 
     wrapper.vm.$x.emit('UserClosedEmpathize');
+    jest.runAllTimers();
     await wrapper.vm.$nextTick();
+
+    // Both should exist, as v-show doesn't remove the elements in the DOM, but not be visible
     expect(wrapper.find('.x-empathize').exists()).toBe(true);
-    // FAILS, IT SHOULD EXIST AND NOT BE VISIBLE
-    // expect(wrapper.find('.x-empathize').isVisible()).toBe(false);
-    // expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(true);
-    // expect(wrapper.find(getDataTestSelector('empathize-content')).isVisible()).toBe(false);
+    expect(wrapper.find('.x-empathize').isVisible()).toBe(false);
+    expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBe(true);
+    expect(wrapper.find(getDataTestSelector('empathize-content')).isVisible()).toBe(false);
   });
 });
 

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -1,15 +1,18 @@
 <template>
   <component :is="animation">
     <div
-      v-if="isOpen"
+      v-show="isOpen && !emptySlot"
       @mousedown.prevent
       @focusin="open"
       @focusout="close"
       class="x-empathize"
       data-test="empathize"
+      style="content-visibility: auto"
     >
       <!-- @slot (Required) Modal container content -->
-      <slot />
+      <slot>
+        <span ref="emptySlot" hidden aria-hidden="true"></span>
+      </slot>
     </div>
   </component>
 </template>
@@ -74,6 +77,22 @@
     protected isOpen = false;
 
     /**
+     * The default slot is empty to avoid opening empathize with no content.
+     *
+     * @internal
+     */
+    protected emptySlot: boolean | Element = true;
+
+    /**
+     * Detects if the default slot has been replaced.
+     *
+     * @internal
+     */
+    updated(): void {
+      this.emptySlot = !!this.$refs.emptySlot;
+    }
+
+    /**
      * Open empathize. This method will be executed on any event in
      * {@link Empathize.eventsToOpenEmpathize} and on DOM event `focusin` on Empathize root element.
      *
@@ -119,6 +138,7 @@
     changeOpenState(newOpenState: boolean, metadata: WireMetadata): void {
       if (this.isOpen !== newOpenState) {
         this.isOpen = newOpenState;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         this.$x.emit(
           this.isOpen ? 'EmpathizeOpened' : 'EmpathizeClosed',
           undefined,

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -1,7 +1,7 @@
 <template>
   <component :is="animation">
     <div
-      v-show="isOpen && !emptySlot"
+      v-show="isOpen && !isEmptySlot"
       @mousedown.prevent
       @focusin="open"
       @focusout="close"
@@ -11,7 +11,7 @@
     >
       <!-- @slot (Required) Modal container content -->
       <slot>
-        <span ref="emptySlot" hidden aria-hidden="true"></span>
+        <span ref="isEmptySlot" hidden aria-hidden="true"></span>
       </slot>
     </div>
   </component>
@@ -81,7 +81,7 @@
      *
      * @internal
      */
-    protected emptySlot: boolean | Element = true;
+    protected isEmptySlot: boolean | Element = true;
 
     /**
      * Detects if the default slot has been replaced.
@@ -89,7 +89,7 @@
      * @internal
      */
     updated(): void {
-      this.emptySlot = !!this.$refs.emptySlot;
+      this.isEmptySlot = !!this.$refs.isEmptySlot;
     }
 
     /**

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -104,7 +104,9 @@
     @XOn(component => (component as Empathize).eventsToOpenEmpathize)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     open(payload: unknown, metadata: WireMetadata): void {
-      this.changeOpenState(true, metadata);
+      if (this.isEmptySlot === false) {
+        this.changeOpenState(true, metadata);
+      }
     }
 
     /**

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -104,7 +104,7 @@
      */
     @XOn(component => (component as Empathize).eventsToOpenEmpathize)
     open(payload: unknown, metadata: WireMetadata): void {
-      if (this.isEmptySlot === false) {
+      if (!this.$refs.isEmptySlot) {
         this.changeOpenState(true, metadata);
       }
     }
@@ -120,7 +120,6 @@
      * @internal
      */
     @XOn(component => (component as Empathize).eventsToCloseEmpathize)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     close(payload: unknown, metadata: WireMetadata): void {
       this.changeOpenState(false, metadata);
     }

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -87,9 +87,10 @@
      * Detects if the default slot has been replaced.
      *
      * @internal
+     * @returns True if the slot is empty, the slot element if it has content.
      */
-    updated(): void {
-      this.isEmptySlot = !!this.$refs.isEmptySlot;
+    updated(): boolean | Element {
+      return (this.isEmptySlot = !!this.$refs.isEmptySlot);
     }
 
     /**
@@ -102,7 +103,6 @@
      * @internal
      */
     @XOn(component => (component as Empathize).eventsToOpenEmpathize)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     open(payload: unknown, metadata: WireMetadata): void {
       if (this.isEmptySlot === false) {
         this.changeOpenState(true, metadata);


### PR DESCRIPTION
[EX-7169](https://searchbroker.atlassian.net/browse/EX-7169)

## Motivation and context
No more need to check if there is Empathize content to show it or not, It will do it by itself.
This was a recurrent problem in the setups.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

- Test adding a fake button inside the `predictive-layer` component to remove empathize content and check that it doesn't get opened if the slot is empty while the `isOpen` state also remains `false` for this use case.

- Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.

