### PR TITLE
fix: restore sliding panel state after a search

### DIFF
--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -176,7 +176,7 @@
         this.isScrollAtStart = !scrollLeft;
         /* The 2 px extra is to fix some cases in some resolutions where the scroll + client size is
          *  less than the scroll width even when the scroll is at the end */
-        this.isScrollAtEnd = scrollLeft + clientWidth + 2 >= scrollWidth;
+        this.isScrollAtEnd = scrollLeft + clientWidth + 2 >= scrollWidth && !this.isScrollAtStart;
       }
     }
 

--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -159,7 +159,7 @@
      *
      * @internal
      */
-    @Debounce(100, { leading: true })
+    @Debounce(50, { leading: true })
     restoreAndUpdateScroll(): void {
       this.$refs.scrollContainer.scroll({ left: 0, behavior: 'smooth' });
       this.updateScrollPosition();
@@ -176,7 +176,7 @@
         this.isScrollAtStart = !scrollLeft;
         /* The 2 px extra is to fix some cases in some resolutions where the scroll + client size is
          *  less than the scroll width even when the scroll is at the end */
-        this.isScrollAtEnd = scrollLeft + clientWidth + 2 >= scrollWidth && !this.isScrollAtStart;
+        this.isScrollAtEnd = scrollLeft + clientWidth + 2 >= scrollWidth;
       }
     }
 
@@ -186,7 +186,7 @@
      *
      * @internal
      */
-    @Debounce(100, { leading: true })
+    @Debounce(50, { leading: true })
     debouncedUpdateScrollPosition(): void {
       this.updateScrollPosition();
     }


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
After making a search and deleting a query, top clicked sliding panel arrows don’t show up. This is because the variables `isScrollAtStart` and `isScrollAtEnd` were restored both at `true`.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-750](https://searchbroker.atlassian.net/browse/EMP-750)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
If you want to test it in the **x-archetype** project, you have to remove from the `BaseResultImage` component (in the `result.vue` file) the `showNextImageOnHover` parameter. If not, you can test it for example in **x-conforama-next** project.

Steps to follow:

- Run the **build** in X project. This is going to generate a local file in `src` folder. Example: _empathyco-x-components-3.0.0-alpha.400.tgz_
- In the project that you want to test, go to the `package.json` and in the `"install:local"` script paste the local build file and run it. 
- Finally follow the task steps:

  ![Screenshot 2023-08-11 at 11 03 04](https://github.com/empathyco/x/assets/114984466/8296b22f-1f15-4fb2-8a4d-93716ea18d75)


## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [X] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[EMP-750]: https://searchbroker.atlassian.net/browse/EMP-750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ