### PR TITLE
chore: configure nx task runner and local caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,16 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": ["build", "test"]
+      }
+    }
+  },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/dist", "{projectRoot}/showcase"]
+    }
+  }
+}


### PR DESCRIPTION
EX-7907

Configure `nx` task runner to have `local caching` and specify the dependants of each task.
