### PR TITLE
feat(main-scroll-item): Capture listeners so we don't miss events

### DIFF
--- a/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
+++ b/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="tag" :data-scroll="item.id">
+  <component :is="tag" v-on="$listeners" :data-scroll="item.id">
     <slot />
   </component>
 </template>


### PR DESCRIPTION
When a tag is defined on a `main-scroll-item`, it's events are not captured.

# Pull request template
The only change made is just adding a `v-on="$listeners"` on `main-scroll-item` component so the events from a potential child is captured on this component and we don't miss them.

## Motivation and context
At motive, our intention is to handle hovering state via JS on our results, right now we are not able to have this events triggered.
result.vue
```vue
<template>
  <ResultVariantsProvider :result="result" :autoSelectDepth="0" #default="{ result }">
    <MainScrollItem
      @mouseover="hovered = true"
      @focusin="hovered = true"
      @mouseleave="hovered = false"
      @focusout="hovered = false"
      tag="article"
      ...
```      

⚠️ This solution [is a breaking change](https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html) when migrating to Vue3 

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

It has no tests since there's not a suite case for this component before :trollface: 


Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
