### PR TITLE
fix(search): ignore page from url when going to a different query

### DIFF
--- a/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/search/store/__tests__/actions.spec.ts
@@ -613,8 +613,8 @@ describe('testing search module actions', () => {
   });
 
   describe('setUrlParams', () => {
-    it('should set the params of the search module', async () => {
-      resetSearchStateWith(store, { query: 'funko', page: 1, sort: '' });
+    it('should set the params of the search module when the query is the same', async () => {
+      resetSearchStateWith(store, { query: 'lego', page: 1, sort: '' });
 
       await store.dispatch('setUrlParams', {
         query: 'lego',
@@ -627,22 +627,37 @@ describe('testing search module actions', () => {
       expect(store.state.sort).toEqual('priceSort asc');
     });
 
+    // eslint-disable-next-line max-len
+    it('should set the params of the search module, except page, when the query is different', async () => {
+      resetSearchStateWith(store, { query: 'funko', page: 1, sort: '' });
+
+      await store.dispatch('setUrlParams', {
+        query: 'lego',
+        page: 2,
+        sort: 'priceSort asc'
+      } as UrlParams);
+
+      expect(store.state.query).toEqual('lego');
+      expect(store.state.page).toEqual(1);
+      expect(store.state.sort).toEqual('priceSort asc');
+    });
+
     it('should set in the search module the query value even if empty', async () => {
       resetSearchStateWith(store, { query: 'funko' });
 
-      await store.dispatch('setUrlParams', { page: 2, query: '' } as UrlParams);
+      await store.dispatch('setUrlParams', { sort: 'priceSort asc', query: '' } as UrlParams);
 
       expect(store.state.query).toEqual('');
-      expect(store.state.page).toEqual(2);
+      expect(store.state.sort).toEqual('priceSort asc');
     });
 
     it('should set in the search module the sort value even if empty', async () => {
       resetSearchStateWith(store, { sort: 'priceSort asc' });
 
-      await store.dispatch('setUrlParams', { page: 2, sort: '' } as UrlParams);
+      await store.dispatch('setUrlParams', { page: 1, sort: '' } as UrlParams);
 
       expect(store.state.sort).toEqual('');
-      expect(store.state.page).toEqual(2);
+      expect(store.state.page).toEqual(1);
     });
   });
 

--- a/packages/x-components/src/x-modules/search/store/actions/set-url-params.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/set-url-params.action.ts
@@ -11,10 +11,12 @@ import { SearchXStoreModule } from '../types';
  * @public
  */
 export const setUrlParams: SearchXStoreModule['actions']['setUrlParams'] = (
-  { commit },
+  { commit, state },
   { query, page, sort }
 ) => {
+  const currentQuery = state.query;
+
   commit('setQuery', query);
-  commit('setPage', page);
+  commit('setPage', currentQuery === query ? page : 1);
   commit('setSort', sort);
 };


### PR DESCRIPTION
[EMP-1194](https://searchbroker.atlassian.net/browse/EMP-1195)

## Motivation and context
There was a bug where the `rows` for a search query was being calculated with the `results.length` of a previous search when loading from URL, sometimes causing errors

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Search `beanie hat` -> Scroll to page 2 -> Search `skirt` -> scroll to page 3 at least -> Click the browser "back" button -> It should search for the first page of beanie hats, previously it requested a negative row.


[EMP-1194]: https://searchbroker.atlassian.net/browse/EMP-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ