### PR TITLE
chore: Remove unused configs and docs

### DIFF
--- a/packages/x-components/src/components/suggestions/base-suggestions.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestions.vue
@@ -209,7 +209,7 @@ another toy in the input field to try it out!_
 
 ```vue
 <template>
-  <BaseSuggestions :suggestions="suggestions" :maxItemToRender="3" />
+  <BaseSuggestions :suggestions="suggestions" :maxItemsToRender="3" />
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -135,7 +135,7 @@ queries it will show them
 ```
 
 The component has three optional props. `animation` to render the component with an animation,
-`maxItemToRender` to limit the number of next queries will be rendered (by default it is 5) and
+`maxItemsToRender` to limit the number of next queries will be rendered (by default it is 5) and
 `highlightCurated` to indicate if the curated Next Queries inside the list should be highlighted.
 
 ```vue live

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -98,7 +98,7 @@ searches it will show them.
 ```
 
 The component has two optional props. `animation` to render the component with an animation and
-`maxItemToRender` to limit the number of popular searches will be rendered (by default it is 5).
+`maxItemsToRender` to limit the number of popular searches will be rendered (by default it is 5).
 
 ```vue live
 <template>

--- a/packages/x-components/src/x-modules/popular-searches/config.types.ts
+++ b/packages/x-components/src/x-modules/popular-searches/config.types.ts
@@ -30,24 +30,4 @@ export interface PopularSearchesConfig {
    * ```
    */
   hideSessionQueries: boolean;
-  /**
-   * Show the extra suggestion that has filters without the filter.
-   *
-   * @example
-   * When set to true:
-   * ```
-   * query = 'trou';
-   * suggestions = ['trousers in man', 'trousers in woman'];
-   * // Suggests ['trousers', 'trousers in man', 'trousers in woman']
-   * ```
-   *
-   * @example
-   * When set to false:
-   * ```
-   * query = 'trou';
-   * suggestions = ['trousers in man', 'trousers in woman'];
-   * // Suggests ['trousers in man', 'trousers in woman']
-   * ```
-   */
-  showExtraSuggestionWithoutFilter: boolean;
 }

--- a/packages/x-components/src/x-modules/popular-searches/store/module.ts
+++ b/packages/x-components/src/x-modules/popular-searches/store/module.ts
@@ -20,8 +20,7 @@ export const popularSearchesXStoreModule: PopularSearchesXStoreModule = {
     status: 'initial',
     config: {
       hideSessionQueries: true,
-      maxItemsToRequest: 20,
-      showExtraSuggestionWithoutFilter: false
+      maxItemsToRequest: 20
     },
     params: {}
   }),

--- a/packages/x-components/src/x-modules/query-suggestions/config.types.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/config.types.ts
@@ -14,29 +14,6 @@ export interface QuerySuggestionsConfig {
    */
   maxItemsToRequest: number;
   /**
-   * Show the extra suggestion that has filters without the filter.
-   *
-   * @remarks
-   * Remember this property might be affected by {@link QuerySuggestionsConfig.hideIfEqualsQuery}
-   *
-   * @example
-   * When set to true:
-   * ```
-   * query = 'trou';
-   * suggestions = ['trousers in man', 'trousers in woman'];
-   * // Suggests ['trousers', 'trousers in man', 'trousers in woman']
-   * ```
-   *
-   * @example
-   * When set to false:
-   * ```
-   * query = 'trou';
-   * suggestions = ['trousers in man', 'trousers in woman'];
-   * // Suggests ['trousers in man', 'trousers in woman']
-   * ```
-   */
-  showExtraSuggestionWithoutFilter: boolean;
-  /**
    * Hides the suggestion if it is equal to the current query.
    *
    * @example

--- a/packages/x-components/src/x-modules/query-suggestions/store/module.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/store/module.ts
@@ -24,7 +24,6 @@ export const querySuggestionsXStoreModule: QuerySuggestionsXStoreModule = {
     config: {
       debounceInMs: 200,
       maxItemsToRequest: 10,
-      showExtraSuggestionWithoutFilter: true,
       hideIfEqualsQuery: true
     },
     params: {}

--- a/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
+++ b/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
@@ -161,43 +161,6 @@ recommendations.
 </Recommendations>
 ```
 
-### Play with props
-
-In this example, the suggestions has been limited to render a maximum of 3 items.
-
-_Type “puzzle” or another toy in the input field to try it out!_
-
-```vue
-<template>
-  <BaseSuggestions :suggestions="suggestions" :maxItemToRender="3" />
-</template>
-
-<script>
-  import { BaseSuggestions } from '@empathyco/x-components';
-
-  export default {
-    name: 'BaseSuggestionsDemo',
-    components: {
-      BaseSuggestions
-    },
-    data() {
-      return {
-        suggestions: [
-          {
-            facets: [],
-            key: 'chips',
-            query: 'Chips',
-            totalResults: 10,
-            results: [],
-            modelName: 'PopularSearch'
-          }
-        ]
-      };
-    }
-  };
-</script>
-```
-
 ## Events
 
 A list of events that the component will emit:

--- a/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
+++ b/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
@@ -111,60 +111,124 @@
 </style>
 
 <docs lang="mdx">
-## Examples
-
-It renders a list of recommendations from recommendations state by default. The component provides
-the slot layout which wraps the whole component with the recommendations bound. It also provides the
-default slot to customize the item, which is within the layout slot, with the recommendation bound.
-Each recommendation should be represented by a BaseResultLink component besides any other component.
-
-### Basic example
-
-### Adding a custom BaseResultLink component
-
-A BaseResultLink **must** be used inside the Recommendations component. In the example below the
-BaseResultLink default slot is filled with an image of the result and a span for the title. Besides
-that, an additional button has been added.
-
-```vue
-<Recommendations>
-  <template #default="{ recommendation }">
-    <BaseResultLink :result="recommendation" class="x-recommendations__link">
-      <template #default="{ result }">
-        <img :src="result.images[0]" class="x-recommendations__image"/>
-        <span class="x-recommendations__title">{{ result.name }}</span>
-      </template>
-    </BaseResultLink>
-    <button>Custom Behaviour</button>
-  </template>
-</Recommendations>
-```
-
-### Overriding layout content
-
-It renders a list of recommendations customizing the layout slot. In the example below, instead of
-using the default Recommendations content, a BaseGrid component is used to render the
-recommendations.
-
-```vue
-<Recommendations :animation="staggeredFadeAndSlide">
-  <template #layout="{ recommendations, animation }">
-    <BaseGrid :items="recommendations" :animation="animation">
-      <template #result="{ item }">
-        <BaseResultLink :result="item">
-          <BaseResultImage :result="item" />
-          <span class="x-result__title">{{ item.name }}</span>
-        </BaseResultLink>
-      </template>
-    </BaseGrid>
-  </template>
-</Recommendations>
-```
-
 ## Events
 
-A list of events that the component will emit:
+This component emits no events, but it makes components such as `BaseResultLink` emit additional
+events:
 
-- `UserClickedARecommendation`: the event is emitted after the user clicks the button.
-- A list of events emitted by the `BaseResultLink`.
+- `UserClickedARecommendation`: the event is emitted after the user clicks the link of a
+  recommendation.
+
+## See it in action
+
+<!-- prettier-ignore-start -->
+:::warning Backend service required
+To use this component, the Topclicked service must be implemented.
+:::
+<!-- prettier-ignore-end -->
+
+Here you have a basic example on how the recommendations are rendered. You can customize how each
+result is rendered by using the `default` slot. It is highly recommended to use base components such
+as the `BaseResultLink` or the `BaseResultAddToCart`, as they provides integration with other
+modules such like the `tagging` one.
+
+```vue live
+<template>
+  <Recommendations #default="{ recommendation }">
+    <BaseResultLink :result="recommendation" class="x-recommendations__link">
+      <img :src="recommendation.images[0]" class="x-recommendations__image" />
+      <span class="x-recommendations__title">{{ recommendation.name }}</span>
+    </BaseResultLink>
+    <BaseResultAddToCart>Add to cart</BaseResultAddToCart>
+  </Recommendations>
+</template>
+<script>
+  import { Recommendations } from '@empathyco/x-components/recommendations';
+  import { BaseResultLink, BaseResultAddToCart } from '@empathyco/x-components';
+
+  export default {
+    name: 'RecommendationsDemo',
+    components: {
+      Recommendations,
+      BaseResultLink,
+      BaseResultAddToCart
+    }
+  };
+</script>
+```
+
+### Play with props
+
+In this example, the component will render a maximum of 4 result recommendations, and will use the
+`StaggeredFadeAndSlide` animation for the results, smoothing the entrance.
+
+```vue live
+<template>
+  <Recommendations
+    #default="{ recommendation }"
+    :maxItemsToRender="4"
+    animation="StaggeredFadeAndSlide"
+  >
+    <BaseResultLink :result="recommendation" class="x-recommendations__link">
+      <img :src="recommendation.images[0]" class="x-recommendations__image" />
+      <span class="x-recommendations__title">{{ recommendation.name }}</span>
+    </BaseResultLink>
+    <BaseResultAddToCart>Add to cart</BaseResultAddToCart>
+  </Recommendations>
+</template>
+<script>
+  import Vue from 'vue';
+  import { Recommendations } from '@empathyco/x-components/recommendations';
+  import { BaseResultLink, BaseResultAddToCart } from '@empathyco/x-components';
+
+  Vue.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide);
+  export default {
+    name: 'RecommendationsDemo',
+    components: {
+      Recommendations,
+      BaseResultLink,
+      BaseResultAddToCart
+    }
+  };
+</script>
+```
+
+### Play with the layout
+
+In this example you can build your own layout, and the `Recommendations` component will just act as
+a provider of the result recommendations data. Using the component this way, and due to Vue 2
+limitations you will only be allowed to render a single element inside the `layout` slot.
+
+```vue live
+<template>
+  <Recommendations #layout="{ recommendations }">
+    <div class="x-recommendations">
+      <article
+        class="x-recommendations-list"
+        v-for="recommendation in recommendations"
+        :key="recommendation.id"
+      >
+        <BaseResultLink :result="recommendation" class="x-recommendations__link">
+          <img :src="recommendation.images[0]" class="x-recommendations__image" />
+          <span class="x-recommendations__title">{{ recommendation.name }}</span>
+        </BaseResultLink>
+        <BaseResultAddToCart>Add to cart</BaseResultAddToCart>
+      </article>
+    </div>
+  </Recommendations>
+</template>
+<script>
+  import { Recommendations } from '@empathyco/x-components/recommendations';
+  import { BaseResultLink, BaseResultAddToCart } from '@empathyco/x-components';
+
+  export default {
+    name: 'RecommendationsDemo',
+    components: {
+      Recommendations,
+      BaseResultLink,
+      BaseResultAddToCart
+    }
+  };
+</script>
+```
 </docs>


### PR DESCRIPTION
This configurations now belong to the suggestion components. The recommendations docs where talking about suggestions  (copy & paste :troll:)