### PR TITLE
fix(facets): implement the possibility to set a strategy for what filters are sent to the request. leaves-only strategy also implemented

### DIFF
--- a/packages/x-components/src/components/scroll/scroll.mixin.ts
+++ b/packages/x-components/src/components/scroll/scroll.mixin.ts
@@ -61,6 +61,7 @@ export default class ScrollMixin extends Vue {
       'SearchBoxQueryChanged',
       'SortChanged',
       'SelectedFiltersChanged',
+      'SelectedFiltersForRequestChanged',
       'SelectedRelatedTagsChanged',
       'UserChangedExtraParams'
     ]

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -14,6 +14,7 @@ const xModulesURLConfig = JSON.parse(new URL(location.href).searchParams.get('xM
 export const baseInstallXOptions: InstallXOptions = {
   adapter,
   xModules: {
-    ...xModulesURLConfig
+    ...xModulesURLConfig,
+    facets: {}
   }
 };

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -17,7 +17,7 @@ export const baseInstallXOptions: InstallXOptions = {
     ...xModulesURLConfig,
     facets: {
       config: {
-        filtersForRequestStrategy: 'leaves-only'
+        filtersStrategyForRequest: 'leaves-only'
       }
     }
   }

--- a/packages/x-components/src/views/base-config.ts
+++ b/packages/x-components/src/views/base-config.ts
@@ -15,6 +15,10 @@ export const baseInstallXOptions: InstallXOptions = {
   adapter,
   xModules: {
     ...xModulesURLConfig,
-    facets: {}
+    facets: {
+      config: {
+        filtersForRequestStrategy: 'leaves-only'
+      }
+    }
   }
 };

--- a/packages/x-components/src/x-modules/facets/events.types.ts
+++ b/packages/x-components/src/x-modules/facets/events.types.ts
@@ -37,6 +37,11 @@ export interface FacetsXEvents {
    */
   SelectedFiltersChanged: Filter[];
   /**
+   * The selected filters that conform to the filters for request strategy have changed.
+   * Payload: the new list of selected filters.
+   */
+  SelectedFiltersForRequestChanged: Filter[];
+  /**
    * A user action has changed the selected filters.
    * Payload: The new list of selected filters.
    */

--- a/packages/x-components/src/x-modules/facets/store/__tests__/getters.spec.ts
+++ b/packages/x-components/src/x-modules/facets/store/__tests__/getters.spec.ts
@@ -240,7 +240,7 @@ describe('testing facets module getters', () => {
 
       const store = createFacetsStore([parentFilter, childFilter, parentFilterWithoutChild], []);
       store.commit('setFacetsConfig', {
-        filtersForRequestStrategy: 'leaves-only'
+        filtersStrategyForRequest: 'leaves-only'
       });
 
       expect(store.getters.selectedFiltersForRequest).toEqual([

--- a/packages/x-components/src/x-modules/facets/store/emitters.ts
+++ b/packages/x-components/src/x-modules/facets/store/emitters.ts
@@ -16,6 +16,13 @@ export const facetsEmitters = createStoreEmitters(facetsXStoreModule, {
       priority: 12
     }
   },
+  SelectedFiltersForRequestChanged: {
+    selector: (_, getters) => getters.selectedFiltersForRequest,
+    filter: areFiltersDifferent,
+    metadata: {
+      priority: 12
+    }
+  },
   FacetsQueryChanged: {
     selector: state => state.query,
     filter: isNewQuery

--- a/packages/x-components/src/x-modules/facets/store/getters/facets.getter.ts
+++ b/packages/x-components/src/x-modules/facets/store/getters/facets.getter.ts
@@ -6,7 +6,7 @@ import { FacetsXStoreModule } from '../types';
 /**
  * Default implementation for the {@link FacetsGetters.facets} getter.
  *
- * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the facets
+ * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the facets'
  * module.
  * @returns An array containing the facets with the filters.
  *

--- a/packages/x-components/src/x-modules/facets/store/getters/selected-filters-by-facet.getter.ts
+++ b/packages/x-components/src/x-modules/facets/store/getters/selected-filters-by-facet.getter.ts
@@ -9,7 +9,7 @@ import { FacetsXStoreModule, FiltersByFacet } from '../types';
  * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the facets
  * module.
  * @param getters - Current {@link https://vuex.vuejs.org/guide/getters.html | getters} of the
- * facets module.
+ * facets' module.
  *
  * @returns A record containing the selected filters indexed by its facet id.
  * @remarks If there are filters without facet Id (RawFilter), they will be grouped under

--- a/packages/x-components/src/x-modules/facets/store/getters/selected-filters-for-request.getter.ts
+++ b/packages/x-components/src/x-modules/facets/store/getters/selected-filters-for-request.getter.ts
@@ -11,18 +11,21 @@ import { FacetsXStoreModule } from '../types';
  *
  * @public
  */
-export const selectedFiltersForRequest: FacetsXStoreModule['getters']['selectedFilters'] = state =>
-  Object.values(state.filters)
-    .filter(filter => filter.selected)
-    .filter((filter, _, filters) => {
-      if (
-        state.config.filtersForRequestStrategy === 'leaves-only' &&
-        isHierarchicalFilter(filter)
-      ) {
-        const childrenIds = filter.children?.map(child => child.id);
+export const selectedFiltersForRequest: FacetsXStoreModule['getters']['selectedFiltersForRequest'] =
+  state => {
+    const selectedFilters = Object.values(state.filters).filter(filter => filter.selected);
 
-        return !filters.some(newFilter => childrenIds?.includes(newFilter.id));
-      }
+    if (state.config.filtersForRequestStrategy === 'leaves-only') {
+      return selectedFilters.filter((filter, _, filters) => {
+        if (isHierarchicalFilter(filter)) {
+          const childrenIds = filter.children?.map(child => child.id);
 
-      return true;
-    });
+          return !filters.some(newFilter => childrenIds?.includes(newFilter.id));
+        }
+
+        return true;
+      });
+    }
+
+    return selectedFilters;
+  };

--- a/packages/x-components/src/x-modules/facets/store/getters/selected-filters-for-request.getter.ts
+++ b/packages/x-components/src/x-modules/facets/store/getters/selected-filters-for-request.getter.ts
@@ -1,0 +1,28 @@
+import { isHierarchicalFilter } from '@empathyco/x-types';
+import { FacetsXStoreModule } from '../types';
+
+/**
+ * Default implementation for the {@link FacetsGetters.selectedFiltersForRequest} getter.
+ *
+ * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the facets'
+ * module.
+ *
+ * @returns A list containing the selected filters that conform to the filters for request strategy.
+ *
+ * @public
+ */
+export const selectedFiltersForRequest: FacetsXStoreModule['getters']['selectedFilters'] = state =>
+  Object.values(state.filters)
+    .filter(filter => filter.selected)
+    .filter((filter, _, filters) => {
+      if (
+        state.config.filtersForRequestStrategy === 'leaves-only' &&
+        isHierarchicalFilter(filter)
+      ) {
+        const childrenIds = filter.children?.map(child => child.id);
+
+        return !filters.some(newFilter => childrenIds?.includes(newFilter.id));
+      }
+
+      return true;
+    });

--- a/packages/x-components/src/x-modules/facets/store/getters/selected-filters-for-request.getter.ts
+++ b/packages/x-components/src/x-modules/facets/store/getters/selected-filters-for-request.getter.ts
@@ -15,7 +15,7 @@ export const selectedFiltersForRequest: FacetsXStoreModule['getters']['selectedF
   state => {
     const selectedFilters = Object.values(state.filters).filter(filter => filter.selected);
 
-    if (state.config.filtersForRequestStrategy === 'leaves-only') {
+    if (state.config.filtersStrategyForRequest === 'leaves-only') {
       return selectedFilters.filter((filter, _, filters) => {
         if (isHierarchicalFilter(filter)) {
           const childrenIds = filter.children?.map(child => child.id);

--- a/packages/x-components/src/x-modules/facets/store/getters/selected-filters.getter.ts
+++ b/packages/x-components/src/x-modules/facets/store/getters/selected-filters.getter.ts
@@ -3,7 +3,7 @@ import { FacetsXStoreModule } from '../types';
 /**
  * Default implementation for the {@link FacetsGetters.selectedFilters} getter.
  *
- * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the facets
+ * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the facets'
  * module.
  *
  * @returns A list containing the selected filters.

--- a/packages/x-components/src/x-modules/facets/store/module.ts
+++ b/packages/x-components/src/x-modules/facets/store/module.ts
@@ -20,7 +20,7 @@ export const facetsXStoreModule: FacetsXStoreModule = {
     preselectedFilters: [],
     stickyFilters: {},
     config: {
-      filtersForRequestStrategy: 'all'
+      filtersStrategyForRequest: 'all'
     }
   }),
   getters: {

--- a/packages/x-components/src/x-modules/facets/store/module.ts
+++ b/packages/x-components/src/x-modules/facets/store/module.ts
@@ -19,7 +19,6 @@ export const facetsXStoreModule: FacetsXStoreModule = {
     facets: {},
     preselectedFilters: [],
     stickyFilters: {},
-    preselectedFilters: [],
     config: {
       filtersForRequestStrategy: 'all'
     }

--- a/packages/x-components/src/x-modules/facets/store/module.ts
+++ b/packages/x-components/src/x-modules/facets/store/module.ts
@@ -3,7 +3,8 @@ import Vue from 'vue';
 import { facets } from './getters/facets.getter';
 import { selectedFiltersByFacet } from './getters/selected-filters-by-facet.getter';
 import { selectedFilters } from './getters/selected-filters.getter';
-import { FacetGroupEntry, FacetsXStoreModule } from './types';
+import { FacetGroupEntry, FacetsConfig, FacetsXStoreModule } from './types';
+import { selectedFiltersForRequest } from './getters/selected-filters-for-request.getter';
 
 /**
  * {@link XStoreModule} For the facets module.
@@ -16,10 +17,14 @@ export const facetsXStoreModule: FacetsXStoreModule = {
     filters: {},
     groups: {},
     facets: {},
-    preselectedFilters: []
+    preselectedFilters: [],
+    config: {
+      filtersForRequestStrategy: 'all'
+    }
   }),
   getters: {
     selectedFilters,
+    selectedFiltersForRequest,
     selectedFiltersByFacet,
     facets
   },
@@ -48,6 +53,9 @@ export const facetsXStoreModule: FacetsXStoreModule = {
     },
     setFacet(state, facet: Facet) {
       Vue.set(state.facets, facet.id, facet);
+    },
+    setFacetsConfig(state, config: FacetsConfig) {
+      state.config = config;
     },
     setQuery(state, query) {
       state.query = query;

--- a/packages/x-components/src/x-modules/facets/store/types.ts
+++ b/packages/x-components/src/x-modules/facets/store/types.ts
@@ -215,7 +215,7 @@ export interface MutateFilterPayload {
  */
 export interface FacetsConfig {
   /** The filter strategy to use when providing the selected filters for requests. */
-  filtersForRequestStrategy: FiltersForRequestStrategy;
+  filtersStrategyForRequest: filtersStrategyForRequest;
 }
 
 /**
@@ -223,4 +223,4 @@ export interface FacetsConfig {
  *
  * @public
  */
-export type FiltersForRequestStrategy = 'all' | 'leaves-only';
+export type filtersStrategyForRequest = 'all' | 'leaves-only';

--- a/packages/x-components/src/x-modules/facets/store/types.ts
+++ b/packages/x-components/src/x-modules/facets/store/types.ts
@@ -7,6 +7,8 @@ import { XActionContext, XStoreModule } from '../../../store';
  * @public
  */
 export interface FacetsState {
+  /** The current facets config {@link FacetsState.config}. */
+  config: FacetsConfig;
   /** The current query {@link FacetsState.query}. */
   query: string;
   /** Record of all available filters indexed by its id. */
@@ -29,6 +31,10 @@ export interface FacetsGetters {
    * List of all selected filters.
    */
   selectedFilters: Filter[];
+  /**
+   * List of all selected filters that conform to the filters for request strategy.
+   */
+  selectedFiltersForRequest: Filter[];
   /**
    * List of all selected filters grouped by their facet.
    */
@@ -101,6 +107,12 @@ export interface FacetsMutations {
    * @param facet - The facet to set in the store.
    */
   setFacet(facet: Facet): void;
+  /**
+   * Sets the {@link FacetsState.facets | facets} config.
+   *
+   * @param config - The new config.
+   */
+  setFacetsConfig(config: FacetsConfig): void;
 }
 
 /**
@@ -176,3 +188,20 @@ export interface MutateFilterPayload {
    */
   newFilterState: Partial<Filter>;
 }
+
+/**
+ * Configuration options for the {@link FacetsXModule}.
+ *
+ * @public
+ */
+export interface FacetsConfig {
+  /** The filter strategy to use when providing the selected filters for requests. */
+  filtersForRequestStrategy: FiltersForRequestStrategy;
+}
+
+/**
+ * Type for the filter strategy to use when providing the selected filters.
+ *
+ * @public
+ */
+export type FiltersForRequestStrategy = 'all' | 'leaves-only';

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -113,7 +113,7 @@ export interface SearchMutations extends StatusMutations, QueryMutations {
    */
   setFacets(facets: Facet[]): void;
   /**
-   * Set the the `isAppendResuls` flag value.
+   * Set the `isAppendResuls` flag value.
    *
    * @param isAppendResults - The new flag value.
    */

--- a/packages/x-components/src/x-modules/search/wiring.ts
+++ b/packages/x-components/src/x-modules/search/wiring.ts
@@ -208,7 +208,7 @@ export const searchWiring = createWiring({
   SelectedRelatedTagsChanged: {
     setRelatedTags
   },
-  SelectedFiltersChanged: {
+  SelectedFiltersForRequestChanged: {
     setSelectedFilters
   },
   ResultsChanged: {

--- a/packages/x-components/src/x-modules/url/wiring.ts
+++ b/packages/x-components/src/x-modules/url/wiring.ts
@@ -82,7 +82,7 @@ export const urlWiring = createWiring({
   SelectedRelatedTagsChanged: {
     setUrlRelatedTags
   },
-  SelectedFiltersChanged: {
+  SelectedFiltersForRequestChanged: {
     setUrlFilters
   },
   PageChanged: {


### PR DESCRIPTION
EX-7550

## Motivation and context
Sometimes the backend doesn't handle the hierarchical filters sent as expected and only filters by the parent. This PR implements the posibility of applying a strategy to filter the filters that are sent to the requests or that are stored in the URL 

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
The strategy is set to `leaves-only`, which means that only filters without selected children are sent to the request or stored in the URL. Check the request or the url while selecting filters and change the strategy to `all` in the `base-config.ts`.
