### PR TITLE
feat: history-queries-switch wai aria adjustments

### DIFF
--- a/packages/x-components/src/views/accessibility-check.vue
+++ b/packages/x-components/src/views/accessibility-check.vue
@@ -1,118 +1,55 @@
 <template>
-  <Scroll id="accessibility-scroll">
-    <section class="x-list x-padding--07 x-list--gap-05">
-      <div>
-        <h1>BaseIdTogglePanelButton</h1>
-        <BaseIdTogglePanelButton class="x-button x-button--ghost" :panelId="panelId">
-          Panel
-        </BaseIdTogglePanelButton>
-        <BaseIdTogglePanel :startOpen="true" panelId="aside-panel">
-          <div class="x-text">Hey there!</div>
-        </BaseIdTogglePanel>
+  <section class="x-list x-padding--07 x-list--gap-05">
+    <div>
+      <h1>BaseColumnPickerDropdown</h1>
+      <BaseColumnPickerDropdown :columns="[2, 4, 6]">
+        <template #item="{ item, isSelected, isHighlighted }">
+          <span v-if="isHighlighted">🟢</span>
+          <span v-if="isSelected">✅</span>
+          <span>{{ item }}</span>
+        </template>
+      </BaseColumnPickerDropdown>
+    </div>
 
-        <BaseIdTogglePanelButton class="x-button x-button--ghost" panelId="panel2" />
-        <BaseIdTogglePanel :startOpen="true" panelId="aside-panel">
-          <div class="x-text">
-            Button without text, an element should have the ID to make it accessible.
-          </div>
-        </BaseIdTogglePanel>
-      </div>
+    <div>
+      <h1>SortDropdown</h1>
+      <SortDropdown :items="sortValues">
+        <template #toggle="{ item, isOpen }">{{ item }} {{ isOpen ? '🔼' : '🔽' }}</template>
+        <template #item="{ item, isHighlighted, isSelected }">
+          <span v-if="isSelected">✅</span>
+          <span v-if="isHighlighted">🟢</span>
+          {{ item }}
+        </template>
+      </SortDropdown>
+    </div>
 
-      <div>
-        <h1>ClearHistoryQueries and RemoveHistoryQuery</h1>
-        <SearchInput />
-        <ClearHistoryQueries>Not reading this since there is an aria-label</ClearHistoryQueries>
-        <HistoryQueries :maxItemsToRender="3" />
-      </div>
-
-      <div>
-        <h1>BaseResultAddToCart</h1>
-        <BaseResultAddToCart result="">
-          <img src="https://picsum.photos/seed/200/50/50" alt="Add to cart" />
-        </BaseResultAddToCart>
-      </div>
-
-      <div>
-        <h1>AllFilter & ClearFilters</h1>
-        <FacetsProvider :facets="[facet]" />
-        <Facets>
-          <template #default="{ facet }">
-            <AllFilter :facet="facet">
-              {{ facet.label }}
-            </AllFilter>
-            <Filters v-slot="{ filter }" :filters="facet.filters">
-              <SimpleFilter :filter="filter" />
-            </Filters>
-          </template>
-        </Facets>
-        <ClearFilters />
-      </div>
-
-      <div>
-        <h1>BaseColumnPickerList</h1>
-        <BaseColumnPickerList #default="{ column }" :columns="[2, 4, 6]">
-          <span>Not reading this since there is an aria-label {{ column }}</span>
-        </BaseColumnPickerList>
-      </div>
-
-      <h1>ScrollToTop</h1>
-      <div>
-        <ScrollToTop scroll-id="accessibility-scroll" :threshold-px="1000">
-          <span>^</span>
-        </ScrollToTop>
-      </div>
-    </section>
-  </Scroll>
+    <div>
+      <h1>HistoryQueriesSwitch</h1>
+      <HistoryQueriesSwitch />
+    </div>
+  </section>
 </template>
 
 <script lang="ts">
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
-  import BaseIdTogglePanelButton from '../components/panels/base-id-toggle-panel-button.vue';
-  import BaseIdTogglePanel from '../components/panels/base-id-toggle-panel.vue';
-  import FacetsProvider from '../x-modules/facets/components/facets/facets-provider.vue';
-  import AllFilter from '../x-modules/facets/components/filters/all-filter.vue';
   // eslint-disable-next-line max-len
-  import ClearHistoryQueries from '../x-modules/history-queries/components/clear-history-queries.vue';
-  import HistoryQueries from '../x-modules/history-queries/components/history-queries.vue';
-  import SearchInput from '../x-modules/search-box/components/search-input.vue';
-  import BaseResultAddToCart from '../components/result/base-result-add-to-cart.vue';
-  import ClearFilters from '../x-modules/facets/components/clear-filters.vue';
-  import BaseColumnPickerList from '../components/column-picker/base-column-picker-list.vue';
-  import SimpleFilter from '../x-modules/facets/components/filters/simple-filter.vue';
-  import Filters from '../x-modules/facets/components/lists/filters-list.vue';
-  import ScrollToTop from '../x-modules/scroll/components/scroll-to-top.vue';
-  import { getSimpleFacetStub } from '../__stubs__';
-  import Facets from '../x-modules/facets/components/facets/facets.vue';
-  import Scroll from '../x-modules/scroll/components/scroll.vue';
+  import BaseColumnPickerDropdown from '../components/column-picker/base-column-picker-dropdown.vue';
+  import SortDropdown from '../x-modules/search/components/sort-dropdown.vue';
+  // eslint-disable-next-line max-len
+  import HistoryQueriesSwitch from '../x-modules/history-queries/components/history-queries-switch.vue';
 
   @Component({
     components: {
-      FacetsProvider,
-      AllFilter,
-      BaseColumnPickerList,
-      BaseIdTogglePanel,
-      BaseIdTogglePanelButton,
-      BaseResultAddToCart,
-      ClearFilters,
-      ClearHistoryQueries,
-      Facets,
-      Filters,
-      HistoryQueries,
-      ScrollToTop,
-      Scroll,
-      SearchInput,
-      SimpleFilter
+      BaseColumnPickerDropdown,
+      HistoryQueriesSwitch,
+      SortDropdown
     }
   })
   export default class AccessibilityCheck extends Vue {
-    protected facet = getSimpleFacetStub();
-    protected panelId = 'aside-panel';
+    mounted(): void {
+      this.$x.emit('UserClickedASort', 'default');
+    }
+    protected sortValues = ['default', 'price asc', 'price desc'];
   }
 </script>
-
-<style lang="scss" scoped>
-  .x-scroll {
-    height: 600px;
-  }
-</style>

--- a/packages/x-components/src/views/accessibility-check.vue
+++ b/packages/x-components/src/views/accessibility-check.vue
@@ -49,6 +49,7 @@
   export default class AccessibilityCheck extends Vue {
     mounted(): void {
       this.$x.emit('UserClickedASort', 'default');
+      this.$x.emit('UserClickedEnableHistoryQueries');
     }
     protected sortValues = ['default', 'price asc', 'price desc'];
   }

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
@@ -1,5 +1,5 @@
 <template>
-  <BaseSwitch @change="toggle" :value="isEnabled" />
+  <BaseSwitch @change="toggle" :value="isEnabled" aria-label="Queries' history" />
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
## Motivation and context
Ensure the component fulfil the following requirements:

**Keyboard Interaction**

- Space: When focus is on the switch, changes the state of the switch.
- Enter (Optional): When focus is on the switch, changes the state of the switch.

**WAI-ARIA Roles, States, and Properties**

- The switch has role switch.
- The switch has an accessible label provided by one of the following:

     1. Visible text content contained within the element with role switch.
     2. A visible label referenced by the value of aria-labelledby set on the element with role switch.
     3. aria-label set on the element with role switch.

- When on, the switch element has state aria-checked set to true.
- When off, the switch element has state aria-checked set to false.
- If the presentation includes additional descriptive static text relevant to a switch or switch group, the switch or switch group has the property aria-describedby set to the ID of the element containing the description.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
