### PR TITLE
build: add report folder to packed tarball

### DIFF
--- a/packages/x-adapter-platform/package.json
+++ b/packages/x-adapter-platform/package.json
@@ -15,7 +15,8 @@
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "report"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
EX-8105

We are not including the `api-extractor` generated `report` folder to the packed `tarball`, which is what we end up publishing to `npm` as a package. It should be included, as it is later on consumed by other packages when referencing its documentation using the `{@link ...}` annotation.
