### PR TITLE
fix: image flickering on re-rendering

### DIFF
--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -142,7 +142,7 @@
     @Watch('result.images', { immediate: true })
     resetImagesState(): void {
       this.pendingImages = [...(this.result.images ?? [])];
-      this.loadedImages = [];
+      this.loadedImages = [...(this.result.images ?? [])];
     }
 
     /**

--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -142,7 +142,7 @@
     @Watch('result.images', { immediate: true })
     resetImagesState(): void {
       this.pendingImages = [...(this.result.images ?? [])];
-      this.loadedImages = [...(this.result.images ?? [])];
+      this.loadedImages = this.pendingImages.filter(image => this.loadedImages.includes(image));
     }
 
     /**

--- a/packages/x-components/tests/unit/base-result-image.spec.ts
+++ b/packages/x-components/tests/unit/base-result-image.spec.ts
@@ -11,20 +11,8 @@ import BaseResultImage from '../../src/components/result/base-result-image.vue';
  */
 function mountBaseResultImage({
   result,
-  showNextImageOnHover = false
-}: MountBaseResultImageOptions): MountBaseResultImageAPI {
-  cy.viewport(1920, 200);
-  mount({
-    components: {
-      BaseResultImage
-    },
-    data() {
-      return {
-        result,
-        showNextImageOnHover
-      };
-    },
-    template: `
+  showNextImageOnHover = false,
+  template = `
         <div>
           <BaseResultImage
               :result="result"
@@ -43,6 +31,19 @@ function mountBaseResultImage({
           </BaseResultImage>
         </div>
       `
+}: MountBaseResultImageOptions): MountBaseResultImageAPI {
+  cy.viewport(1920, 200);
+  mount({
+    components: {
+      BaseResultImage
+    },
+    data() {
+      return {
+        result,
+        showNextImageOnHover
+      };
+    },
+    template
   });
 
   return {
@@ -147,31 +148,33 @@ describe('testing Base Result Image component', () => {
   });
 
   it('resets images state when `result` prop changes', () => {
-    const result = createResultStub('Result', { images: ['/img/test-image-1.jpeg'] });
+    const result = createResultStub('Result', {
+      images: ['/img/test-image-1.jpeg']
+    });
+
     cy.viewport(1920, 200);
-    mount({
-      components: { BaseResultImage },
-      data: () => ({ result }),
+    const { getResultPictureImage } = mountBaseResultImage({
+      result,
       template: `
         <div>
           <BaseResultImage :result="result" />
           <button @click="result.images = ['/img/test-image-2.jpeg']"
                   data-test="button-images-change">
-            Change result images
+            Change result image
           </button>
         </div>
       `
     });
-
-    cy.getByDataTest('result-picture-image').should('have.attr', 'src', '/img/test-image-1.jpeg');
+    getResultPictureImage().should('have.attr', 'src', '/img/test-image-1.jpeg');
     cy.getByDataTest('button-images-change').trigger('click');
-    cy.getByDataTest('result-picture-image').should('have.attr', 'src', '/img/test-image-2.jpeg');
+    getResultPictureImage().should('have.attr', 'src', '/img/test-image-2.jpeg');
   });
 });
 
 interface MountBaseResultImageOptions {
   result: Result;
   showNextImageOnHover?: boolean;
+  template?: string;
 }
 
 interface MountBaseResultImageAPI {

--- a/packages/x-components/tests/unit/base-result-image.spec.ts
+++ b/packages/x-components/tests/unit/base-result-image.spec.ts
@@ -148,9 +148,7 @@ describe('testing Base Result Image component', () => {
   });
 
   it('resets images state when `result` prop changes', () => {
-    const result = createResultStub('Result', {
-      images: ['/img/test-image-1.jpeg']
-    });
+    const result = createResultStub('Result', { images: ['/img/test-image-1.jpeg'] });
 
     cy.viewport(1920, 200);
     const { getResultPictureImage } = mountBaseResultImage({
@@ -160,7 +158,7 @@ describe('testing Base Result Image component', () => {
           <BaseResultImage :result="result" />
           <button @click="result.images = ['/img/test-image-2.jpeg']"
                   data-test="button-images-change">
-            Change result image
+            Change result images
           </button>
         </div>
       `


### PR DESCRIPTION
- search for 'tshirt'
- filter by apparel.
- filter by topwear.
- remove topwear filter.

You will see how the image is not flickering, if you remove the change, the image will flicker again.

EX-7610