### PR TITLE
feat(x-installer): allow retrieving the target element for application mounting based on the snippet configuration

### DIFF
--- a/packages/x-components/.gitignore
+++ b/packages/x-components/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /node_modules
+/coverage
 /dist
 /docs
 /temp

--- a/packages/x-components/src/x-installer/x-installer/types.ts
+++ b/packages/x-components/src/x-installer/x-installer/types.ts
@@ -26,11 +26,10 @@ export interface InstallXOptions<API extends XAPI = XAPI> extends XPluginOptions
    */
   bus?: XBus;
   /**
-   * An Element | string to indicate the HTML element that will contain the Vue
-   * application. If string selector is passed and the element doesn't exits, the
-   * {@link XInstaller} will create it.
+   * An Element | string | function to indicate the HTML element that will contain the Vue
+   * application. If it isn't passed, the {@link XInstaller} will create the target element.
    */
-  domElement?: Element | string;
+  domElement?: Element | string | ((snippetConfig: NormalisedSnippetConfig) => Element | string);
   /**
    * The XPlugin which will be installed. If not passed, an instance of {@link XPlugin} will be
    * installed.

--- a/packages/x-components/src/x-installer/x-installer/x-installer.ts
+++ b/packages/x-components/src/x-installer/x-installer/x-installer.ts
@@ -1,4 +1,4 @@
-import { forEach } from '@empathyco/x-utils';
+import { forEach, isFunction } from '@empathyco/x-utils';
 import Vue, { PluginObject, VueConstructor } from 'vue';
 import { BaseXBus } from '../../plugins/x-bus';
 import { XBus } from '../../plugins/x-bus.types';
@@ -319,7 +319,7 @@ export class XInstaller {
    * @internal
    */
   protected getMountingTarget(domElement?: InstallXOptions['domElement']): Element {
-    if (typeof domElement === 'function') {
+    if (isFunction(domElement)) {
       domElement = domElement(this.snippetConfig!);
     }
     if (typeof domElement === 'string') {
@@ -331,10 +331,7 @@ export class XInstaller {
       }
       return target;
     }
-    if (domElement !== undefined) {
-      return domElement;
-    }
-    return document.body.appendChild(document.createElement('div'));
+    return domElement ?? document.body.appendChild(document.createElement('div'));
   }
 
   /**

--- a/packages/x-components/src/x-installer/x-installer/x-installer.ts
+++ b/packages/x-components/src/x-installer/x-installer/x-installer.ts
@@ -306,29 +306,35 @@ export class XInstaller {
   }
 
   /**
-   * It returns the HTML element to mount the Vue Application. If the `domElement` parameter in the
-   * {@link InstallXOptions} is an Element or a string, then it is used. If it is
-   * not present then a new <div> Element is created and append to the body to be used.
+   * It returns the HTML element to mount the Vue Application. If the `domElement` parameter in
+   * the {@link InstallXOptions} is an Element or an element selector, then this will be used.
+   * The `domElement` can also be a function with the {@link SnippetConfig} as parameter which
+   * returns an Element or element selector to use.
+   * If it is not present, a new <div> Element is created and appended to the body.
    *
-   * @param elementOrSelector - String or Element used to mount the Vue App.
+   * @param domElement - {@link InstallXOptions.domElement | Element, string or function} Used
+   * to mount the Vue Application.
    *
-   * @returns The Element to use as mounting point for the Vue App.
+   * @returns The Element to use as mounting target for the Vue Application.
    * @internal
    */
-  protected getMountingTarget(elementOrSelector?: string | Element): Element {
-    if (typeof elementOrSelector === 'string') {
-      const target = document.querySelector(elementOrSelector);
+  protected getMountingTarget(domElement?: InstallXOptions['domElement']): Element {
+    if (typeof domElement === 'function') {
+      domElement = domElement(this.snippetConfig!);
+    }
+    if (typeof domElement === 'string') {
+      const target = document.querySelector(domElement);
       if (!target) {
         throw Error(
-          `XComponents app couldn't be mounted: Element "${elementOrSelector}" couldn't be found`
+          `XComponents app couldn't be mounted: Element "${domElement}" couldn't be found`
         );
       }
       return target;
-    } else if (elementOrSelector !== undefined) {
-      return elementOrSelector;
-    } else {
-      return document.body.appendChild(document.createElement('div'));
     }
+    if (domElement !== undefined) {
+      return domElement;
+    }
+    return document.body.appendChild(document.createElement('div'));
   }
 
   /**


### PR DESCRIPTION
[MOTPRD-9239](https://searchbroker.atlassian.net/browse/MOTPRD-9239)

`domElement` in `InstallXOptions` now allows a function in addition to an element selector or a DOM element. With this change, the target element where the Vue application is gonna mount, can be a dynamic element based on the `SnippetConfig`.

At Motive, we are working on encapsulating motive-x under a shadowDOM only if an `isolated` property is activated through the `SnippetConfig`. So at runtime, we want to decide if we have to create a DOM tree for the `shadowRoot` or, on the other hand, we have to create a simple `div` based in the snippet configuration. Something like that: 

```TS
function getDomElement({ isolated }: SnippetConfig): Element {
  const xDomElement = document.createElement('div');

  if (isolated) {
    const container = document.createElement('div');
    const shadowRoot = container.attachShadow({ mode: 'closed' });
    shadowRoot.appendChild(xDomElement);
    document.body.appendChild(container);
    setStyleHost(shadowRoot);
  } else {
    document.body.appendChild(xDomElement);
    setStyleHost(document.head);
  }

  return xDomElement;
}
```

I also improved a bit the coverage percentage of the `x-installer` file 😉 
From:
![Screenshot 2022-11-09 at 2 24 17 PM](https://user-images.githubusercontent.com/10746604/200846723-12da7912-d90d-4d2f-8994-d14cfa635e65.png)

To:
![Screenshot 2022-11-09 at 2 22 29 PM](https://user-images.githubusercontent.com/10746604/200846714-e9fa63ee-922f-4e1d-ac43-88d46e2b5c40.png)