### PR TITLE
feat: Emit SearchResponseProvided event from Search Module

### DIFF
--- a/packages/x-components/src/x-modules/search/events.types.ts
+++ b/packages/x-components/src/x-modules/search/events.types.ts
@@ -7,7 +7,7 @@ import {
   Promoted,
   Banner
 } from '@empathyco/x-types';
-import { InternalSearchRequest } from './types';
+import { InternalSearchRequest, InternalSearchResponse } from './types';
 
 /**
  * Dictionary of the events of Search XModule, where each key is the event name, and the value is
@@ -42,6 +42,11 @@ export interface SearchXEvents {
    * Payload: The new internal request object.
    */
   SearchRequestUpdated: InternalSearchRequest;
+  /**
+   * A search response has been provided.
+   * Payload: The provided internal response object.
+   */
+  SearchResponseProvided: InternalSearchResponse;
   /**
    * Query tagging has been changed.
    * Payload: The new query tagging object.

--- a/packages/x-components/src/x-modules/search/store/emitters.ts
+++ b/packages/x-components/src/x-modules/search/store/emitters.ts
@@ -40,7 +40,7 @@ export const searchEmitters = createStoreEmitters(searchXStoreModule, {
       };
     },
     filter: (newValue, oldValue) =>
-      oldValue.status === 'loading' && newValue.status !== oldValue.status
+      newValue.status !== oldValue.status && oldValue.status === 'loading' && !!newValue.request
   },
   SearchTaggingChanged: {
     selector: state => state.queryTagging,

--- a/packages/x-components/src/x-modules/search/store/emitters.ts
+++ b/packages/x-components/src/x-modules/search/store/emitters.ts
@@ -23,6 +23,24 @@ export const searchEmitters = createStoreEmitters(searchXStoreModule, {
       return !!newValue && !!oldValue;
     }
   },
+  SearchResponseProvided: {
+    selector: (state, getters) => {
+      return {
+        request: getters.request!,
+        status: state.status,
+        banners: state.banners,
+        facets: state.facets,
+        partialResults: state.partialResults,
+        promoteds: state.promoteds,
+        queryTagging: state.queryTagging,
+        redirections: state.redirections,
+        results: state.results,
+        spellcheck: state.spellcheckedQuery,
+        totalResults: state.totalResults
+      };
+    },
+    filter: (newValue, oldValue) => oldValue.status === 'loading'
+  },
   SearchTaggingChanged: {
     selector: state => state.queryTagging,
     filter: ({ url }) => !isStringEmpty(url)

--- a/packages/x-components/src/x-modules/search/store/emitters.ts
+++ b/packages/x-components/src/x-modules/search/store/emitters.ts
@@ -39,7 +39,8 @@ export const searchEmitters = createStoreEmitters(searchXStoreModule, {
         totalResults: state.totalResults
       };
     },
-    filter: (newValue, oldValue) => oldValue.status === 'loading'
+    filter: (newValue, oldValue) =>
+      oldValue.status === 'loading' && newValue.status !== oldValue.status
   },
   SearchTaggingChanged: {
     selector: state => state.queryTagging,

--- a/packages/x-components/src/x-modules/search/types.ts
+++ b/packages/x-components/src/x-modules/search/types.ts
@@ -1,4 +1,5 @@
-import { SearchRequest } from '@empathyco/x-types';
+import { SearchRequest, SearchResponse } from '@empathyco/x-types';
+import { RequestStatus } from '../../store/utils/status-store.utils';
 
 /**
  * An internal search request containing the page used to calculate the start and rows properties of
@@ -20,4 +21,17 @@ export interface InternalSearchRequest extends SearchRequest {
 export interface WatchedInternalSearchRequest {
   newRequest: InternalSearchRequest;
   oldRequest: InternalSearchRequest;
+}
+
+/**
+ * An internal search response containing the {@link InternalSearchRequest} performed to get a
+ * {@link @empathyco/x-types#SearchResponse} and its {@link RequestStatus}.
+ *
+ * @public
+ */
+export interface InternalSearchResponse extends SearchResponse {
+  /** The search request. */
+  request: InternalSearchRequest;
+  /** The response status. */
+  status: RequestStatus;
 }


### PR DESCRIPTION
[EX-5167](https://searchbroker.atlassian.net/browse/EX-5167)

Following a similar approach than the `SearchRequestChanged` event, a new `SearchResponseProvided` is emitted every time a search response is received.

This new event will be used [here](https://github.com/empathyco/x/pull/865).