### PR TITLE
bugfix: save the number of pages loaded

### DIFF
--- a/packages/x-components/src/x-modules/search/store/actions/set-url-params.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/set-url-params.action.ts
@@ -17,6 +17,6 @@ export const setUrlParams: SearchXStoreModule['actions']['setUrlParams'] = (
   const currentQuery = state.query;
 
   commit('setQuery', query);
-  commit('setPage', currentQuery === query ? page : 1);
+  commit('setPage', !currentQuery || currentQuery === query ? page : 1);
   commit('setSort', sort);
 };


### PR DESCRIPTION

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
The scroll was not kept when you loaded a page greater than 1. It happens when you don't have a filter and also when you select any. We have solved the problem setting a configuration on the `set-url-params.actions.ts` in the `search` module.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-1017](https://searchbroker.atlassian.net/browse/EMP-1017)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
Add this code to the `adapter.ts` file in the `views` folder:

> resultSchema.$override<any, Partial<Result>>({
>   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
>   id: ({ id }) => id.toString()
> });

Then scroll to different pages and reload the page. The scroll should be kept.


[EMP-1017]: https://searchbroker.atlassian.net/browse/EMP-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ