### PR TITLE
feat: adding edocs preview

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,5 @@
 # These owners will be requested for review when someone opens a pull request.
 
 * @empathyco/x
+# Adding tech-writers to EPDocs folder
+packages/x-components/static-docs/ @empathyco/x @empathyco/tech-writers

--- a/.github/workflows/edocs-dynamic-sync.yml
+++ b/.github/workflows/edocs-dynamic-sync.yml
@@ -1,13 +1,5 @@
-name: Synchronize with eDocs
-on:
-  workflow_dispatch:
-    inputs:
-      content:
-        type: choice
-        description: Content to be synchronized
-        options: 
-        - static
-        - all
+name: Synchronize Dynamic docs with EPDocs
+on: [workflow_dispatch]
 jobs:
   connect-with-edocs:
     runs-on: ubuntu-latest
@@ -28,8 +20,8 @@ jobs:
           curl --request POST \
           -u empathyco:${GITHUB_TOKEN} \
           --header 'content-type: application/json' \
-          --url https://api.github.com/repos/empathyco/docs-empathy-documentation/actions/workflows/${{ github.event.inputs.content == 'static' && '26816599' || '14218449' }}/dispatches \
+          --url https://api.github.com/repos/empathyco/docs-empathy/actions/workflows/40134850/dispatches \
           --data '{"ref": "main",  "inputs": {"branchName": "${{ env.BRANCH_NAME }}", "version": "${{ steps.package-version.outputs.current-version }}"}}'
         env:
           GITHUB_TOKEN: ${{ secrets.SUPPORT_TOKEN }}
-          
+

--- a/.github/workflows/edocs-preview.yaml
+++ b/.github/workflows/edocs-preview.yaml
@@ -1,0 +1,18 @@
+name: Create EPDocs preview
+on:
+  pull_request:
+    paths:
+      - packages/x-components/static-docs/**
+jobs:
+  preview-edocs:
+    if: "! github.event.pull_request.head.repo.fork"
+    uses: empathyco/platform-reusable-github-actions/.github/workflows/edocs-preview.yml@main
+    with:
+      teamRepo: 'x'
+      branch: ${{ github.head_ref }}
+      prNum: ${{ github.event.pull_request.number }}
+      prMessage: '⚠️ Only for Empathy members ⚠️ We’re sorry for the inconvenience!\n'
+      publicRepo: true
+    secrets:
+      GH_TOKEN: ${{ secrets.SUPPORT_TOKEN }}
+      JIRA_TOKEN: '${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}'

--- a/packages/x-components/static-docs/build-search-ui/sidebar.js
+++ b/packages/x-components/static-docs/build-search-ui/sidebar.js
@@ -1,0 +1,7 @@
+export const sidebar = {
+    children: [
+      '/web-archetype-development-guide.md',
+      '/web-archetype-integration-guide.md',
+      '/web-x-components-development-guide.md',
+    ]
+  };

--- a/packages/x-components/static-docs/experience-search-and-discovery/sidebar.js
+++ b/packages/x-components/static-docs/experience-search-and-discovery/sidebar.js
@@ -1,0 +1,17 @@
+export const sidebar = {
+  children: [
+    '/search-box.md',
+    '/empathize.md',
+    '/query-suggestions.md',
+    '/history-queries.md',
+    '/my-history.md',
+    '/popular-searches.md',
+    '/id-results.md',
+    '/related-tags.md',
+    '/next-queries.md',
+    '/recommendations.md',
+    '/product-results-ui.md',
+    '/serp-ui.md',
+    '/facets-and-filters.md'
+  ]
+};


### PR DESCRIPTION
# Pull request template

Good morning! 

This PR is part of a big refactor that eDocs is doing on the connection between eDocs & different teams. 
From now on this is our approach:

- **Dynamic docs** are going to continue being synchronized via manual github actions (at least until this docs are stored inside X repository), because of this reason we are maintaining the manual github action BUT from now on, this is only opening a PR with the dynamic docs changes.

- About **Static docs**, from now on every PR that has changes in the `static-docs` folder will create an eDocs preview where you can check the changes, also **tech-writers** are going to be automatically assigned as reviewers together with **X**. Once changes are merged into `main`, they will be considered ready to be shown on the eDocs portal and will be updated in the next eDocs deployment.

This PR includes all changes in X needed to change this approach. Including **github actions**, `CODEOWNERS` and adding `sidebar.js`, config files used by eDocs to customize sidebar.

## Motivation and context

Previous approach meant to review changes both in X and eDocs repository, this meant a duplicity that is changed with this approach. Also this is more close to docs-in-code philosophy.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

We have tested Preview github action multiple times (that comment is generated, and changes shown in the preview), assured that will not be had in account when opened a fork PR. Also, in this same PR you will be able to see the generated comment with the preview, as we intended.

Only check missing is about the dynamic github action, that we weren't able to test completely without merging it to `main`, as we changed both name of the file and title.

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works. - **Doesn't apply**
- [ ] New and existing **unit tests pass locally** with my changes. - **Doesn't apply**
