### PR TITLE
feat(history-queries): expose `historyQueriesWithResults` in the alia…

### DIFF
--- a/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
@@ -56,6 +56,7 @@ describe('testing plugin alias', () => {
       device: null,
       facets: {},
       historyQueries: [],
+      historyQueriesWithResults: [],
       fullHistoryQueries: [],
       identifierResults: [],
       searchBoxStatus: undefined,

--- a/packages/x-components/src/plugins/x-plugin.alias.ts
+++ b/packages/x-components/src/plugins/x-plugin.alias.ts
@@ -63,6 +63,11 @@ export function getAliasAPI(component: Vue): XComponentAliasAPI {
     get historyQueries() {
       return component.$store.getters[getGetterPath('historyQueries', 'historyQueries')] ?? [];
     },
+    get historyQueriesWithResults() {
+      return (
+        component.$store.getters[getGetterPath('historyQueries', 'historyQueriesWithResults')] ?? []
+      );
+    },
     get fullHistoryQueries() {
       return component.$store.state.x.historyQueries?.historyQueries ?? [];
     },

--- a/packages/x-components/src/plugins/x-plugin.types.ts
+++ b/packages/x-components/src/plugins/x-plugin.types.ts
@@ -102,6 +102,8 @@ export interface XComponentAliasAPI {
   readonly facets: Record<Facet['id'], Facet>;
   /** The {@link HistoryQueriesXModule} history queries matching the query. */
   readonly historyQueries: ReadonlyArray<HistoryQuery>;
+  /** The {@link HistoryQueriesXModule} history queries with 1 or more results. */
+  readonly historyQueriesWithResults: ReadonlyArray<HistoryQuery>;
   /** The {@link HistoryQueriesXModule} history queries. */
   readonly fullHistoryQueries: ReadonlyArray<HistoryQuery>;
   /** The {@link IdentifierResultsXModule} results. */

--- a/packages/x-components/src/views/home/predictive-layer.vue
+++ b/packages/x-components/src/views/home/predictive-layer.vue
@@ -5,11 +5,16 @@
         class="x-list x-list--horizontal x-list--padding-05 x-list--padding-bottom x-list--gap-06"
       >
         <PopularSearches :maxItemsToRender="10" />
-        <HistoryQueries :maxItemsToRender="controls.historyQueries.maxItemsToRender" />
-        <ClearHistoryQueries class="x-button--ghost x-button--ghost-start">
-          <CrossTinyIcon />
-          <span>Clear previous searches</span>
-        </ClearHistoryQueries>
+        <div v-if="$x.historyQueriesWithResults.length">
+          <h2 class="x-title2">
+            History
+            <ClearHistoryQueries class="x-button--ghost x-button--ghost-start">
+              <CrossTinyIcon />
+              <span>Clear previous searches</span>
+            </ClearHistoryQueries>
+          </h2>
+          <HistoryQueries :maxItemsToRender="controls.historyQueries.maxItemsToRender" />
+        </div>
         <QuerySuggestions :maxItemsToRender="10" />
         <NextQueries :maxItemsToRender="10" />
 

--- a/packages/x-components/src/views/home/predictive-layer.vue
+++ b/packages/x-components/src/views/home/predictive-layer.vue
@@ -5,16 +5,11 @@
         class="x-list x-list--horizontal x-list--padding-05 x-list--padding-bottom x-list--gap-06"
       >
         <PopularSearches :maxItemsToRender="10" />
-        <div v-if="$x.historyQueriesWithResults.length">
-          <h2 class="x-title2">
-            History
-            <ClearHistoryQueries class="x-button--ghost x-button--ghost-start">
-              <CrossTinyIcon />
-              <span>Clear previous searches</span>
-            </ClearHistoryQueries>
-          </h2>
-          <HistoryQueries :maxItemsToRender="controls.historyQueries.maxItemsToRender" />
-        </div>
+        <HistoryQueries :maxItemsToRender="controls.historyQueries.maxItemsToRender" />
+        <ClearHistoryQueries class="x-button--ghost x-button--ghost-start">
+          <CrossTinyIcon />
+          <span>Clear previous searches</span>
+        </ClearHistoryQueries>
         <QuerySuggestions :maxItemsToRender="10" />
         <NextQueries :maxItemsToRender="10" />
 


### PR DESCRIPTION
…s API.

EX-7476

Exposes the history queries with results in the alias API.

```html
        <div v-if="$x.historyQueriesWithResults.length">
          <h2 class="x-title2">
            History
            <ClearHistoryQueries class="x-button--ghost x-button--ghost-start">
              <CrossTinyIcon />
              <span>Clear previous searches</span>
            </ClearHistoryQueries>
          </h2>
          <HistoryQueries :maxItemsToRender="controls.historyQueries.maxItemsToRender" />
        </div>
```
