### PR TITLE
style: update `prettier` and format code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,10 +97,10 @@
         "husky": "~7.0.2",
         "lerna": "~4.0.0",
         "lint-staged": "~11.1.2",
-        "prettier": "~2.3.2"
+        "prettier": "~2.8.3"
       },
       "engines": {
-        "node": "16",
+        "node": ">=16",
         "npm": ">=7"
       }
     },
@@ -16907,14 +16907,17 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.2",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-      "devOptional": true,
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -20869,20 +20872,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-vue2/node_modules/prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/vite-plugin-vue2/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -22089,7 +22078,7 @@
     },
     "packages/eslint-plugin-x": {
       "name": "@empathyco/eslint-plugin-x",
-      "version": "2.0.0-alpha.22",
+      "version": "2.0.0-alpha.24",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -22110,10 +22099,10 @@
       },
       "devDependencies": {
         "eslint": "~8.32.0",
-        "prettier": "~2.3.2"
+        "prettier": "~2.8.3"
       },
       "engines": {
-        "node": "16"
+        "node": ">=16"
       },
       "peerDependencies": {
         "eslint": "~8.32.0",
@@ -23105,7 +23094,7 @@
         "eslint-plugin-tsdoc": "~0.2.16",
         "eslint-plugin-vue": "~8.7.1",
         "eslint-plugin-vuejs-accessibility": "~2.0.0",
-        "prettier": "~2.3.2"
+        "prettier": "~2.8.3"
       }
     },
     "@es-joy/jsdoccomment": {
@@ -34542,9 +34531,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.2",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-      "devOptional": true
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -37535,11 +37524,6 @@
           "requires": {
             "sourcemap-codec": "^1.4.8"
           }
-        },
-        "prettier": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-          "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw=="
         },
         "source-map": {
           "version": "0.7.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "husky": "~7.0.2",
     "lerna": "~4.0.0",
     "lint-staged": "~11.1.2",
-    "prettier": "~2.3.2"
+    "prettier": "~2.8.3"
   },
   "engines": {
     "node": ">=16",

--- a/packages/deep-merge/jest.config.js
+++ b/packages/deep-merge/jest.config.js
@@ -1,8 +1,5 @@
 module.exports = {
-  moduleFileExtensions: [
-    'ts',
-    'js'
-  ],
+  moduleFileExtensions: ['ts', 'js'],
   transform: {
     '^.+\\.ts?$': 'ts-jest'
   },

--- a/packages/eslint-plugin-x/lib/configs/eslint.js
+++ b/packages/eslint-plugin-x/lib/configs/eslint.js
@@ -7,7 +7,7 @@ module.exports = {
       curly: ['error', 'all'],
       eqeqeq: ['error', 'always', { null: 'ignore' }],
       indent: 'off',
-      'max-len': ['error', { code: 100, ignoreComments: false }],
+      'max-len': ['error', { code: 100, ignoreComments: false, ignorePattern: 'class=".*"$' }],
       'no-alert': process.env.NODE_ENV === 'production' ? 'error' : 'off',
       'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',

--- a/packages/eslint-plugin-x/package.json
+++ b/packages/eslint-plugin-x/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "eslint": "~8.32.0",
-    "prettier": "~2.3.2"
+    "prettier": "~2.8.3"
   },
   "peerDependencies": {
     "eslint": "~8.32.0",

--- a/packages/x-archetype-utils/src/home/home-template.html
+++ b/packages/x-archetype-utils/src/home/home-template.html
@@ -1,11 +1,7 @@
 <header class="x-archetype-header x-archetype-list x-archetype-list--horizontal">
   <div class="x-archetype-list__item--expand x-archetype-row x-archetype-gap--04">
     <div
-      class="
-        x-archetype-header__logo-container
-        x-archetype-row__item x-archetype-row__item--span-2
-        x-archetype-list
-      "
+      class="x-archetype-header__logo-container x-archetype-row__item x-archetype-row__item--span-2 x-archetype-list"
     >
       <svg
         class="x-archetype-logo"
@@ -69,12 +65,7 @@
       </svg>
     </div>
     <div
-      class="
-        x-archetype-header__input-container
-        x-archetype-row__item x-archetype-row__item--span-8
-        x-archetype-list
-        x-archetype-gap--05
-      "
+      class="x-archetype-header__input-container x-archetype-row__item x-archetype-row__item--span-8 x-archetype-list x-archetype-gap--05"
     >
       <div class="x-archetype-pulse-circle"></div>
       <div class="x-archetype-header__input-group">
@@ -109,11 +100,7 @@
     <div class="x-archetype-section1__container">
       <div class="x-archetype-divider"></div>
       <div
-        class="
-          x-archetype-section1__center
-          x-archetype-list x-archetype-align-center
-          x-archetype-gap--09
-        "
+        class="x-archetype-section1__center x-archetype-list x-archetype-align-center x-archetype-gap--09"
       >
         <div class="x-archetype-section1__column x-archetype-flex-1">
           <h2 class="x-archetype-section1__pretitle">LET'S EXPERIENCE</h2>
@@ -137,10 +124,7 @@
           </div>
         </div>
         <div
-          class="
-            x-archetype-section1__column x-archetype-section1__image-container
-            x-archetype-list x-archetype-flex-1
-          "
+          class="x-archetype-section1__column x-archetype-section1__image-container x-archetype-list x-archetype-flex-1"
         >
           <svg
             class="x-archetype-welcome-image"
@@ -568,12 +552,7 @@
   </section>
   <section class="x-archetype-section2 x-archetype-row">
     <div
-      class="
-        x-archetype-section2__container
-        x-archetype-list x-archetype-align-center
-        x-archetype-gap--09
-        x-archetype-row__item
-      "
+      class="x-archetype-section2__container x-archetype-list x-archetype-align-center x-archetype-gap--09 x-archetype-row__item"
     >
       <div class="x-archetype-margin-top--08 x-archetype-margin-bottom--08">
         <svg
@@ -1396,7 +1375,9 @@
             target="_blank"
             href="https://docs.empathy.co/develop-empathy-platform/build-search-ui/web-archetype-integration-guide.html"
           >
-            integration documentation</a>. Just load the Archetype JS file and initialise it!
+            integration documentation
+          </a>
+          . Just load the Archetype JS file and initialise it!
         </p>
       </div>
     </div>
@@ -1605,11 +1586,7 @@
 </div>
 
 <footer
-  class="
-    x-archetype-footer x-archetype-list x-archetype-list--horizontal
-    x-archetype-align-center
-    x-archetype-gap--04
-  "
+  class="x-archetype-footer x-archetype-list x-archetype-list--horizontal x-archetype-align-center x-archetype-gap--04"
 >
   <p>Made with love by Interface X</p>
   <span>|</span>

--- a/packages/x-components/src/components/__tests__/location-provider.spec.ts
+++ b/packages/x-components/src/components/__tests__/location-provider.spec.ts
@@ -5,7 +5,9 @@ import { FeatureLocation } from '../../types';
 import LocationProvider from '../location-provider.vue';
 
 @Component({
-  template: `<button/>`
+  template: `
+    <button />
+  `
 })
 class Child extends Vue {
   @Inject('location')

--- a/packages/x-components/src/components/animations/animate-scale/animate-scale.style.scss
+++ b/packages/x-components/src/components/animations/animate-scale/animate-scale.style.scss
@@ -1,4 +1,4 @@
-@use "sass:math" as *;
+@use 'sass:math' as *;
 
 .x-animate-scale {
   $p: &;

--- a/packages/x-components/src/components/decorators/__tests__/injection.decorators.spec.ts
+++ b/packages/x-components/src/components/decorators/__tests__/injection.decorators.spec.ts
@@ -4,7 +4,9 @@ import { Component, Prop } from 'vue-property-decorator';
 import { XInject, XProvide } from '../injection.decorators';
 
 @Component({
-  template: `<div><slot/></div>`,
+  template: `
+    <div><slot /></div>
+  `,
   provide: {
     defaultInjectWayValue: 'DefaultInjectValue'
   }
@@ -23,7 +25,9 @@ class Provider extends Vue {
 }
 
 @Component({
-  template: `<div><slot/></div>`,
+  template: `
+    <div><slot /></div>
+  `,
   inject: ['defaultInjectWayValue']
 })
 class FilterItems extends Vue {
@@ -39,7 +43,9 @@ class FilterItems extends Vue {
 }
 
 @Component({
-  template: `<div><slot/></div>`,
+  template: `
+    <div><slot /></div>
+  `,
   inject: ['defaultInjectWayValue']
 })
 class Child extends Vue {

--- a/packages/x-components/src/design-system-deprecated/components/button/pill.scss
+++ b/packages/x-components/src/design-system-deprecated/components/button/pill.scss
@@ -4,12 +4,12 @@
   --x-size-border-radius-button-default: var(--x-size-border-radius-button-pill);
   --x-size-border-radius-top-left-button-default: var(--x-size-border-radius-top-left-button-pill);
   --x-size-border-radius-top-right-button-default: var(
-      --x-size-border-radius-top-right-button-pill
+    --x-size-border-radius-top-right-button-pill
   );
   --x-size-border-radius-bottom-right-button-default: var(
-      --x-size-border-radius-bottom-right-button-pill
+    --x-size-border-radius-bottom-right-button-pill
   );
   --x-size-border-radius-bottom-left-button-default: var(
-      --x-size-border-radius-bottom-left-button-pill
+    --x-size-border-radius-bottom-left-button-pill
   );
 }

--- a/packages/x-components/src/design-system-deprecated/components/suggestion-group/default.scss
+++ b/packages/x-components/src/design-system-deprecated/components/suggestion-group/default.scss
@@ -35,9 +35,9 @@
   border-inline-start-width: var(--x-size-border-width-left-suggestion-group-default);
   border-inline-end-width: var(--x-size-border-width-right-suggestion-group-default);
   border-radius: var(--x-size-border-radius-top-left-suggestion-group-default)
-  var(--x-size-border-radius-top-right-suggestion-group-default)
-  var(--x-size-border-radius-bottom-right-suggestion-group-default)
-  var(--x-size-border-radius-bottom-left-suggestion-group-default);
+    var(--x-size-border-radius-top-right-suggestion-group-default)
+    var(--x-size-border-radius-bottom-right-suggestion-group-default)
+    var(--x-size-border-radius-bottom-left-suggestion-group-default);
 
   .x-suggestion {
     // layout

--- a/packages/x-components/src/design-system-deprecated/components/suggestion-group/default.tokens.scss
+++ b/packages/x-components/src/design-system-deprecated/components/suggestion-group/default.tokens.scss
@@ -1,7 +1,9 @@
 :root {
   // color
   --x-color-text-suggestion-group-default: var(--x-color-text-suggestion-default);
-  --x-color-text-suggestion-group-matching-part-default: var(--x-color-text-suggestion-matching-part-default);
+  --x-color-text-suggestion-group-matching-part-default: var(
+    --x-color-text-suggestion-matching-part-default
+  );
   --x-color-background-suggestion-group-default: var(--x-color-background-suggestion-default);
   --x-color-border-suggestion-group-default: var(--x-color-text-suggestion-group-default);
 
@@ -15,15 +17,29 @@
   // border
   --x-size-border-width-suggestion-group-default: 0;
   --x-size-border-width-top-suggestion-group-default: var(--x-size-border-width-suggestion-default);
-  --x-size-border-width-right-suggestion-group-default: var(--x-size-border-width-suggestion-default);
-  --x-size-border-width-bottom-suggestion-group-default: var(--x-size-border-width-suggestion-default);
-  --x-size-border-width-left-suggestion-group-default: var(--x-size-border-width-suggestion-default);
+  --x-size-border-width-right-suggestion-group-default: var(
+    --x-size-border-width-suggestion-default
+  );
+  --x-size-border-width-bottom-suggestion-group-default: var(
+    --x-size-border-width-suggestion-default
+  );
+  --x-size-border-width-left-suggestion-group-default: var(
+    --x-size-border-width-suggestion-default
+  );
 
   --x-size-border-radius-suggestion-group-default: var(--x-size-border-radius-base-none);
-  --x-size-border-radius-top-left-suggestion-group-default: var(--x-size-border-radius-suggestion-default);
-  --x-size-border-radius-top-right-suggestion-group-default: var(--x-size-border-radius-suggestion-default);
-  --x-size-border-radius-bottom-right-suggestion-group-default: var(--x-size-border-radius-suggestion-default);
-  --x-size-border-radius-bottom-left-suggestion-group-default: var(--x-size-border-radius-suggestion-default);
+  --x-size-border-radius-top-left-suggestion-group-default: var(
+    --x-size-border-radius-suggestion-default
+  );
+  --x-size-border-radius-top-right-suggestion-group-default: var(
+    --x-size-border-radius-suggestion-default
+  );
+  --x-size-border-radius-bottom-right-suggestion-group-default: var(
+    --x-size-border-radius-suggestion-default
+  );
+  --x-size-border-radius-bottom-left-suggestion-group-default: var(
+    --x-size-border-radius-suggestion-default
+  );
 
   // typography
   --x-font-family-suggestion-group-default: var(--x-font-family-suggestion-default);

--- a/packages/x-components/src/design-system-deprecated/components/suggestion/default.scss
+++ b/packages/x-components/src/design-system-deprecated/components/suggestion/default.scss
@@ -37,10 +37,9 @@
   border-inline-start-width: var(--x-size-border-width-left-suggestion-default);
   border-inline-end-width: var(--x-size-border-width-right-suggestion-default);
   border-radius: var(--x-size-border-radius-top-left-suggestion-default)
-  var(--x-size-border-radius-top-right-suggestion-default)
-  var(--x-size-border-radius-bottom-right-suggestion-default)
-  var(--x-size-border-radius-bottom-left-suggestion-default);
-
+    var(--x-size-border-radius-top-right-suggestion-default)
+    var(--x-size-border-radius-bottom-right-suggestion-default)
+    var(--x-size-border-radius-bottom-left-suggestion-default);
 
   &__matching-part,
   .x-identifier-result__matching-part {
@@ -109,15 +108,23 @@
 
     &.x-suggestion--matching {
       // typography
-      --x-font-family-suggestion-default-curated: var(--x-font-family-suggestion-default-matching-curated);
-      --x-size-font-suggestion-default-curated: var(--x-size-font-suggestion-default-matching-curated);
-      --x-size-line-height-suggestion-default-curated: var(--x-size-line-height-suggestion-default-matching-curated);
+      --x-font-family-suggestion-default-curated: var(
+        --x-font-family-suggestion-default-matching-curated
+      );
+      --x-size-font-suggestion-default-curated: var(
+        --x-size-font-suggestion-default-matching-curated
+      );
+      --x-size-line-height-suggestion-default-curated: var(
+        --x-size-line-height-suggestion-default-matching-curated
+      );
       --x-number-font-weight-suggestion-default-curated: var(
-                      --x-number-font-weight-suggestion-default-matching-curated
+        --x-number-font-weight-suggestion-default-matching-curated
       );
 
       // color
-      --x-color-text-suggestion-default-curated: var(--x-color-text-suggestion-default-matching-curated);
+      --x-color-text-suggestion-default-curated: var(
+        --x-color-text-suggestion-default-matching-curated
+      );
     }
   }
 }

--- a/packages/x-components/src/design-system-deprecated/components/suggestion/default.tokens.scss
+++ b/packages/x-components/src/design-system-deprecated/components/suggestion/default.tokens.scss
@@ -12,8 +12,12 @@
 
   // color curated
   --x-color-text-suggestion-default-curated: var(--x-color-text-suggestion-default);
-  --x-color-text-suggestion-matching-part-default-curated: var(--x-color-text-suggestion-matching-part-default);
-  --x-color-text-suggestion-default-matching-curated: var(--x-color-text-suggestion-default-matching);
+  --x-color-text-suggestion-matching-part-default-curated: var(
+    --x-color-text-suggestion-matching-part-default
+  );
+  --x-color-text-suggestion-default-matching-curated: var(
+    --x-color-text-suggestion-default-matching
+  );
   --x-color-background-suggestion-default-curated: var(--x-color-background-suggestion-default);
   --x-color-border-suggestion-default-curated: var(--x-color-border-suggestion-default);
 
@@ -32,10 +36,18 @@
   --x-size-border-width-left-suggestion-default: var(--x-size-border-width-suggestion-default);
 
   --x-size-border-radius-suggestion-default: var(--x-size-border-radius-base-none);
-  --x-size-border-radius-top-left-suggestion-default: var(--x-size-border-radius-suggestion-default);
-  --x-size-border-radius-top-right-suggestion-default: var(--x-size-border-radius-suggestion-default);
-  --x-size-border-radius-bottom-right-suggestion-default: var(--x-size-border-radius-suggestion-default);
-  --x-size-border-radius-bottom-left-suggestion-default: var(--x-size-border-radius-suggestion-default);
+  --x-size-border-radius-top-left-suggestion-default: var(
+    --x-size-border-radius-suggestion-default
+  );
+  --x-size-border-radius-top-right-suggestion-default: var(
+    --x-size-border-radius-suggestion-default
+  );
+  --x-size-border-radius-bottom-right-suggestion-default: var(
+    --x-size-border-radius-suggestion-default
+  );
+  --x-size-border-radius-bottom-left-suggestion-default: var(
+    --x-size-border-radius-suggestion-default
+  );
 
   // typography
   --x-font-family-suggestion-default: var(--x-font-family-text);
@@ -59,9 +71,7 @@
   --x-font-family-suggestion-filter-default: var(--x-font-family-suggestion-default);
   --x-size-font-suggestion-filter-default: var(--x-size-font-suggestion-default);
   --x-size-line-height-suggestion-filter-default: var(--x-size-line-height-suggestion-default);
-  --x-number-font-weight-suggestion-filter-default: var(
-      --x-number-font-weight-suggestion-default
-  );
+  --x-number-font-weight-suggestion-filter-default: var(--x-number-font-weight-suggestion-default);
   --x-text-transform-suggestion-filter-default: none;
 
   // typography curated
@@ -69,20 +79,26 @@
   --x-size-font-suggestion-default-curated: var(--x-size-font-suggestion-default);
   --x-size-line-height-suggestion-default-curated: var(--x-size-line-height-suggestion-default);
   --x-number-font-weight-suggestion-default-curated: var(--x-number-font-weight-suggestion-default);
-  --x-font-family-suggestion-matching-part-default-curated: var(--x-font-family-suggestion-matching-part-default);
-  --x-size-font-suggestion-matching-part-default-curated: var(--x-size-font-suggestion-matching-part-default);
+  --x-font-family-suggestion-matching-part-default-curated: var(
+    --x-font-family-suggestion-matching-part-default
+  );
+  --x-size-font-suggestion-matching-part-default-curated: var(
+    --x-size-font-suggestion-matching-part-default
+  );
   --x-size-line-height-suggestion-matching-part-default-curated: var(
-                  --x-size-line-height-suggestion-matching-part-default
+    --x-size-line-height-suggestion-matching-part-default
   );
   --x-number-font-weight-suggestion-matching-part-default-curated: var(
-                  --x-number-font-weight-suggestion-matching-part-default
+    --x-number-font-weight-suggestion-matching-part-default
   );
-  --x-font-family-suggestion-default-matching-curated: var(--x-font-family-suggestion-default-matching);
+  --x-font-family-suggestion-default-matching-curated: var(
+    --x-font-family-suggestion-default-matching
+  );
   --x-size-font-suggestion-default-matching-curated: var(--x-size-font-suggestion-default-matching);
   --x-size-line-height-suggestion-default-matching-curated: var(
-                  --x-size-line-height-suggestion-default-matching
+    --x-size-line-height-suggestion-default-matching
   );
   --x-number-font-weight-suggestion-default-matching-curated: var(
-                  --x-number-font-weight-suggestion-default-matching
+    --x-number-font-weight-suggestion-default-matching
   );
 }

--- a/packages/x-components/src/design-system-deprecated/utilities/font-size.scss
+++ b/packages/x-components/src/design-system-deprecated/utilities/font-size.scss
@@ -4,7 +4,7 @@
   @each $size, $size-value in $sizes {
     &--#{$size} {
       font-size: var(--x-size-base-#{$size}) !important;
-      line-height: 1.5
+      line-height: 1.5;
     }
   }
 }

--- a/packages/x-components/src/design-system/components/facet/default.scss
+++ b/packages/x-components/src/design-system/components/facet/default.scss
@@ -17,7 +17,7 @@
   border-inline-end-width: var(--x-size-border-width-right-facet-default);
   border-block-end-width: var(--x-size-border-width-bottom-facet-default);
   border-inline-start-width: var(--x-size-border-width-left-facet-default);
-  border-radius:var(--x-size-border-radius-top-left-facet-default)
+  border-radius: var(--x-size-border-radius-top-left-facet-default)
     var(--x-size-border-radius-top-right-facet-default)
     var(--x-size-border-radius-bottom-right-facet-default)
     var(--x-size-border-radius-bottom-left-facet-default);

--- a/packages/x-components/src/design-system/components/facet/line.scss
+++ b/packages/x-components/src/design-system/components/facet/line.scss
@@ -6,7 +6,13 @@
   // border
   --x-size-border-width-facet-header-default: var(--x-size-border-width-facet-header-line);
   --x-size-border-width-top-facet-header-default: var(--x-size-border-width-top-facet-header-line);
-  --x-size-border-width-right-facet-header-default: var(--x-size-border-width-right-facet-header-line);
-  --x-size-border-width-bottom-facet-header-default: var(--x-size-border-width-bottom-facet-header-line);
-  --x-size-border-width-left-facet-header-default: var(--x-size-border-width-left-facet-header-line);
+  --x-size-border-width-right-facet-header-default: var(
+    --x-size-border-width-right-facet-header-line
+  );
+  --x-size-border-width-bottom-facet-header-default: var(
+    --x-size-border-width-bottom-facet-header-line
+  );
+  --x-size-border-width-left-facet-header-default: var(
+    --x-size-border-width-left-facet-header-line
+  );
 }

--- a/packages/x-components/src/design-system/components/filter/default.tokens.scss
+++ b/packages/x-components/src/design-system/components/filter/default.tokens.scss
@@ -33,6 +33,8 @@
   --x-number-font-weight-filter-default: var(--x-number-font-weight-base-regular);
   --x-number-font-weight-filter-default-selected: var(--x-number-font-weight-base-bold);
   --x-number-font-weight-filter-count-default: var(--x-number-font-weight-base-light);
-  --x-number-font-weight-filter-count-default-selected: var(--x-number-font-weight-filter-count-default);
+  --x-number-font-weight-filter-count-default-selected: var(
+    --x-number-font-weight-filter-count-default
+  );
   --x-size-line-height-filter-default: var(--x-size-line-height-text);
 }

--- a/packages/x-components/src/design-system/components/input-group/card.tokens.scss
+++ b/packages/x-components/src/design-system/components/input-group/card.tokens.scss
@@ -3,6 +3,8 @@
   --x-size-border-radius-input-group-card: var(--x-size-border-radius-base-s);
   --x-size-border-radius-top-left-input-group-card: var(--x-size-border-radius-input-group-card);
   --x-size-border-radius-top-right-input-group-card: var(--x-size-border-radius-input-group-card);
-  --x-size-border-radius-bottom-right-input-group-card: var(--x-size-border-radius-input-group-card);
+  --x-size-border-radius-bottom-right-input-group-card: var(
+    --x-size-border-radius-input-group-card
+  );
   --x-size-border-radius-bottom-left-input-group-card: var(--x-size-border-radius-input-group-card);
 }

--- a/packages/x-components/src/design-system/components/input-group/pill.scss
+++ b/packages/x-components/src/design-system/components/input-group/pill.scss
@@ -2,15 +2,15 @@
 .x-input-group--pill .x-input-group {
   --x-size-border-radius-input-group-default: var(--x-size-border-radius-input-group-pill);
   --x-size-border-radius-top-left-input-group-default: var(
-      --x-size-border-radius-top-left-input-group-pill
+    --x-size-border-radius-top-left-input-group-pill
   );
   --x-size-border-radius-top-right-input-group-default: var(
-      --x-size-border-radius-top-right-input-group-pill
+    --x-size-border-radius-top-right-input-group-pill
   );
   --x-size-border-radius-bottom-right-input-group-default: var(
-      --x-size-border-radius-bottom-right-input-group-pill
+    --x-size-border-radius-bottom-right-input-group-pill
   );
   --x-size-border-radius-bottom-left-input-group-default: var(
-      --x-size-border-radius-bottom-left-input-group-pill
+    --x-size-border-radius-bottom-left-input-group-pill
   );
 }

--- a/packages/x-components/src/design-system/components/input-group/pill.tokens.scss
+++ b/packages/x-components/src/design-system/components/input-group/pill.tokens.scss
@@ -3,6 +3,8 @@
   --x-size-border-radius-input-group-pill: var(--x-size-border-radius-base-pill);
   --x-size-border-radius-top-left-input-group-pill: var(--x-size-border-radius-input-group-pill);
   --x-size-border-radius-top-right-input-group-pill: var(--x-size-border-radius-input-group-pill);
-  --x-size-border-radius-bottom-right-input-group-pill: var(--x-size-border-radius-input-group-pill);
+  --x-size-border-radius-bottom-right-input-group-pill: var(
+    --x-size-border-radius-input-group-pill
+  );
   --x-size-border-radius-bottom-left-input-group-pill: var(--x-size-border-radius-input-group-pill);
 }

--- a/packages/x-components/src/design-system/components/input/card.tokens.scss
+++ b/packages/x-components/src/design-system/components/input/card.tokens.scss
@@ -1,4 +1,4 @@
-:root{
+:root {
   // border
   --x-size-border-radius-input-card: var(--x-size-border-radius-base-s);
   --x-size-border-radius-top-left-input-card: var(--x-size-border-radius-input-card);

--- a/packages/x-components/src/design-system/components/input/pill.tokens.scss
+++ b/packages/x-components/src/design-system/components/input/pill.tokens.scss
@@ -1,4 +1,4 @@
-:root{
+:root {
   // border
   --x-size-border-radius-input-pill: var(--x-size-border-radius-base-pill);
   --x-size-border-radius-top-left-input-pill: var(--x-size-border-radius-input-pill);

--- a/packages/x-components/src/design-system/components/row/padding.scss
+++ b/packages/x-components/src/design-system/components/row/padding.scss
@@ -1,6 +1,6 @@
 /* @deprecated */
 @for $i from 2 through 6 {
-  .x-row--padding-0#{$i}{
+  .x-row--padding-0#{$i} {
     --x-size-padding-row: var(--x-size-padding-row-0#{$i});
   }
 }

--- a/packages/x-components/src/design-system/components/tag/card.tokens.scss
+++ b/packages/x-components/src/design-system/components/tag/card.tokens.scss
@@ -1,4 +1,4 @@
-:root{
+:root {
   // border
   --x-size-border-radius-tag-card: var(--x-size-border-radius-base-s);
   --x-size-border-radius-top-left-tag-card: var(--x-size-border-radius-tag-card);

--- a/packages/x-components/src/design-system/components/tag/default.scss
+++ b/packages/x-components/src/design-system/components/tag/default.scss
@@ -48,7 +48,7 @@
     --x-color-border-suggestion-default: var(--x-color-border-tag-default);
 
     // size
-    --x-size-padding-top-suggestion-default:  0;
+    --x-size-padding-top-suggestion-default: 0;
     --x-size-padding-right-suggestion-default: var(--x-size-padding-right-tag-default);
     --x-size-padding-bottom-suggestion-default: 0;
     --x-size-padding-left-suggestion-default: var(--x-size-padding-left-tag-default);
@@ -61,10 +61,18 @@
     --x-size-border-width-bottom-suggestion-default: var(--x-size-border-width-tag-default);
     --x-size-border-width-left-suggestion-default: var(--x-size-border-width-tag-default);
 
-    --x-size-border-radius-bottom-right-suggestion-default: var(--x-size-border-radius-bottom-right-tag-default);
-    --x-size-border-radius-bottom-left-suggestion-default: var(--x-size-border-radius-bottom-leftt-tag-default);
-    --x-size-border-radius-top-right-suggestion-default: var(--x-size-border-radius-top-right-tag-default);
-    --x-size-border-radius-top-left-suggestion-default: var(--x-size-border-radius-top-left-tag-default);
+    --x-size-border-radius-bottom-right-suggestion-default: var(
+      --x-size-border-radius-bottom-right-tag-default
+    );
+    --x-size-border-radius-bottom-left-suggestion-default: var(
+      --x-size-border-radius-bottom-leftt-tag-default
+    );
+    --x-size-border-radius-top-right-suggestion-default: var(
+      --x-size-border-radius-top-right-tag-default
+    );
+    --x-size-border-radius-top-left-suggestion-default: var(
+      --x-size-border-radius-top-left-tag-default
+    );
 
     // typography
     --x-font-family-suggestion-default: var(--x-font-family-tag-default);
@@ -80,7 +88,7 @@
     --x-color-border-suggestion-group-default: var(--x-color-border-tag-default);
 
     // size
-    --x-size-padding-top-suggestion-group-default:  0;
+    --x-size-padding-top-suggestion-group-default: 0;
     --x-size-padding-right-suggestion-group-default: var(--x-size-padding-right-tag-default);
     --x-size-padding-bottom-suggestion-group-default: 0;
     --x-size-padding-left-suggestion-group-default: var(--x-size-padding-left-tag-default);
@@ -93,10 +101,18 @@
     --x-size-border-width-bottom-suggestion-group-default: var(--x-size-border-width-tag-default);
     --x-size-border-width-left-suggestion-group-default: var(--x-size-border-width-tag-default);
 
-    --x-size-border-radius-bottom-right-suggestion-group-default: var(--x-size-border-radius-bottom-right-tag-default);
-    --x-size-border-radius-bottom-left-suggestion-group-default: var(--x-size-border-radius-bottom-leftt-tag-default);
-    --x-size-border-radius-top-right-suggestion-group-default: var(--x-size-border-radius-top-right-tag-default);
-    --x-size-border-radius-top-left-suggestion-group-default: var(--x-size-border-radius-top-left-tag-default);
+    --x-size-border-radius-bottom-right-suggestion-group-default: var(
+      --x-size-border-radius-bottom-right-tag-default
+    );
+    --x-size-border-radius-bottom-left-suggestion-group-default: var(
+      --x-size-border-radius-bottom-leftt-tag-default
+    );
+    --x-size-border-radius-top-right-suggestion-group-default: var(
+      --x-size-border-radius-top-right-tag-default
+    );
+    --x-size-border-radius-top-left-suggestion-group-default: var(
+      --x-size-border-radius-top-left-tag-default
+    );
 
     // typography
     --x-font-family-suggestion-group-default: var(--x-font-family-tag-default);

--- a/packages/x-components/src/design-system/components/tag/ghost.scss
+++ b/packages/x-components/src/design-system/components/tag/ghost.scss
@@ -7,10 +7,14 @@
   --x-color-border-tag-default-curated: var(--x-color-border-tag-curated-ghost);
   --x-color-background-tag-default-selected: var(--x-color-background-tag-selected-ghost);
   --x-color-border-tag-default-selected: var(--x-color-border-tag-selected-ghost);
-  --x-color-background-tag-default-curated-selected: var(--x-color-background-tag-curated-selected-ghost);
+  --x-color-background-tag-default-curated-selected: var(
+    --x-color-background-tag-curated-selected-ghost
+  );
   --x-color-border-tag-default-curated-selected: var(--x-color-border-tag-curated-selected-ghost);
 
   // typography
   --x-number-font-weight-tag-default-selected: var(--x-number-font-weight-tag-selected-ghost);
-  --x-number-font-weight-tag-default-curated-selected: var(--x-number-font-weight-tag-curated-selected-ghost);
+  --x-number-font-weight-tag-default-curated-selected: var(
+    --x-number-font-weight-tag-curated-selected-ghost
+  );
 }

--- a/packages/x-components/src/design-system/components/tag/pill.tokens.scss
+++ b/packages/x-components/src/design-system/components/tag/pill.tokens.scss
@@ -1,4 +1,4 @@
-:root{
+:root {
   // border
   --x-size-border-radius-tag-pill: var(--x-size-border-radius-base-pill);
   --x-size-border-radius-top-left-tag-pill: var(--x-size-border-radius-tag-pill);

--- a/packages/x-components/src/design-system/variables.scss
+++ b/packages/x-components/src/design-system/variables.scss
@@ -1,12 +1,12 @@
 $colors: (
   'lead': #243d48,
-  'auxiliary': #BFE1EC,
+  'auxiliary': #bfe1ec,
   'neutral-10': #1a1a1a,
   'neutral-35': #595959,
   'neutral-70': #b3b3b3,
   'neutral-95': #f2f2f2,
   'neutral-100': #ffffff,
-  'accent': #0086B2,
+  'accent': #0086b2,
   'enable': #00705c,
   'disable': #e11f26,
   'transparent': transparent

--- a/packages/x-components/src/views/design-system/design-system-list.vue
+++ b/packages/x-components/src/views/design-system/design-system-list.vue
@@ -197,10 +197,7 @@
       <div class="x-list x-list--gap-03 x-list-alignment-horizontal">
         <h2 class="x-title3">Horizontal Justify & Align Start</h2>
         <ul
-          class="
-            x-list x-list--horizontal x-list--justify-start x-list--align-start
-            x-list-show-case
-          "
+          class="x-list x-list--horizontal x-list--justify-start x-list--align-start x-list-show-case"
         >
           <li></li>
           <li></li>
@@ -208,10 +205,7 @@
         </ul>
         <h2 class="x-title3">Horizontal Justify & Align Center</h2>
         <ul
-          class="
-            x-list x-list--horizontal x-list--justify-center x-list--align-center
-            x-list-show-case
-          "
+          class="x-list x-list--horizontal x-list--justify-center x-list--align-center x-list-show-case"
         >
           <li></li>
           <li></li>
@@ -243,10 +237,7 @@
         </ul>
         <h2 class="x-title3">Vertical Justify & Align Center</h2>
         <ul
-          class="
-            x-list x-list--vertical x-list--justify-center x-list--align-center
-            x-list-show-case
-          "
+          class="x-list x-list--vertical x-list--justify-center x-list--align-center x-list-show-case"
         >
           <li></li>
           <li></li>

--- a/packages/x-components/src/views/design-system/design-system-sliding-panel.vue
+++ b/packages/x-components/src/views/design-system/design-system-sliding-panel.vue
@@ -246,11 +246,7 @@
     <article class="x-list x-list--wrap x-list--gap-06 x-list--align-start">
       <h2 class="x-title2">Buttons visible on hover, with overflow and no gradient</h2>
       <SlidingPanel
-        class="
-          x-sliding-panel--no-gradient
-          x-sliding-panel--show-buttons-on-hover
-          x-sliding-panel--buttons-overflow
-        "
+        class="x-sliding-panel--no-gradient x-sliding-panel--show-buttons-on-hover x-sliding-panel--buttons-overflow"
       >
         <template #sliding-panel-left-button>
           <ChevronLeftIcon />

--- a/packages/x-components/src/views/design-system/design-system-utilities.vue
+++ b/packages/x-components/src/views/design-system/design-system-utilities.vue
@@ -5,12 +5,7 @@
     <article class="x-list x-list--vertical x-self-stretch x-list--gap-06 x-padding-bottom--06">
       <h2 class="x-title2">Flex</h2>
       <div
-        class="
-          x-list x-list--horizontal x-list--gap-03
-          x-self-stretch
-          x-padding--02
-          x-background--neutral-95
-        "
+        class="x-list x-list--horizontal x-list--gap-03 x-self-stretch x-padding--02 x-background--neutral-95"
       >
         <div class="x-flex-1 x-background--auxiliary x-padding--03 x-font-color--neutral-100">
           x-flex-1
@@ -33,12 +28,7 @@
     <article class="x-list x-list--vertical x-self-stretch x-list--gap-06 x-padding-bottom--06">
       <h2 class="x-title2">Self Align</h2>
       <div
-        class="
-          x-list x-list--horizontal x-list--gap-03
-          x-self-stretch
-          x-padding--02
-          x-background--neutral-95
-        "
+        class="x-list x-list--horizontal x-list--gap-03 x-self-stretch x-padding--02 x-background--neutral-95"
         style="height: 100px"
       >
         <div class="x-self-auto x-background--auxiliary x-padding--03 x-font-color--neutral-100">
@@ -128,27 +118,14 @@
       <h2 class="x-title2">Border Width Combinations</h2>
       <div class="x-list x-list--wrap x-list--gap-06 x-list--align-start">
         <div
-          class="
-            x-list
-            x-padding--06
-            x-border-width--10 x-border-width--left-01 x-border-width--right-02
-            x-border-color--lead
-          "
+          class="x-list x-padding--06 x-border-width--10 x-border-width--left-01 x-border-width--right-02 x-border-color--lead"
         >
           <span>Border Width 10</span>
           <span>Border Width Left 01</span>
           <span>Border Width Right 02</span>
         </div>
         <div
-          class="
-            x-list
-            x-padding--06
-            x-border-width--top-10
-            x-border-width--bottom-05
-            x-border-width--left-01
-            x-border-width--right-03
-            x-border-color--lead
-          "
+          class="x-list x-padding--06 x-border-width--top-10 x-border-width--bottom-05 x-border-width--left-01 x-border-width--right-03 x-border-color--lead"
         >
           <span>Border Width Top 10</span>
           <span>Border Width Bottom 05</span>
@@ -179,46 +156,22 @@
       <h2 class="x-title2">Border Radius Sides</h2>
       <div class="x-list x-list--wrap x-list--gap-06 x-list--align-start">
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--top-03
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--top-03"
         >
           Border Radius Top 03
         </div>
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--right-04
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--right-04"
         >
           Border Radius Right 04
         </div>
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--bottom-05
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--bottom-05"
         >
           Border Radius Bottom 05
         </div>
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--left-06
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--left-06"
         >
           Border Radius Left 06
         </div>
@@ -229,46 +182,22 @@
       <h2 class="x-title2">Border Radius Individuals</h2>
       <div class="x-list x-list--wrap x-list--gap-06 x-list--align-start">
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--top-left-03
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--top-left-03"
         >
           Border Radius Top Left 03
         </div>
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--top-right-04
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--top-right-04"
         >
           Border Radius Top Right 04
         </div>
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--bottom-right-05
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--bottom-right-05"
         >
           Border Radius Bottom Right 05
         </div>
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--bottom-left-06
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--bottom-left-06"
         >
           Border Radius Bottom Left 06
         </div>
@@ -279,29 +208,14 @@
       <h2 class="x-title2">Border Radius Combinations</h2>
       <div class="x-list x-list--wrap x-list--gap-06 x-list--align-start">
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--04 x-border-radius--top-left-08 x-border-radius--bottom-right-08
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--04 x-border-radius--top-left-08 x-border-radius--bottom-right-08"
         >
           <span>Border Radius 04</span>
           <span>Border Radius Top Left 08</span>
           <span>Border Radius Bottom Right 08</span>
         </div>
         <div
-          class="
-            x-list
-            x-padding--10
-            x-border-width--01
-            x-border-color--lead
-            x-border-radius--top-left-02
-            x-border-radius--top-right-04
-            x-border-radius--bottom-right-08
-            x-border-radius--bottom-left-10
-          "
+          class="x-list x-padding--10 x-border-width--01 x-border-color--lead x-border-radius--top-left-02 x-border-radius--top-right-04 x-border-radius--bottom-right-08 x-border-radius--bottom-left-10"
         >
           <span>Border Radius Top Left 02</span>
           <span>Border Radius Top Right 04</span>

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -102,9 +102,7 @@
       <MultiColumnMaxWidthLayout class="x-background--neutral-100">
         <template #header-middle>
           <div
-            class="
-              x-list x-list--vertical x-list--gap-05 x-list--align-stretch x-list__item--expand
-            "
+            class="x-list x-list--vertical x-list--gap-05 x-list--align-stretch x-list__item--expand"
           >
             <BaseKeyboardNavigation>
               <div class="x-input-group x-input-group--card">
@@ -336,17 +334,7 @@
                             <NextQuery
                               :suggestion="nextQueries[0]"
                               data-test="view-all-results"
-                              class="
-                                x-tag x-tag--pill
-                                x-font-bold x-text-lead-50
-                                x-margin--left-auto x-margin--right-auto x-margin--top-03
-                                x-padding--top-04
-                                x-padding--bottom-04
-                                x-padding--right-05
-                                x-padding--left-05
-                                x-border-color--lead
-                                x-margin--bottom-06
-                              "
+                              class="x-tag x-tag--pill x-font-bold x-text-lead-50 x-margin--left-auto x-margin--right-auto x-margin--top-03 x-padding--top-04 x-padding--bottom-04 x-padding--right-05 x-padding--left-05 x-border-color--lead x-margin--bottom-06"
                             >
                               {{ 'View all results' }}
                             </NextQuery>

--- a/packages/x-components/src/views/home/aside.vue
+++ b/packages/x-components/src/views/home/aside.vue
@@ -1,8 +1,6 @@
 <template>
   <div
-    class="
-      x-list x-list--padding-05 x-list--padding-top x-list--gap-06 x-list--border x-list--border-top
-    "
+    class="x-list x-list--padding-05 x-list--padding-top x-list--gap-06 x-list--border x-list--border-top"
   >
     <FacetsProvider :facets="staticFacets" />
     <ClearFilters />

--- a/packages/x-components/src/views/layouts/fixed-header-and-asides-layout.vue
+++ b/packages/x-components/src/views/layouts/fixed-header-and-asides-layout.vue
@@ -25,25 +25,14 @@
     </template>
     <template #toolbar>
       <div
-        class="
-          x-title3
-          x-list__item--expand
-          x-border-width--02
-          x-border-color--neutral-70
-          x-margin--top-03
-        "
+        class="x-title3 x-list__item--expand x-border-width--02 x-border-color--neutral-70 x-margin--top-03"
       >
         TOOLBAR
       </div>
     </template>
     <template #left-aside>
       <div
-        class="
-          x-background--neutral-100
-          x-list__item--expand
-          x-border-radius--right-06
-          x-padding--05
-        "
+        class="x-background--neutral-100 x-list__item--expand x-border-radius--right-06 x-padding--05"
       >
         LEFT SIDE
       </div>
@@ -80,13 +69,7 @@
     </template>
     <template #scroll-to-top>
       <div
-        class="
-          x-text1 x-text1-lg
-          x-padding--03
-          x-background--neutral-95
-          x-border-width--01
-          x-border-color--neutral-35
-        "
+        class="x-text1 x-text1-lg x-padding--03 x-background--neutral-95 x-border-width--01 x-border-color--neutral-35"
       >
         SCROLL TO TOP
       </div>

--- a/packages/x-components/src/views/layouts/multi-column-layout.vue
+++ b/packages/x-components/src/views/layouts/multi-column-layout.vue
@@ -2,61 +2,35 @@
   <MultiColumnMaxWidthLayout :dev-mode="true">
     <template #header-start>
       <span
-        class="
-          x-title
-          x-list__item--expand
-          x-list x-list--horizontal x-list--justify-center
-          x-margin--bottom-03 x-margin--top-03
-        "
+        class="x-title x-list__item--expand x-list x-list--horizontal x-list--justify-center x-margin--bottom-03 x-margin--top-03"
       >
         HEADER START
       </span>
     </template>
     <template #header-middle>
       <span
-        class="
-          x-title1
-          x-list__item--expand
-          x-list x-list--horizontal x-list--justify-center
-          x-margin--bottom-03 x-margin--top-03
-        "
+        class="x-title1 x-list__item--expand x-list x-list--horizontal x-list--justify-center x-margin--bottom-03 x-margin--top-03"
       >
         HEADER MIDDLE
       </span>
     </template>
     <template #header-end>
       <span
-        class="
-          x-title2
-          x-list__item--expand
-          x-list x-list--horizontal x-list--justify-center
-          x-margin--bottom-03 x-margin--top-03
-        "
+        class="x-title2 x-list__item--expand x-list x-list--horizontal x-list--justify-center x-margin--bottom-03 x-margin--top-03"
       >
         HEADER END
       </span>
     </template>
     <template #sub-header>
       <span
-        class="
-          x-title2
-          x-list__item--expand
-          x-list x-list--horizontal x-list--justify-center
-          x-margin--bottom-03 x-margin--top-03
-        "
+        class="x-title2 x-list__item--expand x-list x-list--horizontal x-list--justify-center x-margin--bottom-03 x-margin--top-03"
       >
         SUB HEADER
       </span>
     </template>
     <template #toolbar-aside>
       <div
-        class="
-          x-title3
-          x-list__item--expand
-          x-border-width--02
-          x-border-color--neutral-70
-          x-margin--top-03 x-margin--bottom-03
-        "
+        class="x-title3 x-list__item--expand x-border-width--02 x-border-color--neutral-70 x-margin--top-03 x-margin--bottom-03"
       >
         <BaseIdTogglePanelButton class="x-button x-button--ghost" panelId="aside-panel">
           <FiltersIcon />
@@ -66,26 +40,14 @@
     </template>
     <template #toolbar-body>
       <div
-        class="
-          x-title3
-          x-list__item--expand
-          x-border-width--02
-          x-border-color--neutral-70
-          x-margin--top-03 x-margin--bottom-03
-        "
+        class="x-title3 x-list__item--expand x-border-width--02 x-border-color--neutral-70 x-margin--top-03 x-margin--bottom-03"
       >
         TOOLBAR
       </div>
     </template>
     <template #main-aside>
       <div
-        class="
-          x-list__item--stretch
-          x-margin--top-05 x-margin--bottom-05
-          x-background--neutral-95
-          x-border-width--02
-          x-border-color--neutral-70
-        "
+        class="x-list__item--stretch x-margin--top-05 x-margin--bottom-05 x-background--neutral-95 x-border-width--02 x-border-color--neutral-70"
       >
         MAIN ASIDE
         <article class="x-background--neutral-70 x-padding--top-13 x-padding--left-6" />

--- a/packages/x-components/src/views/layouts/single-column-layout.vue
+++ b/packages/x-components/src/views/layouts/single-column-layout.vue
@@ -2,39 +2,21 @@
   <SingleColumnLayout :dev-mode="true">
     <template #header>
       <span
-        class="
-          x-title1
-          x-list__item--expand
-          x-list x-list--horizontal x-list--justify-center
-          x-margin--bottom-03 x-margin--top-03
-          x-background--neutral-95
-        "
+        class="x-title1 x-list__item--expand x-list x-list--horizontal x-list--justify-center x-margin--bottom-03 x-margin--top-03 x-background--neutral-95"
       >
         HEADER
       </span>
     </template>
     <template #sub-header>
       <span
-        class="
-          x-title2
-          x-list__item--expand
-          x-list x-list--horizontal x-list--justify-center
-          x-margin--bottom-03 x-margin--top-03
-          x-background--neutral-95
-        "
+        class="x-title2 x-list__item--expand x-list x-list--horizontal x-list--justify-center x-margin--bottom-03 x-margin--top-03 x-background--neutral-95"
       >
         SUB HEADER
       </span>
     </template>
     <template #toolbar>
       <div
-        class="
-          x-title3
-          x-list__item--expand
-          x-border-width--02
-          x-border-color--neutral-70
-          x-margin--top-03 x-margin--bottom-03
-        "
+        class="x-title3 x-list__item--expand x-border-width--02 x-border-color--neutral-70 x-margin--top-03 x-margin--bottom-03"
       >
         TOOLBAR
         <BaseIdModalOpen modalId="extra-aside-modal" class="x-button--ghost">
@@ -49,12 +31,7 @@
     </template>
     <template #floating>
       <div
-        class="
-          x-title3
-          x-list__item--expand
-          x-margin--top-03 x-margin--bottom-03
-          x-list x-list--horizontal x-list--justify-center
-        "
+        class="x-title3 x-list__item--expand x-margin--top-03 x-margin--bottom-03 x-list x-list--horizontal x-list--justify-center"
       >
         <BaseIdModalOpen modalId="aside-modal">
           <FiltersIcon />
@@ -78,14 +55,7 @@
     </template>
     <template #footer>
       <div
-        class="
-          x-list__item--expand
-          x-text1 x-text1-lg
-          x-padding--03
-          x-background--neutral-95
-          x-border-width--01
-          x-border-color--neutral-35
-        "
+        class="x-list__item--expand x-text1 x-text1-lg x-padding--03 x-background--neutral-95 x-border-width--01 x-border-color--neutral-35"
       >
         FOOTER
       </div>

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -80,11 +80,9 @@ export interface XAPI {
  *
  * @public
  */
-export type XEventListeners = Partial<
-  {
-    [Event in XEvent]: (payload: XEventPayload<Event>, metadata: WireMetadata) => unknown;
-  }
->;
+export type XEventListeners = Partial<{
+  [Event in XEvent]: (payload: XEventPayload<Event>, metadata: WireMetadata) => unknown;
+}>;
 
 /**
  * Interface with the possible parameters to receive through the snippet integration.

--- a/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
@@ -21,10 +21,7 @@
         @change="setMin($event.target.valueAsNumber)"
         name="min"
         type="number"
-        class="
-          x-input
-          x-editable-number-range-filter__input x-editable-number-range-filter__input--min
-        "
+        class="x-input x-editable-number-range-filter__input x-editable-number-range-filter__input--min"
         :value="min"
         data-test="range-min"
         :aria-label="rangeFilterMin"
@@ -34,10 +31,7 @@
         @change="setMax($event.target.valueAsNumber)"
         name="max"
         type="number"
-        class="
-          x-input
-          x-editable-number-range-filter__input x-editable-number-range-filter__input--max
-        "
+        class="x-input x-editable-number-range-filter__input x-editable-number-range-filter__input--max"
         :value="max"
         data-test="range-max"
         :aria-label="rangeFilterMax"

--- a/packages/x-components/src/x-modules/facets/components/lists/__tests__/filters-injection-mixin.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/lists/__tests__/filters-injection-mixin.spec.ts
@@ -12,8 +12,9 @@ import FiltersInjectionMixin from '../filters-injection.mixin';
 @Component({
   template: `
     <div>
-    <slot/>
-    </div>`
+      <slot />
+    </div>
+  `
 })
 class Provider extends Vue {
   @Prop()

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-queries-list.spec.ts
@@ -46,7 +46,9 @@ function renderNextQueriesList({
   ...props
 }: RenderNextQueriesListOptions = {}): RenderNextQueriesListAPI {
   @Component({
-    template: `<div><slot/></div>`
+    template: `
+      <div><slot /></div>
+    `
   })
   class ProviderWrapper extends Vue {
     @XProvide(QUERY_KEY)

--- a/packages/x-components/src/x-modules/search/components/__tests__/banners-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/banners-list.spec.ts
@@ -128,7 +128,9 @@ describe('testing BannersList component', () => {
 
     /* It provides an array with some results */
     @Component({
-      template: `<div><slot/></div>`
+      template: `
+        <div><slot /></div>
+      `
     })
     class Provider extends Vue {
       @XProvide(LIST_ITEMS_KEY)

--- a/packages/x-components/src/x-modules/search/components/__tests__/promoteds-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/promoteds-list.spec.ts
@@ -131,7 +131,9 @@ describe('testing PromotedsList component', () => {
 
     /* It provides an array with some results */
     @Component({
-      template: `<div><slot/></div>`
+      template: `
+        <div><slot /></div>
+      `
     })
     class Provider extends Vue {
       @XProvide(LIST_ITEMS_KEY)

--- a/packages/x-components/tests/support/component-index.html
+++ b/packages/x-components/tests/support/component-index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-  <title>X Components - Cypress Component Testing</title>
-</head>
-<body>
-<div data-cy-root></div>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>X Components - Cypress Component Testing</title>
+  </head>
+  <body>
+    <div data-cy-root></div>
+  </body>
 </html>

--- a/packages/x-tailwindcss/demo/index.html
+++ b/packages/x-tailwindcss/demo/index.html
@@ -6,8 +6,7 @@
     <title>x-tailwindcss demo</title>
   </head>
   <body>
-    <div id="app">
-    </div>
+    <div id="app"></div>
   </body>
   <script type="module" src="./src/main.ts"></script>
 </html>

--- a/packages/x-tailwindcss/demo/src/components/xds-base-showcase.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-base-showcase.vue
@@ -15,11 +15,7 @@
       </div>
     </div>
     <div
-      class="
-        x-fixed x-left-1/2 x-top-1/2
-        -translate-x-1/2 -translate-y-1/2
-        x-bg-neutral-25 x-p-8 x-transition-opacity x-duration-300 x-pointer-events-none
-      "
+      class="x-fixed x-left-1/2 x-top-1/2 -translate-x-1/2 -translate-y-1/2 x-bg-neutral-25 x-p-8 x-transition-opacity x-duration-300 x-pointer-events-none"
       :class="isMessageVisible ? 'x-opacity-100' : 'x-opacity-0'"
     >
       CSS classes copied to Clipboard!

--- a/packages/x-tailwindcss/demo/src/components/xds-sliding-panel.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-sliding-panel.vue
@@ -15,9 +15,7 @@
         <div
           v-for="(item, index) of items"
           :key="index"
-          class="
-            x-min-h-[100px] x-min-w-[100px] x-flex x-justify-center x-items-center x-bg-lead-25
-          "
+          class="x-min-h-[100px] x-min-w-[100px] x-flex x-justify-center x-items-center x-bg-lead-25"
         >
           <span>{{ item }}</span>
         </div>

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/utils/map-colors.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/utils/map-colors.ts
@@ -5,7 +5,7 @@ import pluginTheme from '../theme';
 /**
  * Type of the colors from Theme.
  */
-export type ThemeColors = typeof pluginTheme['colors'];
+export type ThemeColors = (typeof pluginTheme)['colors'];
 
 /**
  * Type of each Theme color.

--- a/packages/x-translations/jest.config.js
+++ b/packages/x-translations/jest.config.js
@@ -1,8 +1,5 @@
 module.exports = {
-  moduleFileExtensions: [
-    'ts',
-    'js'
-  ],
+  moduleFileExtensions: ['ts', 'js'],
   transform: {
     '^.+\\.ts?$': 'ts-jest'
   },

--- a/packages/x-translations/tsconfig.json
+++ b/packages/x-translations/tsconfig.json
@@ -7,18 +7,9 @@
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "types": [
-      "node",
-      "jest"
-    ],
-    "lib": [
-      "esnext"
-    ]
+    "types": ["node", "jest"],
+    "lib": ["esnext"]
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/packages/x-types/src/named-model.model.ts
+++ b/packages/x-types/src/named-model.model.ts
@@ -64,4 +64,4 @@ export const BooleanFilterModelNames = [
  *
  * @public
  */
-export type BooleanFilterModelName = typeof BooleanFilterModelNames[number];
+export type BooleanFilterModelName = (typeof BooleanFilterModelNames)[number];

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -2,4 +2,4 @@ const { execSync } = require('child_process');
 
 module.exports.exec = function exec(command) {
   return execSync(command, { encoding: 'utf-8' });
-}
+};


### PR DESCRIPTION
EX-7288

With this update, `css` classes are not wrapped any more and are all displayed in the same line. In order to avoid `eslint` errors, @ajperezbau found an option to avoid triggering errors in lines with more than 100 characters, which is our limit, using the [ignorePattern](https://eslint.org/docs/latest/rules/max-len#ignorepattern) config.


