### PR TITLE
fix: fix prettierignore to ignore CHANGELOG files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
-./**/CHANGELOG.md
+**/CHANGELOG.md
 ./**/pnpm-lock.yaml


### PR DESCRIPTION
Update prettierignore
# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Change the prettierignore to ignore CHANGELOG files which is causing some undesired formatting on CHANGELOG, and also possibly the inclusion of many changelog headers

## Motivation and context
Avoid prettier to modify CHANGELOG files

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: EMP-270

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

Manually changing the `x-bus` `CHANGELOG` file in the project with a long line and launching this command `prettier -c packages/x-bus` it shows the file in the list.

After the change, the file is not shown.

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
