### PR TITLE
fix(design-system): Use class instead of img tag

### DIFF
--- a/packages/x-tailwindcss/demo/src/components/xds-picture.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-picture.vue
@@ -17,6 +17,7 @@
         src="https://assets.empathy.co/images-demo/2885.jpg"
         alt="Summer Sandal"
         role="presentation"
+        class="x-picture-image"
       />
     </div>
   </XdsBaseShowcase>

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/picture/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/picture/default.ts
@@ -12,7 +12,8 @@ export function pictureDefault(helpers: TailwindHelpers) {
     display: 'block',
     aspectRatio: theme('aspectRatio.default'),
     overflow: 'hidden',
-    img: {
+    '&-image': {
+      aspectRatio: theme('aspectRatio.default'),
       objectFit: 'contain'
     }
   };

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/picture/overlay.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/picture/overlay.ts
@@ -13,7 +13,7 @@ export function overlay(helpers: TailwindHelpers) {
       '&:hover': {
         mixBlendMode: 'multiply'
       },
-      img: {
+      '.picture-image': {
         '&:hover': {
           maskImage: `linear-gradient(to top, transparent, 20%, ${theme('colors.neutral.100')})`
         }

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/picture/zoom.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/picture/zoom.ts
@@ -6,7 +6,7 @@
 export function zoom() {
   return {
     zoom: {
-      img: {
+      '.picture-image': {
         transition: 'transform 0.3s ease-out',
         '&:hover': {
           transform: 'scale(1.1)'


### PR DESCRIPTION
[EX-7836](https://searchbroker.atlassian.net/browse/EX-7836)

Update XDS picture component to avoid using an `img` tag in XDS, use a `class` instead.

[EX-7836]: https://searchbroker.atlassian.net/browse/EX-7836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ