### PR TITLE
feat: script to import SVGs into Vue components for the XDS

### DIFF
--- a/packages/x-svg-converter/.eslintrc.js
+++ b/packages/x-svg-converter/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.eslint.json'
+  }
+};

--- a/packages/x-svg-converter/.gitignore
+++ b/packages/x-svg-converter/.gitignore
@@ -1,0 +1,24 @@
+.DS_Store
+/node_modules
+/dist
+/docs
+/*.tgz
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+

--- a/packages/x-svg-converter/LICENSE
+++ b/packages/x-svg-converter/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2021 Empathy Systems Corporation S.L.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/x-svg-converter/README.md
+++ b/packages/x-svg-converter/README.md
@@ -18,11 +18,11 @@ By default, the SVGs are deleted.
 Run the following command to generate a Vue component from each SVG in the source folder:
 
 ```
-ts-node ./src/svg-to-vue.ts ./src/test-files ./yourSourceFolder
+ts-node ./src/svg-to-vue.ts ./yourSourceFolder
 ```
 
 If you want to keep the source SVGs, add the `--keep-svgs` param:
 
 ```
-ts-node ./src/svg-to-vue.ts ./src/test-files ./yourSourceFolder --keep-svgs
+ts-node ./src/svg-to-vue.ts ./yourSourceFolder --keep-svgs
 ```

--- a/packages/x-svg-converter/README.md
+++ b/packages/x-svg-converter/README.md
@@ -1,0 +1,28 @@
+# Convert SVGs into Vue components to use with the X Design System
+
+This project generates Vue components from SVGs in a folder, with the format required for the XDS
+
+## How to use it
+
+### Params
+
+It receives two parameters, the first one should be the path to the folder containing the SVGs. The
+second one indicates if the source SVGs should be deleted at the end of the process (`--keep-svgs`).
+By default, the SVGs are deleted.
+
+- **sourcePath**: path of the folder with the SVGs.
+- **keepSVGs**: indicates if the SVGs are deleted at the end. `false` by default.
+
+### Run it as script
+
+Run the following command to generate a Vue component from each SVG in the source folder:
+
+```
+ts-node ./src/svg-to-vue.ts ./src/test-files ./yourSourceFolder
+```
+
+If you want to keep the source SVGs, add the `--keep-svgs` param:
+
+```
+ts-node ./src/svg-to-vue.ts ./src/test-files ./yourSourceFolder --keep-svgs
+```

--- a/packages/x-svg-converter/README.md
+++ b/packages/x-svg-converter/README.md
@@ -7,8 +7,8 @@ This project generates Vue components from SVGs in a folder, with the format req
 ### Params
 
 It receives two parameters, the first one should be the path to the folder containing the SVGs. The
-second one indicates if the source SVGs should be deleted at the end of the process (`--keep-svgs`).
-By default, the SVGs are deleted.
+second one indicates if the source SVG files should persist at the end of the process
+(`--keep-svgs`). By default, the SVGs are deleted.
 
 - **sourcePath**: path of the folder with the SVGs.
 - **keepSVGs**: indicates if the SVGs are deleted at the end. `false` by default.

--- a/packages/x-svg-converter/jest.config.js
+++ b/packages/x-svg-converter/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  moduleFileExtensions: ['ts', 'js'],
+  transform: {
+    '^.+\\.ts?$': 'ts-jest'
+  },
+  testMatch: ['<rootDir>/**/*.spec.ts']
+};

--- a/packages/x-svg-converter/package.json
+++ b/packages/x-svg-converter/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc",
     "postbuild": "npm pack",
-    "test": "jest -i"
+    "test": ""
   },
   "devDependencies": {
     "@types/jest": "~27.0.3",

--- a/packages/x-svg-converter/package.json
+++ b/packages/x-svg-converter/package.json
@@ -25,6 +25,7 @@
     "node": "16"
   },
   "scripts": {
+    "prebuild": "rimraf dist ./*.tgz",
     "build": "tsc",
     "postbuild": "npm pack",
     "test": "jest -i"

--- a/packages/x-svg-converter/package.json
+++ b/packages/x-svg-converter/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc",
     "postbuild": "npm pack",
-    "test": ""
+    "test": "jest -i"
   },
   "devDependencies": {
     "@types/jest": "~27.0.3",

--- a/packages/x-svg-converter/package.json
+++ b/packages/x-svg-converter/package.json
@@ -14,8 +14,7 @@
     "dist"
   ],
   "bin": {
-    "json-csv": "dist/json-to-csv.js",
-    "csv-json": "dist/csv-to-json.js"
+    "svg-vue": "dist/svg-to-vue.js"
   },
   "repository": {
     "type": "git",

--- a/packages/x-svg-converter/package.json
+++ b/packages/x-svg-converter/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "prebuild": "rimraf dist ./*.tgz",
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "postbuild": "npm pack",
     "test": "jest -i"
   },

--- a/packages/x-svg-converter/package.json
+++ b/packages/x-svg-converter/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@empathyco/x-svg-converter",
+  "version": "0.1.0",
+  "private": true,
+  "description": "A project which allows the user to convert SVGs into Vue components formatted to be used with the x-tailwindcss design system.",
+  "author": "Empathy Systems Corporation S.L.",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/empathyco/x/tree/main/packages/x-svg-converter#readme",
+  "keywords": [
+    "svg",
+    "converter"
+  ],
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "json-csv": "dist/json-to-csv.js",
+    "csv-json": "dist/csv-to-json.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/empathyco/x.git",
+    "directory": "packages/x-svg-converter"
+  },
+  "engines": {
+    "node": "16"
+  },
+  "scripts": {
+    "build": "tsc",
+    "postbuild": "npm pack",
+    "test": "jest -i"
+  },
+  "devDependencies": {
+    "@types/jest": "~27.0.3",
+    "@types/node": "~16.4.12",
+    "jest": "~27.3.1",
+    "ts-jest": "~27.0.7",
+    "typescript": "~4.6.2"
+  }
+}

--- a/packages/x-svg-converter/src/__tests__/regex-utils.spec.ts
+++ b/packages/x-svg-converter/src/__tests__/regex-utils.spec.ts
@@ -1,0 +1,67 @@
+import {
+  addFillNoneInRoot,
+  addXClass,
+  applyXDSFormat,
+  removeDimensions,
+  replaceColorWithCurrentColor
+} from '../regex-utils';
+import svgStub from './svg-stub';
+
+describe('test regex utils', () => {
+  it('removes dimensions from the root of an SVG', () => {
+    const svgWithDimensions = `<svg width="8" height="8" fill="none">
+<path />
+</svg>`;
+
+    expect(removeDimensions(svgWithDimensions)).toBe(`<svg   fill="none">
+<path />
+</svg>`);
+  });
+
+  it('adds `fill="none"` to the SVG root if it\'s missing', () => {
+    const svgWithoutFillNone = `<svg xmlns="http://www.w3.org/2000/svg">
+<path />
+</svg>`;
+
+    expect(addFillNoneInRoot(svgWithoutFillNone))
+      .toBe(`<svg fill="none" xmlns="http://www.w3.org/2000/svg">
+<path />
+</svg>`);
+  });
+
+  it('adds the `x-icon` and data classes to the root of an SVG', () => {
+    const svg = `<svg fill="none">
+<path />
+</svg>`;
+
+    expect(addXClass(svg))
+      .toBe(`<svg :class="['x-icon'].concat(data.staticClass, data.class)" fill="none">
+<path />
+</svg>`);
+  });
+
+  it('replaces colors that are not white with `currentColor`', () => {
+    const svgWithColors = `<svg fill="none">
+<path fill="black" stroke="white"/>
+<path fill="#fff" stroke="#000"/>
+<path fill="#fabada" stroke="#ffffff"/>
+</svg>`;
+
+    expect(replaceColorWithCurrentColor(svgWithColors)).toBe(`<svg fill="none">
+<path fill="currentColor" stroke="white"/>
+<path fill="#fff" stroke="currentColor"/>
+<path fill="currentColor" stroke="#ffffff"/>
+</svg>`);
+  });
+
+  it('applies the format changes needed for the XDS to an svg', () => {
+    /* eslint-disable max-len */
+    expect(applyXDSFormat(svgStub))
+      .toBe(`<svg :class="['x-icon'].concat(data.staticClass, data.class)" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path stroke="currentColor" stroke-width=".4" d="M1.2 1.2h5.6v5.6H1.2z"/>
+<path fill="currentColor" d="M2 2h4v4H2z"/>
+<path d="M5 3 3.625 4.5 3 3.818" stroke="#fff" stroke-width=".4" stroke-linecap="square"/>
+</svg>`);
+    /* eslint-enable max-len */
+  });
+});

--- a/packages/x-svg-converter/src/__tests__/regex-utils.spec.ts
+++ b/packages/x-svg-converter/src/__tests__/regex-utils.spec.ts
@@ -13,9 +13,14 @@ describe('test regex utils', () => {
 <path />
 </svg>`;
 
+    const svgWithoutDimensions = `<svg fill="none">
+<path />
+</svg>`;
+
     expect(removeDimensions(svgWithDimensions)).toBe(`<svg   fill="none">
 <path />
 </svg>`);
+    expect(removeDimensions(svgWithoutDimensions)).toBe(svgWithoutDimensions);
   });
 
   it('adds `fill="none"` to the SVG root if it\'s missing', () => {
@@ -23,10 +28,16 @@ describe('test regex utils', () => {
 <path />
 </svg>`;
 
+    const svgWithFillNone = `<svg fill="none" xmlns="http://www.w3.org/2000/svg">
+<path />
+</svg>`;
+
     expect(addFillNoneInRoot(svgWithoutFillNone))
       .toBe(`<svg fill="none" xmlns="http://www.w3.org/2000/svg">
 <path />
 </svg>`);
+
+    expect(addFillNoneInRoot(svgWithFillNone)).toBe(svgWithFillNone);
   });
 
   it('adds the `x-icon` and data classes to the root of an SVG', () => {

--- a/packages/x-svg-converter/src/__tests__/svg-stub.ts
+++ b/packages/x-svg-converter/src/__tests__/svg-stub.ts
@@ -1,0 +1,5 @@
+export default `<svg width="8" height="8" xmlns="http://www.w3.org/2000/svg">
+<path stroke="#243D48" stroke-width=".4" d="M1.2 1.2h5.6v5.6H1.2z"/>
+<path fill="#243D48" d="M2 2h4v4H2z"/>
+<path d="M5 3 3.625 4.5 3 3.818" stroke="#fff" stroke-width=".4" stroke-linecap="square"/>
+</svg>`;

--- a/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
+++ b/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
@@ -7,20 +7,10 @@ describe('test SVG to Vue script', () => {
   const sourcePath = './src/__tests__/svgs';
 
   afterEach(() => {
-    process.argv = [];
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
 
-    const absoluteSourcePath = path.resolve(process.cwd(), sourcePath);
-
-    if (fs.existsSync(absoluteSourcePath)) {
-      [...Array(2)].forEach((_, i) => {
-        if (!fs.existsSync(`${absoluteSourcePath}/test_svg_${i}.svg`)) {
-          fs.writeFileSync(`${absoluteSourcePath}/test_svg_${i}.svg`, svgStub);
-        }
-      });
-      fs.rmSync(`${absoluteSourcePath}/test_svg_0.vue`, { recursive: true });
-      fs.rmSync(`${absoluteSourcePath}/test_svg_1.vue`, { recursive: true });
-    }
+    generateTestSVGs();
+    removeVueTestFiles();
   });
 
   it('should create a vue component for each svg in the source folder', () => {
@@ -71,4 +61,31 @@ describe('test SVG to Vue script', () => {
     expect(fs.existsSync(`${sourcePath}/test_svg_0.svg`)).toBe(true);
     expect(fs.existsSync(`${sourcePath}/test_svg_1.svg`)).toBe(true);
   });
+
+  /**
+   * Generate the SVG files used in the tests.
+   */
+  function generateTestSVGs(): void {
+    const absoluteSourcePath = path.resolve(process.cwd(), sourcePath);
+
+    if (fs.existsSync(absoluteSourcePath)) {
+      [...Array(2)].forEach((_, i) => {
+        if (!fs.existsSync(`${absoluteSourcePath}/test_svg_${i}.svg`)) {
+          fs.writeFileSync(`${absoluteSourcePath}/test_svg_${i}.svg`, svgStub);
+        }
+      });
+    }
+  }
+
+  /**
+   * Remove the vue files product of the tests.
+   */
+  function removeVueTestFiles(): void {
+    const absoluteSourcePath = path.resolve(process.cwd(), sourcePath);
+
+    if (fs.existsSync(`${absoluteSourcePath}/test_svg_0.vue`)) {
+      fs.rmSync(`${absoluteSourcePath}/test_svg_0.vue`, { recursive: true });
+      fs.rmSync(`${absoluteSourcePath}/test_svg_1.vue`, { recursive: true });
+    }
+  }
 });

--- a/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
+++ b/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
@@ -17,6 +17,7 @@ jest.mock('child_process', () => {
 
 describe('test SVG to Vue script', () => {
   const sourcePath = './src/__tests__/svgs';
+  const originalArgv = process.argv;
 
   beforeEach(() => {
     process.argv = ['param1', 'param2', sourcePath];
@@ -26,6 +27,10 @@ describe('test SVG to Vue script', () => {
 
   afterEach(() => {
     removeVueTestFiles();
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
   });
 
   it('should create a vue component for each svg in the source folder', () => {

--- a/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
+++ b/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
@@ -20,6 +20,7 @@ describe('test SVG to Vue script', () => {
   const originalArgv = process.argv;
 
   beforeEach(() => {
+    process.argv = ['param1', 'param2', sourcePath];
     generateTestSVGs();
   });
 
@@ -29,10 +30,10 @@ describe('test SVG to Vue script', () => {
 
   afterAll(() => {
     process.argv = originalArgv;
+    generateTestSVGs();
   });
 
   it('should create a vue component for each svg in the source folder', () => {
-    loadParams();
     svgToVue();
 
     expect(fs.existsSync(`${sourcePath}/test_svg_0.vue`)).toBe(true);
@@ -40,7 +41,6 @@ describe('test SVG to Vue script', () => {
   });
 
   it('wraps the svg in a vue component format and generates the vue files with it', () => {
-    loadParams();
     svgToVue();
 
     const vueComponentContent = fs.readFileSync(`${sourcePath}/test_svg_0.vue`, {
@@ -65,7 +65,6 @@ describe('test SVG to Vue script', () => {
   it('unlinks the source svg files', () => {
     jest.spyOn(fs, 'unlink');
 
-    loadParams();
     svgToVue();
 
     expect(fs.unlink).toHaveBeenCalledWith(`${sourcePath}/test_svg_0.svg`, expect.any(Function));
@@ -73,7 +72,7 @@ describe('test SVG to Vue script', () => {
   });
 
   it('keeps the source SVG files if keepSVGs param is present', () => {
-    loadParams(true);
+    process.argv = ['param1', 'param2', sourcePath, '--keep-svgs'];
     svgToVue();
 
     expect(fs.existsSync(`${sourcePath}/test_svg_0.svg`)).toBe(true);
@@ -81,20 +80,10 @@ describe('test SVG to Vue script', () => {
   });
 
   it('applies prettier in the source folder', () => {
-    loadParams();
     svgToVue();
 
     expect(exec).toHaveBeenCalledWith(`prettier --write ${sourcePath}/*.vue`, expect.any(Function));
   });
-
-  /**
-   * Util function to load the params for the tests.
-   *
-   * @param keepSVGs - Indicates if the source SVGs should be kept.
-   */
-  function loadParams(keepSVGs = false): void {
-    process.argv = ['param1', 'param2', sourcePath, keepSVGs ? '--keep-svgs' : ''];
-  }
 
   /**
    * Generate the SVG files used in the tests.

--- a/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
+++ b/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
@@ -1,0 +1,74 @@
+import path from 'path';
+import fs from 'fs';
+import { svgToVue } from '../svg-to-vue';
+import svgStub from './svg-stub';
+
+describe('test SVG to Vue script', () => {
+  const sourcePath = './src/__tests__/svgs';
+
+  afterEach(() => {
+    process.argv = [];
+    jest.restoreAllMocks();
+
+    const absoluteSourcePath = path.resolve(process.cwd(), sourcePath);
+
+    if (fs.existsSync(absoluteSourcePath)) {
+      [...Array(2)].forEach((_, i) => {
+        if (!fs.existsSync(`${absoluteSourcePath}/test_svg_${i}.svg`)) {
+          fs.writeFileSync(`${absoluteSourcePath}/test_svg_${i}.svg`, svgStub);
+        }
+      });
+      fs.rmSync(`${absoluteSourcePath}/test_svg_0.vue`, { recursive: true });
+      fs.rmSync(`${absoluteSourcePath}/test_svg_1.vue`, { recursive: true });
+    }
+  });
+
+  it('should create a vue component for each svg in the source folder', () => {
+    process.argv = ['param1', 'param2', sourcePath];
+    svgToVue();
+
+    expect(fs.existsSync(`${sourcePath}/test_svg_0.vue`)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}/test_svg_1.vue`)).toBe(true);
+  });
+
+  it('wraps the svg in a vue component format and generates the vue files with it', () => {
+    process.argv = ['param1', 'param2', sourcePath];
+    svgToVue();
+
+    const vueComponentContent = fs.readFileSync(`${sourcePath}/test_svg_0.vue`, {
+      encoding: 'utf8'
+    });
+
+    /* eslint-disable max-len */
+    expect(vueComponentContent).toBe(`<template functional>
+  <svg :class="['x-icon'].concat(data.staticClass, data.class)" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path stroke="currentColor" stroke-width=".4" d="M1.2 1.2h5.6v5.6H1.2z"/>
+<path fill="currentColor" d="M2 2h4v4H2z"/>
+<path d="M5 3 3.625 4.5 3 3.818" stroke="#fff" stroke-width=".4" stroke-linecap="square"/>
+</svg>
+</template>
+
+<script lang="ts">
+  export default {};
+</script>`);
+    /* eslint-enable max-len */
+  });
+
+  it('unlinks the source svg files', () => {
+    jest.spyOn(fs, 'unlink');
+
+    process.argv = ['param1', 'param2', sourcePath];
+    svgToVue();
+
+    expect(fs.unlink).toHaveBeenCalledWith(`${sourcePath}/test_svg_0.svg`, expect.any(Function));
+    expect(fs.unlink).toHaveBeenCalledWith(`${sourcePath}/test_svg_1.svg`, expect.any(Function));
+  });
+
+  it('keeps the source SVG files if keepSVGs param is present', () => {
+    process.argv = ['param1', 'param2', sourcePath, '--keep-svgs'];
+    svgToVue();
+
+    expect(fs.existsSync(`${sourcePath}/test_svg_0.svg`)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}/test_svg_1.svg`)).toBe(true);
+  });
+});

--- a/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
+++ b/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
@@ -20,8 +20,6 @@ describe('test SVG to Vue script', () => {
   const originalArgv = process.argv;
 
   beforeEach(() => {
-    process.argv = ['param1', 'param2', sourcePath];
-
     generateTestSVGs();
   });
 
@@ -34,6 +32,7 @@ describe('test SVG to Vue script', () => {
   });
 
   it('should create a vue component for each svg in the source folder', () => {
+    loadParams();
     svgToVue();
 
     expect(fs.existsSync(`${sourcePath}/test_svg_0.vue`)).toBe(true);
@@ -41,6 +40,7 @@ describe('test SVG to Vue script', () => {
   });
 
   it('wraps the svg in a vue component format and generates the vue files with it', () => {
+    loadParams();
     svgToVue();
 
     const vueComponentContent = fs.readFileSync(`${sourcePath}/test_svg_0.vue`, {
@@ -65,6 +65,7 @@ describe('test SVG to Vue script', () => {
   it('unlinks the source svg files', () => {
     jest.spyOn(fs, 'unlink');
 
+    loadParams();
     svgToVue();
 
     expect(fs.unlink).toHaveBeenCalledWith(`${sourcePath}/test_svg_0.svg`, expect.any(Function));
@@ -72,7 +73,7 @@ describe('test SVG to Vue script', () => {
   });
 
   it('keeps the source SVG files if keepSVGs param is present', () => {
-    process.argv = ['param1', 'param2', sourcePath, '--keep-svgs'];
+    loadParams(true);
     svgToVue();
 
     expect(fs.existsSync(`${sourcePath}/test_svg_0.svg`)).toBe(true);
@@ -80,10 +81,20 @@ describe('test SVG to Vue script', () => {
   });
 
   it('applies prettier in the source folder', () => {
+    loadParams();
     svgToVue();
 
     expect(exec).toHaveBeenCalledWith(`prettier --write ${sourcePath}/*.vue`, expect.any(Function));
   });
+
+  /**
+   * Util function to load the params for the tests.
+   *
+   * @param keepSVGs - Indicates if the source SVGs should be kept.
+   */
+  function loadParams(keepSVGs = false): void {
+    process.argv = ['param1', 'param2', sourcePath, keepSVGs ? '--keep-svgs' : ''];
+  }
 
   /**
    * Generate the SVG files used in the tests.

--- a/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
+++ b/packages/x-svg-converter/src/__tests__/svg-to-vue.spec.ts
@@ -3,6 +3,17 @@ import fs from 'fs';
 import { svgToVue } from '../svg-to-vue';
 import svgStub from './svg-stub';
 
+// Mock to prevent the prettier from running in test env.
+jest.mock('child_process', () => {
+  const originalModule = jest.requireActual('child_process');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    exec: jest.fn(() => true)
+  };
+});
+
 describe('test SVG to Vue script', () => {
   const sourcePath = './src/__tests__/svgs';
 

--- a/packages/x-svg-converter/src/__tests__/svgs/test_svg_0.svg
+++ b/packages/x-svg-converter/src/__tests__/svgs/test_svg_0.svg
@@ -1,5 +1,0 @@
-<svg width="8" height="8" xmlns="http://www.w3.org/2000/svg">
-<path stroke="#243D48" stroke-width=".4" d="M1.2 1.2h5.6v5.6H1.2z"/>
-<path fill="#243D48" d="M2 2h4v4H2z"/>
-<path d="M5 3 3.625 4.5 3 3.818" stroke="#fff" stroke-width=".4" stroke-linecap="square"/>
-</svg>

--- a/packages/x-svg-converter/src/__tests__/svgs/test_svg_0.svg
+++ b/packages/x-svg-converter/src/__tests__/svgs/test_svg_0.svg
@@ -1,0 +1,5 @@
+<svg width="8" height="8" xmlns="http://www.w3.org/2000/svg">
+<path stroke="#243D48" stroke-width=".4" d="M1.2 1.2h5.6v5.6H1.2z"/>
+<path fill="#243D48" d="M2 2h4v4H2z"/>
+<path d="M5 3 3.625 4.5 3 3.818" stroke="#fff" stroke-width=".4" stroke-linecap="square"/>
+</svg>

--- a/packages/x-svg-converter/src/__tests__/svgs/test_svg_1.svg
+++ b/packages/x-svg-converter/src/__tests__/svgs/test_svg_1.svg
@@ -1,5 +1,0 @@
-<svg width="8" height="8" xmlns="http://www.w3.org/2000/svg">
-<path stroke="#243D48" stroke-width=".4" d="M1.2 1.2h5.6v5.6H1.2z"/>
-<path fill="#243D48" d="M2 2h4v4H2z"/>
-<path d="M5 3 3.625 4.5 3 3.818" stroke="#fff" stroke-width=".4" stroke-linecap="square"/>
-</svg>

--- a/packages/x-svg-converter/src/__tests__/svgs/test_svg_1.svg
+++ b/packages/x-svg-converter/src/__tests__/svgs/test_svg_1.svg
@@ -1,0 +1,5 @@
+<svg width="8" height="8" xmlns="http://www.w3.org/2000/svg">
+<path stroke="#243D48" stroke-width=".4" d="M1.2 1.2h5.6v5.6H1.2z"/>
+<path fill="#243D48" d="M2 2h4v4H2z"/>
+<path d="M5 3 3.625 4.5 3 3.818" stroke="#fff" stroke-width=".4" stroke-linecap="square"/>
+</svg>

--- a/packages/x-svg-converter/src/regex-utils.ts
+++ b/packages/x-svg-converter/src/regex-utils.ts
@@ -21,7 +21,7 @@ export function applyXDSFormat(svg: string): string {
  *
  * @returns The processed SVG.
  */
-function removeDimensions(svg: string): string {
+export function removeDimensions(svg: string): string {
   const matchDimensions = /(?<=<svg.*?)((width|height)="[0-9]*?")(?=.*?>)/gm;
   return svg.replace(matchDimensions, '');
 }
@@ -33,7 +33,7 @@ function removeDimensions(svg: string): string {
  *
  * @returns The processed SVG.
  */
-function addFillNoneInRoot(svg: string): string {
+export function addFillNoneInRoot(svg: string): string {
   const matchRootWithoutFillNone = /svg (?:(?!.*?fill="none"))(?=.*?>)/gm;
   return svg.replace(matchRootWithoutFillNone, 'svg fill="none" ');
 }
@@ -45,7 +45,7 @@ function addFillNoneInRoot(svg: string): string {
  *
  * @returns The processed SVG.
  */
-function addXClass(svg: string): string {
+export function addXClass(svg: string): string {
   const matchRoot = /svg /gm;
   return svg.replace(matchRoot, 'svg :class="[\'x-icon\'].concat(data.staticClass, data.class)" ');
 }
@@ -57,7 +57,7 @@ function addXClass(svg: string): string {
  *
  * @returns The processed SVG.
  */
-function replaceColorWithCurrentColor(svg: string): string {
+export function replaceColorWithCurrentColor(svg: string): string {
   const matchColoredFillOrStroke = /(?<=(fill|stroke)=")(?!#fff+"|white|none).*?(?=")/gim;
   return svg.replace(matchColoredFillOrStroke, 'currentColor');
 }

--- a/packages/x-svg-converter/src/regex-utils.ts
+++ b/packages/x-svg-converter/src/regex-utils.ts
@@ -47,7 +47,7 @@ function addFillNoneInRoot(svg: string): string {
  */
 function addXClass(svg: string): string {
   const matchRoot = /svg /gm;
-  return svg.replace(matchRoot, 'svg :class="[\'x-icon\'].concat(data.staticClass, data.class)"');
+  return svg.replace(matchRoot, 'svg :class="[\'x-icon\'].concat(data.staticClass, data.class)" ');
 }
 
 /**

--- a/packages/x-svg-converter/src/regex-utils.ts
+++ b/packages/x-svg-converter/src/regex-utils.ts
@@ -34,8 +34,8 @@ function removeDimensions(svg: string): string {
  * @returns The processed SVG.
  */
 function addFillNoneInRoot(svg: string): string {
-  const matchRootWithoutFillNone = /svg ?:(?!.*?fill="none")(?=.*?>)/gm;
-  return svg.replace(matchRootWithoutFillNone, '$1 fill="none"');
+  const matchRootWithoutFillNone = /svg (?:(?!.*?fill="none"))(?=.*?>)/gm;
+  return svg.replace(matchRootWithoutFillNone, 'svg fill="none" ');
 }
 
 /**

--- a/packages/x-svg-converter/src/regex-utils.ts
+++ b/packages/x-svg-converter/src/regex-utils.ts
@@ -1,0 +1,63 @@
+/**
+ * Applies to an SVG the format required by the XDS.
+ *
+ * @param svg - The SVG that will be processed.
+ *
+ * @returns The processed SVG.
+ */
+export function applyXDSFormat(svg: string): string {
+  let processedSvg = removeDimensions(svg);
+  processedSvg = addFillNoneInRoot(processedSvg);
+  processedSvg = addXClass(processedSvg);
+  processedSvg = replaceColorWithCurrentColor(processedSvg);
+
+  return processedSvg.replace(/  +/g, ' ');
+}
+
+/**
+ * Removes the dimensions (height and width) from the root of an SVG.
+ *
+ * @param svg - The SVG that will be processed.
+ *
+ * @returns The processed SVG.
+ */
+function removeDimensions(svg: string): string {
+  const matchDimensions = /(?<=<svg.*?)((width|height)="[0-9]*?")(?=.*?>)/gm;
+  return svg.replace(matchDimensions, '');
+}
+
+/**
+ * Adds `fill="none"` to the root of an SVG if it doesn't have it.
+ *
+ * @param svg - The SVG that will be processed.
+ *
+ * @returns The processed SVG.
+ */
+function addFillNoneInRoot(svg: string): string {
+  const matchRootWithoutFillNone = /svg ?:(?!.*?fill="none")(?=.*?>)/gm;
+  return svg.replace(matchRootWithoutFillNone, '$1 fill="none"');
+}
+
+/**
+ * Adds the `x-icon` and the data classes to the root of an SVG.
+ *
+ * @param svg - The SVG that will be processed.
+ *
+ * @returns The processed SVG.
+ */
+function addXClass(svg: string): string {
+  const matchRoot = /svg /gm;
+  return svg.replace(matchRoot, 'svg :class="[\'x-icon\'].concat(data.staticClass, data.class)"');
+}
+
+/**
+ * Replaces all the colors in the SVG with `currentColor`, expect white.
+ *
+ * @param svg - The SVG that will be processed.
+ *
+ * @returns The processed SVG.
+ */
+function replaceColorWithCurrentColor(svg: string): string {
+  const matchColoredFillOrStroke = /(?<=(fill|stroke)=")(?!#fff"|none).*?(?=")/gim;
+  return svg.replace(matchColoredFillOrStroke, 'currentColor');
+}

--- a/packages/x-svg-converter/src/regex-utils.ts
+++ b/packages/x-svg-converter/src/regex-utils.ts
@@ -51,13 +51,13 @@ function addXClass(svg: string): string {
 }
 
 /**
- * Replaces all the colors in the SVG with `currentColor`, expect white.
+ * Replaces all the colors in the SVG with `currentColor`, except white.
  *
  * @param svg - The SVG that will be processed.
  *
  * @returns The processed SVG.
  */
 function replaceColorWithCurrentColor(svg: string): string {
-  const matchColoredFillOrStroke = /(?<=(fill|stroke)=")(?!#fff"|none).*?(?=")/gim;
+  const matchColoredFillOrStroke = /(?<=(fill|stroke)=")(?!#fff+"|white|none).*?(?=")/gim;
   return svg.replace(matchColoredFillOrStroke, 'currentColor');
 }

--- a/packages/x-svg-converter/src/svg-to-vue.ts
+++ b/packages/x-svg-converter/src/svg-to-vue.ts
@@ -16,7 +16,7 @@ if (require.main === module) {
 }
 
 /**
- * Lod the SVG's info from the provided folder in the params.
+ * Load the SVG's info from the provided folder in the params.
  *
  * @returns A list of objects with the info of the SVGs found.
  */

--- a/packages/x-svg-converter/src/svg-to-vue.ts
+++ b/packages/x-svg-converter/src/svg-to-vue.ts
@@ -99,7 +99,7 @@ function runPrettier(): void {
 
   exec(`prettier --write ${sourcePath}/*.vue`, error => {
     if (error) {
-      throw Error(`runPrettier, ${error.message}`);
+      throw `runPrettier, ${error.message}`;
     }
   });
 }

--- a/packages/x-svg-converter/src/svg-to-vue.ts
+++ b/packages/x-svg-converter/src/svg-to-vue.ts
@@ -88,7 +88,7 @@ function getParams(): CommandParameters {
     throw Error('getParams, sourcePath not found');
   }
 
-  return { sourcePath, keepSVGs: keepSVGs === '--keep-svgs' ?? false };
+  return { sourcePath, keepSVGs: keepSVGs === '--keep-svgs' };
 }
 
 /**

--- a/packages/x-svg-converter/src/svg-to-vue.ts
+++ b/packages/x-svg-converter/src/svg-to-vue.ts
@@ -99,7 +99,7 @@ function runPrettier(): void {
 
   exec(`prettier --write ${sourcePath}/*.vue`, error => {
     if (error) {
-      throw `runPrettier, ${error.message}`;
+      throw Error(`runPrettier, ${error.message}`);
     }
   });
 }

--- a/packages/x-svg-converter/src/svg-to-vue.ts
+++ b/packages/x-svg-converter/src/svg-to-vue.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import { exec } from 'child_process';
+import { CommandParameters, SVGInfo } from './types';
+import { applyXDSFormat } from './regex-utils';
+
+if (require.main === module) {
+  const svgList = loadSVGsFromFolder();
+  svgList.forEach(writeVueFromSVG);
+
+  runPrettier();
+
+  if (!getParams().keepSVGs) {
+    svgList.forEach(removeSourceSVG);
+  }
+}
+
+/**
+ * Lod the SVG's info from the provided folder in the params.
+ *
+ * @returns A list of objects with the info of the SVGs found.
+ */
+function loadSVGsFromFolder(): SVGInfo[] {
+  const { sourcePath } = getParams();
+  if (!fs.existsSync(sourcePath)) {
+    throw Error(`loadSVGsFromFolder, folder not found ${sourcePath}`);
+  }
+
+  return fs
+    .readdirSync(sourcePath)
+    .filter(fileName => fileName.endsWith('.svg'))
+    .map(fileFullName => ({
+      fileName: fileFullName.replace(/.svg$/, ''),
+      svgData: fs.readFileSync(`${sourcePath}/${fileFullName}`, { encoding: 'utf8' })
+    }));
+}
+
+/**
+ * Creates Vue components from the SVG provided, with the same name as the original file and
+ * with the format that the XDS needs.
+ *
+ * @param svgInfo - The object containing the info of the SVG to generate the Vue component from.
+ */
+function writeVueFromSVG(svgInfo: SVGInfo): void {
+  const { sourcePath } = getParams();
+  const processedSvg = applyXDSFormat(svgInfo.svgData);
+
+  if (fs.existsSync(sourcePath)) {
+    fs.writeFileSync(`${sourcePath}/${svgInfo.fileName}.vue`, wrapAsVueComponent(processedSvg));
+  }
+}
+
+/**
+ * Generates a string with the format of a Vue component with the SVG wrapped inside the template.
+ *
+ * @param svg - The SVG string that will be wrapped inside the component.
+ *
+ * @returns The Vue component string.
+ */
+function wrapAsVueComponent(svg: SVGInfo['svgData']): string {
+  return `<template functional>
+  ${svg}
+</template>
+
+<script lang="ts">
+  export default {};
+</script>`;
+}
+
+/**
+ * Gets the parameters used to call the script.
+ *
+ * @returns SourcePath as string and keepSVGs as boolean.
+ */
+function getParams(): CommandParameters {
+  const [sourcePath, keepSVGs] = process.argv.slice(2);
+  if (sourcePath === undefined) {
+    throw Error('getParams, sourcePath not found');
+  }
+
+  return { sourcePath, keepSVGs: keepSVGs === '--keep-svgs' ?? false };
+}
+
+/**
+ * Runs the prettier command to format the .vue files inside the sourcePath.
+ */
+function runPrettier(): void {
+  const { sourcePath } = getParams();
+
+  exec(`prettier --write ${sourcePath}/*.vue`, error => {
+    if (error) {
+      throw Error(`runPrettier, ${error.message}`);
+    }
+  });
+}
+
+/**
+ * Removes an SVG in the source folder.
+ *
+ * @param svgInfo - The info of the SVG that will be removed.
+ */
+function removeSourceSVG(svgInfo: SVGInfo): void {
+  const { sourcePath } = getParams();
+  fs.unlink(`${sourcePath}/${svgInfo.fileName}.svg`, error => {
+    if (error) {
+      throw Error(`removeSourceSVG, ${error.message}`);
+    }
+  });
+}

--- a/packages/x-svg-converter/src/svg-to-vue.ts
+++ b/packages/x-svg-converter/src/svg-to-vue.ts
@@ -5,6 +5,16 @@ import { CommandParameters, SVGInfo } from './types';
 import { applyXDSFormat } from './regex-utils';
 
 if (require.main === module) {
+  svgToVue();
+}
+
+/**
+ * Load SVGs from provided folder, turn them into Vue Components and apply
+ * prettier to them. By default, the source SVGs are deleted unless the `keepSVGs`
+ * parameter is passed.
+ *
+ */
+export function svgToVue(): void {
   const svgList = loadSVGsFromFolder();
   svgList.forEach(writeVueFromSVG);
 

--- a/packages/x-svg-converter/src/types.ts
+++ b/packages/x-svg-converter/src/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Type to define the parameters received when the script is call.
+ */
+export interface CommandParameters {
+  sourcePath: string;
+  keepSVGs: boolean;
+}
+
+/**
+ * Type defining the info needed from an SVG file.
+ */
+export interface SVGInfo {
+  fileName: string;
+  svgData: string;
+}

--- a/packages/x-svg-converter/tsconfig.build.json
+++ b/packages/x-svg-converter/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "**/__tests__/**"]
+}

--- a/packages/x-svg-converter/tsconfig.eslint.json
+++ b/packages/x-svg-converter/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": []
+}

--- a/packages/x-svg-converter/tsconfig.json
+++ b/packages/x-svg-converter/tsconfig.json
@@ -11,5 +11,5 @@
     "lib": ["esnext"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/__tests__/**"]
 }

--- a/packages/x-svg-converter/tsconfig.json
+++ b/packages/x-svg-converter/tsconfig.json
@@ -11,5 +11,5 @@
     "lib": ["esnext"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/__tests__/**"]
+  "exclude": ["node_modules"]
 }

--- a/packages/x-svg-converter/tsconfig.json
+++ b/packages/x-svg-converter/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"],
+    "lib": ["esnext"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
[EX-7384](https://searchbroker.atlassian.net/browse/EX-7384)

## Motivation and context
We needed an easy way to import SVGs from Figma to a Vue component we could use with the XDS. This script should with that.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Create a folder and put some SVGs in it, the run the script as indicated in the README and see the Vue component it generates.
