### PR TITLE
feat: set configuration for base-result-link to ignore tagging of click

### DIFF
--- a/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
@@ -117,17 +117,25 @@ describe('testing BaseResultLink component', () => {
     expect(resultClickListener).toHaveBeenCalledTimes(1);
     expect(resultClickListener).toHaveBeenCalledWith({
       eventPayload: result,
-      metadata:
-        expect.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedAResult) &&
-        expect.not.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedResultAddToCart)
+      metadata: expect.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedAResult)
+    });
+    expect(resultClickListener).toHaveBeenCalledWith({
+      eventPayload: result,
+      metadata: expect.not.objectContaining(
+        injectedResultLinkMetadataPerEvent.UserClickedResultAddToCart
+      )
     });
 
     expect(addToCartClickListener).toHaveBeenCalledTimes(1);
     expect(addToCartClickListener).toHaveBeenCalledWith({
       eventPayload: result,
-      metadata:
-        expect.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedResultAddToCart) &&
-        expect.not.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedAResult)
+      metadata: expect.objectContaining(
+        injectedResultLinkMetadataPerEvent.UserClickedResultAddToCart
+      )
+    });
+    expect(addToCartClickListener).toHaveBeenCalledWith({
+      eventPayload: result,
+      metadata: expect.not.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedAResult)
     });
   });
 

--- a/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
@@ -114,15 +114,20 @@ describe('testing BaseResultLink component', () => {
       .subscribe(addToCartClickListener);
     resultLinkWrapper.trigger('click');
 
+    expect(resultClickListener).toHaveBeenCalledTimes(1);
     expect(resultClickListener).toHaveBeenCalledWith({
       eventPayload: result,
-      metadata: expect.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedAResult)
+      metadata:
+        expect.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedAResult) &&
+        expect.not.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedResultAddToCart)
     });
+
+    expect(addToCartClickListener).toHaveBeenCalledTimes(1);
     expect(addToCartClickListener).toHaveBeenCalledWith({
       eventPayload: result,
-      metadata: expect.objectContaining(
-        injectedResultLinkMetadataPerEvent.UserClickedResultAddToCart
-      )
+      metadata:
+        expect.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedResultAddToCart) &&
+        expect.not.objectContaining(injectedResultLinkMetadataPerEvent.UserClickedAResult)
     });
   });
 

--- a/packages/x-components/src/components/result/base-result-link.vue
+++ b/packages/x-components/src/components/result/base-result-link.vue
@@ -71,6 +71,7 @@
        * have extra events so this record pairs each event to its metadata.
        */
       const resultLinkMetadataPerEvent = inject<
+        // TODO: Refactor this inject key to the constants when doing EMP-909
         Partial<
           Record<
             PropsWithType<XEventsTypes, Result>,

--- a/packages/x-components/src/components/result/base-result-link.vue
+++ b/packages/x-components/src/components/result/base-result-link.vue
@@ -22,6 +22,7 @@
   import { PropsWithType } from '../../utils/types';
   import { XEventsTypes } from '../../wiring/events.types';
   import { use$x } from '../../composables/index';
+  import { WireMetadata } from '../../wiring';
 
   /**
    * Component to be reused that renders an `<a>` wrapping the result contents.
@@ -66,15 +67,31 @@
       );
 
       /**
+       * The metadata to be injected in the events emitted by the component. This component can emit
+       * have extra events so this record pairs each event to its metadata.
+       */
+      const resultLinkMetadataPerEvent = inject<
+        Partial<
+          Record<
+            PropsWithType<XEventsTypes, Result>,
+            Omit<WireMetadata, 'moduleName' | 'origin' | 'location'>
+          >
+        >
+      >('resultLinkMetadataPerEvent', {});
+
+      /**
        * Emits the {@link XEventsTypes.UserClickedAResult} when user clicks on the result, and also
        * additional events if have been injected in the component.
        *
        * @internal
        */
       const emitUserClickedAResult = (): void => {
-        $x.emit('UserClickedAResult', props.result, { target: el.value! });
+        $x.emit('UserClickedAResult', props.result, {
+          target: el.value!,
+          ...resultLinkMetadataPerEvent['UserClickedAResult']
+        });
         resultClickExtraEvents.forEach(event => {
-          $x.emit(event, props.result, { target: el.value! });
+          $x.emit(event, props.result, { target: el.value!, ...resultLinkMetadataPerEvent[event] });
         });
       };
 

--- a/packages/x-components/src/wiring/wiring.types.ts
+++ b/packages/x-components/src/wiring/wiring.types.ts
@@ -53,6 +53,10 @@ export interface WireMetadata {
    * based on its priority.
    */
   replaceable?: boolean;
+  /**
+   * The event can be ignored if it is received in the wiring of the modules in the array.
+   */
+  ignoreInModules?: XModuleName[];
 }
 
 /**

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -161,7 +161,8 @@ export function createTrackWire(property: keyof Tagging): Wire<Taggable> {
       taggingInfo.params.location = location as string;
       return taggingInfo;
     }),
-    ({ eventPayload: { tagging } }) => !!tagging?.[property]
+    ({ eventPayload: { tagging }, metadata: { ignoreInModules } }) =>
+      !!tagging?.[property] && !ignoreInModules?.includes(moduleName)
   );
 }
 


### PR DESCRIPTION
[EMP-864](https://searchbroker.atlassian.net/browse/EMP-864)

## Motivation and context
With the future inclusion of the `displayClick` event we needed a way of ignoring the click event of the base-result-link in the tagging if we decided so. This PR adds a property to the wiring metadata to do that and check it in the module's wiring.

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

New tests have been done for the new features of `BaseResultLink`.


[EMP-864]: https://searchbroker.atlassian.net/browse/EMP-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ