### PR TITLE
fix: mutable schema types

### DIFF
--- a/packages/x-adapter-platform/src/schemas/models/banner.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/banner.schema.ts
@@ -1,9 +1,9 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { Banner } from '@empathyco/x-types';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformBanner } from '../../types/models/banner.model';
 
-export const bannerSchema = createMutableSchema<Schema<PlatformBanner, Banner>>({
+export const bannerSchema = createMutableSchema<PlatformBanner, Banner>({
   id: 'id',
   title: 'title',
   url: 'url',

--- a/packages/x-adapter-platform/src/schemas/models/facet.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/facet.schema.ts
@@ -1,4 +1,4 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import {
   EditableNumberRangeFacet,
   HierarchicalFacet,
@@ -9,10 +9,8 @@ import { PlatformFacet } from '../../types/models/facet.model';
 import { getFacetConfig } from '../facets/utils';
 
 export const facetSchema = createMutableSchema<
-  Schema<
-    PlatformFacet,
-    HierarchicalFacet | NumberRangeFacet | SimpleFacet | EditableNumberRangeFacet
-  >
+  PlatformFacet,
+  HierarchicalFacet | NumberRangeFacet | SimpleFacet | EditableNumberRangeFacet
 >({
   id: 'facet',
   label: 'facet',

--- a/packages/x-adapter-platform/src/schemas/models/filters/hierarchical-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/filters/hierarchical-filter.schema.ts
@@ -1,9 +1,10 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { HierarchicalFilter } from '@empathyco/x-types';
 import { PlatformHierarchicalFilter } from '../../../types/models/facet.model';
 
 export const hierarchicalFilterSchema = createMutableSchema<
-  Schema<PlatformHierarchicalFilter, HierarchicalFilter>
+  PlatformHierarchicalFilter,
+  HierarchicalFilter
 >({
   facetId: (_, $context) => $context?.facetId as string,
   label: 'value',

--- a/packages/x-adapter-platform/src/schemas/models/filters/number-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/filters/number-filter.schema.ts
@@ -1,8 +1,8 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { NumberRangeFilter } from '@empathyco/x-types';
 import { PlatformFilter } from '../../../types/models/facet.model';
 
-export const numberFilterSchema = createMutableSchema<Schema<PlatformFilter, NumberRangeFilter>>({
+export const numberFilterSchema = createMutableSchema<PlatformFilter, NumberRangeFilter>({
   id: 'filter',
   facetId: (_, $context) => $context?.facetId as string,
   label: 'value',

--- a/packages/x-adapter-platform/src/schemas/models/filters/simple-filter.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/filters/simple-filter.schema.ts
@@ -1,8 +1,8 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { SimpleFilter } from '@empathyco/x-types';
 import { PlatformFilter } from '../../../types/models/facet.model';
 
-export const simpleFilterSchema = createMutableSchema<Schema<PlatformFilter, SimpleFilter>>({
+export const simpleFilterSchema = createMutableSchema<PlatformFilter, SimpleFilter>({
   facetId: (_, $context) => $context?.facetId as string,
   label: 'value',
   id: 'filter',

--- a/packages/x-adapter-platform/src/schemas/models/next-query.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/next-query.schema.ts
@@ -1,8 +1,8 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { NextQuery } from '@empathyco/x-types';
 import { PlatformNextQuery } from '../../types/models/next-query.model';
 
-export const nextQuerySchema = createMutableSchema<Schema<PlatformNextQuery, NextQuery>>({
+export const nextQuerySchema = createMutableSchema<PlatformNextQuery, NextQuery>({
   query: 'query',
   results: () => [],
   facets: () => [],

--- a/packages/x-adapter-platform/src/schemas/models/partial-results.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/partial-results.schema.ts
@@ -1,11 +1,9 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { PartialResult } from '@empathyco/x-types';
 import { PlatformPartialResult } from '../../types/models/partials.model';
 import { resultSchema } from './result.schema';
 
-export const partialResultsSchema = createMutableSchema<
-  Schema<PlatformPartialResult, PartialResult>
->({
+export const partialResultsSchema = createMutableSchema<PlatformPartialResult, PartialResult>({
   query: 'term',
   results: {
     $path: 'content',

--- a/packages/x-adapter-platform/src/schemas/models/promoted.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/promoted.schema.ts
@@ -1,9 +1,9 @@
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { Promoted } from '@empathyco/x-types';
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
-import { PlatformPromoted } from '../../types/models/promoted.model';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
+import { PlatformPromoted } from '../../types/models/promoted.model';
 
-export const promotedSchema = createMutableSchema<Schema<PlatformPromoted, Promoted>>({
+export const promotedSchema = createMutableSchema<PlatformPromoted, Promoted>({
   id: 'id',
   url: 'url',
   title: 'title',

--- a/packages/x-adapter-platform/src/schemas/models/redirection.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/redirection.schema.ts
@@ -1,9 +1,9 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { Redirection } from '@empathyco/x-types';
-import { PlatformRedirection } from '../../types/models/redirection.model';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
+import { PlatformRedirection } from '../../types/models/redirection.model';
 
-export const redirectionSchema = createMutableSchema<Schema<PlatformRedirection, Redirection>>({
+export const redirectionSchema = createMutableSchema<PlatformRedirection, Redirection>({
   id: 'id',
   url: 'url',
   modelName: () => 'Redirection',

--- a/packages/x-adapter-platform/src/schemas/models/related-tag.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/related-tag.schema.ts
@@ -1,8 +1,8 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { RelatedTag } from '@empathyco/x-types';
 import { PlatformRelatedTag } from '../../types/models/related-tag.model';
 
-export const relatedTagSchema = createMutableSchema<Schema<PlatformRelatedTag, RelatedTag>>({
+export const relatedTagSchema = createMutableSchema<PlatformRelatedTag, RelatedTag>({
   query: 'query',
   tag: 'tag',
   modelName: () => 'RelatedTag',

--- a/packages/x-adapter-platform/src/schemas/models/result.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/result.schema.ts
@@ -1,9 +1,9 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { Result } from '@empathyco/x-types';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformResult } from '../../types/models/result.model';
 
-export const resultSchema = createMutableSchema<Schema<PlatformResult, Result>>({
+export const resultSchema = createMutableSchema<PlatformResult, Result>({
   id: 'id',
   images: ({ image }) => {
     return image ? [image] : [];

--- a/packages/x-adapter-platform/src/schemas/models/suggestion.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/suggestion.schema.ts
@@ -1,8 +1,8 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { Suggestion } from '@empathyco/x-types';
 import { PlatformSuggestion } from '../../types/models/suggestion.model';
 
-export const suggestionSchema = createMutableSchema<Schema<PlatformSuggestion, Suggestion>>({
+export const suggestionSchema = createMutableSchema<PlatformSuggestion, Suggestion>({
   query: 'title_raw',
   key: 'title_raw',
   modelName: (_, $context) =>

--- a/packages/x-adapter-platform/src/schemas/requests/identifier-results-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/identifier-results-request.schema.ts
@@ -1,10 +1,11 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { IdentifierResultsRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformIdentifierResultsRequest } from '../../types/requests/identifier-results-request.model';
 
 export const identifierResultsRequestSchema = createMutableSchema<
-  Schema<IdentifierResultsRequest, PlatformIdentifierResultsRequest>
+  IdentifierResultsRequest,
+  PlatformIdentifierResultsRequest
 >({
   query: 'query',
   origin: 'origin',

--- a/packages/x-adapter-platform/src/schemas/requests/next-queries-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/next-queries-request.schema.ts
@@ -1,9 +1,10 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { NextQueriesRequest } from '@empathyco/x-types';
 import { PlatformNextQueriesRequest } from '../../types/requests/next-queries-request.model';
 
 export const nextQueriesRequestSchema = createMutableSchema<
-  Schema<NextQueriesRequest, PlatformNextQueriesRequest>
+  NextQueriesRequest,
+  PlatformNextQueriesRequest
 >({
   query: 'query',
   extraParams: 'extraParams'

--- a/packages/x-adapter-platform/src/schemas/requests/popular-searches-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/popular-searches-request.schema.ts
@@ -1,10 +1,11 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { PopularSearchesRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformPopularSearchesRequest } from '../../types/requests/popular-searches-request.model';
 
 export const popularSearchesRequestSchema = createMutableSchema<
-  Schema<PopularSearchesRequest, PlatformPopularSearchesRequest>
+  PopularSearchesRequest,
+  PlatformPopularSearchesRequest
 >({
   start: 'start',
   rows: 'rows',

--- a/packages/x-adapter-platform/src/schemas/requests/query-suggestions-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/query-suggestions-request.schema.ts
@@ -1,10 +1,11 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { QuerySuggestionsRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformQuerySuggestionsRequest } from '../../types/requests/query-suggestions-request.model';
 
 export const querySuggestionsRequestSchema = createMutableSchema<
-  Schema<QuerySuggestionsRequest, PlatformQuerySuggestionsRequest>
+  QuerySuggestionsRequest,
+  PlatformQuerySuggestionsRequest
 >({
   query: 'query',
   start: 'start',

--- a/packages/x-adapter-platform/src/schemas/requests/recommendations-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/recommendations-request.schema.ts
@@ -1,10 +1,11 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { RecommendationsRequest } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformRecommendationsRequest } from '../../types/requests/recommendations-request.model';
 
 export const recommendationsRequestSchema = createMutableSchema<
-  Schema<RecommendationsRequest, PlatformRecommendationsRequest>
+  RecommendationsRequest,
+  PlatformRecommendationsRequest
 >({
   start: 'start',
   rows: 'rows',

--- a/packages/x-adapter-platform/src/schemas/requests/related-tags-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/related-tags-request.schema.ts
@@ -1,9 +1,10 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { RelatedTagsRequest } from '@empathyco/x-types';
 import { PlatformRelatedTagsRequest } from '../../types/requests/related-tags-request.model';
 
 export const relatedTagsRequestSchema = createMutableSchema<
-  Schema<RelatedTagsRequest, PlatformRelatedTagsRequest>
+  RelatedTagsRequest,
+  PlatformRelatedTagsRequest
 >({
   query: 'query',
   extraParams: 'extraParams'

--- a/packages/x-adapter-platform/src/schemas/requests/search-request.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/requests/search-request.schema.ts
@@ -1,11 +1,9 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
-import { reduce } from '@empathyco/x-utils';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { isHierarchicalFilter, SearchRequest } from '@empathyco/x-types';
+import { reduce } from '@empathyco/x-utils';
 import { PlatformSearchRequest } from '../../types/requests/search-request.model';
 
-export const searchRequestSchema = createMutableSchema<
-  Schema<SearchRequest, PlatformSearchRequest>
->({
+export const searchRequestSchema = createMutableSchema<SearchRequest, PlatformSearchRequest>({
   query: 'query',
   origin: 'origin',
   start: 'start',

--- a/packages/x-adapter-platform/src/schemas/responses/identifier-results-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/identifier-results-response.schema.ts
@@ -1,11 +1,12 @@
-import { Schema, createMutableSchema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { IdentifierResultsResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformIdentifierResultsResponse } from '../../types/responses/identifier-results-response.model';
 import { resultSchema } from '../models/result.schema';
 
 export const identifierResultsResponseSchema = createMutableSchema<
-  Schema<PlatformIdentifierResultsResponse, IdentifierResultsResponse>
+  PlatformIdentifierResultsResponse,
+  IdentifierResultsResponse
 >({
   results: {
     $path: 'catalog.content',

--- a/packages/x-adapter-platform/src/schemas/responses/next-queries-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/next-queries-response.schema.ts
@@ -1,10 +1,11 @@
-import { Schema, createMutableSchema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { NextQueriesResponse } from '@empathyco/x-types';
 import { PlatformNextQueriesResponse } from '../../types/responses/next-queries-response.model';
 import { nextQuerySchema } from '../models/next-query.schema';
 
 export const nextQueriesResponseSchema = createMutableSchema<
-  Schema<PlatformNextQueriesResponse, NextQueriesResponse>
+  PlatformNextQueriesResponse,
+  NextQueriesResponse
 >({
   nextQueries: {
     $path: 'data.nextqueries',

--- a/packages/x-adapter-platform/src/schemas/responses/popular-searches-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/popular-searches-response.schema.ts
@@ -1,11 +1,12 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { PopularSearchesResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformPopularSearchesResponse } from '../../types/responses/popular-searches-response.model';
 import { suggestionSchema } from '../models/suggestion.schema';
 
 export const popularSearchesResponseSchema = createMutableSchema<
-  Schema<PlatformPopularSearchesResponse, PopularSearchesResponse>
+  PlatformPopularSearchesResponse,
+  PopularSearchesResponse
 >({
   suggestions: {
     $path: 'topTrends.content',

--- a/packages/x-adapter-platform/src/schemas/responses/query-suggestions-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/query-suggestions-response.schema.ts
@@ -1,11 +1,12 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { QuerySuggestionsResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformQuerySuggestionsResponse } from '../../types/responses/query-suggestions-response.model';
 import { suggestionSchema } from '../models/suggestion.schema';
 
 export const querySuggestionsResponseSchema = createMutableSchema<
-  Schema<PlatformQuerySuggestionsResponse, QuerySuggestionsResponse>
+  PlatformQuerySuggestionsResponse,
+  QuerySuggestionsResponse
 >({
   suggestions: {
     $path: 'topTrends.content',

--- a/packages/x-adapter-platform/src/schemas/responses/recommendations-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/recommendations-response.schema.ts
@@ -1,11 +1,12 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { RecommendationsResponse } from '@empathyco/x-types';
 // eslint-disable-next-line max-len
 import { PlatformRecommendationsResponse } from '../../types/responses/recommendations-response.model';
 import { resultSchema } from '../models/result.schema';
 
 export const recommendationsResponseSchema = createMutableSchema<
-  Schema<PlatformRecommendationsResponse, RecommendationsResponse>
+  PlatformRecommendationsResponse,
+  RecommendationsResponse
 >({
   results: {
     $path: 'topclicked.content',

--- a/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
@@ -1,17 +1,15 @@
-import { createMutableSchema, Schema } from '@empathyco/x-adapter';
+import { createMutableSchema } from '@empathyco/x-adapter';
 import { SearchResponse } from '@empathyco/x-types';
 import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
 import { bannerSchema } from '../models/banner.schema';
 import { facetSchema } from '../models/facet.schema';
+import { partialResultsSchema } from '../models/partial-results.schema';
 import { promotedSchema } from '../models/promoted.schema';
 import { redirectionSchema } from '../models/redirection.schema';
 import { resultSchema } from '../models/result.schema';
-import { partialResultsSchema } from '../models/partial-results.schema';
 
-export const searchResponseSchema = createMutableSchema<
-  Schema<PlatformSearchResponse, SearchResponse>
->({
+export const searchResponseSchema = createMutableSchema<PlatformSearchResponse, SearchResponse>({
   results: {
     $path: 'catalog.content',
     $subSchema: resultSchema

--- a/packages/x-adapter/src/mappers/schema-mapper.factory.ts
+++ b/packages/x-adapter/src/mappers/schema-mapper.factory.ts
@@ -9,7 +9,7 @@ import {
   isPath,
   reduce
 } from '@empathyco/x-utils';
-import { Schema, SubSchemaTransformer } from '../schemas/types';
+import { MutableSchema, Schema, SubSchemaTransformer } from '../schemas/types';
 import { createMutableSchema, isInternalMethod } from '../schemas/utils';
 import { Mapper, MapperContext } from './types';
 
@@ -22,7 +22,7 @@ import { Mapper, MapperContext } from './types';
  * @public
  */
 export function schemaMapperFactory<Source, Target>(
-  schema: Schema<Source, Target>
+  schema: Schema<Source, Target> | MutableSchema<Source, Target>
 ): Mapper<Source, Target> {
   return function mapper(source: Source, context: MapperContext): Target {
     return mapSchema(source, schema, context);

--- a/packages/x-adapter/src/schemas/types.ts
+++ b/packages/x-adapter/src/schemas/types.ts
@@ -1,7 +1,6 @@
 import {
   AnyFunction,
   DeepPartial,
-  EmptyObject,
   ExtractPath,
   ExtractPathByType,
   ExtractType,
@@ -62,7 +61,7 @@ export type MutableSchema<Source, Target> = Schema<Source, Target> & {
    * @param newSchema - The {@link Schema | schema} to use instead of the original one.
    * @returns The new {@link Schema | schema} that will be used.
    */
-  $replace<NewSource, NewTarget = EmptyObject>(
+  $replace<NewSource, NewTarget>(
     newSchema: Schema<NewSource, NewTarget>
   ): MutableSchema<NewSource, NewTarget>;
   /**

--- a/packages/x-adapter/src/schemas/types.ts
+++ b/packages/x-adapter/src/schemas/types.ts
@@ -1,5 +1,7 @@
 import {
   AnyFunction,
+  DeepPartial,
+  EmptyObject,
   ExtractPath,
   ExtractPathByType,
   ExtractType,
@@ -60,7 +62,7 @@ export type MutableSchema<Source, Target> = Schema<Source, Target> & {
    * @param newSchema - The {@link Schema | schema} to use instead of the original one.
    * @returns The new {@link Schema | schema} that will be used.
    */
-  $replace<NewSource, NewTarget>(
+  $replace<NewSource, NewTarget = EmptyObject>(
     newSchema: Schema<NewSource, NewTarget>
   ): MutableSchema<NewSource, NewTarget>;
   /**
@@ -69,8 +71,10 @@ export type MutableSchema<Source, Target> = Schema<Source, Target> & {
    * @param newSchema - The {@link Schema | schema} to use to merge with the original one.
    * @returns The {@link Schema | schema} returned by the merge.
    */
-  $override<NewSource, NewTarget>(
-    newSchema: Partial<Schema<Source & NewSource, Target>> & Schema<Source & NewSource, NewTarget>
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  $override<NewSource, NewTarget = {}>(
+    newSchema: DeepPartial<Schema<Source & NewSource, Target>> &
+      Schema<Source & NewSource, NewTarget>
   ): MutableSchema<Source & NewSource, Target & NewTarget>;
   /**
    * Creates a new {@link Schema | schema} using the original one as starting point.
@@ -79,8 +83,10 @@ export type MutableSchema<Source, Target> = Schema<Source, Target> & {
    * @param newSchema - The {@link Schema | schema} to be used to extend the original one.
    * @returns The {@link Schema | schema} created.
    */
-  $extends<NewSource, NewTarget>(
-    newSchema: Partial<Schema<Source & NewSource, Target>> & Schema<Source & NewSource, NewTarget>
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  $extends<NewSource, NewTarget = {}>(
+    newSchema: DeepPartial<Schema<Source & NewSource, Target>> &
+      Schema<Source & NewSource, NewTarget>
   ): MutableSchema<Source & NewSource, Target & NewTarget>;
   /**
    * Returns a string representing of the {@link Schema | schema}.
@@ -91,7 +97,6 @@ export type MutableSchema<Source, Target> = Schema<Source, Target> & {
    */
   toString(includeInternalMethods?: boolean): string;
 };
-
 /**
  * The possible transformers to apply to the target key.
  *

--- a/packages/x-adapter/src/schemas/types.ts
+++ b/packages/x-adapter/src/schemas/types.ts
@@ -53,25 +53,25 @@ export type Schema<Source = any, Target = any> = {
  * @param OriginalSchema - The {@link Schema | schema} that will be mutable.
  * @public
  */
-export type MutableSchema<OriginalSchema extends Schema> = OriginalSchema & {
+export type MutableSchema<Source, Target> = Schema<Source, Target> & {
   /**
    * Replaces all usages of the original {@link Schema | schema} with the given one.
    *
    * @param newSchema - The {@link Schema | schema} to use instead of the original one.
    * @returns The new {@link Schema | schema} that will be used.
    */
-  $replace: <Source, Target>(
-    newSchema: Schema<Source, Target>
-  ) => MutableSchema<Schema<Source, Target>>;
+  $replace<NewSource, NewTarget>(
+    newSchema: Schema<NewSource, NewTarget>
+  ): MutableSchema<NewSource, NewTarget>;
   /**
    * Merges the original {@link Schema | schema} with the given one.
    *
    * @param newSchema - The {@link Schema | schema} to use to merge with the original one.
    * @returns The {@link Schema | schema} returned by the merge.
    */
-  $override: <Source, Target>(
-    newSchema: Schema<Source, Target>
-  ) => MutableSchema<Schema<Source, Target>>;
+  $override<NewSource, NewTarget>(
+    newSchema: Partial<Schema<Source & NewSource, Target>> & Schema<Source & NewSource, NewTarget>
+  ): MutableSchema<Source & NewSource, Target & NewTarget>;
   /**
    * Creates a new {@link Schema | schema} using the original one as starting point.
    * The original {@link Schema | schema} will remain unchanged.
@@ -79,9 +79,9 @@ export type MutableSchema<OriginalSchema extends Schema> = OriginalSchema & {
    * @param newSchema - The {@link Schema | schema} to be used to extend the original one.
    * @returns The {@link Schema | schema} created.
    */
-  $extends: <Source, Target>(
-    newSchema: Schema<Source, Target>
-  ) => MutableSchema<Schema<Source, Target>>;
+  $extends<NewSource, NewTarget>(
+    newSchema: Partial<Schema<Source & NewSource, Target>> & Schema<Source & NewSource, NewTarget>
+  ): MutableSchema<Source & NewSource, Target & NewTarget>;
   /**
    * Returns a string representing of the {@link Schema | schema}.
    *
@@ -89,7 +89,7 @@ export type MutableSchema<OriginalSchema extends Schema> = OriginalSchema & {
    * the internal methods. Disabled by default.
    * @returns The string representation.
    */
-  toString: (includeInternalMethods?: boolean) => string;
+  toString(includeInternalMethods?: boolean): string;
 };
 
 /**

--- a/packages/x-adapter/src/schemas/utils.ts
+++ b/packages/x-adapter/src/schemas/utils.ts
@@ -5,7 +5,7 @@ import { MutableSchema, Schema } from './types';
 /**
  * Collection of internal method names for {@link MutableSchema | mutable schemas}.
  */
-const mutableSchemasInternalMethods = ['$replace', '$override', '$extends', 'toString'];
+const mutableSchemasInternalMethods: string[] = ['$replace', '$override', '$extends', 'toString'];
 
 /**
  * Creates a {@link MutableSchema | mutable schema } version of a given {@link Schema | schema}.
@@ -16,32 +16,30 @@ const mutableSchemasInternalMethods = ['$replace', '$override', '$extends', 'toS
  *
  * @public
  */
-export function createMutableSchema<T extends Schema>(schema: T): MutableSchema<T> {
+export function createMutableSchema<Source, Target>(
+  schema: Schema<Source, Target>
+): MutableSchema<Source, Target> {
   return {
     ...schema,
-    $replace: function <Source = any, Target = any>(
-      newSchema: Schema<Source, Target>
-    ): MutableSchema<Schema<Source, Target>> {
-      Object.keys(this).forEach(key => {
-        if (isInternalMethod(key)) {
+    $replace(newSchema) {
+      forEach(this, key => {
+        if (isInternalMethod(key as string)) {
           return;
         }
         delete this[key];
       });
       Object.assign(this, newSchema);
-      return this;
+      /* We are replacing the schema with a completely new schema , so it makes sense that TS
+       complains that the old schema and the new one are not the same. */
+      return this as any;
     },
-    $override: function <Source = any, Target = any>(
-      newSchema: Schema<Source, Target>
-    ): MutableSchema<Schema<Source, Target>> {
+    $override(newSchema) {
       return deepMerge(this, newSchema);
     },
-    $extends: function <Source = any, Target = any>(
-      newSchema: Schema<Source, Target>
-    ): MutableSchema<Schema<Source, Target>> {
+    $extends(newSchema) {
       return deepMerge({}, this, newSchema);
     },
-    toString: function (includeInternalMethods = false) {
+    toString(includeInternalMethods = false) {
       return serialize(this, !!includeInternalMethods);
     }
   };


### PR DESCRIPTION
BREAKING CHANGE: `MutableSchema` now receives a `Source` and a `Target` object instead of a `Schema`
BREAKING CHANGE: `$replace`, `$extends` and `$override` function types now reflect the allowed operations more correctly.

EX-7702


Modifies `MutableSchema` types so overriding, extending, and replacing function types reflect correctly the operations made.

- `$replace` should replace **completely** the old schema. That's why in the implementation there are some casts, as this operation is not modelable with TypeScript.
- `$override` should **mutate** the current schema, allowing to add new properties or modifying mappings. Therefore  you are allowed to pass a new `Source` and `Target` generic types that will be combined with the old ones.
- `$extends` works pretty much the same than `$override` with the exception that it does **not** mutate the current schema, it creates a new one.

Additionally `MutableSchema` type has been modified to allow easier mapping this operations types, by receiving the `Source` and `Target` types directly rather than a `Schema`.


```ts
const base = createMutableSchema<{ _name: string; _id: string; _label: string }, { title: string }>(
  {
    title: '_name'
  }
);

schemaMapperFactory<{ _name: string; _id: string; _label: string }, { title: string }>(base);

const new1 = base.$override<{ _new: string }, { id: string }>({ title: '_label', id: '_id' });
const new2 = new1.$extends<{ _a: unknown }, { a?: unknown }>({ title: '_new' });
const new3 = new2.$extends<{ _image: string }, { images: string[] }>({ images: a => [a._image] });
```


