### PR TITLE
fix: make empty string point to live env

### DIFF
--- a/packages/x-adapter/src/utils/__tests__/interpolate.spec.ts
+++ b/packages/x-adapter/src/utils/__tests__/interpolate.spec.ts
@@ -61,6 +61,18 @@ describe('testing interpolate function', () => {
         instance: 'demo'
       })
     ).toBe('https://search.empathy.co/demo');
+    expect(
+      interpolate('https://search.{(api-)env(.)}empathy.co/{instance}', {
+        env: '',
+        instance: 'demo'
+      })
+    ).toBe('https://search.empathy.co/demo');
+    expect(
+      interpolate('https://api.{env(.)}empathy.co/{instance}', {
+        env: '',
+        instance: 'demo'
+      })
+    ).toBe('https://api.empathy.co/demo');
   });
 
   it('interpolates values when the parameter is passed deeply inside an object', () => {

--- a/packages/x-adapter/src/utils/interpolate.ts
+++ b/packages/x-adapter/src/utils/interpolate.ts
@@ -99,7 +99,7 @@ export function interpolate(string: string, parameters: Record<string, unknown>)
         /* As the replacer function has a very dynamic signature, it is typed as a function with
          * `any` arguments. This makes it impossible for TS to infer the correct `string`
          * type that we are using as default values here. */
-        return value != null ? `${String(head)}${String(value)}${String(tail)}` : '';
+        return value ? `${String(head)}${String(value)}${String(tail)}` : '';
       }
     )
   );


### PR DESCRIPTION
# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Currently, when we use the `live` env, we can't define it as an empty string (`''`) because the request will fail, it will put two `.` one after the other. This doesn't make much sense. 

We fixed it by modifying the behavior of the `interpolate` function. Now if the value of the `env` is `null`, `undefined` or an empty string (`''`), the request of the live env will work correctly.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-1397](https://searchbroker.atlassian.net/jira/software/c/projects/EMP/boards/294?modal=detail&selectedIssue=EMP-1397&quickFilter=1099)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
Change in the `base-config.ts` file the value of the `env` to an empty string.
For example:

```
// @ts-ignore
env: '' 
```

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [X] My changes generate **no new warnings**.
- [X] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[EMP-1397]: https://searchbroker.atlassian.net/browse/EMP-1397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ