### PR TITLE
fix(queries-preview): make the QueryPreviewRequestUpdated not replaceable

### DIFF
--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -185,7 +185,7 @@
      */
     protected get emitQueryPreviewRequestUpdated(): DebouncedFunction<[SearchRequest]> {
       return debounce(request => {
-        this.$x.emit('QueryPreviewRequestUpdated', request, { priority: 0 });
+        this.$x.emit('QueryPreviewRequestUpdated', request, { priority: 0, replaceable: false });
       }, this.debounceTimeMs);
     }
 


### PR DESCRIPTION
EMP-717

<!--Please provide a general summary of changes in the PR title -->

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

There was a bug in the `QueryPreview` component where, if used multiple times, only the last query would load.
This doesn't happen if the `QueryPreviewList` component is used.
The bug was caused by the bus canceling the consecutive events and only accepting the last one.
To fix it, I have made the event `QueryPreviewRequestUpdated` emitted by the component not replaceable.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
