### PR TITLE
feat: make the snippet-config-extra-params component react to prop changes

### DIFF
--- a/packages/x-components/src/x-modules/extra-params/components/__tests__/snippet-config-extra-params.spec.ts
+++ b/packages/x-components/src/x-modules/extra-params/components/__tests__/snippet-config-extra-params.spec.ts
@@ -61,7 +61,7 @@ describe('testing snippet config extra params component', () => {
   });
 
   // eslint-disable-next-line max-len
-  it('emits the ExtraParamsProvided event when the component is loaded and when the snippet config changes', async () => {
+  it('emits the ExtraParamsProvided event when the component is loaded, when the values prop changes, and when the snippet config changes', async () => {
     const { wrapper, setSnippetConfig } = renderSnippetConfigExtraParams();
     const extraParamsProvidedCallback = jest.fn();
 
@@ -74,12 +74,21 @@ describe('testing snippet config extra params component', () => {
       })
     );
 
-    await setSnippetConfig({ warehouse: 45678 });
+    await wrapper.setProps({ values: { store: 'myStore' } });
 
     expect(extraParamsProvidedCallback).toHaveBeenNthCalledWith<[WirePayload<Dictionary<unknown>>]>(
       2,
       expect.objectContaining({
-        eventPayload: { warehouse: 45678 }
+        eventPayload: { warehouse: 1234, store: 'myStore' }
+      })
+    );
+
+    await setSnippetConfig({ warehouse: 45679 });
+
+    expect(extraParamsProvidedCallback).toHaveBeenNthCalledWith<[WirePayload<Dictionary<unknown>>]>(
+      3,
+      expect.objectContaining({
+        eventPayload: { warehouse: 45679, store: 'myStore' }
       })
     );
   });

--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -5,7 +5,7 @@
 <script lang="ts">
   import { forEach, Dictionary } from '@empathyco/x-utils';
   import Vue from 'vue';
-  import { Component, Watch, Inject, Prop } from 'vue-property-decorator';
+  import { Component, Inject, Prop } from 'vue-property-decorator';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { SnippetConfig } from '../../../x-installer/api/api.types';
   import { extraParamsXModule } from '../x-module';
@@ -39,14 +39,26 @@
     protected values?: Dictionary<unknown>;
 
     /**
-     * Custom object containing the extra params from the snippet config.
+     * Custom object containing the extra params from the snippet config and the values prop.
      *
      * @remarks This object keeps manually the desired snippet config properties to avoid
      * unnecessary re-renders.
      *
+     * @returns A dictionary with the extra params.
+     *
      * @internal
      */
-    protected extraParams: Dictionary<unknown> = {};
+    protected get extraParams(): Dictionary<unknown> {
+      const newExtraParams = {};
+
+      forEach({ ...this.values, ...this.snippetConfig }, (name, value) => {
+        if (!this.excludedExtraParams.includes(name)) {
+          this.$set(newExtraParams, name, value);
+        }
+      });
+
+      return newExtraParams;
+    }
 
     /**
      * Collection of properties from the snippet config to exclude from the
@@ -68,22 +80,6 @@
       ]
     })
     protected excludedExtraParams!: Array<keyof SnippetConfig>;
-
-    /**
-     * Updates the extraParams object when the snippet config changes.
-     *
-     * @param snippetConfig - The new snippet config.
-     *
-     * @internal
-     */
-    @Watch('snippetConfig', { deep: true, immediate: true })
-    syncExtraParams(snippetConfig: SnippetConfig): void {
-      forEach({ ...this.values, ...snippetConfig }, (name, value) => {
-        if (!this.excludedExtraParams.includes(name)) {
-          this.$set(this.extraParams, name, value);
-        }
-      });
-    }
   }
 </script>
 


### PR DESCRIPTION
[EMP-1500](https://searchbroker.atlassian.net/browse/EMP-1500)

## Motivation and context
`SnippetConfigExtraParams` wasn't reacting to changes on the `values` prop like it did with the snippet config changes.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Manually change the prop with the vue dev tools.



[EMP-1500]: https://searchbroker.atlassian.net/browse/EMP-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ