### PR TITLE
feat(history-queries): bind formatTime callback to MyHistory suggestion slot

### DIFF
--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/my-history.spec.ts
@@ -3,7 +3,10 @@ import { DeepPartial, forEach } from '@empathyco/x-utils';
 import { createLocalVue, mount, Wrapper, WrapperArray } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
-import { createHistoryQueries } from '../../../../__stubs__/history-queries-stubs.factory';
+import {
+  createHistoryQueries,
+  createHistoryQuery
+} from '../../../../__stubs__/history-queries-stubs.factory';
 import { RootXStoreState } from '../../../../store/store.types';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
@@ -11,6 +14,7 @@ import { baseSnippetConfig } from '../../../../views/base-config';
 import { SnippetConfig } from '../../../../x-installer/api/api.types';
 import { historyQueriesXModule } from '../../x-module';
 import MyHistory from '../my-history.vue';
+import HistoryQueryComponent from '../history-query.vue';
 import { resetXHistoryQueriesStateWith } from './utils';
 
 const historyQueries: HistoryQuery[] = [
@@ -53,7 +57,8 @@ function renderMyHistory({
     {
       template,
       components: {
-        MyHistory
+        MyHistory,
+        HistoryQuery: HistoryQueryComponent
       },
       provide: {
         snippetConfig
@@ -161,6 +166,30 @@ describe('testing MyHistory component', () => {
       expect(contentWrapper.attributes('data-index')).toEqual(index.toString());
       expect(contentWrapper.text()).toEqual(historyQueries[index].query);
     });
+  });
+
+  it('allows changing the history query', () => {
+    const historyQuery = createHistoryQuery({
+      query: 'testQuery',
+      timestamp: Date.parse('2023-01-23T09:40:00')
+    });
+
+    const { wrapper } = renderMyHistory({
+      template: `
+        <MyHistory>
+            <template #suggestion="{ suggestion, formatTime}">
+                <HistoryQuery :suggestion="suggestion">
+                    <span data-test="suggestion-query">{{ suggestion.query }}</span>
+                    <span data-test="suggestion-date">{{ formatTime(suggestion.timestamp) }}</span>
+                </HistoryQuery>
+            </template>
+        </MyHistory>
+      `,
+      historyQueries: [historyQuery]
+    });
+
+    expect(wrapper.get(getDataTestSelector('suggestion-query')).text()).toBe('testQuery');
+    expect(wrapper.get(getDataTestSelector('suggestion-date')).text()).toBe('09:40 AM');
   });
 
   function expectValidHistoryContent(

--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -20,8 +20,9 @@
         @slot History Query item
             @binding {Suggestion} suggestion - History Query suggestion data
             @binding {number} index - History Query suggestion index
+            @binding {() => string} formatTime - Callback to format time to `hh:mm [PM/AM]`
       -->
-          <slot name="suggestion" v-bind="{ suggestion, index }">
+          <slot name="suggestion" v-bind="{ suggestion, index, formatTime }">
             <HistoryQuery
               :suggestion="suggestion"
               data-test="history-query-item"
@@ -32,6 +33,7 @@
               @slot History Query content
                   @binding {Suggestion} suggestion - History Query suggestion data
                   @binding {number} index - History Query suggestion index
+                  @binding {() => string} formatTime - Callback to format time to `hh:mm [PM/AM]`
             -->
                 <slot name="suggestion-content" v-bind="{ suggestion, index, formatTime }">
                   <div class="x-list x-list--vertical">


### PR DESCRIPTION
Needed to be able to format the timestamp when using the `suggestion` slot instead of the `suggestion-content` one.

EX-7879
