### PR TITLE
build(dev-deps): sync `vite` version to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@types/node": "~16.4.12",
         "@types/react": "~16.9.0",
         "@types/react-dom": "~16.9.0",
-        "@types/resize-observer-browser": "~0.1.5",
         "@types/testing-library__jest-dom": "~5.9.1",
         "@typescript-eslint/eslint-plugin": "~5.21.0",
         "@typescript-eslint/parser": "~5.21.0",
@@ -76,7 +75,7 @@
         "tslib": "~2.3.0",
         "tslint": "~5.16.0",
         "typescript": "~4.6.2",
-        "vite": "~3.1.7",
+        "vite": "~3.2.0",
         "vite-plugin-vue2": "~2.0.2",
         "vue": "~2.6.14",
         "vue-class-component": "~7.1.0",
@@ -4511,11 +4510,6 @@
       "dependencies": {
         "@types/react": "^16"
       }
-    },
-    "node_modules/@types/resize-observer-browser": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
-      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -18530,9 +18524,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
       "funding": [
         {
           "type": "opencollective",
@@ -24602,14 +24596,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.7.tgz",
-      "integrity": "sha512-5vCAmU4S8lyVdFCInu9M54f/g8qbOMakVw5xJ4pjoaDy5wgy9sLLZkGdSLN52dlsBqh0tBqxjaqqa8LgPqwRAA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.3.tgz",
+      "integrity": "sha512-h8jl1TZ76eGs3o2dIBSsvXDLb1m/Ec1iej8ZMdz+PsaFUsftZeWe2CZOI3qogEsMNaywc17gu0q6cQDzh/weCQ==",
       "dependencies": {
         "esbuild": "^0.15.9",
-        "postcss": "^8.4.16",
+        "postcss": "^8.4.18",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^2.79.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -24621,12 +24615,17 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
+        "@types/node": ">= 14",
         "less": "*",
         "sass": "*",
         "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
         "less": {
           "optional": true
         },
@@ -24634,6 +24633,9 @@
           "optional": true
         },
         "stylus": {
+          "optional": true
+        },
+        "sugarss": {
           "optional": true
         },
         "terser": {
@@ -24791,9 +24793,9 @@
       }
     },
     "node_modules/vite/node_modules/rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -29825,11 +29827,6 @@
       "requires": {
         "@types/react": "^16"
       }
-    },
-    "@types/resize-observer-browser": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
-      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
     "@types/retry": {
       "version": "0.12.0",
@@ -40529,9 +40526,9 @@
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg=="
     },
     "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -45123,15 +45120,15 @@
       }
     },
     "vite": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.7.tgz",
-      "integrity": "sha512-5vCAmU4S8lyVdFCInu9M54f/g8qbOMakVw5xJ4pjoaDy5wgy9sLLZkGdSLN52dlsBqh0tBqxjaqqa8LgPqwRAA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.3.tgz",
+      "integrity": "sha512-h8jl1TZ76eGs3o2dIBSsvXDLb1m/Ec1iej8ZMdz+PsaFUsftZeWe2CZOI3qogEsMNaywc17gu0q6cQDzh/weCQ==",
       "requires": {
         "esbuild": "^0.15.9",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.16",
+        "postcss": "^8.4.18",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^2.79.1"
       },
       "dependencies": {
         "fsevents": {
@@ -45141,9 +45138,9 @@
           "optional": true
         },
         "rollup": {
-          "version": "2.78.1",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-          "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+          "version": "2.79.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+          "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
           "requires": {
             "fsevents": "~2.3.2"
           }

--- a/packages/x-tailwindcss/package.json
+++ b/packages/x-tailwindcss/package.json
@@ -65,7 +65,7 @@
     "rollup-plugin-vue": "~5.1.9",
     "tailwindcss": "~3.1.8",
     "typescript": "~4.6.2",
-    "vite": "~3.1.7",
+    "vite": "~3.2.0",
     "vite-plugin-vue2": "~2.0.2",
     "vue": "~2.6.14",
     "vue-class-component": "~7.1.0",


### PR DESCRIPTION
Syncs the `vite` version to 3.2.0 version in every package. The other way we might end up with 2 vite installations with is not ideal.