### PR TITLE
feat(tagging): add fallback for displayId

### DIFF
--- a/packages/x-adapter-platform/src/mappers/__tests__/url.spec.ts
+++ b/packages/x-adapter-platform/src/mappers/__tests__/url.spec.ts
@@ -63,5 +63,18 @@ describe('url utils methods tests', () => {
         follow: false
       });
     });
+
+    it('should set no_query tagging info when no q param exist as in topclicked response', () => {
+      const { url, params } = getDisplayClickTagging(
+        'https://api.empathy.co/?env=mobile&lang=english&lang=spanish'
+      );
+      expect(url).toBe('https://api.empathy.co/');
+      expect(params).toStrictEqual({
+        displayId: 'no_query',
+        env: 'mobile',
+        lang: ['english', 'spanish'],
+        follow: false
+      });
+    });
   });
 });

--- a/packages/x-adapter-platform/src/mappers/url.utils.ts
+++ b/packages/x-adapter-platform/src/mappers/url.utils.ts
@@ -32,7 +32,7 @@ export function getDisplayClickTagging(displayTaggingUrl: string): TaggingReques
   const displayClickTagging = getTaggingInfoFromUrl(displayTaggingUrl);
   const displayClickTaggingParams = displayClickTagging.params;
 
-  displayClickTaggingParams.displayId = displayClickTaggingParams.q;
+  displayClickTaggingParams.displayId = displayClickTaggingParams.q ?? 'no_query';
   delete displayClickTaggingParams.q;
 
   return displayClickTagging;


### PR DESCRIPTION
EMP-1105

<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Added 'no_query" as default value when we don't have a q parameter to fill the displayId

## Motivation and context
When calling to a TopClicked endpoint, the response has no query parameter in the click or displayClick properties inside the tagging object. 

As we use that param to set the value of the displayId, w need a fallback for endpoints that don’t have that param, as topclicked, as displayId is mandatory as you can see.

https://api.staging.empathy.co/tagging/v1/track/empathy/displayClick?lang=en&title=skirt&productId=112233&position=1&page=1&url=https%3A%2F%2Fcdn-images.farfetch-contents.com%2F13%2F59%2F38%2F77%2F13593877_16243944_300.jpg&follow=false&origin=default&filtered=false&spellcheck=false&location=predictive_layer&displayFamily=recommendations%3Apredictive_layer&session=zh6JHQA4Z0bGrRBrarRJt

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: EMP-1105

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
