### PR TITLE
ci: fix cypress cache path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: |
             ${{ steps.pnpm-store-directory.outputs.PATH }}
-            ~/.cache/Cypress
+            /root/.cache/Cypress
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,19 +24,20 @@ jobs:
         with:
           version: 7
 
-      - name: save pnpm store directory
-        id: pnpm-store-directory
+      - name: setup ENV variables
+        id: setup-env-vars
         shell: bash
         run: |
-          echo "PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "CYPRESS_CACHE_FOLDER=$CYPRESS_CACHE_FOLDER" >> $GITHUB_OUTPUT
+          echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: setup pnpm cache
         id: pnpm-cache
         uses: actions/cache@v3
         with:
           path: |
-            ${{ steps.pnpm-store-directory.outputs.PATH }}
-            /root/.cache/Cypress
+            ${{ steps.setup-env-vars.outputs.PNPM_STORE_PATH }}
+            ${{ steps.setup-env-vars.outputs.CYPRESS_CACHE_FOLDER }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-


### PR DESCRIPTION
EX-8149

This change solves one of the issues related to Cypress in the pipeline:

![image](https://user-images.githubusercontent.com/77450928/229082969-2f1fe7bc-054a-4a62-811d-0183c8d350e2.png)

In this case, the problem was caused by a wrong Cypress cache path passed to the `setup pnpm cache` step. 

- We were using the default Cypress cache path (`~/.cache/Cypress`) but it is being overridden by the environment variable `CYPRESS_CACHE_FOLDER` with value `/root/.cache/Cypress` in the docker image. 

> Check [https://github.com/search?q=repo:cypress-io/cypress-docker-images CYPRESS_CACHE_FOLDER&type=code](https://github.com/search?q=repo:cypress-io/cypress-docker-images%20CYPRESS_CACHE_FOLDER&type=code)

- When `pnpm` cache is restored, the `postinstall` of Cypress, which downloads the binary, is not executed and this causes the tests to fail if the binary is not either restored from the cache or downloaded.

- Before this change, the `setup pnpm cache` size was `~107 MB`, now it is `~267 MB`.



Regarding the other issue, I didn't find the cause yet, I suggest fixing it in an independent PR. 

![image](https://user-images.githubusercontent.com/77450928/229083691-9ac51603-add9-48ff-b228-e524573eecbd.png)




