### PR TITLE
feat: add dynamic classes to the suggestion item inside the `base-suggestions`

### DIFF
--- a/packages/x-components/src/components/suggestions/__tests__/base-suggestions.spec.ts
+++ b/packages/x-components/src/components/suggestions/__tests__/base-suggestions.spec.ts
@@ -17,7 +17,8 @@ function renderBaseSuggestions({
                 </BaseSuggestions>`,
   suggestions = getPopularSearchesStub(),
   showFacets = false,
-  showPlainSuggestion = false
+  showPlainSuggestion = false,
+  suggestionItemClass
 }: BaseSuggestionsOptions = {}): BaseSuggestionsAPI {
   const wrapper = mount(
     {
@@ -27,7 +28,7 @@ function renderBaseSuggestions({
       }
     },
     {
-      propsData: { suggestions, showFacets, showPlainSuggestion }
+      propsData: { suggestions, showFacets, showPlainSuggestion, suggestionItemClass }
     }
   );
 
@@ -162,6 +163,15 @@ describe('testing Base Suggestions component', () => {
     expect(suggestionsWrappers[4].text()).toEqual('jeans - kids');
     expect(suggestionsWrappers[5].text()).toEqual('jeans - adults');
   });
+
+  it('allows to add classes to the `suggestion item`', () => {
+    const { getSuggestionsWrappers } = renderBaseSuggestions({
+      suggestionItemClass: 'custom-class'
+    });
+    getSuggestionsWrappers().forEach(suggestionWrapper => {
+      expect(suggestionWrapper.classes('custom-class')).toBe(true);
+    });
+  });
 });
 
 /**
@@ -178,6 +188,8 @@ interface BaseSuggestionsOptions {
   showFacets?: boolean;
   /** Flag to indicate if a suggestion with filters should be rendered. */
   showPlainSuggestion?: boolean;
+  /** Class to add to the node wrapping the suggestion item. */
+  suggestionItemClass?: string;
 }
 
 /**

--- a/packages/x-components/src/components/suggestions/base-suggestions.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestions.vue
@@ -296,4 +296,37 @@ This will render:
   };
 </script>
 ```
+
+In this example, the `contentClass` prop can be used to add classes to the suggestion item.
+
+```vue
+<template>
+  <BaseSuggestions :suggestions="suggestions" suggestionItemClas="x-custom-class" />
+</template>
+
+<script>
+  import { BaseSuggestions } from '@empathyco/x-components';
+
+  export default {
+    name: 'BaseSuggestionsDemo',
+    components: {
+      BaseSuggestions
+    },
+    data() {
+      return {
+        suggestions: [
+          {
+            facets: [],
+            key: 'chips',
+            query: 'Chips',
+            totalResults: 10,
+            results: [],
+            modelName: 'PopularSearch'
+          }
+        ]
+      };
+    }
+  };
+</script>
+```
 </docs>

--- a/packages/x-components/src/components/suggestions/base-suggestions.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestions.vue
@@ -301,7 +301,7 @@ In this example, the `contentClass` prop can be used to add classes to the sugge
 
 ```vue
 <template>
-  <BaseSuggestions :suggestions="suggestions" suggestionItemClas="x-custom-class" />
+  <BaseSuggestions :suggestions="suggestions" suggestionItemClass="x-custom-class" />
 </template>
 
 <script>

--- a/packages/x-components/src/components/suggestions/base-suggestions.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestions.vue
@@ -4,6 +4,7 @@
       v-for="(suggestion, index) in suggestionsToRender"
       :key="suggestionsKeys[index]"
       class="x-list x-suggestions__item"
+      :class="suggestionItemClass"
       data-test="suggestion-item"
     >
       <!--
@@ -19,9 +20,10 @@
 
 <script lang="ts">
   import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { Component, Mixins, Prop } from 'vue-property-decorator';
   import { Suggestion, Facet, Filter } from '@empathyco/x-types';
   import { isArrayEmpty } from '../../utils/array';
+  import { dynamicPropsMixin } from '../dynamic-props.mixin';
 
   /**
    * Paints a list of suggestions passed in by prop. Requires a component for a single suggestion
@@ -30,7 +32,7 @@
    * @public
    */
   @Component
-  export default class BaseSuggestions extends Vue {
+  export default class BaseSuggestions extends Mixins(dynamicPropsMixin(['suggestionItemClass'])) {
     /**
      * The list of suggestions to render.
      *


### PR DESCRIPTION
To test it, add the prop `suggestionItemClass` to a base-suggestions component, for example:

`<HistoryQueries :suggestionItemClass="'x-custom'" />`

EX-7834