### PR TITLE
fix(components): Fix open issue when focused on body. Fix `SearchInputPlaceholder` styles.

### DIFF
--- a/packages/x-components/src/components/modals/__tests__/base-events-modal.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-events-modal.spec.ts
@@ -45,6 +45,7 @@ function mountBaseEventsModal({
       return wrapper.find(getDataTestSelector('modal-content'));
     },
     async fakeFocusIn() {
+      jest.runAllTimers();
       document.body.dispatchEvent(new FocusEvent('focusin'));
       await localVue.nextTick();
     }
@@ -52,6 +53,14 @@ function mountBaseEventsModal({
 }
 
 describe('testing Base Events Modal  component', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('opens and closes when UserClickedOpenX and UserClickedClosedX are emitted', async () => {
     const { emit, getModalContent } = mountBaseEventsModal();
     expect(getModalContent().exists()).toBe(false);

--- a/packages/x-components/src/components/modals/__tests__/base-id-modal.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-id-modal.spec.ts
@@ -43,6 +43,7 @@ function mountBaseIdModal({
       return wrapper.find(getDataTestSelector('modal-content'));
     },
     async fakeFocusIn() {
+      jest.runAllTimers();
       document.body.dispatchEvent(new FocusEvent('focusin'));
       await localVue.nextTick();
     }
@@ -50,6 +51,14 @@ function mountBaseIdModal({
 }
 
 describe('testing BaseIdModal  component', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('opens when UserClickedOpenModal event is emitted', async () => {
     const { emit, getModalContent } = mountBaseIdModal();
     expect(getModalContent().exists()).toBe(false);

--- a/packages/x-components/src/components/modals/__tests__/base-modal.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-modal.spec.ts
@@ -50,12 +50,21 @@ function mountBaseModal({
       });
       appendToBody();
       document.body.appendChild(buttonWrapper.element);
+      jest.runAllTimers();
       await buttonWrapper.trigger('focusin');
     }
   };
 }
 
 describe('testing Base Modal  component', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('renders only when the open prop is set to true', async () => {
     const { getModalContent, setOpen } = mountBaseModal();
 

--- a/packages/x-components/src/components/modals/__tests__/main-modal.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/main-modal.spec.ts
@@ -43,6 +43,7 @@ function renderMainModal({
       return wrapper.find(getDataTestSelector('modal-content'));
     },
     async focusOutOfModal() {
+      jest.runAllTimers();
       document.body.dispatchEvent(new FocusEvent('focusin'));
       await localVue.nextTick();
     }
@@ -50,6 +51,14 @@ function renderMainModal({
 }
 
 describe('testing Main Modal  component', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('opens and closes when UserClickedOpenX and UserClickedClosedX are emitted', async () => {
     const { emit, getModalContent } = renderMainModal();
     expect(getModalContent().exists()).toBe(false);

--- a/packages/x-components/src/components/modals/base-modal.vue
+++ b/packages/x-components/src/components/modals/base-modal.vue
@@ -247,7 +247,7 @@
      * @internal
      */
     protected emitFocusInBody(event: FocusEvent): void {
-      if (!this.$refs.modalContent.contains(getTargetElement(event))) {
+      if (!this.$refs.modalContent?.contains(getTargetElement(event))) {
         this.$emit('focusin:body', event);
       }
     }

--- a/packages/x-components/src/components/modals/base-modal.vue
+++ b/packages/x-components/src/components/modals/base-modal.vue
@@ -207,9 +207,16 @@
      * @internal
      */
     protected addBodyListeners(): void {
-      /* eslint-disable @typescript-eslint/unbound-method */
-      document.body.addEventListener('focusin', this.emitFocusInBody);
-      /* eslint-enable @typescript-eslint/unbound-method */
+      // TODO find a better solution and remove the timeout
+      // to avoid emit the focusin on opening X that provokes closing it immediately.
+      // This is because this event was emitted after the open of main modal when the user clicks
+      // on the customer website search box (focus event). This way we avoid add the listener before
+      // the open and the avoid the event that provokes the close.
+      setTimeout(() => {
+        /* eslint-disable @typescript-eslint/unbound-method */
+        document.body.addEventListener('focusin', this.emitFocusInBody);
+        /* eslint-enable @typescript-eslint/unbound-method */
+      });
     }
 
     /**

--- a/packages/x-components/src/x-modules/search-box/components/search-input-placeholder.vue
+++ b/packages/x-components/src/x-modules/search-box/components/search-input-placeholder.vue
@@ -234,6 +234,7 @@
     inset: 0;
     display: flex;
     align-items: center;
+    pointer-events: none;
   }
 </style>
 


### PR DESCRIPTION
EX-8011

Workaround to fix the issue when opening the XArchetype.

To reproduce the issue, go to XArchetype and change the dynamic import of the MainModal to a normal import. Then run the proyect and you won't be able to open X. It is open and immediately closed.

Sometimes the issue is not reproducible due to the code order 🤷🏻