### PR TITLE
fix: cross-fade animation doesn't need min width to work properly

### DIFF
--- a/packages/x-components/src/components/animations/cross-fade.vue
+++ b/packages/x-components/src/components/animations/cross-fade.vue
@@ -38,8 +38,8 @@
       mix-blend-mode: multiply;
     }
 
-    &--leave-active {
-      position: absolute;
+    &--enter-active {
+      transform: translateY(-100%);
     }
 
     &--leave-to,

--- a/packages/x-components/src/components/animations/cross-fade.vue
+++ b/packages/x-components/src/components/animations/cross-fade.vue
@@ -38,8 +38,8 @@
       mix-blend-mode: multiply;
     }
 
-    &--enter-active {
-      transform: translateY(-100%);
+    &--leave-active {
+      position: absolute;
     }
 
     &--leave-to,

--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -152,6 +152,11 @@
         visibility: 'hidden !important'
       };
 
+      /**
+       * Reactive reference to the result images.
+       *
+       * @internal
+       */
       const resultImages = toRef(props.result, 'images');
 
       /**
@@ -192,7 +197,7 @@
        */
       const imageSrc = computed<string>(() => {
         return loadedImages.value[
-          !props.showNextImageOnHover || !isHovering ? 0 : loadedImages.value.length - 1
+          !props.showNextImageOnHover || !isHovering.value ? 0 : loadedImages.value.length - 1
         ];
       });
 


### PR DESCRIPTION
EMP-684

## Motivation and context
When the functionality to swap between result images on hover was active and the `CrossFade` animation was used, there was an issue with the hovered NQ shrinking and then expanding. The issue was caused by the `CrossFade` animation making the leaving image `absolute` so the element lost the width until the new image loaded. Also added a fix for the hovering functionality after migrating the `BaseResultImage` to vue 3 OptionsAPI.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Make sure you have cache disabled. Set the `BaseResultImage` prop `showNextImageOnHover` to `true`, remove the `x-picture-zoom` class and then navigate to a NQ and hover it. The animation should shrink the image.
