### PR TITLE
fix: watch `props.result.images` directly

### DIFF
--- a/packages/x-components/src/components/result/base-result-image.vue
+++ b/packages/x-components/src/components/result/base-result-image.vue
@@ -41,16 +41,7 @@
 
 <script lang="ts">
   import { Result } from '@empathyco/x-types';
-  import {
-    computed,
-    DefineComponent,
-    defineComponent,
-    PropType,
-    Ref,
-    ref,
-    toRef,
-    watch
-  } from 'vue';
+  import { computed, DefineComponent, defineComponent, PropType, Ref, ref, watch } from 'vue';
   import { NoElement } from '../no-element';
   import { animationProp } from '../../utils/options-api';
 
@@ -153,19 +144,12 @@
       };
 
       /**
-       * Reactive reference to the result images.
-       *
-       * @internal
-       */
-      const resultImages = toRef(props.result, 'images');
-
-      /**
        * Initializes images state and resets when the result's images change.
        *
        * @internal
        */
       watch(
-        resultImages,
+        () => props.result.images,
         () => {
           pendingImages.value = [...(props.result.images ?? [])];
           loadedImages.value = pendingImages.value.filter(image =>


### PR DESCRIPTION
This PR addresses an issue encountered after updating the `BaseResultImage` component to the new syntax.  The recent changes caused a problem where the watch function failed to trigger when the images property of the result changed.