### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do NOT** raise a GitHub Issue to report a security vulnerability. This kind of issues must
+be communicated in a private manner. If you believe you have found a security vulnerability, report
+it to our dedicated email address
+[security_champions@empathy.co](mailto:security_champions@empathy.co). We ask that you do not use
+other channels or contact project contributors directly. Non-vulnerability related security issues
+such as new great new ideas for security features are welcome on GitHub Issues.
+
+On top of that, if you would like to provide a patch, please **do not open a pull request** as it is
+another public way to discover the vulnerability. Instead, create a commit on your fork of
+**empathyco/x** and run this command:
+
+```bash
+git format-patch -1 HEAD --stdout > x_security_patch.txt
+```
+
+This command will create a file called `x_security_patch` with the content of your last commit.
+
+As a summary, send an email with:
+
+- Subject: Interface X Security Alert
+- Content: Description of the vulnerability
+- Attach the `x_security_patch` file if you have created one.
+
+Thanks for your contribution.
+


### PR DESCRIPTION
Add Security Policy 

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Add security.md

## Motivation and context
Complete the community standards and provide a way to communicate security issues
https://github.com/empathyco/x/community

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [x] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
