### PR TITLE
Feature/ex 7721 fix cache ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
           CI: 1
         # print Cypress and OS info
         run: |
-          npm ci
           npx cypress verify
           npx cypress info
           npx cypress version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,27 +23,10 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
+          path: |
+           **/node_modules
+            ~/.cache/Cypress
           key: node-modules-${{ hashFiles('**/package-lock.json') }}
-      - name: Cache Cypress
-        id: cache-cypress
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-cache
-      - name: install dependencies and verify Cypress
-        env:
-          # make sure every Cypress install prints minimal information
-          CI: 1
-        # print Cypress and OS info
-        run: |
-          npx cypress verify
-          npx cypress info
-          npx cypress version
-          npx cypress version --component package
-          npx cypress version --component binary
-          npx cypress version --component electron
-          npx cypress version --component node
       - name: Cache eslint
         id: cache-eslint
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-cache
+          key: cypress-cache-${{ hashFiles('**/package-lock.json') }}
       - name: Cache eslint
         id: cache-eslint
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           path: .eslintcache
           key: eslint-${{github.sha}}
+          restore-keys: eslint-
       - name: Install lerna and all packages
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,21 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-cache-${{ hashFiles('**/package-lock.json') }}
+          key: cypress-cache
+      - name: install dependencies and verify Cypress
+        env:
+          # make sure every Cypress install prints minimal information
+          CI: 1
+        # print Cypress and OS info
+        run: |
+          npm ci
+          npx cypress verify
+          npx cypress info
+          npx cypress version
+          npx cypress version --component package
+          npx cypress version --component binary
+          npx cypress version --component electron
+          npx cypress version --component node
       - name: Cache eslint
         id: cache-eslint
         uses: actions/cache@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@vue/vue2-jest": "~27.0.0-alpha.3",
         "autoprefixer": "~10.4.4",
         "concurrently": "~7.6.0",
-        "cypress": "~12.1.0",
+        "cypress": "~12.2.0",
         "esbuild": "0.15.16",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "~3.5.2",
@@ -8287,9 +8287,9 @@
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/cypress": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.1.0.tgz",
-      "integrity": "sha512-7fz8N84uhN1+ePNDsfQvoWEl4P3/VGKKmAg+bJQFY4onhA37Ys+6oBkGbNdwGeC7n2QqibNVPhk8x3YuQLwzfw==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.2.0.tgz",
+      "integrity": "sha512-kvl95ri95KK8mAy++tEU/wUgzAOMiIciZSL97LQvnOinb532m7dGvwN0mDSIGbOd71RREtmT9o4h088RjK5pKw==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
@@ -28305,9 +28305,9 @@
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "cypress": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.1.0.tgz",
-      "integrity": "sha512-7fz8N84uhN1+ePNDsfQvoWEl4P3/VGKKmAg+bJQFY4onhA37Ys+6oBkGbNdwGeC7n2QqibNVPhk8x3YuQLwzfw==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.2.0.tgz",
+      "integrity": "sha512-kvl95ri95KK8mAy++tEU/wUgzAOMiIciZSL97LQvnOinb532m7dGvwN0mDSIGbOd71RREtmT9o4h088RjK5pKw==",
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",

--- a/packages/react-wrapper/package.json
+++ b/packages/react-wrapper/package.json
@@ -48,7 +48,7 @@
     "@types/jest": "~27.0.3",
     "@types/react": "~16.9.0",
     "@types/react-dom": "~16.9.0",
-    "cypress": "~12.1.0",
+    "cypress": "~12.2.0",
     "eslint-plugin-react": "~7.31.11",
     "jest": "~27.3.1",
     "react": "^16.9.0",

--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -105,7 +105,7 @@
     "@vue/test-utils": "~1.0.3",
     "@vue/vue2-jest": "~27.0.0-alpha.3",
     "autoprefixer": "~10.4.4",
-    "cypress": "~12.1.0",
+    "cypress": "~12.2.0",
     "esbuild": "0.15.16",
     "glob": "~7.1.6",
     "jest": "~27.3.1",


### PR DESCRIPTION
EX-7721

Previously Cypress binary was cached with a static key. This caused Cypress updates to break the CI cache, as the project cached Cypress version did not have a proper Cypress binary cached as well.

![image](https://user-images.githubusercontent.com/68222542/210209383-6aaace6c-277d-4ac6-9ad8-208e9e97448c.png)

Now by combining both caches using the lock file hash, we should be safe. Also as we shouldn't update the package-lock in every PR, we should not see any performance drop in most of the PRs, only the ones that update the package-lock.

Also to clear the previous cache, I've updated the minor cypress version.