### PR TITLE
bugfix: fix base rating component

### DIFF
--- a/packages/x-components/src/components/base-rating.vue
+++ b/packages/x-components/src/components/base-rating.vue
@@ -83,6 +83,7 @@
   .x-rating {
     position: relative;
     display: inline-block;
+    max-width: fit-content;
 
     &--empty {
       overflow: hidden;


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Add a `max-widht` to `BaseRating` component because if a `x-flex` class is applied the rating will not be filled correctly.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-1374](https://searchbroker.atlassian.net/jira/software/c/projects/EMP/boards/294?modal=detail&selectedIssue=EMP-1588&quickFilter=1099)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 
Add `<BaseRating :value="3" />` in the result.vue file.


[EMP-1374]: https://searchbroker.atlassian.net/browse/EMP-1374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ