### PR TITLE
fix: add missing `rxjs` dependency and narrow `setTimeout` type

### DIFF
--- a/packages/x-bus/package.json
+++ b/packages/x-bus/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@empathyco/x-priority-queue": "^0.1.0-alpha.10",
     "@empathyco/x-utils": "^1.0.0-alpha.15",
+    "rxjs": "~7.8.0",
     "tslib": "~2.4.1"
   },
   "devDependencies": {

--- a/packages/x-bus/src/x-bus.ts
+++ b/packages/x-bus/src/x-bus.ts
@@ -8,7 +8,6 @@ import {
   Emitters,
   Priority,
   SubjectPayload,
-  TimeoutId,
   EventPayload,
   XBus,
   XPriorityQueueNodeData
@@ -74,19 +73,18 @@ export class XPriorityBus<SomeEvents extends Dictionary, SomeEventMetadata exten
   protected emitters: Emitters<SomeEvents, SomeEventMetadata> = {};
 
   /**
-   * A pending flush operation {@link TimeoutId | timeout identifier} or undefined if there's
-   * none pending.
+   * A pending flush operation timeout identifier or undefined if there's none pending.
    *
    * @internal
    */
-  protected pendingFlushId?: TimeoutId;
+  protected pendingFlushId?: number;
 
   /**
-   * A list of pending pop operations {@link TimeoutId | timeout identifiers}.
+   * A list of pending pop operations timeout identifiers.
    *
    * @internal
    */
-  protected pendingPopsIds: TimeoutId[] = [];
+  protected pendingPopsIds: number[] = [];
 
   /**
    * Creates a new instance of a {@link XPriorityBus}.
@@ -184,9 +182,9 @@ export class XPriorityBus<SomeEvents extends Dictionary, SomeEventMetadata exten
     clearTimeout(this.pendingFlushId);
     this.clearPendingPopsIds();
 
-    this.pendingFlushId = setTimeout(() => {
+    this.pendingFlushId = window.setTimeout(() => {
       for (let i = 0; i < this.queue.size(); ++i) {
-        const popTimeoutId = setTimeout(() => {
+        const popTimeoutId = window.setTimeout(() => {
           const {
             key,
             data: { eventPayload, eventMetadata, resolve }

--- a/packages/x-bus/src/x-bus.ts
+++ b/packages/x-bus/src/x-bus.ts
@@ -8,6 +8,7 @@ import {
   Emitters,
   Priority,
   SubjectPayload,
+  TimeoutId,
   EventPayload,
   XBus,
   XPriorityQueueNodeData
@@ -73,18 +74,19 @@ export class XPriorityBus<SomeEvents extends Dictionary, SomeEventMetadata exten
   protected emitters: Emitters<SomeEvents, SomeEventMetadata> = {};
 
   /**
-   * A pending flush operation timeout identifier or undefined if there's none pending.
+   * A pending flush operation {@link TimeoutId | timeout identifier} or undefined if there's
+   * none pending.
    *
    * @internal
    */
-  protected pendingFlushId?: number;
+  protected pendingFlushId?: TimeoutId;
 
   /**
-   * A list of pending pop operations timeout identifiers.
+   * A list of pending pop operations {@link TimeoutId | timeout identifiers}.
    *
    * @internal
    */
-  protected pendingPopsIds: number[] = [];
+  protected pendingPopsIds: TimeoutId[] = [];
 
   /**
    * Creates a new instance of a {@link XPriorityBus}.
@@ -94,7 +96,7 @@ export class XPriorityBus<SomeEvents extends Dictionary, SomeEventMetadata exten
    * store the events.
    * @param config.priorities - A {@link @empathyco/x-utils#Dictionary} defining the priorities
    * associated to a given string.
-   @param config.emitCallbacks - A list of functions to execute when an event is emitted.
+   * @param config.emitCallbacks - A list of functions to execute when an event is emitted.
    * @param config.defaultEventPriority -  A default priority to assigned to an event.
    */
   public constructor(
@@ -182,9 +184,9 @@ export class XPriorityBus<SomeEvents extends Dictionary, SomeEventMetadata exten
     clearTimeout(this.pendingFlushId);
     this.clearPendingPopsIds();
 
-    this.pendingFlushId = window.setTimeout(() => {
+    this.pendingFlushId = setTimeout(() => {
       for (let i = 0; i < this.queue.size(); ++i) {
-        const popTimeoutId = window.setTimeout(() => {
+        const popTimeoutId = setTimeout(() => {
           const {
             key,
             data: { eventPayload, eventMetadata, resolve }

--- a/packages/x-bus/src/x-bus.ts
+++ b/packages/x-bus/src/x-bus.ts
@@ -8,7 +8,6 @@ import {
   Emitters,
   Priority,
   SubjectPayload,
-  TimeoutId,
   EventPayload,
   XBus,
   XPriorityQueueNodeData
@@ -74,19 +73,18 @@ export class XPriorityBus<SomeEvents extends Dictionary, SomeEventMetadata exten
   protected emitters: Emitters<SomeEvents, SomeEventMetadata> = {};
 
   /**
-   * A pending flush operation {@link TimeoutId | timeout identifier} or undefined if there's
-   * none pending.
+   * A pending flush operation timeout identifier or undefined if there's none pending.
    *
    * @internal
    */
-  protected pendingFlushId?: TimeoutId;
+  protected pendingFlushId?: number;
 
   /**
-   * A list of pending pop operations {@link TimeoutId | timeout identifiers}.
+   * A list of pending pop operations timeout identifiers.
    *
    * @internal
    */
-  protected pendingPopsIds: TimeoutId[] = [];
+  protected pendingPopsIds: number[] = [];
 
   /**
    * Creates a new instance of a {@link XPriorityBus}.
@@ -96,7 +94,7 @@ export class XPriorityBus<SomeEvents extends Dictionary, SomeEventMetadata exten
    * store the events.
    * @param config.priorities - A {@link @empathyco/x-utils#Dictionary} defining the priorities
    * associated to a given string.
-   * @param config.emitCallbacks - A list of functions to execute when an event is emitted.
+   @param config.emitCallbacks - A list of functions to execute when an event is emitted.
    * @param config.defaultEventPriority -  A default priority to assigned to an event.
    */
   public constructor(
@@ -184,9 +182,9 @@ export class XPriorityBus<SomeEvents extends Dictionary, SomeEventMetadata exten
     clearTimeout(this.pendingFlushId);
     this.clearPendingPopsIds();
 
-    this.pendingFlushId = setTimeout(() => {
+    this.pendingFlushId = window.setTimeout(() => {
       for (let i = 0; i < this.queue.size(); ++i) {
-        const popTimeoutId = setTimeout(() => {
+        const popTimeoutId = window.setTimeout(() => {
           const {
             key,
             data: { eventPayload, eventMetadata, resolve }

--- a/packages/x-bus/src/x-bus.types.ts
+++ b/packages/x-bus/src/x-bus.types.ts
@@ -2,15 +2,6 @@ import { Dictionary } from '@empathyco/x-utils';
 import { Observable, Subject } from 'rxjs';
 
 /**
- * Alias representing a
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#return_value | timeoutID}
- * value.
- *
- * @internal
- */
-export type TimeoutId = number;
-
-/**
  * Alias representing a positive number to represent the priority of an event in an
  * {@link XPriorityBus}.
  *

--- a/packages/x-bus/src/x-bus.types.ts
+++ b/packages/x-bus/src/x-bus.types.ts
@@ -2,16 +2,6 @@ import { Dictionary } from '@empathyco/x-utils';
 import { Observable, Subject } from 'rxjs';
 
 /**
- * Alias representing a
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#return_value | timeoutID}
- * value.
- * It is a `number` in browser/jsdom environments, or a `Timeout` object in `node` environments.
- *
- * @internal
- */
-export type TimeoutId = ReturnType<typeof setTimeout>;
-
-/**
  * Alias representing a positive number to represent the priority of an event in an
  * {@link XPriorityBus}.
  *

--- a/packages/x-bus/src/x-bus.types.ts
+++ b/packages/x-bus/src/x-bus.types.ts
@@ -2,6 +2,16 @@ import { Dictionary } from '@empathyco/x-utils';
 import { Observable, Subject } from 'rxjs';
 
 /**
+ * Alias representing a
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#return_value | timeoutID}
+ * value.
+ * It is a `number` in browser/jsdom environments, or a `Timeout` object in `node` environments.
+ *
+ * @internal
+ */
+export type TimeoutId = ReturnType<typeof setTimeout>;
+
+/**
  * Alias representing a positive number to represent the priority of an event in an
  * {@link XPriorityBus}.
  *


### PR DESCRIPTION
EX-7928

add missing dependency `rxjs`.

`typescript` is messing with the `setTimeout` type, as it has a different definition in `nodejs` than in the `window` object, so we have to narrow it to the `window` one. My only concern is that this code is not `ssr` friendly, as we are using the `window.setTimeout` directly. In case we need to support `ssr`, we might have to wrap the setTimeout function to distinguish the platform we are running the code on.