### PR TITLE
feat: remove `x-suggestion` class from `BaseSuggestion` component

### DIFF
--- a/packages/x-components/src/components/suggestions/base-suggestion.vue
+++ b/packages/x-components/src/components/suggestions/base-suggestion.vue
@@ -1,5 +1,5 @@
 <template>
-  <button @click="emitEvents" v-on="$listeners" :class="dynamicCSSClasses" class="x-suggestion">
+  <button @click="emitEvents" v-on="$listeners" :class="dynamicCSSClasses">
     <!--
       @slot Button content
           @binding {Suggestion} suggestion - Suggestion data

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -312,7 +312,7 @@
                           >
                             <h1 class="x-title2">Others clients have searched</h1>
                             <NextQuery
-                              class="x-text1 x-text1-lg"
+                              class="x-suggestion x-text1 x-text1-lg"
                               :suggestion="nextQueries[0]"
                               data-test="next-query-preview-name"
                             >
@@ -334,7 +334,7 @@
                             <NextQuery
                               :suggestion="nextQueries[0]"
                               data-test="view-all-results"
-                              class="x-tag x-tag--pill x-margin--left-auto x-margin--right-auto x-margin--top-03 x-padding--top-04 x-padding--bottom-04 x-padding--right-05 x-padding--left-05 x-border-color--lead x-margin--bottom-06 x-font-bold x-text-lead-50"
+                              class="x-button x-button-outlined x-rounded-full x-mx-auto x-mt-8 x-mb-24"
                             >
                               {{ 'View all results' }}
                             </NextQuery>

--- a/packages/x-components/src/views/home/sliding-next-query-preview.vue
+++ b/packages/x-components/src/views/home/sliding-next-query-preview.vue
@@ -5,7 +5,7 @@
     class="x-list x-list--gap-03"
   >
     <h1 class="x-title2">Others clients have searched</h1>
-    <NextQuery class="x-text1 x-text1-lg" :suggestion="suggestion">
+    <NextQuery class="x-suggestion x-text1 x-text1-lg" :suggestion="suggestion">
       <span class="x-font-bold">{{ suggestion.query }}</span>
       ({{ totalResults }})
     </NextQuery>

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -17,6 +17,7 @@
           :suggestion="baseScope.suggestion"
           data-test="history-query-item"
           class="x-history-queries__item"
+          suggestionClass="x-suggestion"
         >
           <template #default="historyQueryScope">
             <!-- eslint-disable max-len -->

--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -26,7 +26,7 @@
             <HistoryQuery
               :suggestion="suggestion"
               data-test="history-query-item"
-              class="x-history-queries__item"
+              class="x-history-queries__item x-suggestion"
             >
               <template #default>
                 <!--

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -18,7 +18,7 @@
           #default="nextQueryScope"
           :suggestion="baseScope.suggestion"
           :highlightCurated="highlightCurated"
-          class="x-next-queries__suggestion"
+          class="x-next-queries__suggestion x-suggestion"
         >
           <!-- eslint-disable max-len -->
           <!--

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -15,7 +15,7 @@
       <slot name="suggestion" v-bind="{ ...baseScope }">
         <PopularSearch
           :suggestion="baseScope.suggestion"
-          class="x-popular-searches__suggestion"
+          class="x-popular-searches__suggestion x-suggestion"
           #default="popularSearchScope"
         >
           <!-- eslint-disable max-len -->

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
@@ -15,7 +15,7 @@
       <slot name="suggestion" v-bind="{ ...baseScope }">
         <QuerySuggestion
           :suggestion="baseScope.suggestion"
-          class="x-query-suggestions__suggestion"
+          class="x-query-suggestions__suggestion x-suggestion"
           #default="querySuggestionScope"
         >
           <!-- eslint-disable max-len -->

--- a/packages/x-components/tailwind.config.js
+++ b/packages/x-components/tailwind.config.js
@@ -29,6 +29,8 @@ module.exports = {
     'textTransform',
     'textDecoration',
     'textOverflow',
-    'preflight'
+    'borderRadius',
+    'preflight',
+    'margin'
   ]
 };


### PR DESCRIPTION
Add the class to the components used in the lists.

This is needed because in the archetype we want to use a `NextQuery` with `x-button` styles, but adding it right now conflicts with the `x-suggestion` styles.

EX-8006
