### PR TITLE
fix: make `x-bus` package name scoped

### DIFF
--- a/packages/x-bus/package.json
+++ b/packages/x-bus/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "x-bus",
+  "name": "@empathyco/x-bus",
   "version": "0.1.0-alpha.0",
   "description": "Event bus to help with events orchestration",
   "author": "Empathy Systems Corporation S.L.",


### PR DESCRIPTION
Change new `x-bus` package name to `@empathyco/x-bus` so we can publish it under empathy's domain