### PR TITLE
feat: enable `allowWhitespace` in `jsdoc/no-multi-asterisks`

### DIFF
--- a/packages/eslint-plugin-x/lib/configs/jsdoc.js
+++ b/packages/eslint-plugin-x/lib/configs/jsdoc.js
@@ -25,7 +25,7 @@ module.exports = {
       'jsdoc/implements-on-classes': 'off',
       'jsdoc/multiline-blocks': 'warn',
       'jsdoc/newline-after-description': 'error',
-      'jsdoc/no-multi-asterisks': 'warn',
+      'jsdoc/no-multi-asterisks': ['warn', { allowWhitespace: true }],
       'jsdoc/tag-lines': 'off',
       'jsdoc/require-description': 'error',
       'jsdoc/require-description-complete-sentence': 'warn',


### PR DESCRIPTION
See https://github.com/gajus/eslint-plugin-jsdoc/pull/828

I'm enabling this option for the jsdoc plugin for eslint in order to avoid issues like we currently have with the [Related tags](https://github.com/empathyco/x/blob/main/packages/x-components/src/x-modules/related-tags/components/related-tags.vue#L54) where the eslint pre commit hook will remove automatically the * for [friends](https://github.com/empathyco/x/blob/main/packages/x-components/src/x-modules/related-tags/components/related-tags.vue#L54)