### PR TITLE
fix(modal): set focusOnOpen for the main-modal to false

### DIFF
--- a/packages/x-components/src/components/modals/main-modal.vue
+++ b/packages/x-components/src/components/modals/main-modal.vue
@@ -6,7 +6,7 @@
     :eventsToCloseModal="closeEvents"
     :bodyClickEvent="outOfModalClickEvent"
     :animation="animation"
-    :focusOnOpen="false"
+    :focusOnOpen="focusOnOpen"
     v-bind="$attrs"
   >
     <slot />
@@ -57,6 +57,12 @@
      * @internal
      */
     protected outOfModalClickEvent: XEvent = 'UserClickedOutOfMainModal';
+    /**
+     * Determines if the focused element changes to one inside the modal when it opens. Either the
+     * first element with a positive tabindex or just the first focusable element.
+     */
+    @Prop({ default: false })
+    public focusOnOpen!: boolean;
   }
 </script>
 

--- a/packages/x-components/src/components/modals/main-modal.vue
+++ b/packages/x-components/src/components/modals/main-modal.vue
@@ -6,6 +6,7 @@
     :eventsToCloseModal="closeEvents"
     :bodyClickEvent="outOfModalClickEvent"
     :animation="animation"
+    :focusOnOpen="false"
     v-bind="$attrs"
   >
     <slot />


### PR DESCRIPTION
EX-7710

## Motivation and context
The `focusOnOpen` prop is set to true by default in the `BaseModal` component.

In the case of the `MainModal`, it does not make sense, because if there is a focusable element before the `SearchInput`, the user will have to click the input manually to be able to write.

This change is to avoid modifying the prop in all the setups.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Check that the `BaseModal` inside the `MainModal` opens with `focusToOpen` as false. Try changing the prop in `MainModal` to check that the prop is working correctly.
