### PR TITLE
feat: adapt base-column-picker-list to use the XDS component of button group

### DIFF
--- a/packages/x-components/src/components/column-picker/__tests__/base-column-picker-list.spec.ts
+++ b/packages/x-components/src/components/column-picker/__tests__/base-column-picker-list.spec.ts
@@ -119,28 +119,62 @@ describe('testing Base Column Picker List', () => {
   it('allows configuring the number of columns and updates the css class accordingly', () => {
     const columns = [1, 3, 6];
     const { wrapper } = renderBaseColumnPickerListComponent({ columns });
-    const columnPickerListWrapper = wrapper.findAll(getDataTestSelector('column-picker-item'));
+    const columnPickerListWrapper = wrapper.findAll(getDataTestSelector('column-picker-button'));
     columns.forEach((column, index) => {
       expect(columnPickerListWrapper.at(index).classes()).toContain(
-        `x-column-picker-list__item--${column}-cols`
+        `x-column-picker-list__button--${column}-cols`
       );
     });
   });
 
-  it('allows customizing slots', () => {
+  it('allows customizing the picker button slot', () => {
     const columns = [1, 3, 6];
     const customItemSlot = `
       <template #default="{ column }">
-        <p data-test="column-slot">{{ column }}</p>
+        <p data-test="custom-column-slot">{{ column }}</p>
       </template>`;
     const { wrapper } = renderBaseColumnPickerListComponent({
       columns,
       customItemSlot
     });
-    const columnsSlots = wrapper.findAll(getDataTestSelector('column-slot'));
+    const columnsSlots = wrapper.findAll(getDataTestSelector('custom-column-slot'));
     expect(columnsSlots).toHaveLength(columns.length);
     columns.forEach((column, index) => {
       expect(columnsSlots.at(index).text()).toEqual(column.toString());
+    });
+  });
+
+  it('by default there are no divider elements between column picker buttons', () => {
+    const columns = [1, 3, 6];
+    const { wrapper } = renderBaseColumnPickerListComponent({
+      columns
+    });
+
+    const rootChildren = wrapper.element.children;
+    expect(rootChildren).toHaveLength(columns.length);
+  });
+
+  it('divider slot renders only between column picker buttons', () => {
+    const columns = [1, 3, 6];
+    const customItemSlot = `
+      <template #default="{ column }">
+        <p>{{ column }}</p>
+      </template>
+      <template #divider>
+        <span data-test="custom-divider-slot">-</span>
+      </template>`;
+
+    const { wrapper } = renderBaseColumnPickerListComponent({
+      columns,
+      customItemSlot
+    });
+
+    const dividerSlots = wrapper.findAll(getDataTestSelector('custom-divider-slot'));
+    expect(dividerSlots).toHaveLength(columns.length - 1);
+
+    dividerSlots.wrappers.forEach(dividerWrapper => {
+      const nextSibling = dividerWrapper.element.nextSibling! as HTMLElement;
+      expect(nextSibling.getAttribute('data-test')).toBe('column-picker-button');
     });
   });
 

--- a/packages/x-components/src/components/column-picker/base-column-picker-list.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="x-column-picker-list x-button-group" data-test="column-picker-list">
+  <div class="x-column-picker-list x-button-group" data-test="column-picker-list" role="list">
     <template v-for="({ column, cssClasses, events, isSelected }, index) in columnsWithCssClasses">
       <BaseEventButton
         :key="column"
@@ -9,6 +9,7 @@
         :aria-pressed="isSelected"
         :events="events"
         :aria-label="`${column} columns`"
+        role="listitem"
       >
         <!--
           @slot Customized Column Picker Button content. Specifying a slot with the column value
@@ -173,15 +174,18 @@ It also possible to add a divider element between the column picker buttons by o
 ```vue
 <template>
   <BaseColumnPickerList :columns="columns">
-    <template #divider></template>
+    <template #divider>
+      <ChevronRightIcon aria-hidden="true" />
+    </template>
   </BaseColumnPickerList>
 </template>
 <script>
-  import { BaseColumnPickerList } from '@empathyco/xcomponents';
+  import { BaseColumnPickerList, ChevronRightIcon } from '@empathyco/xcomponents';
 
   export default {
     components: {
-      BaseColumnPickerList
+      BaseColumnPickerList,
+      ChevronRightIcon
     },
     data() {
       return { columns: [2, 4, 6] };

--- a/packages/x-components/src/components/column-picker/base-column-picker-list.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-list.vue
@@ -1,15 +1,10 @@
 <template>
-  <ul class="x-option-list x-column-picker-list" data-test="column-picker-list">
-    <li
-      v-for="{ column, cssClasses, events, isSelected } in columnsWithCssClasses"
-      :key="column"
-      :class="cssClasses"
-      class="x-option-list__item x-column-picker-list__item"
-      data-test="column-picker-item"
-    >
+  <div class="x-column-picker-list x-button-group" data-test="column-picker-list">
+    <template v-for="({ column, cssClasses, events, isSelected }, index) in columnsWithCssClasses">
       <BaseEventButton
-        class="column-picker-item__button x-button"
-        :class="buttonClass"
+        :key="column"
+        class="x-column-picker-list__button x-button"
+        :class="[buttonClass, cssClasses]"
         data-test="column-picker-button"
         :aria-pressed="isSelected"
         :events="events"
@@ -25,8 +20,14 @@
           {{ column }}
         </slot>
       </BaseEventButton>
-    </li>
-  </ul>
+
+      <!--
+          @slot Customized Column Picker divider. Specify an element to act as divider for
+          the items in the column picker. Empty by default.
+        -->
+      <slot v-if="index !== columnsWithCssClasses.length - 1" name="divider"></slot>
+    </template>
+  </div>
 </template>
 
 <script lang="ts">
@@ -73,10 +74,9 @@
       return this.columns.map(column => ({
         column,
         cssClasses: [
-          `x-column-picker-list__item--${column}-cols`,
+          `x-column-picker-list__button--${column}-cols`,
           {
-            'x-column-picker-list__item--is-selected': this.selectedColumns === column,
-            'x-option-list__item--is-selected': this.selectedColumns === column
+            'x-selected': this.selectedColumns === column
           }
         ],
         isSelected: this.selectedColumns === column,
@@ -88,13 +88,6 @@
     }
   }
 </script>
-
-<style lang="scss" scoped>
-  .x-column-picker-list {
-    display: flex;
-    list-style-type: none;
-  }
-</style>
 
 <docs lang="mdx">
 ## Examples
@@ -158,6 +151,29 @@ It is possible to override the column picker button content.
 <template>
   <BaseColumnPickerList :columns="columns" #default="{ column, isSelected }">
     <span>{{ column }} {{ isSelected ? '🟢' : '' }}</span>
+  </BaseColumnPickerList>
+</template>
+<script>
+  import { BaseColumnPickerList } from '@empathyco/xcomponents';
+
+  export default {
+    components: {
+      BaseColumnPickerList
+    },
+    data() {
+      return { columns: [2, 4, 6] };
+    }
+  };
+</script>
+```
+
+It also possible to add a divider element between the column picker buttons by overriding the
+`divider` slot.
+
+```vue
+<template>
+  <BaseColumnPickerList :columns="columns">
+    <template #divider></template>
   </BaseColumnPickerList>
 </template>
 <script>

--- a/packages/x-components/src/components/column-picker/base-column-picker-list.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-list.vue
@@ -168,7 +168,7 @@ It is possible to override the column picker button content.
 </script>
 ```
 
-It also possible to add a divider element between the column picker buttons by overriding the
+It is also possible to add a divider element between the column picker buttons by overriding the
 `divider` slot.
 
 ```vue

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -410,7 +410,6 @@
   import ChevronTinyRight from '../../components/icons/chevron-tiny-right.vue';
   import ChevronUp from '../../components/icons/chevron-up.vue';
   import CrossIcon from '../../components/icons/cross.vue';
-  import Grid1Col from '../../components/icons/grid-1-col.vue';
   import Grid2Col from '../../components/icons/grid-2-col.vue';
   import Grid4Col from '../../components/icons/grid-4-col.vue';
   import LightBulbOn from '../../components/icons/light-bulb-on.vue';
@@ -490,7 +489,6 @@
       ClearSearchInput,
       CloseMainModal,
       CrossIcon,
-      Grid1Col,
       Grid2Col,
       Grid4Col,
       LightBulbOn,

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -171,17 +171,19 @@
           >
             <span class="x-text1">{{ $x.totalResults }} Results</span>
             <BaseColumnPickerList
-              #default="{ column }"
               v-model="selectedColumns"
+              class="x-gap-4"
               :columns="columnPickerValues"
             >
-              <template v-if="column === 0">
-                <ChevronTinyRight />
-                <Grid1Col />
-                <ChevronTinyLeft />
+              <template #default="{ column }">
+                <span v-if="column === 0">Auto</span>
+                <Grid2Col v-else-if="column === 2" />
+                <Grid4Col v-else-if="column === 4" />
               </template>
-              <Grid1Col v-else-if="column === 4" />
-              <Grid2Col v-else-if="column === 6" />
+
+              <template #divider>
+                <span class="x-button-group-divider"></span>
+              </template>
             </BaseColumnPickerList>
             <SortDropdown
               :items="sortValues"
@@ -284,7 +286,10 @@
                     <NextQueriesList
                       :show-only-after-offset="controls.nextQueriesList.showOnlyAfterOffset"
                     >
-                      <BaseGrid :animation="resultsAnimation" :columns="4">
+                      <BaseVariableColumnGrid
+                        :animation="resultsAnimation"
+                        :columns="$x.device === 'mobile' ? 2 : 4"
+                      >
                         <template #result="{ item: result }">
                           <MainScrollItem :item="result">
                             <Result :result="result" data-test="search-result" />
@@ -336,7 +341,7 @@
                             </NextQuery>
                           </NextQueryPreview>
                         </template>
-                      </BaseGrid>
+                      </BaseVariableColumnGrid>
                     </NextQueriesList>
                   </BannersList>
                 </PromotedsList>
@@ -385,9 +390,9 @@
 </template>
 
 <script lang="ts">
+  /* eslint-disable max-len */
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
-  // eslint-disable-next-line max-len
   import { animateClipPath } from '../../components/animations/animate-clip-path/animate-clip-path.factory';
   import CollapseHeight from '../../components/animations/collapse-height.vue';
   import StaggeredFadeAndSlide from '../../components/animations/staggered-fade-and-slide.vue';
@@ -407,9 +412,9 @@
   import CrossIcon from '../../components/icons/cross.vue';
   import Grid1Col from '../../components/icons/grid-1-col.vue';
   import Grid2Col from '../../components/icons/grid-2-col.vue';
+  import Grid4Col from '../../components/icons/grid-4-col.vue';
   import LightBulbOn from '../../components/icons/light-bulb-on.vue';
   import SearchIcon from '../../components/icons/search.vue';
-  // eslint-disable-next-line max-len
   import MultiColumnMaxWidthLayout from '../../components/layouts/multi-column-max-width-layout.vue';
   import LocationProvider from '../../components/location-provider.vue';
   import BaseIdTogglePanelButton from '../../components/panels/base-id-toggle-panel-button.vue';
@@ -418,9 +423,7 @@
   import SlidingPanel from '../../components/sliding-panel.vue';
   import SnippetCallbacks from '../../components/snippet-callbacks.vue';
   import { infiniteScroll } from '../../directives/infinite-scroll/infinite-scroll';
-  // eslint-disable-next-line max-len
   import RenderlessExtraParams from '../../x-modules/extra-params/components/renderless-extra-param.vue';
-  // eslint-disable-next-line max-len
   import SnippetConfigExtraParams from '../../x-modules/extra-params/components/snippet-config-extra-params.vue';
   import NextQueriesList from '../../x-modules/next-queries/components/next-queries-list.vue';
   import NextQueries from '../../x-modules/next-queries/components/next-queries.vue';
@@ -434,7 +437,6 @@
   import ClearSearchInput from '../../x-modules/search-box/components/clear-search-input.vue';
   import SearchButton from '../../x-modules/search-box/components/search-button.vue';
   import SearchInput from '../../x-modules/search-box/components/search-input.vue';
-  // eslint-disable-next-line max-len
   import SearchInputPlaceholder from '../../x-modules/search-box/components/search-input-placeholder.vue';
   import Banner from '../../x-modules/search/components/banner.vue';
   import BannersList from '../../x-modules/search/components/banners-list.vue';
@@ -459,6 +461,7 @@
   import PredictiveLayer from './predictive-layer.vue';
   import Result from './result.vue';
   import { HomeControls } from './types';
+  /* eslint-enable max-len */
 
   @Component({
     directives: {
@@ -489,6 +492,7 @@
       CrossIcon,
       Grid1Col,
       Grid2Col,
+      Grid4Col,
       LightBulbOn,
       LocationProvider,
       MainScrollItem,
@@ -537,7 +541,7 @@
       'Find handbags',
       'Find sunglasses'
     ];
-    protected columnPickerValues = [0, 4, 6];
+    protected columnPickerValues = [0, 2, 4];
     protected resultsAnimation = StaggeredFadeAndSlide;
     protected tabsPanelAnimation = StaggeredFadeAndSlide;
     protected modalAnimation = animateClipPath();

--- a/packages/x-components/tests/unit/base-column-pickers.spec.ts
+++ b/packages/x-components/tests/unit/base-column-pickers.spec.ts
@@ -58,14 +58,13 @@ function mountBaseColumnPickerComponents({
   return {
     clickListNthItem(columns: number) {
       cy.getByDataTest('column-picker-list')
-        .children(`.x-column-picker-list__item--${columns}-cols`)
+        .children(`.x-column-picker-list__button--${columns}-cols`)
         .click();
     },
     getListNthItem(columns: number) {
       return cy
         .getByDataTest('column-picker-list')
-        .children(`.x-column-picker-list__item--${columns}-cols`)
-        .getByDataTest('column-picker-button');
+        .children(`.x-column-picker-list__button--${columns}-cols`);
     },
     clickDropdownNthItem(index: number) {
       cy.getByDataTest('dropdown-toggle').click();

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/plugin.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/plugin.ts
@@ -42,6 +42,7 @@ export default plugin.withOptions(
         }
       );
       helpers.addUtilities(deepMerge({}, utilities(helpers), options?.utilities?.(helpers)));
+      helpers.addVariant('selected', '&.selected');
 
       options?.extra?.(helpers);
     };

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/plugin.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/plugin.ts
@@ -42,9 +42,9 @@ export default plugin.withOptions(
         }
       );
       helpers.addUtilities(deepMerge({}, utilities(helpers), options?.utilities?.(helpers)));
-      helpers.addVariant('selected', '&.selected');
 
       options?.extra?.(helpers);
+      helpers.addVariant('selected', '&.selected');
     };
   },
   function (options) {


### PR DESCRIPTION
BREAKING CHANGE: `base-column-picker-list` structure changes. It now wraps the buttons in a div instead of using `ul` and `li`. Additionally, the class for the selected option has been changed to `x-selected`.

[EX-8144](https://searchbroker.atlassian.net/browse/EX-8144)

## Motivation and context
After adding the button group to the XDS adapting the column picker list component was a necessary step given that it's the X-Component that uses it.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
New test done for the new component slot and structure


[EX-8144]: https://searchbroker.atlassian.net/browse/EX-8144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ