### PR TITLE
fix: include tokens in deprecated theme css file

### DIFF
--- a/packages/x-components/build/rollup.config.ts
+++ b/packages/x-components/build/rollup.config.ts
@@ -146,9 +146,7 @@ const commonCssOptions = createRollupOptions({
  */
 export const cssDeprecatedComponentsRollupConfig = createRollupOptions({
   ...commonCssOptions,
-  input: glob('src/design-system-deprecated/**/*.scss', {
-    ignore: 'src/design-system-deprecated/**/*.tokens.scss'
-  }),
+  input: glob('src/design-system-deprecated/**/*.scss'),
   plugins: [
     importTokens(),
     styles({ mode: ['extract', 'deprecated-full-theme.css'] }),


### PR DESCRIPTION
The `deprecated-full-theme.css` file we are currently exporting doesn't include the old design system tokens so it will not work out of the box. This PR makes the rollup build to include the tokens into the file.