### PR TITLE
refactor: make sliding panel take care buttons position and fade

### DIFF
--- a/packages/x-tailwindcss/demo/src/components/xds-sliding-panel.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-sliding-panel.vue
@@ -1,6 +1,6 @@
 <template>
   <XdsBaseShowcase
-    #default="{ cssClass, copyCssClassesToClipboard }"
+    #default="{ cssClass, section, copyCssClassesToClipboard }"
     title="Sliding panel"
     :sections="sections"
   >
@@ -10,8 +10,17 @@
       :class="cssClass"
       title="Click me to copy CSS classes"
     >
-      <button class="x-button x-sliding-panel-button x-sliding-panel-button-left">ᐸ</button>
-      <div class="x-sliding-panel-scroll x-gap-12">
+      <button class="x-button x-sliding-panel-button-left">ᐸ</button>
+      <div
+        class="x-gap-12 x-flex x-flex-row"
+        :class="{
+          'x-sliding-panel-fade': section === 'Fade',
+          'x-sliding-panel-fade-sm':
+            section === 'Combinations' && cssClass.includes('x-sliding-panel-buttons-outside'),
+          'x-sliding-panel-fade-lg':
+            section === 'Combinations' && cssClass.includes('x-sliding-panel-buttons-center')
+        }"
+      >
         <div
           v-for="(item, index) of items"
           :key="index"
@@ -22,7 +31,7 @@
           <span>{{ item }}</span>
         </div>
       </div>
-      <button class="x-button x-sliding-panel-button x-sliding-panel-button-right">ᐳ</button>
+      <button class="x-button x-sliding-panel-button-right">ᐳ</button>
     </div>
   </XdsBaseShowcase>
 </template>
@@ -69,22 +78,17 @@
     public showButtonsOnHover!: string[];
 
     @Prop({
-      default: () => [
-        'x-sliding-panel-fade-sm',
-        'x-sliding-panel-fade-md',
-        'x-sliding-panel-fade-lg'
-      ]
+      default: () => ['', 'x-sliding-panel-at-start', 'x-sliding-panel-at-end']
     })
     public fadeSizes!: string[];
 
     public combinations = [
-      'x-sliding-panel-buttons-center x-sliding-panel-fade-sm',
-      'x-sliding-panel-buttons-center x-sliding-panel-fade-md',
-      'x-sliding-panel-buttons-outside x-sliding-panel-fade-lg',
+      'x-sliding-panel-buttons-center x-sliding-panel-show-buttons-on-hover',
+      'x-sliding-panel-buttons-outside x-sliding-panel-show-buttons-on-hover',
       // eslint-disable-next-line max-len
-      'x-sliding-panel-buttons-outside x-sliding-panel-fade-sm x-sliding-panel-show-buttons-on-hover x-sliding-panel-at-start',
+      'x-sliding-panel-buttons-outside x-sliding-panel-show-buttons-on-hover x-sliding-panel-at-start',
       // eslint-disable-next-line max-len
-      'x-sliding-panel-buttons-center x-sliding-panel-fade-md x-sliding-panel-show-buttons-on-hover x-sliding-panel-at-end'
+      'x-sliding-panel-buttons-center x-sliding-panel-show-buttons-on-hover x-sliding-panel-at-end'
     ];
 
     protected get sections(): ShowcaseSections {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/default.ts
@@ -5,7 +5,6 @@
  */
 export function slidingPanelButtonsDefault() {
   return {
-    pointerEvents: 'none',
     position: 'absolute',
     transition: 'all ease-out 0.2s',
     zIndex: 1,

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/default.ts
@@ -9,14 +9,6 @@ export function slidingPanelButtonsDefault() {
     position: 'absolute',
     transition: 'all ease-out 0.2s',
     zIndex: 1,
-
-    '&-left': {
-      left: 0,
-      transform: 'translateX(0)'
-    },
-    '&-right': {
-      right: 0,
-      transform: 'translateX(0)'
-    }
+    transform: 'translateX(0)'
   };
 }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/hover.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/hover.ts
@@ -5,8 +5,21 @@
  */
 export function slidingPanelButtonsHover() {
   return {
+    '&.sliding-panel-at-start': {
+      '.sliding-panel-button-left': {
+        opacity: 0
+      }
+    },
+    '&.sliding-panel-at-end': {
+      '.sliding-panel-button-right': {
+        opacity: 0
+      }
+    },
     '&.sliding-panel-show-buttons-on-hover': {
-      '.sliding-panel-button': {
+      '.sliding-panel-button-left': {
+        opacity: 0
+      },
+      '.sliding-panel-button-right': {
         opacity: 0
       },
       '&:not(.sliding-panel-at-start):hover': {
@@ -20,18 +33,6 @@ export function slidingPanelButtonsHover() {
           opacity: 1,
           pointerEvents: 'all'
         }
-      }
-    },
-    '&:not(.sliding-panel-show-buttons-on-hover):not(.sliding-panel-at-start)': {
-      '.sliding-panel-button-left': {
-        opacity: 1,
-        pointerEvents: 'all'
-      }
-    },
-    '&:not(.sliding-panel-show-buttons-on-hover):not(.sliding-panel-at-end)': {
-      '.sliding-panel-button-right': {
-        opacity: 1,
-        pointerEvents: 'all'
       }
     }
   };

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/hover.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/hover.ts
@@ -7,12 +7,14 @@ export function slidingPanelButtonsHover() {
   return {
     '&.sliding-panel-at-start': {
       '.sliding-panel-button-left': {
-        opacity: 0
+        opacity: 0,
+        pointerEvents: 'none'
       }
     },
     '&.sliding-panel-at-end': {
       '.sliding-panel-button-right': {
-        opacity: 0
+        opacity: 0,
+        pointerEvents: 'none'
       }
     },
     '&.sliding-panel-show-buttons-on-hover': {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/index.ts
@@ -10,7 +10,14 @@ import { slidingPanelButtonsHover } from './hover';
 export function slidingPanelButtons() {
   return {
     '.sliding-panel-button': {
-      ...slidingPanelButtonsDefault()
+      '&-left': {
+        ...slidingPanelButtonsDefault(),
+        left: 0
+      },
+      '&-right': {
+        ...slidingPanelButtonsDefault(),
+        right: 0
+      }
     },
     ...slidingPanelButtonsHover(),
     ...slidingPanelButtonsPositions()

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/positions.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/buttons/positions.ts
@@ -15,11 +15,9 @@ export function slidingPanelButtonsPositions() {
     },
     '&.sliding-panel-buttons-outside': {
       '.sliding-panel-button-left': {
-        pointerEvents: 'all',
         transform: 'translateX(-100%)'
       },
       '.sliding-panel-button-right': {
-        pointerEvents: 'all',
         transform: 'translateX(100%)'
       }
     }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/default.ts
@@ -1,36 +1,17 @@
-import { TailwindHelpers } from '../../../types';
-import { slidingPanelFade } from './fade';
 import { slidingPanelButtons } from './buttons';
 
 /**
  * Returns the default styles for the component `sliding panel`.
  *
- * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
-export function slidingPanelDefault(helpers: TailwindHelpers) {
+export function slidingPanelDefault() {
   return {
     position: 'relative',
     display: 'flex',
     flexFlow: 'row nowrap',
     alignItems: 'center',
     height: '100%',
-    zIndex: 0,
-    '.sliding-panel-scroll': {
-      display: 'flex',
-      flex: '100%',
-      flexFlow: 'row nowrap',
-      overflowX: 'auto',
-      overflowY: 'hidden',
-      scrollbarWidth: 'none', // Firefox
-      '> *': {
-        flex: '0 0 auto'
-      },
-      '&::-webkit-scrollbar': {
-        display: 'none'
-      }
-    },
-    ...slidingPanelButtons(),
-    ...slidingPanelFade(helpers)
+    ...slidingPanelButtons()
   };
 }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/fade/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/fade/index.ts
@@ -1,24 +1,54 @@
 import { rename } from '@empathyco/x-utils';
 import { TailwindHelpers } from '../../../../types';
-import { fadeSizes } from './sizes';
+import { fadeDefaultSizes, fadeEndSizes, fadeStartSizes } from './sizes';
 
 /**
- * Returns the `fade` variants for the component `sliding panel`.
+ * Returns the styles for the component `sliding panel fade`.
  *
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
 export function slidingPanelFade(helpers: TailwindHelpers) {
-  const sizes = fadeSizes(helpers);
+  const defaultSizes = fadeDefaultSizes(helpers);
+  const startSizes = fadeStartSizes(helpers);
+  const endSizes = fadeEndSizes(helpers);
   return {
-    '&.sliding-panel-fade': {
-      ...sizes.md,
+    '.sliding-panel-fade': {
+      ...defaultSizes.md,
       ...rename(
         {
-          ...sizes
+          ...defaultSizes
         },
-        { prefix: '&-' }
+        {
+          prefix: '&-'
+        }
       )
+    },
+    '.sliding-panel-at-start': {
+      '.sliding-panel-fade': {
+        ...startSizes.md,
+        ...rename(
+          {
+            ...startSizes
+          },
+          {
+            prefix: '&-'
+          }
+        )
+      }
+    },
+    '.sliding-panel-at-end': {
+      '.sliding-panel-fade': {
+        ...endSizes.md,
+        ...rename(
+          {
+            ...endSizes
+          },
+          {
+            prefix: '&-'
+          }
+        )
+      }
     }
   };
 }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/fade/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/fade/index.ts
@@ -24,7 +24,7 @@ export function slidingPanelFade(helpers: TailwindHelpers) {
         }
       )
     },
-    '.sliding-panel-at-start': {
+    '&.sliding-panel-at-start': {
       '.sliding-panel-fade': {
         ...startSizes.md,
         ...rename(
@@ -37,7 +37,7 @@ export function slidingPanelFade(helpers: TailwindHelpers) {
         )
       }
     },
-    '.sliding-panel-at-end': {
+    '&.sliding-panel-at-end': {
       '.sliding-panel-fade': {
         ...endSizes.md,
         ...rename(

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/fade/sizes.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/fade/sizes.ts
@@ -6,90 +6,89 @@ import { TailwindHelpers } from '../../../../types';
  * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the variant.
  */
-export function fadeSizes({ theme }: TailwindHelpers) {
+export function fadeDefaultSizes({ theme }: TailwindHelpers) {
   return {
     sm: {
-      '.sliding-panel-scroll': {
-        mask: `linear-gradient(to right,
+      mask: `linear-gradient(to right,
             transparent calc(0.43 * ${theme('spacing.40')}),
             rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.40')}),
             black ${theme('spacing.40')},
             rgba(0, 0, 0, 0.8) calc(100% - 0.67 * ${theme('spacing.40')}),
             transparent calc(100% - 0.43 * ${theme('spacing.40')}))`
-      },
-      '&.sliding-panel-at-start': {
-        '.sliding-panel-scroll': {
-          mask: `linear-gradient(to left,
-              transparent calc(0.43 * ${theme('spacing.40')}),
-              rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.40')}),
-              black ${theme('spacing.40')});`
-        }
-      },
-      '&.sliding-panel-at-end': {
-        '.sliding-panel-scroll': {
-          mask: `linear-gradient(
-              to right,
-              transparent calc(0.43 * ${theme('spacing.40')}),
-              rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.40')}),
-              black ${theme('spacing.40')});`
-        }
-      }
     },
     md: {
-      '.sliding-panel-scroll': {
-        mask: `linear-gradient(to right,
+      mask: `linear-gradient(to right,
             transparent calc(0.43 * ${theme('spacing.80')}),
             rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.80')}),
             black ${theme('spacing.80')},
             rgba(0, 0, 0, 0.8) calc(100% - 0.67 * ${theme('spacing.80')}),
             transparent calc(100% - 0.43 * ${theme('spacing.80')}))`
-      },
-      '&.sliding-panel-at-start': {
-        '.sliding-panel-scroll': {
-          mask: `linear-gradient(
-              to left,
-              transparent calc(0.43 * ${theme('spacing.80')}),
-              rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.80')}),
-              black ${theme('spacing.80')});`
-        }
-      },
-      '&.sliding-panel-at-end': {
-        '.sliding-panel-scroll': {
-          mask: `linear-gradient(
-              to right,
-              transparent calc(0.43 * ${theme('spacing.80')}),
-              rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.80')}),
-              black ${theme('spacing.80')});`
-        }
-      }
     },
     lg: {
-      '.sliding-panel-scroll': {
-        mask: `linear-gradient(to right,
+      mask: `linear-gradient(to right,
             transparent calc(0.43 * ${theme('spacing.152')}),
             rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.152')}),
             black ${theme('spacing.152')},
             rgba(0, 0, 0, 0.8) calc(100% - 0.67 * ${theme('spacing.152')}),
             transparent calc(100% - 0.43 * ${theme('spacing.152')}))`
-      },
-      '&.sliding-panel-at-start': {
-        '.sliding-panel-scroll': {
-          mask: `linear-gradient(
-              to left,
+    }
+  };
+}
+
+/**
+ * Returns the `sizes` variants for the component `sliding panel fade start`.
+ *
+ * @param helpers - The {@link TailwindHelpers} to generate CSS.
+ * @returns The {@link CssStyleOptions} for the variant.
+ */
+export function fadeStartSizes({ theme }: TailwindHelpers) {
+  return {
+    sm: {
+      mask: `linear-gradient(to left,
+              transparent calc(0.43 * ${theme('spacing.40')}),
+              rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.40')}),
+              black ${theme('spacing.40')});`
+    },
+    md: {
+      mask: `linear-gradient(to left,
+              transparent calc(0.43 * ${theme('spacing.80')}),
+              rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.80')}),
+              black ${theme('spacing.80')});`
+    },
+    lg: {
+      mask: `linear-gradient(to left,
               transparent calc(0.43 * ${theme('spacing.152')}),
               rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.152')}),
               black ${theme('spacing.152')});`
-        }
-      },
-      '&.sliding-panel-at-end': {
-        '.sliding-panel-scroll': {
-          mask: `linear-gradient(
-              to right,
+    }
+  };
+}
+
+/**
+ * Returns the `sizes` for the component `sliding panel fade end`.
+ *
+ * @param helpers - The {@link TailwindHelpers} to generate CSS.
+ * @returns The {@link CssStyleOptions} for the variant.
+ */
+export function fadeEndSizes({ theme }: TailwindHelpers) {
+  return {
+    sm: {
+      mask: `linear-gradient(to right,
+              transparent calc(0.43 * ${theme('spacing.40')}),
+              rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.40')}),
+              black ${theme('spacing.40')});`
+    },
+    md: {
+      mask: `linear-gradient(to right,
+              transparent calc(0.43 * ${theme('spacing.80')}),
+              rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.80')}),
+              black ${theme('spacing.80')});`
+    },
+    lg: {
+      mask: `linear-gradient(to right,
               transparent calc(0.43 * ${theme('spacing.152')}),
               rgba(0, 0, 0, 0.8) calc(0.67 * ${theme('spacing.152')}),
               black ${theme('spacing.152')});`
-        }
-      }
     }
   };
 }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/index.ts
@@ -6,7 +6,7 @@ import { slidingPanelFade } from './fade';
 /**
  * Returns the component `sliding panel` CSS.
  *
- * @param helpers
+ * @param helpers - The {@link TailwindHelpers} to generate CSS.
  * @returns The {@link CssStyleOptions} for the component.
  */
 export function slidingPanel(helpers: TailwindHelpers) {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/index.ts
@@ -1,3 +1,4 @@
+import { deepMerge } from '@empathyco/x-deep-merge';
 import { TailwindHelpers } from '../../../types';
 import { slidingPanelDefault } from './default';
 import { slidingPanelFade } from './fade';
@@ -11,8 +12,7 @@ import { slidingPanelFade } from './fade';
 export function slidingPanel(helpers: TailwindHelpers) {
   return {
     '.sliding-panel': {
-      ...slidingPanelDefault(),
-      ...slidingPanelFade(helpers)
+      ...deepMerge(slidingPanelDefault(), slidingPanelFade(helpers))
     }
   };
 }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/sliding-panel/index.ts
@@ -1,16 +1,18 @@
 import { TailwindHelpers } from '../../../types';
 import { slidingPanelDefault } from './default';
+import { slidingPanelFade } from './fade';
 
 /**
  * Returns the component `sliding panel` CSS.
  *
- * @param helpers - The {@link TailwindHelpers} to generate CSS.
+ * @param helpers
  * @returns The {@link CssStyleOptions} for the component.
  */
 export function slidingPanel(helpers: TailwindHelpers) {
   return {
     '.sliding-panel': {
-      ...slidingPanelDefault(helpers)
+      ...slidingPanelDefault(),
+      ...slidingPanelFade(helpers)
     }
   };
 }


### PR DESCRIPTION
EX-7687

After #1006 and trying to use the new XDS sliding panel in x we saw some potential issues and the need to duplicate css and classes in the sliding panel component from x. In order to avoid those issues, this PR reduces the scope for the XDS sliding panel and makes the design system only care about buttons position and fade. The scroll behaviour for the list will be a responsibility for the consumer of the design system. You can see how this will be used in x in this [branch](https://github.com/empathyco/x/tree/refactor/sliding-panel-xds)