### PR TITLE
docs(integration): add information about sessionId duration

### DIFF
--- a/packages/x-components/static-docs/build-search-ui/web-archetype-integration-guide.md
+++ b/packages/x-components/static-docs/build-search-ui/web-archetype-integration-guide.md
@@ -251,6 +251,10 @@ If page reload is not triggered after accepting cookies, update the `consent` pa
 Although cookie acceptance is bound to the generation of the `sessionID` in local storage, Empathy
 does **not use any cookies** in its libraries.
 
+<br/>
+
+The `sessionId` lasts until there are 30 minutes of inactivity. However, every time the shopper interacts with the commerce search (e.g. queries, clicks, etc.), the session expiration time is reset by adding 30 minutes from the time of that interaction. After 30 minutes of shopper inactivity, a new `sessionId` is generated.
+
 :::
 
 ### Callbacks and Interface X events types

--- a/packages/x-components/static-docs/build-search-ui/web-archetype-integration-guide.md
+++ b/packages/x-components/static-docs/build-search-ui/web-archetype-integration-guide.md
@@ -248,12 +248,15 @@ If page reload is not triggered after accepting cookies, update the `consent` pa
 
  </br>
 
-Although cookie acceptance is bound to the generation of the `sessionID` in local storage, Empathy
+Although cookie acceptance is bound to the generation of the `sessionId` in local storage, Empathy
 does **not use any cookies** in its libraries.
 
 <br/>
 
-The `sessionId` lasts until there are 30 minutes of inactivity. However, every time the shopper interacts with the commerce search (e.g. queries, clicks, etc.), the session expiration time is reset by adding 30 minutes from the time of that interaction. After 30 minutes of shopper inactivity, a new `sessionId` is generated.
+The `sessionId` lasts until there are 30 minutes of inactivity. However, every time the shopper
+interacts with the commerce search (e.g. queries, clicks, etc.), the session expiration time is
+reset by adding 30 minutes from the time of that interaction. After 30 minutes of shopper
+inactivity, a new `sessionId` is generated.
 
 :::
 


### PR DESCRIPTION
SessionId duration information

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Inform the integration developers and customers about sessionId duration and way of working.

## Motivation and context
Questions from Customer Success department

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [x] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
