### PR TITLE
fix(svg-converter): check if file exist before unlink it

### DIFF
--- a/packages/x-svg-converter/src/svg-to-vue.ts
+++ b/packages/x-svg-converter/src/svg-to-vue.ts
@@ -111,9 +111,9 @@ function runPrettier(): void {
  */
 function removeSourceSVG(svgInfo: SVGInfo): void {
   const { sourcePath } = getParams();
-  const filename = `${sourcePath}/${svgInfo.fileName}.svg`;
-  if (fs.existsSync(filename)) {
-    fs.unlink(filename, error => {
+  const filePath = `${sourcePath}/${svgInfo.fileName}.svg`;
+  if (fs.existsSync(filePath)) {
+    fs.unlink(filePath, error => {
       if (error) {
         throw Error(`removeSourceSVG, ${error.message}`);
       }

--- a/packages/x-svg-converter/src/svg-to-vue.ts
+++ b/packages/x-svg-converter/src/svg-to-vue.ts
@@ -111,9 +111,12 @@ function runPrettier(): void {
  */
 function removeSourceSVG(svgInfo: SVGInfo): void {
   const { sourcePath } = getParams();
-  fs.unlink(`${sourcePath}/${svgInfo.fileName}.svg`, error => {
-    if (error) {
-      throw Error(`removeSourceSVG, ${error.message}`);
-    }
-  });
+  const filename = `${sourcePath}/${svgInfo.fileName}.svg`;
+  if (fs.existsSync(filename)) {
+    fs.unlink(filename, error => {
+      if (error) {
+        throw Error(`removeSourceSVG, ${error.message}`);
+      }
+    });
+  }
 }


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
We are getting a random error when running the tests for the `x-svg-converter` package. The error occurs at `removeSourceSVG` when trying to remove a file that doesn't exist anymore. This seems to happen only on the CI and not reproducible locally. Checking that the file exist before trying to unlink it should fix this random issue.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

Prevent the build from failing randomly.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
