### PR TITLE
feat(recommendations): add updateRecommendation mutation

### DIFF
--- a/packages/x-components/src/x-modules/recommendations/store/module.ts
+++ b/packages/x-components/src/x-modules/recommendations/store/module.ts
@@ -33,6 +33,14 @@ export const recommendationsXStoreModule: RecommendationsXStoreModule = {
     setStatus,
     setParams(state, params) {
       state.params = params;
+    },
+    updateRecommendation(state, recommendation) {
+      const stateRecommendation = state.recommendations.find(
+        stateRecommendation => recommendation.id === stateRecommendation.id
+      );
+      if (stateRecommendation) {
+        Object.assign(stateRecommendation, recommendation);
+      }
     }
   },
   actions: {

--- a/packages/x-components/src/x-modules/recommendations/store/types.ts
+++ b/packages/x-components/src/x-modules/recommendations/store/types.ts
@@ -48,6 +48,13 @@ export interface RecommendationsMutations extends StatusMutations {
    * @param params - The new extra params.
    */
   setParams(params: Dictionary<unknown>): void;
+  /**
+   * Updates a recommendation with new fields.
+   *
+   * @param recommendation - A recommendation containing at least an id
+   * and the properties to modify.
+   */
+  updateRecommendation(recommendation: Partial<Result> & Pick<Result, 'id'>): void;
 }
 
 /**


### PR DESCRIPTION
[MOTPRD-9522](https://searchbroker.atlassian.net/browse/MOTPRD-9522)

<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
In Motive, we are modifying the prices coming from the search based on the shopper location (to apply the configured location taxes). For the search results, we will use the `updateResult` mutation already present in the project (added in https://github.com/empathyco/x/pull/706)

We need the same approach with recommendations, so in this PR we want to introduce the same update mutation for the recommendation store `updateRecommendation`.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
