### PR TITLE
test(e2e): make `HistoryQueries` test wait for no results before runn…

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -241,7 +241,11 @@
 
           <template v-if="!$x.redirections.length">
             <!--  No Results Message  -->
-            <div v-if="$x.noResults" class="x-message x-margin--top-03 x-margin--bottom-03">
+            <div
+              v-if="$x.noResults"
+              class="x-message x-margin--top-03 x-margin--bottom-03"
+              data-test="no-results-message"
+            >
               <p>
                 There are no results for
                 <span class="x-font-weight--bold">{{ $x.query.search }}</span>

--- a/packages/x-components/tests/e2e/common/common-steps.spec.ts
+++ b/packages/x-components/tests/e2e/common/common-steps.spec.ts
@@ -344,3 +344,7 @@ And('url contains parameter {string} with value {string}', (key: string, value: 
 When('navigating back', () => {
   cy.go(-1);
 });
+
+Then('no results message is displayed', () => {
+  cy.getByDataTest('no-results-message').should('be.visible');
+});

--- a/packages/x-components/tests/e2e/history-queries.feature
+++ b/packages/x-components/tests/e2e/history-queries.feature
@@ -102,11 +102,11 @@ Feature: History queries component
     And   start button is clicked
     And   no history queries are displayed
     When  "<query>" is searched
-    Then  the searched query is displayed in the search-box
+    Then  no results message is displayed
     When  clear search button is pressed
     Then  no history queries are displayed
     And   clear history queries button is enabled
 
     Examples:
-      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | query   |
-      | false             | 150          | 15              | 5                | true    | puzzle  |
+      | hideIfEqualsQuery | debounceInMs | maxItemsToStore | maxItemsToRender | instant | query  |
+      | false             | 150          | 15              | 5                | true    | puzzle |


### PR DESCRIPTION
Rendered history queries list is empty if no results are provided test does not wait until the no-results is triggered, so it can fail as the needed events to store the number of results for the history query might not have been emitted