### PR TITLE
feat: add alias for the query suggestions that should be displayed

### DIFF
--- a/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-alias.spec.ts
@@ -68,6 +68,7 @@ describe('testing plugin alias', () => {
       partialResults: [],
       popularSearches: [],
       querySuggestions: [],
+      fullQuerySuggestions: [],
       recommendations: [],
       redirections: [],
       relatedTags: [],

--- a/packages/x-components/src/plugins/x-plugin.alias.ts
+++ b/packages/x-components/src/plugins/x-plugin.alias.ts
@@ -99,6 +99,9 @@ export function getAliasAPI(component: Vue): XComponentAliasAPI {
       return component.$store.state.x.popularSearches?.popularSearches ?? [];
     },
     get querySuggestions() {
+      return component.$store.getters[getGetterPath('querySuggestions', 'querySuggestions')] ?? [];
+    },
+    get fullQuerySuggestions() {
       return component.$store.state.x.querySuggestions?.suggestions ?? [];
     },
     get recommendations() {

--- a/packages/x-components/src/plugins/x-plugin.types.ts
+++ b/packages/x-components/src/plugins/x-plugin.types.ts
@@ -127,8 +127,10 @@ export interface XComponentAliasAPI {
   readonly popularSearches: ReadonlyArray<Suggestion>;
   /** The query value of the different modules. */
   readonly query: XComponentAliasQueryAPI;
-  /** The {@link QuerySuggestionsXModule} query suggestions. */
+  /** The {@link QuerySuggestionsXModule} query suggestions that should be displayed. */
   readonly querySuggestions: ReadonlyArray<Suggestion>;
+  /** The {@link QuerySuggestionsXModule} query suggestions. */
+  readonly fullQuerySuggestions: ReadonlyArray<Suggestion>;
   /** The {@link RecommendationsXModule} recommendations. */
   readonly recommendations: ReadonlyArray<Result>;
   /** The {@link SearchXModule} redirections. */


### PR DESCRIPTION
BREAKING CHANGE: the property 'querySuggestions' in '' now returns the query suggestions that should be displayed based on the module's config. A new property called 'fullQuerySuggestions' returns all the query suggestions in the module

[EMP-1463](https://searchbroker.atlassian.net/browse/EMP-1463)

## Motivation and context
CDL was using the `querySuggestions` property in `$x` to check if they should show the empathize. the property in `$x` showed `suggestion` in the module query suggestions, which then won't be rendered due to the `QuerySuggestions` component actually pulling the suggestions from the getter `querySuggestions` instead of the property `suggestions` of the module.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Check the properties of `$x` from the console


[EMP-1463]: https://searchbroker.atlassian.net/browse/EMP-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ