### PR TITLE
feat(endpoint-adapters): send internal field in the requests

### DIFF
--- a/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
+++ b/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
@@ -512,7 +512,7 @@ describe('platformAdapter tests', () => {
     });
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.staging.empathy.co/tagging/v1/track/empathy/click?internal=true&filtered=false&follow=false&lang=en&origin=search_box%3Anone&page=1&position=1&productId=12345-U&q=12345&scope=desktop&spellcheck=false&title=Xoxo+Women+Maroon+Pure+Georgette+Solid+Ready-to-wear+Saree',
+      'https://api.staging.empathy.co/tagging/v1/track/empathy/click?filtered=false&follow=false&lang=en&origin=search_box%3Anone&page=1&position=1&productId=12345-U&q=12345&scope=desktop&spellcheck=false&title=Xoxo+Women+Maroon+Pure+Georgette+Solid+Ready-to-wear+Saree',
       { keepalive: true }
     );
   });

--- a/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
+++ b/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
@@ -115,7 +115,7 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.test.empathy.co/search/v1/query/empathy/search?query=chips&origin=popular_search%3Apredictive_layer&start=0&rows=0&sort=price+asc&filter=categoryIds%3Affc61e1e9__be257cb26&filter=gender%3Amen&filter=price%3A10.0-20.0&instance=empathy&env=test&lang=es&device=mobile&scope=mobile',
+      'https://api.test.empathy.co/search/v1/query/empathy/search?internal=true&query=chips&origin=popular_search%3Apredictive_layer&start=0&rows=0&sort=price+asc&filter=categoryIds%3Affc61e1e9__be257cb26&filter=gender%3Amen&filter=price%3A10.0-20.0&instance=empathy&env=test&lang=es&device=mobile&scope=mobile',
       { signal: expect.anything() }
     );
     expect(response.totalResults).toBe(0);
@@ -182,7 +182,7 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.test.empathy.co/search/v1/query/empathy/empathize?start=0&rows=24&instance=empathy&env=test&lang=en&device=tablet&scope=tablet',
+      'https://api.test.empathy.co/search/v1/query/empathy/empathize?internal=true&start=0&rows=24&instance=empathy&env=test&lang=en&device=tablet&scope=tablet',
       { signal: expect.anything() }
     );
 
@@ -229,7 +229,7 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.test.empathy.co/search/v1/query/empathy/empathize?query=boots&start=0&rows=24&instance=empathy&env=test&lang=en&device=tablet&scope=tablet',
+      'https://api.test.empathy.co/search/v1/query/empathy/empathize?internal=true&query=boots&start=0&rows=24&instance=empathy&env=test&lang=en&device=tablet&scope=tablet',
       { signal: expect.anything() }
     );
 
@@ -278,7 +278,7 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.staging.empathy.co/nextqueries/empathy?query=makeup&scope=mobile&instance=empathy&device=mobile&env=staging&lang=en',
+      'https://api.staging.empathy.co/nextqueries/empathy?internal=true&query=makeup&scope=mobile&instance=empathy&device=mobile&env=staging&lang=en',
       { signal: expect.anything() }
     );
     expect(response).toStrictEqual({
@@ -328,7 +328,7 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.staging.empathy.co/relatedtags/empathy?query=jeans&device=mobile&env=staging&lang=en&scope=mobile&instance=empathy',
+      'https://api.staging.empathy.co/relatedtags/empathy?internal=true&query=jeans&device=mobile&env=staging&lang=en&scope=mobile&instance=empathy',
       { signal: expect.anything() }
     );
     expect(response).toStrictEqual({
@@ -364,7 +364,7 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.staging.empathy.co/search/v1/query/empathy/skusearch?query=jeans&origin=search_box%3Anone&start=0&rows=24&instance=empathy&env=staging&lang=en&device=mobile&scope=mobile',
+      'https://api.staging.empathy.co/search/v1/query/empathy/skusearch?internal=true&query=jeans&origin=search_box%3Anone&start=0&rows=24&instance=empathy&env=staging&lang=en&device=mobile&scope=mobile',
       { signal: expect.anything() }
     );
 
@@ -461,7 +461,7 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.test.empathy.co/search/v1/query/empathy/topclicked?start=0&rows=24&origin=search_box%3Anone&instance=empathy&env=test&lang=en&device=desktop&scope=desktop',
+      'https://api.test.empathy.co/search/v1/query/empathy/topclicked?internal=true&start=0&rows=24&origin=search_box%3Anone&instance=empathy&env=test&lang=en&device=desktop&scope=desktop',
       { signal: expect.anything() }
     );
 
@@ -512,7 +512,7 @@ describe('platformAdapter tests', () => {
     });
     expect(fetchMock).toHaveBeenCalledWith(
       // eslint-disable-next-line max-len
-      'https://api.staging.empathy.co/tagging/v1/track/empathy/click?filtered=false&follow=false&lang=en&origin=search_box%3Anone&page=1&position=1&productId=12345-U&q=12345&scope=desktop&spellcheck=false&title=Xoxo+Women+Maroon+Pure+Georgette+Solid+Ready-to-wear+Saree',
+      'https://api.staging.empathy.co/tagging/v1/track/empathy/click?internal=true&filtered=false&follow=false&lang=en&origin=search_box%3Anone&page=1&position=1&productId=12345-U&q=12345&scope=desktop&spellcheck=false&title=Xoxo+Women+Maroon+Pure+Georgette+Solid+Ready-to-wear+Saree',
       { keepalive: true }
     );
   });

--- a/packages/x-adapter-platform/src/endpoint-adapters/identifier-results.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/identifier-results.endpoint-adapter.ts
@@ -14,6 +14,9 @@ export const identifierResultsEndpointAdapter = endpointAdapterFactory<
   requestMapper: identifierResultsRequestMapper,
   responseMapper: identifierResultsResponseMapper,
   defaultRequestOptions: {
-    id: 'identifier-results'
+    id: 'identifier-results',
+    parameters: {
+      internal: true
+    }
   }
 });

--- a/packages/x-adapter-platform/src/endpoint-adapters/next-queries.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/next-queries.endpoint-adapter.ts
@@ -16,6 +16,9 @@ export const nextQueriesEndpointAdapter = endpointAdapterFactory<
   requestMapper: nextQueriesRequestMapper,
   responseMapper: nextQueriesResponseMapper,
   defaultRequestOptions: {
-    id: 'next-queries'
+    id: 'next-queries',
+    parameters: {
+      internal: true
+    }
   }
 });

--- a/packages/x-adapter-platform/src/endpoint-adapters/popular-searches.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/popular-searches.endpoint-adapter.ts
@@ -13,6 +13,9 @@ export const popularSearchesEndpointAdapter = endpointAdapterFactory<
   requestMapper: popularSearchesRequestMapper,
   responseMapper: popularSearchesResponseMapper,
   defaultRequestOptions: {
-    id: 'popular-searches'
+    id: 'popular-searches',
+    parameters: {
+      internal: true
+    }
   }
 });

--- a/packages/x-adapter-platform/src/endpoint-adapters/query-suggestions.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/query-suggestions.endpoint-adapter.ts
@@ -14,6 +14,9 @@ export const querySuggestionsEndpointAdapter = endpointAdapterFactory<
   requestMapper: querySuggestionsRequestMapper,
   responseMapper: querySuggestionsResponseMapper,
   defaultRequestOptions: {
-    id: 'query-suggestions'
+    id: 'query-suggestions',
+    parameters: {
+      internal: true
+    }
   }
 });

--- a/packages/x-adapter-platform/src/endpoint-adapters/recommendations.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/recommendations.endpoint-adapter.ts
@@ -13,6 +13,9 @@ export const recommendationsEndpointAdapter = endpointAdapterFactory<
   requestMapper: recommendationsRequestMapper,
   responseMapper: recommendationsResponseMapper,
   defaultRequestOptions: {
-    id: 'recommendations'
+    id: 'recommendations',
+    parameters: {
+      internal: true
+    }
   }
 });

--- a/packages/x-adapter-platform/src/endpoint-adapters/related-tags.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/related-tags.endpoint-adapter.ts
@@ -16,6 +16,9 @@ export const relatedTagsEndpointAdapter = endpointAdapterFactory<
   requestMapper: relatedTagsRequestMapper,
   responseMapper: relatedTagsResponseMapper,
   defaultRequestOptions: {
-    id: 'related-tags'
+    id: 'related-tags',
+    parameters: {
+      internal: true
+    }
   }
 });

--- a/packages/x-adapter-platform/src/endpoint-adapters/search.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/search.endpoint-adapter.ts
@@ -9,6 +9,9 @@ export const searchEndpointAdapter = endpointAdapterFactory<SearchRequest, Searc
   requestMapper: searchRequestMapper,
   responseMapper: searchResponseMapper,
   defaultRequestOptions: {
-    id: 'search'
+    id: 'search',
+    parameters: {
+      internal: true
+    }
   }
 });

--- a/packages/x-adapter-platform/src/endpoint-adapters/tagging.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/tagging.endpoint-adapter.ts
@@ -8,6 +8,9 @@ export const taggingEndpointAdapter = endpointAdapterFactory<TaggingRequest, voi
   defaultRequestOptions: {
     id: 'tagging',
     cancelable: false,
-    properties: { keepalive: true }
+    properties: { keepalive: true },
+    parameters: {
+      internal: true
+    }
   }
 });

--- a/packages/x-adapter-platform/src/endpoint-adapters/tagging.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/tagging.endpoint-adapter.ts
@@ -8,9 +8,6 @@ export const taggingEndpointAdapter = endpointAdapterFactory<TaggingRequest, voi
   defaultRequestOptions: {
     id: 'tagging',
     cancelable: false,
-    properties: { keepalive: true },
-    parameters: {
-      internal: true
-    }
+    properties: { keepalive: true }
   }
 });


### PR DESCRIPTION
Keep in mind that the tagging endpoint doesn't need the `internal` field.

EX-7780