### PR TITLE
(soft)(fix): Remove unneeded eslint disable as done globally

### DIFF
--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components.ts
@@ -18,7 +18,6 @@ import { slidingPanel } from './components/sliding-panel';
  *
  * @public
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export default function components(helpers: TailwindHelpers) {
   return {
     ...variables(helpers),

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/colors.ts
@@ -7,7 +7,6 @@ import { mapColors } from '../../utils/map-colors';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonColors(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return mapColors(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/default.ts
@@ -8,7 +8,6 @@ import { buttonSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/ghost.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/ghost.ts
@@ -9,7 +9,6 @@ import { noBackground } from './utils/no-background';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonGhost(helpers: TailwindHelpers) {
   return { ghost: deepMerge(noBackground(helpers), backgroundOnHover(helpers)) };
 }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/index.ts
@@ -17,7 +17,6 @@ import { buttonSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function button(helpers: TailwindHelpers) {
   return {
     '.button': deepMerge(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/layouts.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/layouts.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonLayouts({ theme }: TailwindHelpers) {
   return {
     square: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/link.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/link.ts
@@ -8,7 +8,6 @@ import { noHorizontalPadding } from './utils/no-horizontal-padding';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonLink(helpers: TailwindHelpers) {
   return {
     link: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/outlined.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/outlined.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonOutlined(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/tight.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/tight.ts
@@ -9,7 +9,6 @@ import { noHorizontalPadding } from './utils/no-horizontal-padding';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function buttonTight(helpers: TailwindHelpers) {
   return { tight: deepMerge(noBackground(helpers), noHorizontalPadding(helpers)) };
 }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/utils/background-on-hover.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/utils/background-on-hover.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the util.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function backgroundOnHover(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/utils/no-background.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/utils/no-background.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the util.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function noBackground(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/background-colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/background-colors.ts
@@ -8,7 +8,6 @@ import { mapColors } from '../../utils/map-colors';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function iconBackgroundColors(helpers: TailwindHelpers) {
   return {
     bg: rename(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/colors.ts
@@ -8,7 +8,6 @@ import { mapColors } from '../../utils/map-colors';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function iconColors(helpers: TailwindHelpers) {
   return mapColors(
     color => ({

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/default.ts
@@ -7,7 +7,6 @@ import { iconSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function iconDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/index.ts
@@ -13,7 +13,6 @@ import { iconStrokeWidths } from './stroke-widths';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function icon(helpers: TailwindHelpers) {
   return {
     '.icon': Object.assign(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function iconSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/stroke-widths.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/icon/stroke-widths.ts
@@ -7,7 +7,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function iconStrokeWidths({ theme }: TailwindHelpers) {
   return {
     'stroke-width': rename(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/colors.ts
@@ -7,7 +7,6 @@ import { mapColors } from '../../utils/map-colors';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function inputColors(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return mapColors(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/default.ts
@@ -9,7 +9,6 @@ import { inputSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function inputDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return deepMerge(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/index.ts
@@ -12,7 +12,6 @@ import { inputLine } from './line';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function input(helpers: TailwindHelpers) {
   return {
     '.input': deepMerge(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/line.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/line.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function inputLine(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/input/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function inputSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/default.ts
@@ -3,7 +3,6 @@
  *
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupButtonDefault() {
   return {
     display: 'grid',

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/ghost.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/ghost.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupButtonGhost(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/index.ts
@@ -12,7 +12,6 @@ import { suggestionGroupButtonLighter } from './lighter';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupButton(helpers: TailwindHelpers) {
   return {
     '.suggestion-group-button': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/lighter-colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/lighter-colors.ts
@@ -7,7 +7,6 @@ import { mapColors } from '../../../utils/map-colors';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupLighterColors(helpers: TailwindHelpers) {
   return rename(
     mapColors(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/lighter.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/lighter.ts
@@ -1,10 +1,8 @@
 /**
  * Returns the `lighter` variant for component `suggestion group button`.
  *
- * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupButtonLighter() {
   return {
     lighter: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/rectangle.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/button/rectangle.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupButtonRectangle(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/colors.ts
@@ -8,7 +8,6 @@ import { mapColors } from '../../utils/map-colors';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupColors(helpers: TailwindHelpers) {
   return mapColors(
     color => ({

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/default.ts
@@ -8,7 +8,6 @@ import { suggestionGroupSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/ghost.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/ghost.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupGhost(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/index.ts
@@ -12,7 +12,6 @@ import { suggestionGroupGhost } from './ghost';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroup(helpers: TailwindHelpers) {
   return {
     '.suggestion-group': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/outlined.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/outlined.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupOutlined(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion-group/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGroupSizes(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/colors.ts
@@ -8,7 +8,6 @@ import { mapColors } from '../../utils/map-colors';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionColors(helpers: TailwindHelpers) {
   return mapColors(
     color => ({

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/default.ts
@@ -8,7 +8,6 @@ import { suggestionSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/ghost.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/ghost.ts
@@ -7,7 +7,6 @@ import { commonGhostAndTagStyles } from './utils/common-ghost-and-tag-styles';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionGhost(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/index.ts
@@ -12,7 +12,6 @@ import { suggestionSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestion(helpers: TailwindHelpers) {
   return {
     '.suggestion': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/outlined.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/outlined.ts
@@ -7,7 +7,6 @@ import { commonGhostAndTagStyles } from './utils/common-ghost-and-tag-styles';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionOutlined(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function suggestionSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/utils/common-ghost-and-tag-styles.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/utils/common-ghost-and-tag-styles.ts
@@ -8,7 +8,6 @@ import { paddingBySize } from './padding-by-size';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the util.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function commonGhostAndTagStyles(helpers: TailwindHelpers) {
   const { theme } = helpers;
   const padding = paddingBySize(helpers);

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/utils/padding-by-size.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/suggestion/utils/padding-by-size.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the util.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function paddingBySize(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text1/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text1/default.ts
@@ -7,7 +7,6 @@ import { textSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function textDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text1/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text1/index.ts
@@ -9,7 +9,6 @@ import { textSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function text1(helpers: TailwindHelpers) {
   return {
     '.text1': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text1/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text1/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function textSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text2/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text2/default.ts
@@ -7,7 +7,6 @@ import { textSizes } from '../text2/sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function textDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text2/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text2/index.ts
@@ -9,7 +9,6 @@ import { textSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function text2(helpers: TailwindHelpers) {
   return {
     '.text2': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text2/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/text2/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function textSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title1/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title1/default.ts
@@ -7,7 +7,6 @@ import { titleSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function titleDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title1/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title1/index.ts
@@ -9,7 +9,6 @@ import { titleSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function title1(helpers: TailwindHelpers) {
   return {
     '.title1': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title1/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title1/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function titleSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title2/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title2/default.ts
@@ -7,7 +7,6 @@ import { titleSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function titleDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title2/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title2/index.ts
@@ -9,7 +9,6 @@ import { titleSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function title2(helpers: TailwindHelpers) {
   return {
     '.title2': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title2/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title2/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function titleSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title3/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title3/default.ts
@@ -7,7 +7,6 @@ import { titleSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function titleDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title3/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title3/index.ts
@@ -9,7 +9,6 @@ import { titleSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function title3(helpers: TailwindHelpers) {
   return {
     '.title3': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title3/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title3/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function titleSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title4/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title4/default.ts
@@ -7,7 +7,6 @@ import { titleSizes } from './sizes';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function titleDefault(helpers: TailwindHelpers) {
   const { theme } = helpers;
   return {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title4/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/typography/title4/sizes.ts
@@ -6,7 +6,6 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function titleSizes({ theme }: TailwindHelpers) {
   return {
     sm: {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/dynamic-utilities.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/dynamic-utilities.ts
@@ -8,7 +8,6 @@ import { TailwindHelpers } from '../types';
  *
  * @public
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export default function dynamicUtilities({ theme }: TailwindHelpers) {
   return {
     // TODO: replace this example styles with actual design styles

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/utilities.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/utilities.ts
@@ -8,7 +8,6 @@ import { TailwindHelpers } from '../types';
  *
  * @public
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export default function utilities({ theme }: TailwindHelpers) {
   return {
     // TODO: replace this example styles with actual design styles

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/utils/map-colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/utils/map-colors.ts
@@ -45,7 +45,6 @@ export interface ThemeColor {
  *
  *@returns The {@link CssStyleOptions} with styles for all the colors.
  */
-// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type
 export function mapColors<T extends CssStyleOptions>(
   mapperFn: (color: ThemeColor, colorName: string) => T,
   { theme }: TailwindHelpers


### PR DESCRIPTION
Remove the `// eslint-disable-next-line  @typescript-eslint/explicit-function-return-type` as is done [globally](https://github.com/empathyco/x/blob/main/packages/x-tailwindcss/.eslintrc.js)
