### PR TITLE
feat(history-queries): add dynamic classes to the remove history query button

### DIFF
--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/history-query.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/history-query.spec.ts
@@ -15,7 +15,8 @@ import { resetXHistoryQueriesStateWith } from './utils';
 function renderHistoryQuery({
   suggestion = createHistoryQuery({ query: 'milk' }),
   query = '',
-  template = '<HistoryQuery v-bind="$attrs"/>'
+  template = '<HistoryQuery v-bind="$attrs"/>',
+  removeHistoryQueryClass
 }: RenderHistoryQueryOptions = {}): RenderHistoryQueryApi {
   const localVue = createLocalVue();
   localVue.use(Vuex);
@@ -33,7 +34,7 @@ function renderHistoryQuery({
     },
     {
       localVue,
-      propsData: { suggestion },
+      propsData: { suggestion, removeHistoryQueryClass },
       store
     }
   );
@@ -136,6 +137,15 @@ describe('testing history-query component', () => {
 
     expect(getRemoveWrapper().text()).toBe('Remove cruzcampo ❌');
   });
+
+  it('allows to add classes to the `RemoveHistoryQuery` button', () => {
+    const { getRemoveWrapper } = renderHistoryQuery({
+      suggestion: createHistoryQuery({ query: 'baileys' }),
+      query: 'Bá',
+      removeHistoryQueryClass: 'custom-class'
+    });
+    expect(getRemoveWrapper().classes('custom-class')).toBe(true);
+  });
 });
 
 interface RenderHistoryQueryOptions {
@@ -145,6 +155,8 @@ interface RenderHistoryQueryOptions {
   query?: string;
   /** The template to render. */
   template?: string;
+  /** Class to add to the node wrapping the remove history query button. */
+  removeHistoryQueryClass?: string;
 }
 
 interface RenderHistoryQueryApi {

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -17,6 +17,7 @@
     </BaseSuggestion>
     <RemoveHistoryQuery
       class="x-history-query__remove x-suggestion-group-button"
+      :class="removeHistoryQueryClass"
       :historyQuery="suggestion"
       data-test="remove-history-query"
     >
@@ -31,14 +32,14 @@
 
 <script lang="ts">
   import { HistoryQuery as HistoryQueryModel } from '@empathyco/x-types';
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { Component, Mixins, Prop } from 'vue-property-decorator';
   import { Getter } from '../../../components/decorators/store.decorators';
   import Highlight from '../../../components/highlight.vue';
   import BaseSuggestion from '../../../components/suggestions/base-suggestion.vue';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { XEventsTypes } from '../../../wiring/events.types';
   import { historyQueriesXModule } from '../x-module';
+  import { dynamicPropsMixin } from '../../../components/dynamic-props.mixin';
   import RemoveHistoryQuery from './remove-history-query.vue';
 
   /**
@@ -52,7 +53,7 @@
     mixins: [xComponentMixin(historyQueriesXModule)],
     components: { Highlight, RemoveHistoryQuery, BaseSuggestion }
   })
-  export default class HistoryQuery extends Vue {
+  export default class HistoryQuery extends Mixins(dynamicPropsMixin(['removeHistoryQueryClass'])) {
     /**
      * The history query suggestion to render.
      *


### PR DESCRIPTION
TO test it, change the history queries component in the predictive layer with this one:

```
<HistoryQueries class="x-list">
          <template #suggestion="{ suggestion }">
            <HistoryQuery :removeHistoryQueryClass="'x-custom-class'" :suggestion="suggestion">
              <template #default="{ query }">
                <HistoryIcon  />
                <Highlight :text="suggestion.query" :highlight="query" />
              </template>
            </HistoryQuery>
          </template>
        </HistoryQueries>
```

EX-7833
