### PR TITLE
Feature/ex 5715 extract highlight component

### DIFF
--- a/packages/x-components/jest.config.js
+++ b/packages/x-components/jest.config.js
@@ -8,5 +8,16 @@ module.exports = {
   setupFilesAfterEnv: ['./jest.setup.ts'],
   // jest 27 changes the default environment to node instead of jsdom
   // https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults
-  testEnvironment: 'jsdom'
+  testEnvironment: 'jsdom',
+  globals: {
+    'vue-jest': {
+      templateCompiler: {
+        compilerOptions: {
+          // Set whitespace to 'condense' to prevent differences between jsdom and browsers.
+          // https://github.com/vuejs/vue/tree/dev/packages/vue-template-compiler#options
+          whitespace: 'condense'
+        }
+      }
+    }
+  }
 };

--- a/packages/x-components/src/components/highlight.vue
+++ b/packages/x-components/src/components/highlight.vue
@@ -1,0 +1,186 @@
+<template>
+  <NoElement>
+    <slot v-bind="{ text, hasMatch, ...matchParts }">
+      <span class="x-highlight" :class="dynamicCSSClasses">
+        <template v-if="hasMatch">
+          <span v-text="matchParts.start" class="x-highlight__text" />
+          <span
+            v-text="matchParts.match"
+            class="x-highlight__text x-highlight__text--is-match"
+            data-test="matching-part"
+          />
+          <span v-text="matchParts.end" class="x-highlight__text" />
+        </template>
+        <span v-else class="x-highlight__text">{{ text }}</span>
+      </span>
+    </slot>
+  </NoElement>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { normalizeString } from '../utils/normalize';
+  import { VueCSSClasses } from '../utils/types';
+  import { NoElement } from './no-element';
+
+  /**
+   * Highlights the given part of the text. The component is smart enough to do matches
+   * between special characters like tilde, cedilla, eñe, capital leters...
+   *
+   * @public
+   */
+  @Component({
+    components: { NoElement }
+  })
+  export default class Highlight extends Vue {
+    @Prop({ default: '' })
+    protected text!: string;
+
+    @Prop({ default: '' })
+    protected highlight!: string;
+
+    /**
+     * Checks if the normalized suggestion query matches with the module's query, so it has a
+     * matching part.
+     *
+     * @returns True if there is a match between the text and the highlight strings.
+     * @internal
+     */
+    protected get hasMatch(): boolean {
+      return this.matchParts !== null;
+    }
+
+    /**
+     * CSS classes to add depending on the component state.
+     *
+     * @remarks
+     * `x-highlight--has-match`: When there is a match between the text and the part to highlight.
+     * @returns The {@link VueCSSClasses} classes.
+     * @public
+     */
+    protected get dynamicCSSClasses(): VueCSSClasses {
+      return {
+        'x-highlight--has-match': this.hasMatch
+      };
+    }
+
+    /**
+     * If possible, splits the text to highlight into 3 parts: a starting part, the matching part
+     * and the ending part. If there is no match between the text and the highlight, it returns
+     * `null`.
+     *
+     * @returns Either an array containing the different parts ofthe match, or `null` if there is
+     * no match.
+     * @internal
+     */
+    protected get matchParts(): HighlightMatch | null {
+      const matcherIndex = normalizeString(this.text).indexOf(normalizeString(this.highlight));
+      return matcherIndex !== -1
+        ? this.splitAt(this.text, matcherIndex, matcherIndex + this.highlight.length)
+        : null;
+    }
+
+    /**
+     * Splits the label in three parts based on two indexes.
+     *
+     * @param label - The string that will be divided in three parts.
+     * @param start - The first index that the label will be divided by.
+     * @param end - The second index that the label will be divided by.
+     *
+     * @returns The three parts of the divided label.
+     * @internal
+     */
+    protected splitAt(label: string, start: number, end: number): HighlightMatch {
+      return {
+        start: label.substring(0, start),
+        match: label.substring(start, end),
+        end: label.substring(end)
+      };
+    }
+  }
+
+  interface HighlightMatch {
+    start: string;
+    match: string;
+    end: string;
+  }
+</script>
+
+<docs lang="mdx">
+## Events
+
+This component emits no events.
+
+## See it in action
+
+Here you have a basic example of how the highlight component is rendered.
+
+_Type any term in the input field to try it out!_
+
+```vue live
+<template>
+  <div>
+    <input v-model="highlight" />
+    <Highlight :highlight="highlight" text="milanesa" />
+  </div>
+</template>
+
+<script>
+  import { Highlight } from '@empathyco/x-components';
+
+  export default {
+    name: 'HighlightDemo',
+    components: {
+      Highlight
+    },
+    data() {
+      return {
+        highlight: ''
+      };
+    }
+  };
+</script>
+```
+
+### Customise the layout
+
+This component allows to customise the whole layout. Be careful as due to Vue 2 limitations you can
+only render a single root element.
+
+```vue live
+<template>
+  <div>
+    <input v-model="highlight" />
+    <Highlight
+      :highlight="highlight"
+      text="Entraña"
+      #default="{ hasMatch, start, match, end, text }"
+    >
+      <span class="custom-layout" v-if="hasMatch">
+        <strong>{{ start }}</strong>
+        {{ match }}
+        <strong>{{ end }}</strong>
+      </span>
+      <span v-else>{{ text }}</span>
+    </Highlight>
+  </div>
+</template>
+
+<script>
+  import { Highlight } from '@empathyco/x-components';
+
+  export default {
+    name: 'HighlightDemo',
+    components: {
+      Highlight
+    },
+    data() {
+      return {
+        highlight: 'entran'
+      };
+    }
+  };
+</script>
+```
+</docs>

--- a/packages/x-components/src/components/highlight.vue
+++ b/packages/x-components/src/components/highlight.vue
@@ -80,11 +80,14 @@
      * and the ending part. If there is no match between the text and the highlight, it returns
      * `null`.
      *
-     * @returns Either an array containing the different parts ofthe match, or `null` if there is
+     * @returns Either an array containing the different parts of the match, or `null` if there is
      * no match.
      * @internal
      */
     protected get matchParts(): HighlightMatch | null {
+      if (!this.highlight) {
+        return null;
+      }
       const matcherIndex = normalizeString(this.text).indexOf(normalizeString(this.highlight));
       return matcherIndex !== -1
         ? this.splitAt(this.text, matcherIndex, matcherIndex + this.highlight.length)

--- a/packages/x-components/src/components/highlight.vue
+++ b/packages/x-components/src/components/highlight.vue
@@ -34,11 +34,21 @@
     components: { NoElement }
   })
   export default class Highlight extends Vue {
+    /**
+     * The text to highlight some part of it.
+     *
+     * @public
+     */
     @Prop({ default: '' })
-    protected text!: string;
+    public text!: string;
 
+    /**
+     * The part of the text to be highlighted.
+     *
+     * @public
+     */
     @Prop({ default: '' })
-    protected highlight!: string;
+    public highlight!: string;
 
     /**
      * Checks if the normalized suggestion query matches with the module's query, so it has a

--- a/packages/x-components/src/components/suggestions/__tests__/highlight.spec.ts
+++ b/packages/x-components/src/components/suggestions/__tests__/highlight.spec.ts
@@ -1,0 +1,92 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import Highlight from '../../highlight.vue';
+import { getDataTestSelector } from '../../../__tests__/utils';
+
+function renderHighlight({
+  template = '<Highlight v-bind="$attrs"/>',
+  text,
+  highlight
+}: RenderHighlightOptions): RenderHighlightAPI {
+  const wrapper = mount(
+    {
+      inheritAttrs: false,
+      components: {
+        Highlight
+      },
+      template
+    },
+    {
+      propsData: {
+        text,
+        highlight
+      }
+    }
+  );
+  const matchingPart = wrapper.find(getDataTestSelector('matching-part'));
+  return {
+    wrapper,
+    matchingPart,
+    async setHighlight(highlight) {
+      return await wrapper.setProps({ highlight });
+    }
+  };
+}
+
+describe('testing Highlight component', () => {
+  it('highlights the rendered text when the match happens at the beginning', () => {
+    const { matchingPart, wrapper } = renderHighlight({ text: 'Ibérico', highlight: 'ibe' });
+    expect(matchingPart.text()).toEqual('Ibé');
+    expect(wrapper.text()).toEqual('Ibérico');
+  });
+  it('highlights the rendered text when the match happens at the middle', () => {
+    const { matchingPart, wrapper } = renderHighlight({ text: 'Picaña', highlight: 'can' });
+    expect(matchingPart.text()).toEqual('cañ');
+    expect(wrapper.text()).toEqual('Picaña');
+  });
+  it('highlights the rendered text when the match happens at the end', () => {
+    const { matchingPart, wrapper } = renderHighlight({
+      text: 'Jamón Ibérico',
+      highlight: 'iberico'
+    });
+    expect(matchingPart.text()).toEqual('Ibérico');
+    expect(wrapper.text()).toEqual('Jamón Ibérico');
+  });
+  it('renders the given text if no match', () => {
+    const { matchingPart, wrapper } = renderHighlight({ text: 'vacío', highlight: 'chorizo' });
+    expect(matchingPart.exists()).toBe(false);
+    expect(wrapper.text()).toEqual('vacío');
+  });
+  it('allows customising the HTML', async () => {
+    const { wrapper, setHighlight } = renderHighlight({
+      template: `
+        <Highlight v-bind="$attrs" #default="{ hasMatch, start, match, end, text }">
+          <span v-if="hasMatch" class="match-custom-layout">
+            <strong>{{ start }}</strong>{{ match }}<strong>{{ end }}</strong>
+          </span>
+          <span v-else class="no-match-custom">{{ text }}</span>
+        </Highlight>`,
+      text: 'churrasco',
+      highlight: 'chur'
+    });
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      `"<span class=\\"match-custom-layout\\"><strong></strong>chur<strong>rasco</strong></span>"`
+    );
+
+    await setHighlight('no-match');
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      `"<span class=\\"no-match-custom\\">churrasco</span>"`
+    );
+  });
+});
+
+interface RenderHighlightOptions {
+  template?: string;
+  text: string;
+  highlight: string;
+}
+
+interface RenderHighlightAPI {
+  wrapper: Wrapper<Vue>;
+  matchingPart: Wrapper<Vue>;
+  setHighlight: (highlight: string) => Promise<void>;
+}

--- a/packages/x-components/src/components/suggestions/base-suggestion.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestion.vue
@@ -17,7 +17,7 @@
           @binding {Filter} filter - Suggestion's filter
       -->
       <!-- eslint-enable max-len -->
-      <slot v-bind="{ suggestion, start, match, end, hasMatch, filter }">
+      <slot v-bind="{ suggestion, start, match, end, hasMatch, text, filter }">
         <span class="x-suggestion__query x-highlight" :class="dynamicCSSClasses">
           <template v-if="hasMatch">
             <span class="x-highlight__text">{{ start }}</span>
@@ -30,7 +30,7 @@
           </template>
           <template v-else>{{ text }}</template>
         </span>
-        <span v-if="filter" class="x-suggestion__filter">{{ filter.label }}</span>
+        <span v-if="filter" class="x-suggestion__filter">{{ ' ' + filter.label }}</span>
       </slot>
     </button>
   </Highlight>

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -5,20 +5,20 @@
     class="x-history-queries"
     data-test="history-queries"
   >
-    <template #default="props">
+    <template #default="defaultBaseSuggestionsScope">
       <!-- eslint-disable max-len -->
       <!--
         @slot History Query item
             @binding {Object} v-bind - History Query suggestion attributes:<br />&nbsp;&nbsp;- **suggestion** <code>Suggestion</code> - History Query suggestion data<br />&nbsp;&nbsp;- **index** <code>number</code> - History Query suggestion index
       -->
       <!-- eslint-enable max-len -->
-      <slot name="suggestion" v-bind="{ ...props }">
+      <slot name="suggestion" v-bind="{ ...defaultBaseSuggestionsScope }">
         <HistoryQuery
-          :suggestion="props.suggestion"
+          :suggestion="defaultBaseSuggestionsScope.suggestion"
           data-test="history-query-item"
           class="x-history-queries__item"
         >
-          <template #default="{ queryHTML }">
+          <template #default="defaultHistoryQuerySlotScope">
             <!-- eslint-disable max-len -->
             <!--
               @slot History Query content
@@ -26,16 +26,22 @@
                   @binding {string} queryHTML - Suggestion's query with the matching part inside a span tag
             -->
             <!-- eslint-enable max-len -->
-            <slot name="suggestion-content" v-bind="{ ...props, queryHTML }" />
+            <slot
+              name="suggestion-content"
+              v-bind="{ ...defaultBaseSuggestionsScope, ...defaultHistoryQuerySlotScope }"
+            />
           </template>
-          <template #remove-button-content="{ ...props }">
+          <template #remove-button-content="removeHistoryQuerySlotScope">
             <!-- eslint-disable max-len -->
             <!--
               @slot History Query remove button content
                   @binding {Object} v-bind - History Query suggestion attributes:<br />&nbsp;&nbsp;- **suggestion** <code>Suggestion</code> - History Query suggestion data<br />&nbsp;&nbsp;- **index** <code>number</code> - History Query suggestion index
             -->
             <!-- eslint-enable max-len -->
-            <slot name="suggestion-remove-content" v-bind="{ ...props }" />
+            <slot
+              name="suggestion-remove-content"
+              v-bind="{ ...defaultBaseSuggestionsScope, ...removeHistoryQuerySlotScope }"
+            />
           </template>
         </HistoryQuery>
       </slot>
@@ -61,6 +67,7 @@
    * @public
    */
   @Component({
+    inheritAttrs: false,
     components: { BaseSuggestions, HistoryQuery },
     mixins: [xComponentMixin(historyQueriesXModule)]
   })

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -6,15 +6,14 @@
       data-test="history-query"
       feature="history_query"
     >
-      <template #default="{ suggestion, queryHTML }">
+      <template #default="defaultSlotScope">
         <!-- eslint-disable max-len -->
         <!--
           @slot History Query content
               @binding {Suggestion} suggestion - History Query suggestion data
-              @binding {string} queryHTML - Suggestion's query with the matching part inside a span tag
         -->
         <!-- eslint-enable max-len -->
-        <slot v-bind="{ suggestion, queryHTML }" />
+        <slot v-bind="defaultSlotScope" />
       </template>
     </BaseSuggestion>
     <RemoveHistoryQuery
@@ -129,9 +128,14 @@ that serves to remove this query from the history. This slot only has one proper
 ```vue live
 <template>
   <HistoryQuery :suggestion="suggestion">
-    <template #default="{ suggestion, queryHTML }">
+    <template #default="{ suggestion, start, match, end, hasMatch, text }">
       <HistoryIcon />
-      <span class="x-history-query__matching-part" v-html="queryHTML" />
+      <template v-if="hasMatch">
+        <span>{{ start }}</span>
+        <span style="color: blue;">{{ match }}</span>
+        <span>{{ end }}</span>
+      </template>
+      <span v-else>{{ text }}</span>
     </template>
 
     <template #remove-button-content="{ suggestion }">

--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -36,7 +36,7 @@
                 <slot name="suggestion-content" v-bind="{ suggestion, index, formatTime }">
                   <div class="x-list x-list--vertical">
                     <span>{{ suggestion.query }}</span>
-                    <span>{{ formatTime(suggestion.timestamp) }}</span>
+                    <span>{{ ` ${formatTime(suggestion.timestamp)} ` }}</span>
                   </div>
                 </slot>
               </template>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -5,7 +5,7 @@
     data-test="next-queries"
     class="x-next-queries"
   >
-    <template #default="props">
+    <template #default="defaultBaseSuggestionsScope">
       <!-- eslint-disable max-len -->
       <!--
         @slot Next Query item
@@ -13,10 +13,10 @@
             @binding {boolean} highlightCurated - True if the curated NQs should be highlighted
       -->
       <!-- eslint-enable max-len -->
-      <slot name="suggestion" v-bind="{ ...props, highlightCurated }">
+      <slot name="suggestion" v-bind="{ ...defaultBaseSuggestionsScope, highlightCurated }">
         <NextQuery
-          #default="{ shouldHighlightCurated }"
-          :suggestion="props.suggestion"
+          #default="defaultNextQuerySlotScope"
+          :suggestion="defaultBaseSuggestionsScope.suggestion"
           :highlightCurated="highlightCurated"
           class="x-next-queries__suggestion"
         >
@@ -27,7 +27,10 @@
                   @binding {boolean} shouldHighlightCurated - True if the curated NQ should be highlighted
             -->
           <!-- eslint-enable max-len -->
-          <slot name="suggestion-content" v-bind="{ ...props, shouldHighlightCurated }" />
+          <slot
+            name="suggestion-content"
+            v-bind="{ ...defaultBaseSuggestionsScope, ...defaultNextQuerySlotScope }"
+          />
         </NextQuery>
       </slot>
     </template>
@@ -54,6 +57,7 @@
    * @public
    */
   @Component({
+    inheritAttrs: false,
     components: { NextQuery, BaseSuggestions },
     mixins: [xComponentMixin(nextQueriesXModule)]
   })

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
@@ -6,12 +6,12 @@
     data-test="popular-search"
     feature="popular_search"
   >
-    <template #default="{ suggestion }">
+    <template #default="defaultSlotScope">
       <!--
         @slot Popular Search's content
             @binding {Suggestion} suggestion - Popular Search suggestion data
       -->
-      <slot :suggestion="suggestion">{{ suggestion.query }}</slot>
+      <slot v-bind="defaultSlotScope">{{ suggestion.query }}</slot>
     </template>
   </BaseSuggestion>
 </template>

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -5,23 +5,29 @@
     class="x-popular-searches"
     data-test="popular-searches"
   >
-    <template #default="props">
+    <template #default="defaultBaseSuggestionsScope">
       <!-- eslint-disable max-len -->
       <!--
         @slot Popular Search item
             @binding {Object} v-bind - Popular Search suggestion attributes:<br />&nbsp;&nbsp;- **suggestion** <code>Suggestion</code> - Popular Search suggestion data<br />&nbsp;&nbsp;- **index** <code>number</code> - Popular Search suggestion index
       -->
       <!-- eslint-enable max-len -->
-      <slot name="suggestion" v-bind="{ ...props }">
-        <PopularSearch :suggestion="props.suggestion" class="x-popular-searches__suggestion">
-          <template #default="{ ...props }">
+      <slot name="suggestion" v-bind="{ ...defaultBaseSuggestionsScope }">
+        <PopularSearch
+          :suggestion="defaultBaseSuggestionsScope.suggestion"
+          class="x-popular-searches__suggestion"
+        >
+          <template #default="defaultPopularSearchScope">
             <!-- eslint-disable max-len -->
             <!--
               @slot Popular Search content
                   @binding {Object} v-bind - Popular Search suggestion attributes:<br />&nbsp;&nbsp;- **suggestion** <code>Suggestion</code> - Popular Search suggestion data<br />&nbsp;&nbsp;- **index** <code>number</code> - Popular Search suggestion index
             -->
             <!-- eslint-enable max-len -->
-            <slot name="suggestion-content" v-bind="{ ...props }" />
+            <slot
+              name="suggestion-content"
+              v-bind="{ ...defaultBaseSuggestionsScope, ...defaultPopularSearchScope }"
+            />
           </template>
         </PopularSearch>
       </slot>
@@ -48,6 +54,7 @@
    * @public
    */
   @Component({
+    inheritAttrs: false,
     components: { PopularSearch, BaseSuggestions },
     mixins: [xComponentMixin(popularSearchesXModule)]
   })

--- a/packages/x-components/src/x-modules/query-suggestions/components/__tests__/query-suggestions.spec.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/components/__tests__/query-suggestions.spec.ts
@@ -85,34 +85,35 @@ describe('testing Query Suggestions component', () => {
 
   it('renders custom content when overriding the suggestion-content slot', () => {
     resetXQuerySuggestionsStateWith(store, { suggestions });
-
-    const suggestionContentSlotOverridden = {
-      template: `
+    const querySuggestions = mount(
+      {
+        template: `
         <QuerySuggestions>
-          <template #suggestion-content="{ suggestion, queryHTML }">
+          <template #suggestion-content="{ suggestion, start, match, end, hasMatch, text }">
             <img
               class="x-query-suggestion__icon"
               data-test="icon"
               src="/query-suggestion-icon.svg"
             />
             <span
-              :aria-label="'Select ' + suggestion.query"
               class="x-query-suggestion__query"
               data-test="query"
-              v-html="queryHTML"
-            />
+            >
+              <template v-if="hasMatch">{{ start }}<strong>{{ match }}</strong>{{ end }}</template>
+              <span v-else>{{ text }}</span>
+            </span>
           </template>
         </QuerySuggestions>
       `,
-      components: {
-        QuerySuggestions
+        components: {
+          QuerySuggestions
+        }
+      },
+      {
+        localVue,
+        store
       }
-    };
-
-    const querySuggestions = mount(suggestionContentSlotOverridden, {
-      localVue,
-      store
-    });
+    );
 
     const suggestionsItemWrappers = findTestDataById(querySuggestions, 'query-suggestion').wrappers;
     expect(suggestionsItemWrappers).toHaveLength(suggestions.length);

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestion.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestion.vue
@@ -6,15 +6,12 @@
     data-test="query-suggestion"
     feature="query_suggestion"
   >
-    <template #default="{ suggestion, queryHTML }">
-      <!-- eslint-disable max-len -->
+    <template #default="defaultScope">
       <!--
         @slot Custom content that replaces the `QuerySuggestion` default content
             @binding {Suggestion} suggestion - Query Suggestion data
-            @binding {string} queryHTML - Suggestion’s query with the matching part wrapped in a HTML span tag
       -->
-      <!-- eslint-enable max-len -->
-      <slot v-bind="{ suggestion, queryHTML }" />
+      <slot v-bind="defaultScope" />
     </template>
   </BaseSuggestion>
 </template>
@@ -118,8 +115,13 @@ element.
 
 ```vue live
 <template>
-  <QuerySuggestion :suggestion="suggestion" #default="{ queryHTML }">
-    <span v-html="queryHTML" style="color: blue;" />
+  <QuerySuggestion :suggestion="suggestion" #default="{ start, match, end, hasMatch, text }">
+    <template v-if="hasMatch">
+      <span>{{ start }}</span>
+      <span style="color: blue;">{{ match }}</span>
+      <span>{{ end }}</span>
+    </template>
+    <span v-else>{{ text }}</span>
   </QuerySuggestion>
 </template>
 

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
@@ -5,16 +5,19 @@
     class="x-query-suggestions"
     data-test="query-suggestions"
   >
-    <template #default="props">
+    <template #default="defaultBaseSuggestionsScope">
       <!-- eslint-disable max-len -->
       <!--
         @slot Custom component that replaces the `QuerySuggestion` component
             @binding {Object} v-bind - Query Suggestion attributes:<br />&nbsp;&nbsp;- **suggestion** <code>Suggestion</code> - Query Suggestion data<br />&nbsp;&nbsp;- **index** <code>number</code> - Query Suggestion index
       -->
       <!-- eslint-enable max-len -->
-      <slot name="suggestion" v-bind="{ ...props }">
-        <QuerySuggestion :suggestion="props.suggestion" class="x-query-suggestions__suggestion">
-          <template #default="{ queryHTML }">
+      <slot name="suggestion" v-bind="defaultBaseSuggestionsScope">
+        <QuerySuggestion
+          :suggestion="defaultBaseSuggestionsScope.suggestion"
+          class="x-query-suggestions__suggestion"
+        >
+          <template #default="defaultQuerySuggestionSlotScope">
             <!-- eslint-disable max-len -->
             <!--
               @slot Custom content that replaces the `QuerySuggestion` default content
@@ -22,7 +25,10 @@
                   @binding {string} queryHTML - Suggestion’s query with the matching part wrapped in a HTML span tag
             -->
             <!-- eslint-enable max-len -->
-            <slot name="suggestion-content" v-bind="{ ...props, queryHTML }" />
+            <slot
+              name="suggestion-content"
+              v-bind="{ ...defaultBaseSuggestionsScope, ...defaultQuerySuggestionSlotScope }"
+            />
           </template>
         </QuerySuggestion>
       </slot>
@@ -48,6 +54,7 @@
    * @public
    */
   @Component({
+    inheritAttrs: false,
     components: { BaseSuggestions, QuerySuggestion },
     mixins: [xComponentMixin(querySuggestionsXModule)]
   })

--- a/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
+++ b/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
@@ -161,43 +161,6 @@ recommendations.
 </Recommendations>
 ```
 
-### Play with props
-
-In this example, the suggestions has been limited to render a maximum of 3 items.
-
-_Type “puzzle” or another toy in the input field to try it out!_
-
-```vue
-<template>
-  <BaseSuggestions :suggestions="suggestions" :maxItemToRender="3" />
-</template>
-
-<script>
-  import { BaseSuggestions } from '@empathyco/x-components';
-
-  export default {
-    name: 'BaseSuggestionsDemo',
-    components: {
-      BaseSuggestions
-    },
-    data() {
-      return {
-        suggestions: [
-          {
-            facets: [],
-            key: 'chips',
-            query: 'Chips',
-            totalResults: 10,
-            results: [],
-            modelName: 'PopularSearch'
-          }
-        ]
-      };
-    }
-  };
-</script>
-```
-
 ## Events
 
 A list of events that the component will emit:


### PR DESCRIPTION
Extracts a new `Highlight` component from the `BaseSuggestion` component. The idea of this change is to be retrocompatible with the current design system. However it still is a breaking change because we are removing the `queryHTML` from the slot scope.

Once we have the suggestion component in the new design system we should refactor the suggestion component, moving the `Highlight` component inside the suggestion, rather than being outside of it to add the `--matching` css class.
