### PR TITLE
feat: add data-test to searchbar and hover underline to docs links

### DIFF
--- a/packages/x-archetype-utils/src/home/home-template.html
+++ b/packages/x-archetype-utils/src/home/home-template.html
@@ -83,6 +83,7 @@
           class="x-archetype-header__input"
           placeholder="What are you looking for?"
           onfocus="InterfaceX.search()"
+          data-test="start-searchbar">
         />
         <button class="x-archetype-button x-archetype-button--square" onclick="InterfaceX.search()">
           <svg
@@ -2080,6 +2081,10 @@
   .x-archetype-section3__list a {
     color: inherit;
     text-decoration: none;
+  }
+
+  .x-archetype-section3__list a:hover {
+      text-decoration: underline;
   }
 
   .x-archetype-section3__list > div {


### PR DESCRIPTION
EX-7806

## Motivation and context
Links to the docs should have an underline hover effect. Also, to tests this implementation on the `x-archetype`, I've added a `data-test` to the search bar that substitutes the start button we previously had.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Load the HTML in a browser and check the hover effect.

