### PR TITLE
refactor(design-system): Refactor showcase component to make it reusable.

### DIFF
--- a/packages/x-tailwindcss/demo/src/components/xds-base-showcase.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-base-showcase.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="x-flex x-flex-col x-gap-32">
+    <h1 class="x-text-lg">{{ title }}</h1>
+    <div v-for="(classes, section) in sections" :key="section" class="x-flex x-flex-row x-gap-16">
+      <h2 class="x-text-md x-w-128 x-text-right x-flex-none">{{ section }}</h2>
+
+      <div class="x-flex x-flex-row x-flex-wrap x-gap-16">
+        <div v-for="cssClass in classes" :key="cssClass">
+          <slot v-bind="{ cssClass, section, copyCssClassesToClipboard, removeClassPrefix }" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import { Vue, Component, Prop } from 'vue-property-decorator';
+  import { ShowcaseSections } from '../types/types';
+
+  @Component
+  export default class XdsBaseShowcase extends Vue {
+    /**
+     * The sections to display with the list of classes for each element.
+     *
+     * @public
+     */
+    @Prop({ required: true })
+    public sections!: ShowcaseSections;
+
+    /**
+     * The title to display at the beginning of the component.
+     *
+     * @public
+     */
+    @Prop({ required: true })
+    public title!: string;
+
+    /**
+     * Copies the classList of an HTML Element to the clipboard.
+     *
+     * @param event - The MouseEvent to get the HTML Element from.
+     */
+    protected copyCssClassesToClipboard(event: MouseEvent): void {
+      navigator.clipboard.writeText((event.target as HTMLElement).classList.value);
+    }
+
+    /**
+     * Removes the prefix from a CSS class list. If the prefix is full class name, is removed too.
+     *
+     * @param cssClasses - The class list to remove the prefix from.
+     * @param prefix - The prefix to be removed.
+     * @returns The CSS classes with the prefix removed.
+     */
+    protected removeClassPrefix(cssClasses: string, prefix: string): string {
+      return cssClasses.replace(new RegExp(`${prefix}-?`, 'g'), '');
+    }
+  }
+</script>

--- a/packages/x-tailwindcss/demo/src/components/xds-base-showcase.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-base-showcase.vue
@@ -10,6 +10,16 @@
         </div>
       </div>
     </div>
+    <div
+      class="
+        x-fixed x-left-1/2 x-top-1/2
+        -translate-x-1/2 -translate-y-1/2
+        x-bg-neutral-25 x-p-8 x-transition-opacity x-duration-300 x-pointer-events-none
+      "
+      :class="isMessageVisible ? 'x-opacity-100' : 'x-opacity-0'"
+    >
+      CSS classes copied to Clipboard!
+    </div>
   </div>
 </template>
 
@@ -35,13 +45,18 @@
     @Prop({ required: true })
     public title!: string;
 
+    protected isMessageVisible = false;
+
     /**
      * Copies the classList of an HTML Element to the clipboard.
      *
      * @param event - The MouseEvent to get the HTML Element from.
+     *
+     * @internal
      */
     protected copyCssClassesToClipboard(event: MouseEvent): void {
       navigator.clipboard.writeText((event.target as HTMLElement).classList.value);
+      this.showMessage();
     }
 
     /**
@@ -50,9 +65,21 @@
      * @param cssClasses - The class list to remove the prefix from.
      * @param prefix - The prefix to be removed.
      * @returns The CSS classes with the prefix removed.
+     *
+     * @internal
      */
     protected removeClassPrefix(cssClasses: string, prefix: string): string {
       return cssClasses.replace(new RegExp(`${prefix}-?`, 'g'), '');
+    }
+
+    /**
+     * Shows the message of copied classes to clipboard for 2 seconds.
+     *
+     * @internal
+     */
+    protected showMessage(): void {
+      this.isMessageVisible = true;
+      setTimeout(() => (this.isMessageVisible = false), 2000);
     }
   }
 </script>

--- a/packages/x-tailwindcss/demo/src/components/xds-button.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-button.vue
@@ -66,12 +66,16 @@
     protected get sections(): ShowcaseSections {
       return {
         Default: [this.base],
-        Disabled: [this.base],
         Colors: this.colors.map(addParentClasses(this.base)),
         Sizes: this.sizes.map(addParentClasses(this.base)),
         Layout: this.layouts.map(addParentClasses(this.base)),
         Outline: this.colors.map(addParentClasses(this.base, this.outline)),
         Ghost: this.colors.map(addParentClasses(this.base, this.ghost)),
+        Disabled: [
+          this.base,
+          addParentClasses(this.base)(this.outline),
+          addParentClasses(this.base)(this.ghost)
+        ],
         Combinations: this.combinations.map(addParentClasses(this.base))
       };
     }

--- a/packages/x-tailwindcss/demo/src/components/xds-button.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-button.vue
@@ -1,29 +1,32 @@
 <template>
-  <div class="x-flex x-flex-col x-gap-16">
-    <h1 class="x-text-lg">Button</h1>
-    <div
-      v-for="(classes, section) in sections"
-      :key="section"
-      class="x-flex x-flex-row x-items-start x-gap-12 x-align-items-baseline"
+  <XdsBaseShowcase
+    #default="{ cssClass, section, copyCssClassesToClipboard, removeClassPrefix }"
+    title="Button"
+    :sections="sections"
+  >
+    <button
+      :key="cssClass"
+      @click="copyCssClassesToClipboard"
+      :class="cssClass"
+      title="Click me to copy CSS classes"
+      :disabled="section === 'Disabled'"
     >
-      <h2 class="x-text-md">{{ section }}</h2>
-      <button
-        v-for="cssClass in classes"
-        :key="cssClass"
-        @click="copyCSSClasses"
-        :class="cssClass"
-        title="Click me to copy CSS classes"
-      >
-        {{ removeBase(cssClass) }}
-      </button>
-    </div>
-  </div>
+      {{ removeClassPrefix(cssClass, base) || 'button' }}
+    </button>
+  </XdsBaseShowcase>
 </template>
 
 <script lang="ts">
   import { Vue, Component, Prop } from 'vue-property-decorator';
+  import { ShowcaseSections } from '../types/types';
+  import { addParentClasses } from '../utils';
+  import XdsBaseShowcase from './xds-base-showcase.vue';
 
-  @Component
+  @Component({
+    components: {
+      XdsBaseShowcase
+    }
+  })
   export default class XdsButtonShowcase extends Vue {
     @Prop({ default: () => 'x-button' })
     public base!: string;
@@ -60,28 +63,17 @@
     })
     public combinations!: string[];
 
-    protected get sections(): Record<string, string[]> {
+    protected get sections(): ShowcaseSections {
       return {
         Default: [this.base],
-        Colors: this.colors.map(this.prefixWith(this.base)),
-        Sizes: this.sizes.map(this.prefixWith(this.base)),
-        Layout: this.layouts.map(this.prefixWith(this.base)),
-        Outline: this.colors.map(this.prefixWith(this.base, this.outline)),
-        Ghost: this.colors.map(this.prefixWith(this.base, this.ghost)),
-        Combinations: this.combinations.map(this.prefixWith(this.base))
+        Disabled: [this.base],
+        Colors: this.colors.map(addParentClasses(this.base)),
+        Sizes: this.sizes.map(addParentClasses(this.base)),
+        Layout: this.layouts.map(addParentClasses(this.base)),
+        Outline: this.colors.map(addParentClasses(this.base, this.outline)),
+        Ghost: this.colors.map(addParentClasses(this.base, this.ghost)),
+        Combinations: this.combinations.map(addParentClasses(this.base))
       };
-    }
-
-    protected prefixWith(...prefix: string[]): (value: string) => string {
-      return cssClass => `${prefix.join(' ')} ${cssClass}`;
-    }
-
-    protected removeBase(cssClass: string): string {
-      return cssClass.replace(new RegExp(`${this.base}-?`, 'g'), '') || 'button';
-    }
-
-    protected copyCSSClasses(event: MouseEvent): void {
-      navigator.clipboard.writeText((event.target as HTMLElement).classList.value);
     }
   }
 </script>

--- a/packages/x-tailwindcss/demo/src/components/xds-showcase.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-showcase.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="x-flex x-flex-col"><XdsButton /></div>
+  <div class="x-flex x-flex-col x-gap-40"><XdsButton /></div>
 </template>
 <script lang="ts">
   import Vue from 'vue';

--- a/packages/x-tailwindcss/demo/src/index.ts
+++ b/packages/x-tailwindcss/demo/src/index.ts
@@ -1,2 +1,5 @@
 export { default as XdsButton } from './components/xds-button.vue';
+export { default as XdsBaseShowcase } from './components/xds-base-showcase.vue';
 export { default as XdsShowCase } from './components/xds-showcase.vue';
+export * from './types/types';
+export * from './utils';

--- a/packages/x-tailwindcss/demo/src/types/types.ts
+++ b/packages/x-tailwindcss/demo/src/types/types.ts
@@ -1,0 +1,4 @@
+/**
+ * The type of the `sections` prop that XdsBaseShowcase component receives.
+ */
+export type ShowcaseSections = Record<string, string[]>;

--- a/packages/x-tailwindcss/demo/src/utils.ts
+++ b/packages/x-tailwindcss/demo/src/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Adds a list of parent CSS classes to another CSS class.
+ *
+ * @param parentClasses - The list of parent classes.
+ * @returns A string with the new list of classes.
+ */
+export function addParentClasses(...parentClasses: string[]): (value: string) => string {
+  return cssClass => `${parentClasses.join(' ')} ${cssClass}`;
+}


### PR DESCRIPTION

EX-7368

This PR:
- Extracts the common part of the `XdsButton` showcase component to a new `XdsBaseShowcase` component to reuse with new components like the icon.