### PR TITLE
feat(priority-queue): add `XPriorityQueue`

### DIFF
--- a/packages/x-priority-queue/package.json
+++ b/packages/x-priority-queue/package.json
@@ -34,6 +34,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@empathyco/x-utils": "^1.0.0-alpha.10",
     "tslib": "~2.3.0"
   },
   "devDependencies": {

--- a/packages/x-priority-queue/src/__tests__/x-priority-queue.spec.ts
+++ b/packages/x-priority-queue/src/__tests__/x-priority-queue.spec.ts
@@ -215,6 +215,12 @@ describe('x-priority-queue scenarios', () => {
   });
 
   describe('toString', () => {
+    it('returns an empty string if the queue is empty', () => {
+      // Given an empty queue
+      const queue = new XPriorityQueue();
+      expect(queue.toString()).toBe('');
+    });
+
     it("returns queue's data stringified", () => {
       // Given a queue
       const queue = new XPriorityQueue();

--- a/packages/x-priority-queue/src/__tests__/x-priority-queue.spec.ts
+++ b/packages/x-priority-queue/src/__tests__/x-priority-queue.spec.ts
@@ -119,7 +119,7 @@ describe('x-priority-queue scenarios', () => {
       const queue = new XPriorityQueue();
 
       // And an element is peeked
-      // Then the first element is retrieved but not removed
+      // Then no element is returned
       expect(queue.peek()).toBeUndefined();
 
       // Pushing elements
@@ -194,7 +194,7 @@ describe('x-priority-queue scenarios', () => {
   });
 
   describe('at', () => {
-    it('returns the element of the queue at the // Given index', () => {
+    it('returns the element of the queue at the given index', () => {
       // Given a queue
       const queue = new XPriorityQueue();
 

--- a/packages/x-priority-queue/src/__tests__/x-priority-queue.spec.ts
+++ b/packages/x-priority-queue/src/__tests__/x-priority-queue.spec.ts
@@ -1,7 +1,232 @@
-import { xPriorityQueue } from '../index';
+import { XPriorityQueue } from '../x-priority-queue';
 
-describe('x-priority-queue', () => {
-  it('needs tests', () => {
-    expect(xPriorityQueue).toEqual('x-priority-queue');
+describe('x-priority-queue scenarios', () => {
+  describe('constructor', () => {
+    it('uses the comparator function passed to the constructor to sort the queue', () => {
+      // Given a queue passing a comparator function to its constructor
+      const queue = new XPriorityQueue((a, b) => a < b);
+
+      // And elements are inserted
+      queue.push('1', 10);
+      queue.push('2', 20);
+      queue.push('3', 30);
+
+      // Then the order of the elements is sorted by the passed comparator function
+      expect(queue.keys).toEqual(['3', '2', '1']);
+    });
+  });
+
+  describe('push', () => {
+    it('inserts an element when the queue is empty', () => {
+      // Given an empty priority queue
+      const queue = new XPriorityQueue();
+
+      // And an element is pushed
+      const key = '1';
+      const priority = 10;
+      const metadata = { location: 'patata' };
+      queue.push(key, 10, metadata);
+
+      // Then the element is inserted at the first position
+      const insertedElement = queue.at(0);
+      expect(insertedElement!.key).toBe(key);
+      expect(insertedElement!.priority).toBe(priority);
+      expect(insertedElement!.metadata).toEqual(metadata);
+    });
+
+    it('inserts an element when the queue is not empty', () => {
+      // Given a priority queue with elements
+      const queue = new XPriorityQueue();
+      queue.push('1', 10);
+      queue.push('2', 20);
+      queue.push('3', 30);
+
+      // And elements are pushed
+      queue.push('4', 40);
+      queue.push('5', 15);
+      queue.push('6', 0);
+
+      // Then each element is inserted at the correct position
+      expect(queue.keys).toEqual(['6', '1', '5', '2', '3', '4']);
+    });
+
+    // eslint-disable-next-line max-len
+    it('inserts an element with the same key as an already existing non-replaceable element', () => {
+      // Given a priority queue with non-replaceable elements
+      const queue = new XPriorityQueue();
+      queue.push('1', 10, { previous: true });
+      queue.push('2', 20);
+      queue.push('3', 30);
+
+      // And an element with an existing key is inserted
+      queue.push('1', 10, { newer: true });
+
+      // Then the element is inserted without removing the other one
+      const existingElement = queue.at(0);
+      const newElement = queue.at(1);
+
+      expect(existingElement!.key).toBe('1');
+      expect(existingElement!.priority).toBe(10);
+      expect(existingElement!.metadata).toEqual({ previous: true });
+      expect(newElement!.key).toBe('1');
+      expect(newElement!.priority).toBe(10);
+      expect(newElement!.metadata).toEqual({ newer: true });
+    });
+
+    // eslint-disable-next-line max-len
+    it('inserts an element with the same key as an already existing and replaceable element', () => {
+      // Given a priority queue with replaceable elements
+      const queue = new XPriorityQueue();
+      queue.push('1', 10, { replaceable: true });
+      queue.push('2', 20);
+      queue.push('3', 30);
+
+      // And an element with an existing key is inserted
+      queue.push('1', 40);
+
+      // Then the existing element is removed and the new one is inserted at the correct position
+      expect(queue.keys).toEqual(['2', '3', '1']);
+    });
+  });
+
+  describe('pop', () => {
+    it('does not remove anything when the queue is empty', () => {
+      // Given an empty priority queue
+      const queue = new XPriorityQueue();
+
+      // And an element is popped
+      // Then nothing is removed
+      expect(queue.pop()).toBeUndefined();
+    });
+
+    it('removes and retrieves the first element of the queue when it is not empty', () => {
+      // Given a priority queue with elements
+      const queue = new XPriorityQueue();
+      queue.push('3', 30);
+      queue.push('1', 10);
+      queue.push('2', 20);
+
+      // And an element is popped
+      // Then the first element is removed and retrieved
+      expect(queue.pop()!.key).toBe('1');
+      expect(queue.keys).toEqual(['2', '3']);
+    });
+  });
+
+  describe('peek', () => {
+    it('returns the first element of the queue without removing it', () => {
+      // Given an empty queue
+      const queue = new XPriorityQueue();
+
+      // And an element is peeked
+      // Then the first element is retrieved but not removed
+      expect(queue.peek()).toBeUndefined();
+
+      // Pushing elements
+      queue.push('1', 10);
+      queue.push('2', 20);
+      queue.push('3', 5);
+
+      // And an element is peeked
+      // Then the first element is retrieved but not removed
+      expect(queue.peek()!.key).toBe('3');
+      expect(queue.keys).toEqual(['3', '1', '2']);
+    });
+  });
+
+  describe('clear', () => {
+    it('clears the queue', () => {
+      // Given a priority queue with elements
+      const queue = new XPriorityQueue();
+      queue.push('1', 10);
+      queue.push('2', 20);
+      queue.push('3', 30);
+
+      // And the queue is cleared
+      queue.clear();
+
+      // Then the queue is empty
+      expect(queue.size()).toBe(0);
+      expect(queue.isEmpty()).toBe(true);
+    });
+  });
+
+  describe('isEmpty', () => {
+    it('checks if the queue is empty when it is empty', () => {
+      // Given an empty queue
+      const queue = new XPriorityQueue();
+
+      // And the size of the queue is checked
+      // Then the assertion is true
+      expect(queue.isEmpty()).toBe(true);
+    });
+
+    it('checks if the queue is empty when it is not empty', () => {
+      // Given a queue with elements
+      const queue = new XPriorityQueue();
+      queue.push('1', 10);
+      queue.push('2', 20);
+      queue.push('3', 30);
+
+      // And the size of the queue is checked
+      // Then the assertion is false
+      expect(queue.isEmpty()).toBe(false);
+    });
+  });
+
+  describe('size', () => {
+    it('returns the size of the queue', () => {
+      // Given an empty queue
+      const queue = new XPriorityQueue();
+
+      // And the size of the queue is checked
+      // Then the size is 0
+      expect(queue.size()).toBe(0);
+
+      // And elements are added to the queue
+      queue.push('1', 10);
+      queue.push('2', 20);
+      queue.push('3', 30);
+
+      // Then the size is equal to the number of added elements
+      expect(queue.size()).toBe(3);
+    });
+  });
+
+  describe('at', () => {
+    it('returns the element of the queue at the // Given index', () => {
+      // Given a queue
+      const queue = new XPriorityQueue();
+
+      // And an index
+      const index = 2;
+
+      // Then the element at that index is retrieved
+      expect(queue.at(index)).toBeUndefined();
+
+      // And elements are pushed to the queue
+      queue.push('1', 10);
+      queue.push('2', 20);
+      queue.push('3', 30);
+
+      // Then the element at that index is retrieved
+      expect(queue.at(index)!.key).toBe('3');
+    });
+  });
+
+  describe('toString', () => {
+    it("returns queue's data stringified", () => {
+      // Given a queue
+      const queue = new XPriorityQueue();
+      queue.push('1', 10);
+      queue.push('2', 10, { replaceable: true });
+      queue.push('3', 30, { replaceable: true, extra: 'potato' });
+
+      // Then it is possible to output the queue's data as a string
+      expect(queue.toString()).toEqual(`[10] 1 -> {}
+[10] 2 -> {"replaceable":true}
+[30] 3 -> {"replaceable":true,"extra":"potato"}
+`);
+    });
   });
 });

--- a/packages/x-priority-queue/src/__tests__/x-priority-queue.spec.ts
+++ b/packages/x-priority-queue/src/__tests__/x-priority-queue.spec.ts
@@ -135,6 +135,15 @@ describe('x-priority-queue scenarios', () => {
   });
 
   describe('clear', () => {
+    it('does nothing if the queue is empty', () => {
+      // Given an empty priority queue
+      const queue = new XPriorityQueue();
+      queue.clear();
+      // Then the queue is empty
+      expect(queue.size()).toBe(0);
+      expect(queue.isEmpty()).toBe(true);
+    });
+
     it('clears the queue', () => {
       // Given a priority queue with elements
       const queue = new XPriorityQueue();

--- a/packages/x-priority-queue/src/index.ts
+++ b/packages/x-priority-queue/src/index.ts
@@ -1,1 +1,1 @@
-export const xPriorityQueue = 'x-priority-queue';
+export * from './x-priority-queue';

--- a/packages/x-priority-queue/src/x-priority-queue.ts
+++ b/packages/x-priority-queue/src/x-priority-queue.ts
@@ -1,5 +1,7 @@
 import { AnyFunction } from '@empathyco/x-utils';
 
+export type XPriorityQueueNodeMetadata = { replaceable?: boolean; [key: string]: unknown };
+
 /**
  * An XPriorityQueueNode object is a representation of a structure containing a parametrized key, a
  * priority number and metadata record. By default, the key is a string.
@@ -29,7 +31,7 @@ export class XPriorityQueueNode<Key = string> {
    *
    * @public
    */
-  public readonly metadata: Record<string, unknown>;
+  public readonly metadata: XPriorityQueueNodeMetadata;
 
   /**
    * Creates a new PriorityQueueNode with the given key, priority and metadata.
@@ -40,7 +42,7 @@ export class XPriorityQueueNode<Key = string> {
    *
    * @public
    */
-  public constructor(key: Key, priority: number, metadata: Record<string, unknown> = {}) {
+  public constructor(key: Key, priority: number, metadata: XPriorityQueueNodeMetadata = {}) {
     this.key = key;
     this.priority = priority;
     this.metadata = metadata;
@@ -123,7 +125,7 @@ export class XPriorityQueue<Key = string> {
    *
    * @public
    */
-  push(key: Key, priority: number, metadata?: Record<string, unknown>): void {
+  push(key: Key, priority: number, metadata?: XPriorityQueueNodeMetadata): void {
     const node = new XPriorityQueueNode<Key>(key, priority, metadata);
 
     if (this.isEmpty()) {

--- a/packages/x-priority-queue/src/x-priority-queue.ts
+++ b/packages/x-priority-queue/src/x-priority-queue.ts
@@ -1,0 +1,241 @@
+import { AnyFunction } from '@empathyco/x-utils';
+
+/**
+ * An XPriorityQueueNode object is a representation of a structure containing a parametrized key, a
+ * priority number and metadata record. By default, the key is a string.
+ *
+ * @public
+ */
+export class XPriorityQueueNode<Key = string> {
+  /**
+   * The key to store the element in the queue.
+   *
+   * @public
+   */
+  public readonly key: Key;
+  /**
+   * The number used to sort the elements in the queue.
+   *
+   * @public
+   */
+  public readonly priority: number;
+  /**
+   * The extra data to store in the queue associated with a key and priority pair. Optionally, a
+   * `boolean` `replaceable` key can be used in order to make the node replaceable in the queue.
+   * Being replaceable means that if a new element is pushed into the queue with the same key, the
+   * existing one will be removed.
+   *
+   * @public
+   */
+  public readonly metadata: Record<string, unknown>;
+
+  /**
+   * Creates a new PriorityQueueNode with the given key, priority and metadata.
+   *
+   * @param key - The key.
+   * @param priority - The priority.
+   * @param metadata - The metadata.
+   *
+   * @public
+   */
+  public constructor(key: Key, priority: number, metadata: Record<string, unknown> = {}) {
+    this.key = key;
+    this.priority = priority;
+    this.metadata = metadata;
+  }
+
+  /**
+   * Returns a string representation of this object. The string representation consists of: its
+   * priority, enclosed in square brackets ("[]"), followed by its key, an arrow (->) and the
+   * metadata converted to string as by JSON.stringify(Object).
+   *
+   * @example
+   * [10] 1 -> { replaceable: false, randomKey: randomValue }
+   *
+   * @returns A string representation of this object.
+   *
+   * @public
+   */
+  toString(): string {
+    return `[${this.priority}] ${String(this.key)} -> ${JSON.stringify(this.metadata)}`;
+  }
+}
+
+/**.
+ * A priority queue implementation storing replaceable elements with a metadata associated to a
+ * defined key and priority. By default, the keys are strings.
+ *
+ * Method         big-O
+ * ---------------------------
+ * - push         O(n)
+ * - pop          O(1)
+ * - peek         O(1)
+ * - at           O(1)
+ *
+ * @public
+ */
+export class XPriorityQueue<Key = string> {
+  /**
+   * The list of stored {@link XPriorityQueueNode | nodes}.
+   *
+   * @protected
+   */
+  protected nodes: XPriorityQueueNode<Key>[] = [];
+  /**
+   * The comparator function to use for sorting.
+   *
+   * @protected
+   */
+  protected comparatorFn: AnyFunction<boolean>;
+
+  /**
+   * Creates a new {@link XPriorityQueue}.
+   *
+   * @param comparatorFn - Comparator - the comparator that will be used to order this queue.
+   * By default, the elements will be sorted in descending order (an element with priority 1 will
+   * be higher than another with priority 5).
+   */
+  public constructor(comparatorFn: AnyFunction<boolean> = (a: number, b: number) => a > b) {
+    this.comparatorFn = comparatorFn;
+  }
+
+  /**
+   * The `keys` property of a {@link XPriorityQueue} represents the keys of that queue. The value is
+   * an array of the parametrized `Key` type.
+   *
+   * @returns The list of keys.
+   *
+   * @public
+   */
+  public get keys(): Key[] {
+    return this.nodes.map(({ key }) => key);
+  }
+
+  /**
+   * Inserts the specified key and priority pair, with an optional metadata, into the queue.
+   *
+   * @param key - The key to insert.
+   * @param priority - The priority to order the element in the queue.
+   * @param metadata - The extra data associated to a key and priority pair.
+   *
+   * @public
+   */
+  push(key: Key, priority: number, metadata?: Record<string, unknown>): void {
+    const node = new XPriorityQueueNode<Key>(key, priority, metadata);
+
+    if (this.isEmpty()) {
+      this.nodes.push(node);
+    } else {
+      this.pushAndSort(node);
+    }
+  }
+
+  /**
+   * Inserts the node into the queue in the correct position based on the
+   * {@link comparatorFn | comparator function}.
+   *
+   * @param newNode - The {@link XPriorityQueueNode | node} to be inserted.
+   *
+   * @internal
+   */
+  private pushAndSort(newNode: XPriorityQueueNode<Key>): void {
+    const replaceableIndex = this.nodes.findIndex(node => node.key === newNode.key);
+
+    if (replaceableIndex > -1 && this.nodes[replaceableIndex].metadata.replaceable) {
+      this.nodes.splice(replaceableIndex, 1);
+    }
+
+    const insertAtIndex = this.nodes.findIndex(node =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      this.comparatorFn(node.priority, newNode.priority)
+    );
+
+    if (insertAtIndex === -1) {
+      this.nodes.push(newNode);
+    } else {
+      this.nodes.splice(insertAtIndex, 0, newNode);
+    }
+  }
+
+  /**
+   * Retrieves and removes the head {@link XPriorityQueueNode | node} of the queue.
+   *
+   * @returns The head {@link XPriorityQueueNode | node} of the queue or undefined if it is empty.
+   */
+  pop(): XPriorityQueueNode<Key> | undefined {
+    return this.nodes.shift();
+  }
+
+  /**
+   * Retrieves, but does not remove, the head {@link XPriorityQueueNode | node} of the queue.
+   *
+   * @returns The head {@link XPriorityQueueNode | node} of the queue.
+   *
+   * @public
+   */
+  peek(): XPriorityQueueNode<Key> | undefined {
+    return this.nodes[0];
+  }
+
+  /**
+   * Retrieves the {@link XPriorityQueueNode | node} at a given position.
+   *
+   * @param index - The position to look at.
+   *
+   * @returns The {@link XPriorityQueueNode | node} at the passed position in the queue.
+   *
+   * @public
+   */
+  at(index: number): XPriorityQueueNode<Key> | undefined {
+    return this.nodes[index];
+  }
+
+  /**
+   * Removes all of the {@link XPriorityQueueNode | nodes} from the queue.
+   *
+   * @public
+   */
+  clear(): void {
+    this.nodes.length = 0;
+  }
+
+  /**
+   * Checks if the queue is empty.
+   *
+   * @returns True if the queue is empty, false otherwise.
+   *
+   * @public
+   */
+  isEmpty(): boolean {
+    return this.nodes.length === 0;
+  }
+
+  /**
+   * Retrieves the number of {@link XPriorityQueueNode | nodes} stored in the queue.
+   *
+   * @returns The number of {@link XPriorityQueueNode | nodes} stored in the queue.
+   *
+   * @public
+   */
+  size(): number {
+    return this.nodes.length;
+  }
+
+  /**
+   * Returns a string representation of this collection. The string representation consists of a
+   * list of the queue {@link XPriorityQueueNode | nodes} split in multiple lines, one for each
+   * one. Nodes are converted to strings as by {@link XPriorityQueueNode.toString | toString()}.
+   *
+   * @example
+   * [10] 1 -> { replaceable: false, a: 'b' }
+   * [20] 2 -> { replaceable: false }
+   * [30] 3 -> { replaceable: false, c: 1 }
+   *
+   * @returns A string representation of the queue.
+   *
+   * @public
+   */
+  toString(): string {
+    return this.nodes.reduce<string>((output, node) => output.concat(node.toString(), '\n'), '');
+  }
+}

--- a/packages/x-priority-queue/src/x-priority-queue.ts
+++ b/packages/x-priority-queue/src/x-priority-queue.ts
@@ -13,12 +13,14 @@ export class XPriorityQueueNode<Key = string> {
    * @public
    */
   public readonly key: Key;
+
   /**
    * The number used to sort the elements in the queue.
    *
    * @public
    */
   public readonly priority: number;
+
   /**
    * The extra data to store in the queue associated with a key and priority pair. Optionally, a
    * `boolean` `replaceable` key can be used in order to make the node replaceable in the queue.
@@ -78,13 +80,14 @@ export class XPriorityQueue<Key = string> {
   /**
    * The list of stored {@link XPriorityQueueNode | nodes}.
    *
-   * @protected
+   * @internal
    */
   protected nodes: XPriorityQueueNode<Key>[] = [];
+
   /**
    * The comparator function to use for sorting.
    *
-   * @protected
+   * @internal
    */
   protected comparatorFn: AnyFunction<boolean>;
 

--- a/packages/x-priority-queue/src/x-priority-queue.ts
+++ b/packages/x-priority-queue/src/x-priority-queue.ts
@@ -149,7 +149,6 @@ export class XPriorityQueue<Key = string> {
     }
 
     const insertAtIndex = this.nodes.findIndex(node =>
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       this.comparatorFn(node.priority, newNode.priority)
     );
 

--- a/packages/x-utils/src/types/utils.types.ts
+++ b/packages/x-utils/src/types/utils.types.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export type AnyFunction = (...args: any[]) => any;
+export type AnyFunction<ReturnType = any> = (...args: any[]) => ReturnType;
 /**
  * TypeScript type non-primitives. Array or Record with all possible types.
  *


### PR DESCRIPTION
EX-7459

Creates a `XPriorityQueue` class that allows to add elements with a defined priority and to retrieve the most prioritised. It also allows to replace elements that are configured as `replaceable`.