### PR TITLE
feat: modify base-events-modal-close and base-events-modal-open for WCAG compliance

### DIFF
--- a/packages/x-components/src/components/modals/base-events-modal-close.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-close.vue
@@ -4,6 +4,7 @@
     :events="events"
     class="x-button x-events-modal-close-button"
     data-test="close-modal"
+    aria-label="Close"
   >
     <!-- @slot (Required) Button content with a text, an icon or both -->
     <slot />

--- a/packages/x-components/src/components/modals/base-events-modal-open.vue
+++ b/packages/x-components/src/components/modals/base-events-modal-open.vue
@@ -4,6 +4,7 @@
     :events="events"
     class="x-button x-events-modal-open-button"
     data-test="open-modal"
+    aria-label="Open"
   >
     <!-- @slot (Required) Button content with a text, an icon or both -->
     <slot />

--- a/packages/x-components/src/views/accessibility/wai-base-event-button.vue
+++ b/packages/x-components/src/views/accessibility/wai-base-event-button.vue
@@ -57,9 +57,9 @@
 
       <div>
         <h1>BaseEventsModalOpen and BaseEventsModalClose</h1>
-        <BaseEventsModalOpen>Open</BaseEventsModalOpen>
+        <BaseEventsModalOpen>This button opens the modal</BaseEventsModalOpen>
         <BaseEventsModal>
-          <BaseEventsModalClose>Close</BaseEventsModalClose>
+          <BaseEventsModalClose>This button closes the modal</BaseEventsModalClose>
         </BaseEventsModal>
       </div>
 

--- a/packages/x-components/src/views/accessibility/wai-base-event-button.vue
+++ b/packages/x-components/src/views/accessibility/wai-base-event-button.vue
@@ -55,6 +55,14 @@
         </BaseColumnPickerList>
       </div>
 
+      <div>
+        <h1>BaseEventsModalOpen and BaseEventsModalClose</h1>
+        <BaseEventsModalOpen>Open</BaseEventsModalOpen>
+        <BaseEventsModal>
+          <BaseEventsModalClose>Close</BaseEventsModalClose>
+        </BaseEventsModal>
+      </div>
+
       <h1>ScrollToTop</h1>
       <div>
         <ScrollToTop scroll-id="accessibility-scroll" :threshold-px="1000">
@@ -68,6 +76,9 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
+  import BaseEventsModal from '../../components/modals/base-events-modal.vue';
+  import BaseEventsModalClose from '../../components/modals/base-events-modal-close.vue';
+  import BaseEventsModalOpen from '../../components/modals/base-events-modal-open.vue';
   import BaseIdTogglePanelButton from '../../components/panels/base-id-toggle-panel-button.vue';
   import BaseIdTogglePanel from '../../components/panels/base-id-toggle-panel.vue';
   import FacetsProvider from '../../x-modules/facets/components/facets/facets-provider.vue';
@@ -91,6 +102,9 @@
       FacetsProvider,
       AllFilter,
       BaseColumnPickerList,
+      BaseEventsModal,
+      BaseEventsModalClose,
+      BaseEventsModalOpen,
       BaseIdTogglePanel,
       BaseIdTogglePanelButton,
       BaseResultAddToCart,


### PR DESCRIPTION
## Motivation and context
`base-events-modal-close` and `base-events-modal-open` are using `base-event-button` component but yet they were no identified for WCAG compliance when modifying all components using `base-event-button`. This PR tries to solve that and make them accessible.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

Screen Reader (Chrome extension)

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
