### PR TITLE
fix(base-result-image): reset images state when results prop changes

### DIFF
--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -41,7 +41,7 @@
 <script lang="ts">
   import { Result } from '@empathyco/x-types';
   import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { Component, Prop, Watch } from 'vue-property-decorator';
   import { NoElement } from '../no-element';
 
   /**
@@ -96,7 +96,7 @@
      *
      * @internal
      */
-    protected pendingImages: string[] = [...(this.result.images ?? [])];
+    protected pendingImages: string[] = [];
 
     /**
      * Contains the images that have been loaded successfully.
@@ -133,6 +133,17 @@
       pointerEvents: 'none !important',
       visibility: 'hidden !important'
     };
+
+    /**
+     * Initializes images state and resets when the result changes.
+     *
+     * @internal
+     */
+    @Watch('result', { immediate: true })
+    resetImagesState(): void {
+      this.pendingImages = [...(this.result.images ?? [])];
+      this.loadedImages = [];
+    }
 
     /**
      * Animation to be used.

--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -135,11 +135,11 @@
     };
 
     /**
-     * Initializes images state and resets when the result changes.
+     * Initializes images state and resets when the result's images change.
      *
      * @internal
      */
-    @Watch('result', { immediate: true })
+    @Watch('result.images', { immediate: true })
     resetImagesState(): void {
       this.pendingImages = [...(this.result.images ?? [])];
       this.loadedImages = [];

--- a/packages/x-components/tests/unit/base-result-image.spec.ts
+++ b/packages/x-components/tests/unit/base-result-image.spec.ts
@@ -145,6 +145,28 @@ describe('testing Base Result Image component', () => {
     // It should have load the third image after the second one failed.
     getResultPictureImage().should('have.attr', 'src', '/img/test-image-2.jpeg');
   });
+
+  it('resets images state when `result` prop changes', () => {
+    const result = createResultStub('Result', { images: ['/img/test-image-1.jpeg'] });
+    cy.viewport(1920, 200);
+    mount({
+      components: { BaseResultImage },
+      data: () => ({ result }),
+      template: `
+        <div>
+          <BaseResultImage :result="result" />
+          <button @click="result.images = ['/img/test-image-2.jpeg']"
+                  data-test="button-images-change">
+            Change result images
+          </button>
+        </div>
+      `
+    });
+
+    cy.getByDataTest('result-picture-image').should('have.attr', 'src', '/img/test-image-1.jpeg');
+    cy.getByDataTest('button-images-change').trigger('click');
+    cy.getByDataTest('result-picture-image').should('have.attr', 'src', '/img/test-image-2.jpeg');
+  });
 });
 
 interface MountBaseResultImageOptions {


### PR DESCRIPTION
[MOTPRD-9540](https://searchbroker.atlassian.net/browse/MOTPRD-9540)

`BaseResultImage` didn't restore its images state when the `result` prop changed. So if the `images` array of the `result` changed, the `BaseResultImage` didn't display the current images. 
This is the case of `ResultVariantsProvider`. The selected variant is merged with the result info and if the variant contains `images`, the `result` provided to the `BaseResultImage` component contains the images of the variant, but they are not reactively referenced.

EXTRA: I would like to do a cypress component test, but I don't know how to change the prop value dynamically. Something like: 

```TS
  it('resets images state when `result` prop changes', () => {
    const result = createResultStub('Result', { images: ['/img/test-image-1.jpeg'] });
    const { component, getResultPictureImage } = mountBaseResultImage({
      result
    });

    getResultPictureImage().should('have.attr', 'src', '/img/test-image-1.jpeg');
    // Change `result` prop replacing `images` for `['/img/test-image-2.jpeg']`;
    getResultPictureImage().should('have.attr', 'src', '/img/test-image-2.jpeg');
  });
```