### PR TITLE
fix: blur related tag when deselected

### DIFF
--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -85,6 +85,10 @@
         this.createEventMetadata()
       );
       this.$x.emit('UserPickedARelatedTag', this.relatedTag, this.createEventMetadata());
+
+      if (this.isSelected) {
+        (this.$el as HTMLElement).blur();
+      }
     }
 
     /**

--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    @click="emitEvents"
+    @click="clickRelatedTag"
     class="x-tag x-related-tag"
     data-test="related-tag"
     :class="dynamicClasses"
@@ -59,6 +59,27 @@
     public selectedRelatedTags!: RelatedTagModel[];
 
     /**
+     * Blurs the related tag if it is selected.
+     *
+     * @public
+     */
+    protected blurRelatedTag(): void {
+      if (this.isSelected) {
+        (this.$el as HTMLElement).blur();
+      }
+    }
+
+    /**
+     * Handles the click on the button.
+     *
+     * @public
+     */
+    protected clickRelatedTag(): void {
+      this.emitEvents();
+      this.blurRelatedTag();
+    }
+
+    /**
      * Generates the {@link WireMetadata | event metadata} object omitting the moduleName.
      *
      * @returns The {@link WireMetadata} object omitting the moduleName.
@@ -85,10 +106,6 @@
         this.createEventMetadata()
       );
       this.$x.emit('UserPickedARelatedTag', this.relatedTag, this.createEventMetadata());
-
-      if (this.isSelected) {
-        (this.$el as HTMLElement).blur();
-      }
     }
 
     /**


### PR DESCRIPTION
## Motivation and context
Active element wasn't being removed after deselecting a related tag, causing it to seem hovered.
This bug came out during Conforama setup thanks to the high contrast between colours used.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
