### PR TITLE
fix(animations): make content-visibility CSS property and createCollapseAnimationMixin work together

### DIFF
--- a/packages/x-components/src/components/animations/animations.mixin.ts
+++ b/packages/x-components/src/components/animations/animations.mixin.ts
@@ -20,12 +20,23 @@ export function createCollapseAnimationMixin(property: AnimatedProperty): Compon
       /**
        * Changes the element's animated property from 0 to the element's content size.
        *
+       * @remarks `content-visibility` CSS property boosts the rendering performance waiting to be
+       * needed until rendering the content. This behaviour collides with this animation method.
+       * When the `scrollProperty` is evaluated, the content has not been rendered yet and the value
+       * is 0 so nothing is animated. To avoid this behaviour, we change the `content-visibility` to
+       * default value, force a layer repaint and then, evaluate the `scrollProperty` value which
+       * now has value. Then we restore the `content-visibility` value to its previous state.
+       *
        * @param element - The DOM element that is going to be animated.
        * @internal
        */
       expand(element: HTMLElement): void {
         element.style[property] = '0';
+        const originalValue = (element.style as any)['content-visibility'];
+        (element.style as any)['content-visibility'] = 'visible';
+        element.getBoundingClientRect();
         element.style[property] = `${element[scrollProperty]}px`;
+        (element.style as any)['content-visibility'] = originalValue;
       },
       /**
        * Removes the animated property from the element.


### PR DESCRIPTION
Remarks section explains why it is needed 😄

```
@remarks `content-visibility` CSS property boosts the rendering performance waiting to be
needed until rendering the content. This behaviour collides with this animation method.
When the `scrollProperty` is evaluated, the content has not been rendered yet and the value
is 0 so nothing is animated. To avoid this behaviour, we change the `content-visibility` to
default value, force a layer repaint and then, evaluate the `scrollProperty` value which
now has value. Then we restore the `content-visibility` value to its previous state.
```

Fixing this issue:
https://user-images.githubusercontent.com/10746604/201149174-598fdfad-7e23-4804-b636-76f16dd46e20.mov