### PR TITLE
feat(tagging): track banner clicks

### DIFF
--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -1,5 +1,3 @@
-import { bannerSchema, PlatformBanner } from '@empathyco/x-adapter-platform';
-import { Banner } from '@empathyco/x-types';
 import { SnippetConfig } from '../x-installer/api/api.types';
 import { InstallXOptions } from '../x-installer/x-installer/types';
 import { adapter } from './adapter';
@@ -12,15 +10,6 @@ export const baseSnippetConfig: SnippetConfig = {
 };
 
 const xModulesURLConfig = JSON.parse(new URL(location.href).searchParams.get('xModules') ?? '{}');
-
-bannerSchema.$override<PlatformBanner, Partial<Banner>>({
-  tagging: {
-    click: {
-      url: () => 'https://jsonplaceholder.typicode.com/todos/1',
-      params: () => Object.assign({})
-    }
-  }
-});
 
 export const baseInstallXOptions: InstallXOptions = {
   adapter,

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -1,3 +1,5 @@
+import { bannerSchema, PlatformBanner } from '@empathyco/x-adapter-platform';
+import { Banner } from '@empathyco/x-types';
 import { SnippetConfig } from '../x-installer/api/api.types';
 import { InstallXOptions } from '../x-installer/x-installer/types';
 import { adapter } from './adapter';
@@ -10,6 +12,15 @@ export const baseSnippetConfig: SnippetConfig = {
 };
 
 const xModulesURLConfig = JSON.parse(new URL(location.href).searchParams.get('xModules') ?? '{}');
+
+bannerSchema.$override<PlatformBanner, Partial<Banner>>({
+  tagging: {
+    click: {
+      url: () => 'https://jsonplaceholder.typicode.com/todos/1',
+      params: () => Object.assign({})
+    }
+  }
+});
 
 export const baseInstallXOptions: InstallXOptions = {
   adapter,

--- a/packages/x-components/src/x-modules/search/components/__tests__/banner.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/banner.spec.ts
@@ -61,6 +61,25 @@ describe('testing Banner component', () => {
 
     expect(wrapper.get(getDataTestSelector('banner')).text()).toEqual('Search UIs');
   });
+
+  // eslint-disable-next-line max-len
+  it('emits UserClickedABanner when the user clicks in the left, middle or right button on the component', () => {
+    const listener = jest.fn();
+    const banner = createBannerStub('banner');
+    const { wrapper } = renderBanner({ banner });
+    wrapper.vm.$x.on('UserClickedABanner').subscribe(listener);
+
+    wrapper.trigger('click');
+    expect(listener).toHaveBeenNthCalledWith(1, banner);
+
+    wrapper.trigger('click', { button: 1 });
+    expect(listener).toHaveBeenNthCalledWith(2, banner);
+
+    wrapper.trigger('click', { button: 2 });
+    expect(listener).toHaveBeenNthCalledWith(3, banner);
+
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
 });
 
 interface RenderBannerOptions {

--- a/packages/x-components/src/x-modules/search/components/banner.vue
+++ b/packages/x-components/src/x-modules/search/components/banner.vue
@@ -1,5 +1,11 @@
 <template>
-  <a @click="emitClickEvent" :href="banner.url" class="x-banner" data-test="banner">
+  <a
+    @click="emitClickEvent"
+    @click.middle="emitClickEvent"
+    :href="banner.url"
+    class="x-banner"
+    data-test="banner"
+  >
     <img :src="banner.image" class="x-banner__image" :alt="banner.title" />
     <h2 class="x-banner__title">{{ banner.title }}</h2>
   </a>

--- a/packages/x-components/src/x-modules/search/components/banner.vue
+++ b/packages/x-components/src/x-modules/search/components/banner.vue
@@ -1,6 +1,7 @@
 <template>
   <a
     @click="emitClickEvent"
+    @click.right="emitClickEvent"
     @click.middle="emitClickEvent"
     :href="banner.url"
     class="x-banner"

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -147,10 +147,10 @@ export const trackBannerClickedWire = createTrackWire('click');
 export const trackAddToCartWire = createTrackWire('add2cart');
 
 /**
- * Factory helper to create a wire for the track of a taggable object.
+ * Factory helper to create a wire for the track of a taggable element.
  *
  * @param property - Key of the tagging object to track.
- * @returns A new wire for the given property of the result tagging.
+ * @returns A new wire for the given property of the taggable element.
  *
  * @internal
  */

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -1,4 +1,4 @@
-import { Result, Tagging, TaggingRequest } from '@empathyco/x-types';
+import { Banner, Result, Tagging, TaggingRequest } from '@empathyco/x-types';
 import { DefaultSessionService } from '@empathyco/x-utils';
 import {
   namespacedWireCommit,
@@ -132,6 +132,8 @@ export const setQueryTaggingInfo = moduleDebounce(
  */
 export const trackResultClickedWire = createTrackResultWire('click');
 
+export const trackBannerClickedWire = createTrackResultWire('click');
+
 /**
  * Performs a track of a result added to the cart.
  *
@@ -147,7 +149,7 @@ export const trackAddToCartWire = createTrackResultWire('add2cart');
  *
  * @internal
  */
-function createTrackResultWire(property: keyof Tagging): Wire<Result> {
+function createTrackResultWire(property: keyof Tagging): Wire<Result | Banner> {
   return filter(
     wireDispatch('track', ({ eventPayload: { tagging }, metadata: { location } }) => {
       const taggingInfo: TaggingRequest = tagging[property];
@@ -195,5 +197,8 @@ export const taggingWiring = createWiring({
   },
   UserClickedPDPAddToCart: {
     trackAddToCartFromSessionStorage
+  },
+  UserClickedABanner: {
+    trackBannerClickedWire
   }
 });

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -152,9 +152,9 @@ export const trackAddToCartWire = createTrackWire('add2cart');
  * @param property - Key of the tagging object to track.
  * @returns A new wire for the given property of the taggable element.
  *
- * @internal
+ * @public
  */
-function createTrackWire(property: keyof Tagging): Wire<Taggable> {
+export function createTrackWire(property: keyof Tagging): Wire<Taggable> {
   return filter(
     wireDispatch('track', ({ eventPayload: { tagging }, metadata: { location } }) => {
       const taggingInfo: TaggingRequest = tagging[property];

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -1,4 +1,4 @@
-import { Banner, Result, Tagging, TaggingRequest } from '@empathyco/x-types';
+import { Taggable, Tagging, TaggingRequest } from '@empathyco/x-types';
 import { DefaultSessionService } from '@empathyco/x-utils';
 import {
   namespacedWireCommit,
@@ -130,26 +130,31 @@ export const setQueryTaggingInfo = moduleDebounce(
  *
  * @public
  */
-export const trackResultClickedWire = createTrackResultWire('click');
+export const trackResultClickedWire = createTrackWire('click');
 
-export const trackBannerClickedWire = createTrackResultWire('click');
+/**
+ * Tracks the tagging of the banner.
+ *
+ * @public
+ */
+export const trackBannerClickedWire = createTrackWire('click');
 
 /**
  * Performs a track of a result added to the cart.
  *
  * @public
  */
-export const trackAddToCartWire = createTrackResultWire('add2cart');
+export const trackAddToCartWire = createTrackWire('add2cart');
 
 /**
- * Factory helper to create a wire for the track of a result.
+ * Factory helper to create a wire for the track of a taggable object.
  *
  * @param property - Key of the tagging object to track.
  * @returns A new wire for the given property of the result tagging.
  *
  * @internal
  */
-function createTrackResultWire(property: keyof Tagging): Wire<Result | Banner> {
+function createTrackWire(property: keyof Tagging): Wire<Taggable> {
   return filter(
     wireDispatch('track', ({ eventPayload: { tagging }, metadata: { location } }) => {
       const taggingInfo: TaggingRequest = tagging[property];


### PR DESCRIPTION
EX-7339 

This change is a request from motive where the banners have tagging information. Currently in platform we don't have tagging for banners, so if you wan to test this locally you can by overriding the bannerSchema and mocking the tagging:

```
bannerSchema.$override<PlatformBanner, Partial<Banner>>({
  tagging: {
    click: {
      url: () => 'https://localhost',
      params: () => Object.assign({})
    }
  }
});
```

