### PR TITLE
feat: make `XAPI` init method async

### DIFF
--- a/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
+++ b/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
@@ -11,10 +11,32 @@ describe('testing default X API', () => {
   defaultXAPI.setBus(bus);
   const query = 'maserati';
 
+  it('should allow asynchronous initialization', async () => {
+    const listener = jest.fn();
+    const someOtherBus = new XDummyBus();
+    defaultXAPI.setInitCallback(() => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          defaultXAPI.setBus(someOtherBus);
+          resolve(true);
+        });
+      });
+    });
+
+    someOtherBus.on('UserClickedOpenX').subscribe(listener);
+    await defaultXAPI.init({
+      instance: 'test',
+      scope: 'test',
+      lang: 'es'
+    });
+    defaultXAPI.search();
+
+    expect(listener).toHaveBeenCalled();
+  });
+
   it('should emit `UserAcceptedAQuery` through the `search` function', () => {
     const listener = jest.fn();
     bus.on('UserAcceptedAQuery').subscribe(listener);
-
     defaultXAPI.search(query);
 
     expect(listener).toHaveBeenCalledWith(query);

--- a/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
+++ b/packages/x-components/src/x-installer/api/__tests__/default-api.spec.ts
@@ -13,23 +13,24 @@ describe('testing default X API', () => {
 
   it('should allow asynchronous initialization', async () => {
     const listener = jest.fn();
+    const someXAPI = new BaseXAPI();
     const someOtherBus = new XDummyBus();
-    defaultXAPI.setInitCallback(() => {
+    someXAPI.setInitCallback(() => {
       return new Promise(resolve => {
         setTimeout(() => {
-          defaultXAPI.setBus(someOtherBus);
+          someXAPI.setBus(someOtherBus);
           resolve(true);
         });
       });
     });
 
     someOtherBus.on('UserClickedOpenX').subscribe(listener);
-    await defaultXAPI.init({
+    await someXAPI.init({
       instance: 'test',
       scope: 'test',
       lang: 'es'
     });
-    defaultXAPI.search();
+    someXAPI.search();
 
     expect(listener).toHaveBeenCalled();
   });

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -72,7 +72,7 @@ export interface XAPI {
    *
    * @public
    */
-  init(config: SnippetConfig): Promise<void>;
+  init(config: SnippetConfig): Promise<any>;
 }
 
 /**

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -36,7 +36,7 @@ export interface XAPI {
    *
    * @internal
    */
-  setInitCallback(initCallback: (config: SnippetConfig) => void): void;
+  setInitCallback(initCallback: (config: SnippetConfig) => Promise<any>): void;
 
   /**
    * To set or update any property of the {@link SnippetConfig}.
@@ -72,7 +72,7 @@ export interface XAPI {
    *
    * @public
    */
-  init(config: SnippetConfig): void;
+  init(config: SnippetConfig): Promise<void>;
 }
 
 /**

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -36,7 +36,7 @@ export interface XAPI {
    *
    * @internal
    */
-  setInitCallback(initCallback: (config: SnippetConfig) => Promise<any>): void;
+  setInitCallback(initCallback: (config: SnippetConfig) => void): void;
 
   /**
    * To set or update any property of the {@link SnippetConfig}.
@@ -72,7 +72,7 @@ export interface XAPI {
    *
    * @public
    */
-  init(config: SnippetConfig): Promise<any>;
+  init(config: SnippetConfig): void;
 }
 
 /**

--- a/packages/x-components/src/x-installer/api/api.types.ts
+++ b/packages/x-components/src/x-installer/api/api.types.ts
@@ -72,7 +72,7 @@ export interface XAPI {
    *
    * @public
    */
-  init(config: SnippetConfig): void;
+  init(config: SnippetConfig): Promise<void>;
 }
 
 /**

--- a/packages/x-components/src/x-installer/api/base-api.ts
+++ b/packages/x-components/src/x-installer/api/base-api.ts
@@ -28,7 +28,7 @@ export class BaseXAPI implements XAPI {
    *
    * @internal
    */
-  protected initCallback!: (config: SnippetConfig) => any;
+  protected initCallback!: (config: SnippetConfig) => Promise<any>;
 
   /**
    * Callback that allows to update the snippet config. The logic of initialization is out of this
@@ -63,7 +63,7 @@ export class BaseXAPI implements XAPI {
    *
    * @param initCallback - The callback to call.
    */
-  setInitCallback(initCallback: (config: SnippetConfig) => any): void {
+  setInitCallback(initCallback: (config: SnippetConfig) => Promise<any>): void {
     this.initCallback = initCallback;
   }
 
@@ -108,15 +108,18 @@ export class BaseXAPI implements XAPI {
    *
    * @param config - The config coming from the customer snippet.
    *
+   * @returns A promise that will be resolved once x components are initialized.
+   *
    * @public
    */
-  init(config: SnippetConfig): void {
+  init(config: SnippetConfig): Promise<void> {
     if (!this.isXInitialized) {
       this.isXInitialized = true;
-      this?.initCallback(config);
+      return this?.initCallback(config);
     } else {
       //eslint-disable-next-line no-console
       console.warn('We know X is awesome, but you only need to initialize it once.');
+      return Promise.resolve();
     }
   }
 

--- a/packages/x-components/src/x-installer/api/base-api.ts
+++ b/packages/x-components/src/x-installer/api/base-api.ts
@@ -112,7 +112,7 @@ export class BaseXAPI implements XAPI {
    *
    * @public
    */
-  init(config: SnippetConfig): Promise<void> {
+  init(config: SnippetConfig): Promise<any> {
     if (!this.isXInitialized) {
       this.isXInitialized = true;
       return this?.initCallback(config);

--- a/packages/x-components/src/x-installer/api/base-api.ts
+++ b/packages/x-components/src/x-installer/api/base-api.ts
@@ -28,7 +28,7 @@ export class BaseXAPI implements XAPI {
    *
    * @internal
    */
-  protected initCallback!: (config: SnippetConfig) => Promise<any>;
+  protected initCallback!: (config: SnippetConfig) => any;
 
   /**
    * Callback that allows to update the snippet config. The logic of initialization is out of this
@@ -63,7 +63,7 @@ export class BaseXAPI implements XAPI {
    *
    * @param initCallback - The callback to call.
    */
-  setInitCallback(initCallback: (config: SnippetConfig) => Promise<any>): void {
+  setInitCallback(initCallback: (config: SnippetConfig) => any): void {
     this.initCallback = initCallback;
   }
 
@@ -112,14 +112,13 @@ export class BaseXAPI implements XAPI {
    *
    * @public
    */
-  init(config: SnippetConfig): Promise<any> {
+  async init(config: SnippetConfig): Promise<void> {
     if (!this.isXInitialized) {
       this.isXInitialized = true;
-      return this?.initCallback(config);
+      await this?.initCallback(config);
     } else {
       //eslint-disable-next-line no-console
       console.warn('We know X is awesome, but you only need to initialize it once.');
-      return Promise.resolve();
     }
   }
 


### PR DESCRIPTION
EMP-273

You can take a look at how it works on this [archetype branch](https://github.com/empathyco/x-archetype/tree/test/open-search-on-init) (just for testing purposes)