### PR TITLE
(feat) Remove duplicates from image placeholder/fallback classes

### DIFF
--- a/packages/x-components/src/components/result/base-result-fallback-image.vue
+++ b/packages/x-components/src/components/result/base-result-fallback-image.vue
@@ -1,6 +1,6 @@
 <template functional>
   <svg
-    :class="['x-picture__image x-picture__image--fallback'].concat(data.staticClass, data.class)"
+    :class="['x-picture__image--fallback'].concat(data.staticClass, data.class)"
     version="1.1"
     viewBox="0 0 256 371"
     xmlns="http://www.w3.org/2000/svg"

--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -253,10 +253,10 @@ displayed while the real one is loaded.
 ```vue
 <BaseResultImage :result="result">
   <template #placeholder>
-    <img class="x-result-picture-placeholder" src="./placeholder-image.svg"/>
+    <img class="x-picture__image--placeholder" src="./placeholder-image.svg"/>
   </template>
   <template #fallback>
-    <img class="x-result-picture-fallback" src="./fallback-image.svg"/>
+    <img class="x-picture__image--fallback" src="./fallback-image.svg"/>
   </template>
 </BaseResultImage>
 ```

--- a/packages/x-components/src/components/result/base-result-placeholder-image.vue
+++ b/packages/x-components/src/components/result/base-result-placeholder-image.vue
@@ -1,6 +1,6 @@
 <template functional>
   <svg
-    :class="['x-picture__image x-picture__image--placeholder'].concat(data.staticClass, data.class)"
+    :class="['x-picture__image--placeholder'].concat(data.staticClass, data.class)"
     version="1.1"
     viewBox="0 0 256 371"
     xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
[EX-7836](https://searchbroker.atlassian.net/browse/EX-7836)

While I was implementing the component in the archetype I realized we had duplicated classes:

![Captura de pantalla 2023-01-24 a les 8 31 57](https://user-images.githubusercontent.com/21217131/214239450-03e832a4-4721-4a8e-ad8f-a27c85040638.png)
![Captura de pantalla 2023-01-24 a les 8 32 19](https://user-images.githubusercontent.com/21217131/214239457-97a6c42e-727e-4017-bfb8-4392eb6d9949.png)

This PR removes duplicated classes and also updates fallback/placeholder documentation classes to set the project currently used.

[EX-7836]: https://searchbroker.atlassian.net/browse/EX-7836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ