### PR TITLE
feat(tagging): track displayClick

### DIFF
--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -147,6 +147,13 @@ export const trackBannerClickedWire = createTrackWire('click');
 export const trackAddToCartWire = createTrackWire('add2cart');
 
 /**
+ * Performs a track of a display result being clicked.
+ *
+ * @public
+ */
+export const trackDisplayClickedWire = createTrackWire('displayClick');
+
+/**
  * Factory helper to create a wire for the track of a taggable element.
  *
  * @param property - Key of the tagging object to track.
@@ -206,5 +213,8 @@ export const taggingWiring = createWiring({
   },
   UserClickedABanner: {
     trackBannerClickedWire
+  },
+  UserClickedADisplayResult: {
+    trackDisplayClickedWire
   }
 });


### PR DESCRIPTION
[EMP-929](https://searchbroker.atlassian.net/browse/EMP-929)

## Motivation and context
We need to track the new type of click in the tagging.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Inject a new event to trigger when the `base-result-link` is clicked that emits a `UserClickedADisplayResult` and see that the tagging tracks it.

[EMP-929]: https://searchbroker.atlassian.net/browse/EMP-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ