### PR TITLE
fix(design-system): Change the xds button size variants.

### DIFF
--- a/packages/x-tailwindcss/demo/src/components/xds-button.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-button.vue
@@ -27,13 +27,13 @@
   export default class XdsButtonShowcase extends Vue {
     @Prop({ default: () => 'x-button' })
     public base!: string;
-    @Prop({ default: () => ['x-button-xs', 'x-button-sm', 'x-button-md', 'x-button-lg'] })
+    @Prop({ default: () => ['x-button-sm', 'x-button-md', 'x-button-lg', 'x-button-xl'] })
     public sizes!: string[];
     @Prop({
       default: () => [
         'x-button-neutral',
-        'x-button-primary',
-        'x-button-secondary',
+        'x-button-lead',
+        'x-button-auxiliary',
         'x-button-accent',
         'x-button-highlight',
         'x-button-success',
@@ -54,8 +54,8 @@
 
     @Prop({
       default: () => [
-        'x-button-primary x-button-xs',
-        'x-button-secondary x-button-circle x-button-outlined'
+        'x-button-lead x-button-sm',
+        'x-button-auxiliary x-button-circle x-button-outlined'
       ]
     })
     public combinations!: string[];

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/default.ts
@@ -1,4 +1,6 @@
 import { TailwindHelpers } from '../../../types';
+import { buttonColors } from './colors';
+import { buttonSizes } from './sizes';
 
 /**
  * Returns the default styles for component `button`.
@@ -7,55 +9,26 @@ import { TailwindHelpers } from '../../../types';
  * @returns The {@link CssStyleOptions} for the component.
  */
 // eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
-export function buttonDefault({ theme }: TailwindHelpers) {
+export function buttonDefault(helpers: TailwindHelpers) {
+  const { theme } = helpers;
   return {
-    '--button-color-25': theme('colors.neutral.25'),
-    '--button-color-50': theme('colors.neutral.50'),
-    '--button-color-75': theme('colors.neutral.75'),
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     alignContent: 'center',
     flexFlow: 'row nowrap',
     boxSizing: 'border-box',
-    minHeight: theme('spacing.48'),
-    gap: theme('spacing.8'),
-    paddingInlineStart: theme('spacing.16'),
-    paddingInlineEnd: theme('spacing.16'),
-    borderRadius: theme('borderRadius.none'),
 
     borderStyle: 'solid',
     borderWidth: theme('borderWidth.1'),
 
-    borderColor: 'var(--button-color-50)',
-    backgroundColor: 'var(--button-color-50)',
-    color: theme('colors.neutral.0'),
-
     fontFamily: theme('fontFamily.primary'),
-    fontSize: theme('fontSize.md'),
     fontWeight: theme('fontWeight.bold'),
     letterSpacing: theme('letterSpacing.md'),
     lineHeight: theme('lineHeight.sm'),
 
-    cursor: 'default',
-
-    '&:hover': {
-      borderColor: 'var(--button-color-75)',
-      backgroundColor: 'var(--button-color-75)',
-      color: theme('colors.neutral.0')
-    },
-
-    '&:active': {
-      borderColor: 'var(--button-color-75)',
-      backgroundColor: 'var(--button-color-75)',
-      color: theme('colors.neutral.0')
-    },
-
-    '&:disabled': {
-      borderColor: theme('colors.neutral.10'),
-      backgroundColor: theme('colors.neutral.10'),
-      color: theme('colors.neutral.25'),
-      cursor: 'not-allowed'
-    }
+    cursor: 'pointer',
+    ...buttonColors(helpers).neutral,
+    ...buttonSizes(helpers).md
   };
 }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/sizes.ts
@@ -9,44 +9,36 @@ import { TailwindHelpers } from '../../../types';
 // eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonSizes({ theme }: TailwindHelpers) {
   return {
-    xs: {
+    sm: {
       minHeight: theme('spacing.32'),
       gap: theme('spacing.8'),
       paddingInlineStart: theme('spacing.8'),
       paddingInlineEnd: theme('spacing.8'),
-      fontSize: theme('fontSize.xs'),
-      fontWeight: theme('fontWeight.bold'),
-      letterSpacing: theme('letterSpacing.md')
+      fontSize: theme('fontSize.xs')
     },
 
-    sm: {
+    md: {
       minHeight: theme('spacing.40'),
       gap: theme('spacing.8'),
       paddingInlineStart: theme('spacing.12'),
       paddingInlineEnd: theme('spacing.12'),
-      fontSize: theme('fontSize.sm'),
-      fontWeight: theme('fontWeight.bold'),
-      letterSpacing: theme('letterSpacing.md')
+      fontSize: theme('fontSize.sm')
     },
 
-    md: {
+    lg: {
       minHeight: theme('spacing.48'),
       gap: theme('spacing.8'),
       paddingInlineStart: theme('spacing.16'),
       paddingInlineEnd: theme('spacing.16'),
-      fontSize: theme('fontSize.md'),
-      fontWeight: theme('fontWeight.bold'),
-      letterSpacing: theme('letterSpacing.md')
+      fontSize: theme('fontSize.md')
     },
 
-    lg: {
+    xl: {
       minHeight: theme('spacing.56'),
       gap: theme('spacing.8'),
       paddingInlineStart: theme('spacing.24'),
       paddingInlineEnd: theme('spacing.24'),
-      fontSize: theme('fontSize.lg'),
-      fontWeight: theme('fontWeight.bold'),
-      letterSpacing: theme('letterSpacing.md')
+      fontSize: theme('fontSize.lg')
     }
   };
 }


### PR DESCRIPTION
EX-7369

This PR:
- Changes the naming of the XDS Button from [`xs`, `sm`, `md`, `lg`] to: [ `sm`, `md`, `lg`, `xl`] to make it coherent with the next icon XDS component.
- The default size would be the new `md` so the buttons will be smaller by default.
- Also refactored the way default styles reusing the corresponding variant.
- Fixed the colors in the button showcase to use the new colors naming.

