### PR TITLE
feat: base-result-link wcag compliance

### DIFF
--- a/packages/x-components/src/router.ts
+++ b/packages/x-components/src/router.ts
@@ -87,6 +87,11 @@ if (process.env.NODE_ENV !== 'production') {
           path: 'wai-base-dropdown-and-base-switch',
           name: 'Base Dropdown and Base Switch',
           component: () => import('./views/accessibility/wai-base-dropdown-and-base-switch.vue')
+        },
+        {
+          path: 'wai-base-result-link',
+          name: 'Base Result Link',
+          component: () => import('./views/accessibility/wai-base-result-link.vue')
         }
       ]
     }

--- a/packages/x-components/src/views/accessibility/accessibility-check.vue
+++ b/packages/x-components/src/views/accessibility/accessibility-check.vue
@@ -13,6 +13,9 @@
             Base Dropdown and Base Switch
           </router-link>
         </li>
+        <li>
+          <router-link to="/accessibility-check/wai-base-result-link">Base Result Link</router-link>
+        </li>
       </ul>
       <router-view />
     </div>

--- a/packages/x-components/src/views/accessibility/wai-base-result-link.vue
+++ b/packages/x-components/src/views/accessibility/wai-base-result-link.vue
@@ -1,0 +1,56 @@
+<template>
+  <article class="x-result" style="max-width: 300px; overflow: hidden">
+    <BaseResultLink class="x-result__picture" :result="result">
+      <BaseResultImage
+        :result="result"
+        class="x-picture--fixed-ratio x-picture--zoom"
+      ></BaseResultImage>
+    </BaseResultLink>
+
+    <BaseResultLink
+      class="x-result__description x-list x-list--vertical x-list--gap-02"
+      :result="result"
+    >
+      <h2 class="x-small x-ellipsis x-uppercase" data-test="result-title">
+        {{ result.name }}
+      </h2>
+      <div class="x-list x-list--horizontal x-list--wrap x-list--gap-03">
+        <BaseResultCurrentPrice :result="result" class="x-text x-text--bold" />
+        <BaseResultPreviousPrice
+          :result="result"
+          class="x-text x-text--secondary x-text--light x-text--stroke"
+        />
+      </div>
+    </BaseResultLink>
+  </article>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component } from 'vue-property-decorator';
+  import { createResultStub } from '../../__stubs__';
+  import BaseResultLink from '../../components/result/base-result-link.vue';
+  import BaseResultImage from '../../components/result/base-result-image.vue';
+  import BaseResultCurrentPrice from '../../components/result/base-result-current-price.vue';
+  import BaseResultPreviousPrice from '../../components/result/base-result-previous-price.vue';
+
+  @Component({
+    components: {
+      BaseResultCurrentPrice,
+      BaseResultPreviousPrice,
+      BaseResultImage,
+      BaseResultLink
+    }
+  })
+  export default class AccessibilityCheck extends Vue {
+    protected result = createResultStub('Demo result', {
+      images: ['https://picsum.photos/seed/5/100/100'],
+      price: {
+        hasDiscount: false,
+        originalValue: 11.99,
+        value: 11.99
+      },
+      url: 'https://www.lolahome.es/escobilla-zen-ceramica-blanco-gris-29075'
+    });
+  }
+</script>


### PR DESCRIPTION
## Motivation and context
WCAG compliance 

**Keyboard Interaction**
- Enter: Executes the link and moves focus to the link target.
- Shift + F10 (Optional): Opens a context menu for the link. → N/A

**WAI-ARIA Roles, States, and Properties**
- The element containing the link text or graphic has role of [link](https://w3c.github.io/aria/#link).

### BUT
**The link pattern is used when it is necessary for elements other than the HTML `a` element to have link behaviours.**

### THEN 
No changes are needed. Adding `role="link"` to `base-result-link.vue` triggers `vuejs-accessibility` plugin error: 
**The element a has an implicit role of link. Defining this explicitly is redundant and should be avoided  vuejs-accessibility/no-redundant-roles**

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

Test view was created (accessibility-check/wai-base-result-link)

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
