### PR TITLE
fix: Avoid creating npmrc file on Github Actions

### DIFF
--- a/.github/actions/release-alpha/action.yml
+++ b/.github/actions/release-alpha/action.yml
@@ -15,8 +15,10 @@ runs:
         git config --local user.email "x@empathy.co"
         git config --local user.name "empathy/x"
       shell: bash
-    - name: Create .npmrc file with authorization token
-      run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+    - name: Configure npm auth
+      run: |
+        npm config set registry="http://registry.npmjs.org/"
+        npm config set _authToken=${NPM_TOKEN}
       shell: bash
       env:
         NPM_TOKEN: ${{ inputs.npm_token }}

--- a/.github/actions/release-alpha/action.yml
+++ b/.github/actions/release-alpha/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
     - name: Configure npm auth
       run: |
-        npm config set registry="http://registry.npmjs.org/"
+        npm config set registry="https://registry.npmjs.org/"
         npm config set _authToken=${NPM_TOKEN}
       shell: bash
       env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,7 +28,7 @@ jobs:
           git config --local user.name "empathy/x"
       - name: Configure npm auth
         run: |
-          npm config set registry="//registry.npmjs.org/"
+          npm config set registry="https://registry.npmjs.org/"
           npm config set _authToken=${NPM_TOKEN}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,8 +26,10 @@ jobs:
         run: |
           git config --local user.email "x@empathy.co"
           git config --local user.name "empathy/x"
-      - name: Create .npmrc file with authorization token
-        run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+      - name: Configure npm auth
+        run: |
+          npm config set registry="//registry.npmjs.org/"
+          npm config set _authToken=${NPM_TOKEN}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish the release


### PR DESCRIPTION
The previous implementation of the Github Actions to release a version included creating a new .npmrc file. Now that this file already exists, there is no way to edit it without creating a change in the repo that Lerna will complain about.

The solution is to perform the same operation, which is configure the npm auth, without modifying the .npmrc file. `npm config set` changes the root .npmrc file, so it shouldn't be a problem.

https://docs.npmjs.com/cli/v8/commands/npm-config
https://stackoverflow.com/a/43012838

A different approach would be to ignore the .npmrc file on Lerna checking for pending changes, [here](https://github.com/empathyco/x/blob/main/lerna.json#L4):
![Screenshot 2022-11-22 at 15 18 36](https://user-images.githubusercontent.com/72568818/203337144-e9da0e32-7817-4002-b5da-058e9c1108a9.png)
