### PR TITLE
feat: layout for custom alignment

### DIFF
--- a/packages/x-tailwindcss/demo/src/components/xds-layout.vue
+++ b/packages/x-tailwindcss/demo/src/components/xds-layout.vue
@@ -16,6 +16,12 @@
             There are as many classes as spacing variables declared in the Tailwind theme:
             <code>x-layout-min-margin-[spacing-value]</code>
           </div>
+          <div
+            v-if="cssClass.includes('x-layout-container-mx-128')"
+            class="x-text-md x-mb-16 x-px-16"
+          >
+            Custom alignment is available with Tailwind spacing classes or arbitrary values:
+          </div>
           <code class="x-py-8 x-px-16">{{ cssClass }}</code>
           <div
             @click="copyCssClassesToClipboard"
@@ -62,10 +68,21 @@
     })
     public minMargin!: string[];
 
+    @Prop({
+      default: () => [
+        'x-layout-container-mx-128',
+        'x-layout-container-mr-128',
+        'x-layout-container-ml-128',
+        'x-layout-container-ml-[375px]'
+      ]
+    })
+    public customAlign!: string[];
+
     public modalContent = {
       Layout: [this.base],
       'Max Width': this.maxWidth.map(addParentClasses(this.base)),
-      'Min Width': this.minMargin.map(addParentClasses(this.base))
+      'Min Width': this.minMargin.map(addParentClasses(this.base)),
+      'Custom Alignment': this.customAlign.map(addParentClasses(this.base))
     };
 
     protected get sections(): ShowcaseSections {

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/dynamic-components.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/dynamic-components.ts
@@ -1,4 +1,5 @@
 import { TailwindHelpers } from '../types';
+import { dynamicLayout } from './dynamic-components/layout';
 
 /**
  * Default dynamic component styles.
@@ -8,11 +9,10 @@ import { TailwindHelpers } from '../types';
  *
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default function dynamicComponents(helpers: TailwindHelpers) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { theme } = helpers;
-  return {};
+  return {
+    ...dynamicLayout(helpers)
+  };
 }
 
 /**

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/dynamic-components/layout/index.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/dynamic-components/layout/index.ts
@@ -1,0 +1,14 @@
+import { TailwindHelpers } from '../../../types';
+import { dynamicLayoutContainer } from './layout-container';
+
+/**
+ * Returns the dynamic features of the `layout` CSS.
+ *
+ * @param helpers - The {@link TailwindHelpers} to generate CSS.
+ * @returns The {@link CssStyleOptions} for the component.
+ */
+export function dynamicLayout(helpers: TailwindHelpers) {
+  return {
+    ...dynamicLayoutContainer(helpers)
+  };
+}

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/dynamic-components/layout/layout-container.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/dynamic-components/layout/layout-container.ts
@@ -1,0 +1,48 @@
+import { map, rename } from '@empathyco/x-utils';
+import { TailwindHelpers } from '../../../types';
+
+/**
+ * Returns the `layout-container` dynamic features of component `layout`.
+ *
+ * @param helpers - The {@link TailwindHelpers} to generate CSS.
+ * @returns The {@link CssStyleOptions} for the component.
+ */
+export function dynamicLayoutContainer(helpers: TailwindHelpers) {
+  const { theme } = helpers;
+
+  return {
+    ...map(
+      {
+        ...rename(
+          {
+            mx: (value: any) => ({
+              '& > .layout-item': {
+                '--x-margin-left': value,
+                '--x-margin-right': value
+              }
+            }),
+            ml: (value: any) => ({
+              '& > .layout-item': {
+                '--x-margin-left': value
+              }
+            }),
+            mr: (value: any) => ({
+              '& > .layout-item': {
+                '--x-margin-right': value
+              }
+            })
+          },
+          { prefix: 'layout-container-' }
+        )
+      },
+      (name, styles) => {
+        return {
+          styles,
+          values: {
+            ...theme('spacing')
+          }
+        };
+      }
+    )
+  };
+}


### PR DESCRIPTION
[EMP-564](https://searchbroker.atlassian.net/browse/EMP-563)

## Motivation and context
We needed a way to place the empathize aligned to the search box even if they were in different contexts. This new layout allows custom alignment of any element.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
New showcase of the layout created


[EMP-564]: https://searchbroker.atlassian.net/browse/EMP-564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ