### PR TITLE
fix: make appear attribute configurable on animations that have it set to true by default

### DIFF
--- a/packages/x-components/src/components/animations/collapse-height.vue
+++ b/packages/x-components/src/components/animations/collapse-height.vue
@@ -4,9 +4,9 @@
     @enter="expand"
     @after-enter="cleanUpAnimationStyles"
     @leave="collapse"
-    appear
     name="x-collapse-height-"
     v-bind="$attrs"
+    :appear="appear"
   >
     <!-- @slot (Required) to add content to the transition -->
     <slot />
@@ -15,7 +15,7 @@
 
 <script lang="ts">
   import Vue from 'vue';
-  import { Component } from 'vue-property-decorator';
+  import { Component, Prop } from 'vue-property-decorator';
   import { createCollapseAnimationMixin } from './animations.mixin';
 
   /**
@@ -29,6 +29,14 @@
     inheritAttrs: false
   })
   export default class CollapseHeight extends Vue {
+    /**
+     * Indicates if the transition must be applied on the initial render of the node.
+     */
+    @Prop({
+      type: Boolean,
+      default: true
+    })
+    public appear!: boolean;
     // TODO Add support for extending enter, after-enter and leave transitions
   }
 </script>

--- a/packages/x-components/src/components/animations/collapse-width.vue
+++ b/packages/x-components/src/components/animations/collapse-width.vue
@@ -4,9 +4,9 @@
     @enter="expand"
     @after-enter="cleanUpAnimationStyles"
     @leave="collapse"
-    appear
     name="x-collapse-width-"
     v-bind="$attrs"
+    :appear="appear"
   >
     <!-- @slot (Required) to add content to the transition -->
     <slot />
@@ -15,7 +15,7 @@
 
 <script lang="ts">
   import Vue from 'vue';
-  import { Component } from 'vue-property-decorator';
+  import { Component, Prop } from 'vue-property-decorator';
   import { createCollapseAnimationMixin } from './animations.mixin';
 
   /**
@@ -29,6 +29,14 @@
     inheritAttrs: false
   })
   export default class CollapseWidth extends Vue {
+    /**
+     * Indicates if the transition must be applied on the initial render of the node.
+     */
+    @Prop({
+      type: Boolean,
+      default: true
+    })
+    public appear!: boolean;
     // TODO Add support for extending enter, after-enter and leave transitions
   }
 </script>

--- a/packages/x-components/src/components/animations/cross-fade.vue
+++ b/packages/x-components/src/components/animations/cross-fade.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition v-on="$listeners" appear name="x-cross-fade-" v-bind="$attrs">
+  <transition v-on="$listeners" name="x-cross-fade-" v-bind="$attrs" :appear="appear">
     <!-- @slot (Required) to add content to the transition -->
     <slot />
   </transition>
@@ -7,7 +7,7 @@
 
 <script lang="ts">
   import Vue from 'vue';
-  import { Component } from 'vue-property-decorator';
+  import { Component, Prop } from 'vue-property-decorator';
 
   /**
    * Renders a transition wrapping the element passed in the default slot. The transition
@@ -18,7 +18,16 @@
   @Component({
     inheritAttrs: false
   })
-  export default class CrossFade extends Vue {}
+  export default class CrossFade extends Vue {
+    /**
+     * Indicates if the transition must be applied on the initial render of the node.
+     */
+    @Prop({
+      type: Boolean,
+      default: true
+    })
+    public appear!: boolean;
+  }
 </script>
 
 <style lang="scss" scoped>

--- a/packages/x-components/src/components/animations/fade-and-slide.vue
+++ b/packages/x-components/src/components/animations/fade-and-slide.vue
@@ -2,10 +2,10 @@
   <transition-group
     v-on="$listeners"
     class="x-fade-and-slide"
-    appear
     :name="name"
     :tag="tag"
     v-bind="$attrs"
+    :appear="appear"
   >
     <!-- @slot (Required) Transition-group content -->
     <slot />
@@ -41,6 +41,15 @@
      */
     @Prop()
     protected tag!: string;
+
+    /**
+     * Indicates if the transition must be applied on the initial render of the node.
+     */
+    @Prop({
+      type: Boolean,
+      default: true
+    })
+    public appear!: boolean;
   }
 </script>
 

--- a/packages/x-components/src/components/animations/fade.vue
+++ b/packages/x-components/src/components/animations/fade.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition v-on="$listeners" appear name="x-fade-" v-bind="$attrs">
+  <transition v-on="$listeners" name="x-fade-" v-bind="$attrs" :appear="appear">
     <!-- @slot (Required) to add content to the transition -->
     <slot />
   </transition>
@@ -7,7 +7,7 @@
 
 <script lang="ts">
   import Vue from 'vue';
-  import { Component } from 'vue-property-decorator';
+  import { Component, Prop } from 'vue-property-decorator';
 
   /**
    * Renders a transition wrapping the element passed in the default slot. The animation just fades
@@ -18,7 +18,16 @@
   @Component({
     inheritAttrs: false
   })
-  export default class Fade extends Vue {}
+  export default class Fade extends Vue {
+    /**
+     * Indicates if the transition must be applied on the initial render of the node.
+     */
+    @Prop({
+      type: Boolean,
+      default: true
+    })
+    public appear!: boolean;
+  }
 </script>
 
 <style lang="scss" scoped>

--- a/packages/x-components/src/components/animations/staggered-fade-and-slide.vue
+++ b/packages/x-components/src/components/animations/staggered-fade-and-slide.vue
@@ -1,10 +1,10 @@
 <template>
   <staggering-transition-group
     v-on="$listeners"
-    appear
     class="x-staggered-fade-and-slide"
     :name="name"
     v-bind="$attrs"
+    :appear="appear"
   >
     <!-- @slot (Required) Transition-group content -->
     <slot />
@@ -13,7 +13,7 @@
 
 <script lang="ts">
   import { mixins } from 'vue-class-component';
-  import { Component } from 'vue-property-decorator';
+  import { Component, Prop } from 'vue-property-decorator';
   import StaggeringTransitionGroup from '../animations/staggering-transition-group.vue';
   import DisableAnimationMixin from './disable-animation.mixin';
 
@@ -28,6 +28,14 @@
     inheritAttrs: false
   })
   export default class StaggeredFadeAndSlide extends mixins(DisableAnimationMixin) {
+    /**
+     * Indicates if the transition must be applied on the initial render of the node.
+     */
+    @Prop({
+      type: Boolean,
+      default: true
+    })
+    public appear!: boolean;
     /**
      * The name of the animation.
      *


### PR DESCRIPTION
This change is needed to be able to change the animation of the image on hover without applying the new transition before the image is loaded.

Related to [this](https://github.com/empathyco/x/pull/863) PR.

EX-5970