### PR TITLE
Support max-len in Vue components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,50 +12,5 @@ module.exports = {
   parserOptions: {
     tsconfigRootDir: __dirname,
     project: './packages/**/tsconfig.eslint.json'
-  },
-  overrides: [
-    {
-      files: ['*.vue'],
-      rules: {
-        /*
-         * We disable "max-len" rule to ".vue" files because it has some limitations
-         * https://github.com/vuejs/vue-eslint-parser#%EF%B8%8F-known-limitations.
-         *
-         * Instead we use the one that "eslint-plugin-vue" has. This rule understands much better
-         * the ".vue" files.
-         * It helps us in cases that the "<style>" tag's section has long lines of
-         * code.
-         * (e.g: "@include foo(background-color, color, $selector: '#{$component-class}__kpi');
-         * https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/max-len.md
-         */
-        'max-len': 'off',
-        'vue/max-len': [
-          'error',
-          {
-            ignoreStrings: true,
-            ignoreTemplateLiterals: true,
-            ignoreUrls: true,
-            /*
-             * "ignoreHTMLAttributeValues" helps us when an attribute is too long, and it does not fit in the defined max-len
-             * but prettier wouldn't want to wrap it in multiple lines.
-             * Pretty useful when the "class" attribute is too long.
-             * e.g:
-             * - "<div  class="example-component example-component--expanded">.
-             * - "<path
-             *     d="M11 .5c-1.7.2-3.4.9-4.7 2-1.1.9-2 2-2.5 3.2-1.2 2.4-1.2 5.1-.1 7.7 1.1 2.6 2.8 5 5.3 7.5 1.2 1.2 2.8 2.7 3 2.7 0 0
-             *    />"
-             *
-             * Previously prettier would have formatted this with one class per line. like so:
-             * "<div class="example-component
-             *             example-component--expanded"
-             * >"
-             * But it is no longer an option since prettier@2.5.0.
-             * https://prettier.io/blog/2021/11/25/2.5.0.html#collapse-html-class-attributes-onto-one-line-11827httpsgithubcomprettierprettierpull11827-by-jlongsterhttpsgithubcomjlongster
-             */
-            ignoreHTMLAttributeValues: true
-          }
-        ]
-      }
-    }
-  ]
+  }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,50 @@ module.exports = {
   parserOptions: {
     tsconfigRootDir: __dirname,
     project: './packages/**/tsconfig.eslint.json'
-  }
+  },
+  overrides: [
+    {
+      files: ['*.vue'],
+      rules: {
+        /*
+         * We disable "max-len" rule to ".vue" files because it has some limitations
+         * https://github.com/vuejs/vue-eslint-parser#%EF%B8%8F-known-limitations.
+         *
+         * Instead we use the one that "eslint-plugin-vue" has. This rule understands much better
+         * the ".vue" files.
+         * It helps us in cases that the "<style>" tag's section has long lines of
+         * code.
+         * (e.g: "@include foo(background-color, color, $selector: '#{$component-class}__kpi');
+         * https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/max-len.md
+         */
+        'max-len': 'off',
+        'vue/max-len': [
+          'error',
+          {
+            ignoreStrings: true,
+            ignoreTemplateLiterals: true,
+            ignoreUrls: true,
+            /*
+             * "ignoreHTMLAttributeValues" helps us when an attribute is too long, and it does not fit in the defined max-len
+             * but prettier wouldn't want to wrap it in multiple lines.
+             * Pretty useful when the "class" attribute is too long.
+             * e.g:
+             * - "<div  class="example-component example-component--expanded">.
+             * - "<path
+             *     d="M11 .5c-1.7.2-3.4.9-4.7 2-1.1.9-2 2-2.5 3.2-1.2 2.4-1.2 5.1-.1 7.7 1.1 2.6 2.8 5 5.3 7.5 1.2 1.2 2.8 2.7 3 2.7 0 0
+             *    />"
+             *
+             * Previously prettier would have formatted this with one class per line. like so:
+             * "<div class="example-component
+             *             example-component--expanded"
+             * >"
+             * But it is no longer an option since prettier@2.5.0.
+             * https://prettier.io/blog/2021/11/25/2.5.0.html#collapse-html-class-attributes-onto-one-line-11827httpsgithubcomprettierprettierpull11827-by-jlongsterhttpsgithubcomjlongster
+             */
+            ignoreHTMLAttributeValues: true
+          }
+        ]
+      }
+    }
+  ]
 };

--- a/packages/eslint-plugin-x/lib/configs/eslint.js
+++ b/packages/eslint-plugin-x/lib/configs/eslint.js
@@ -9,7 +9,13 @@ module.exports = {
       indent: 'off',
       'max-len': [
         'error',
-        { code: 100, ignoreStrings: true, ignoreTemplateLiterals: true, ignoreUrls: true }
+        {
+          code: 100,
+          ignoreStrings: true,
+          ignoreTemplateLiterals: true,
+          ignoreUrls: true,
+          ignorePattern: 'class=".*"$'
+        }
       ],
       'no-alert': process.env.NODE_ENV === 'production' ? 'error' : 'off',
       'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',

--- a/packages/eslint-plugin-x/lib/configs/eslint.js
+++ b/packages/eslint-plugin-x/lib/configs/eslint.js
@@ -7,8 +7,10 @@ module.exports = {
       curly: ['error', 'all'],
       eqeqeq: ['error', 'always', { null: 'ignore' }],
       indent: 'off',
-      // THESE 'max-len' rules ARE ALMOST THE SAME OVERRIDE CONFIG THAT IS SET IN x-components/.eslintrc.js for vue files, except the ignorePattern, so we will override it below in vue files
-      'max-len': ['error', { code: 100, ignoreComments: false, ignorePattern: 'class=".*"$' }],
+      'max-len': [
+        'error',
+        { code: 100, ignoreStrings: true, ignoreTemplateLiterals: true, ignoreUrls: true }
+      ],
       'no-alert': process.env.NODE_ENV === 'production' ? 'error' : 'off',
       'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
@@ -24,48 +26,6 @@ module.exports = {
       'require-atomic-updates': 'error',
       'require-await': 'error',
       strict: ['error', 'global']
-    },
-    overrides: [
-      {
-        files: ['src/**/*.vue'],
-        rules: {
-          /*
-           * We use 'vue/max-len' that "eslint-plugin-vue" has. This rule understands much better
-           * the ".vue" files.
-           * It helps us in cases that the "<style>" tag's section has long lines of
-           * code.
-           * (e.g: "@include foo(background-color, color, $selector: '#{$component-class}__kpi');
-           * https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/max-len.md
-           */
-          'vue/max-len': [
-            'error',
-            {
-              ignorePattern: '|class=".*"$ |https://github',
-              ignoreStrings: true,
-              ignoreTemplateLiterals: true,
-              ignoreUrls: true,
-              /*
-               * "ignoreHTMLAttributeValues" helps us when an attribute is too long, and it does not fit in the defined max-len
-               * but prettier wouldn't want to wrap it in multiple lines.
-               * Pretty useful when the "class" attribute is too long.
-               * e.g:
-               * - "<div  class="example-component example-component--expanded">.
-               * - "<path
-               *     d="M11 .5c-1.7.2-3.4.9-4.7 2-1.1.9-2 2-2.5 3.2-1.2 2.4-1.2 5.1-.1 7.7 1.1 2.6 2.8 5 5.3 7.5 1.2 1.2 2.8 2.7 3 2.7 0 0
-               *    />"
-               *
-               * Previously prettier would have formatted this with one class per line. like so:
-               * "<div class="example-component
-               *             example-component--expanded"
-               * >"
-               * But it is no longer an option since prettier@2.5.0.
-               * https://prettier.io/blog/2021/11/25/2.5.0.html#collapse-html-class-attributes-onto-one-line-11827httpsgithubcomprettierprettierpull11827-by-jlongsterhttpsgithubcomjlongster
-               */
-              ignoreHTMLAttributeValues: true
-            }
-          ]
-        }
-      }
-    ]
+    }
   }
 };

--- a/packages/eslint-plugin-x/lib/configs/eslint.js
+++ b/packages/eslint-plugin-x/lib/configs/eslint.js
@@ -7,6 +7,7 @@ module.exports = {
       curly: ['error', 'all'],
       eqeqeq: ['error', 'always', { null: 'ignore' }],
       indent: 'off',
+      // THESE 'max-len' rules ARE ALMOST THE SAME OVERRIDE CONFIG THAT IS SET IN x-components/.eslintrc.js for vue files, except the ignorePattern, so we will override it below in vue files
       'max-len': ['error', { code: 100, ignoreComments: false, ignorePattern: 'class=".*"$' }],
       'no-alert': process.env.NODE_ENV === 'production' ? 'error' : 'off',
       'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
@@ -23,6 +24,48 @@ module.exports = {
       'require-atomic-updates': 'error',
       'require-await': 'error',
       strict: ['error', 'global']
-    }
+    },
+    overrides: [
+      {
+        files: ['src/**/*.vue'],
+        rules: {
+          /*
+           * We use 'vue/max-len' that "eslint-plugin-vue" has. This rule understands much better
+           * the ".vue" files.
+           * It helps us in cases that the "<style>" tag's section has long lines of
+           * code.
+           * (e.g: "@include foo(background-color, color, $selector: '#{$component-class}__kpi');
+           * https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/max-len.md
+           */
+          'vue/max-len': [
+            'error',
+            {
+              ignorePattern: '|class=".*"$ |https://github',
+              ignoreStrings: true,
+              ignoreTemplateLiterals: true,
+              ignoreUrls: true,
+              /*
+               * "ignoreHTMLAttributeValues" helps us when an attribute is too long, and it does not fit in the defined max-len
+               * but prettier wouldn't want to wrap it in multiple lines.
+               * Pretty useful when the "class" attribute is too long.
+               * e.g:
+               * - "<div  class="example-component example-component--expanded">.
+               * - "<path
+               *     d="M11 .5c-1.7.2-3.4.9-4.7 2-1.1.9-2 2-2.5 3.2-1.2 2.4-1.2 5.1-.1 7.7 1.1 2.6 2.8 5 5.3 7.5 1.2 1.2 2.8 2.7 3 2.7 0 0
+               *    />"
+               *
+               * Previously prettier would have formatted this with one class per line. like so:
+               * "<div class="example-component
+               *             example-component--expanded"
+               * >"
+               * But it is no longer an option since prettier@2.5.0.
+               * https://prettier.io/blog/2021/11/25/2.5.0.html#collapse-html-class-attributes-onto-one-line-11827httpsgithubcomprettierprettierpull11827-by-jlongsterhttpsgithubcomjlongster
+               */
+              ignoreHTMLAttributeValues: true
+            }
+          ]
+        }
+      }
+    ]
   }
 };

--- a/packages/eslint-plugin-x/lib/configs/vue.js
+++ b/packages/eslint-plugin-x/lib/configs/vue.js
@@ -35,7 +35,17 @@ module.exports = {
       'vue/component-tags-order': 'warn',
       'vue/v-on-function-call': 'error',
       'vue/v-slot-style': 'off',
-      'vue/valid-v-slot': 'warn'
+      'vue/valid-v-slot': 'warn',
+      'vue/max-len': [
+        'error',
+        {
+          code: 100,
+          ignoreStrings: true,
+          ignoreTemplateLiterals: true,
+          ignoreUrls: true,
+          ignoreHTMLAttributeValues: true
+        }
+      ]
     }
   }
 };

--- a/packages/x-components/.eslintrc.js
+++ b/packages/x-components/.eslintrc.js
@@ -12,21 +12,12 @@ module.exports = {
   },
   overrides: [
     {
-      files: 'src/**/*.vue',
+      files: ['src/**/*.vue'],
       rules: {
-        'max-len': [
-          'error',
-          {
-            code: 100,
-            ignoreComments: false,
-            ignorePattern: '|class=".*"$ |https://github'
-          }
-        ]
-      }
-    },
-    {
-      files: 'src/components/icons/*.vue',
-      rules: {
+        /*
+         * We disable "max-len" rule to ".vue" files because it has some limitations
+         * https://github.com/vuejs/vue-eslint-parser#%EF%B8%8F-known-limitations.
+         */
         'max-len': 'off'
       }
     }

--- a/packages/x-components/.eslintrc.js
+++ b/packages/x-components/.eslintrc.js
@@ -12,12 +12,8 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/**/*.vue'],
+      files: ['*.vue'],
       rules: {
-        /*
-         * We disable "max-len" rule to ".vue" files because it has some limitations
-         * https://github.com/vuejs/vue-eslint-parser#%EF%B8%8F-known-limitations.
-         */
         'max-len': 'off'
       }
     }

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -428,7 +428,6 @@
 </template>
 
 <script lang="ts">
-  /* eslint-disable max-len */
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
   import { animateClipPath } from '../../components/animations/animate-clip-path/animate-clip-path.factory';

--- a/packages/x-components/src/views/home/aside.vue
+++ b/packages/x-components/src/views/home/aside.vue
@@ -129,7 +129,6 @@
 </template>
 
 <script lang="ts">
-  /* eslint-disable max-len */
   import {
     EditableNumberRangeFacet,
     EditableNumberRangeFilter,
@@ -156,7 +155,6 @@
   import SlicedFilters from '../../x-modules/facets/components/lists/sliced-filters.vue';
   import SortedFilters from '../../x-modules/facets/components/lists/sorted-filters.vue';
   import { HomeControls } from './types';
-  /* eslint-enable max-len */
 
   @Component({
     components: {

--- a/packages/x-components/src/x-modules/tagging/components/tagging.vue
+++ b/packages/x-components/src/x-modules/tagging/components/tagging.vue
@@ -6,7 +6,7 @@
   import { SnippetConfig } from '../../../x-installer/api/api.types';
   import { taggingXModule } from '../x-module';
   import { TaggingConfig } from '../config.types';
-  /* eslint-disable max-len */
+
   /**
    * This component enables and manages the sending of information to the
    * [Empathy Tagging API](https://docs.empathy.co/develop-empathy-platform/api-reference/tagging-api.html).


### PR DESCRIPTION
[EMP-1908](https://searchbroker.atlassian.net/browse/EMP-1908)

resolves #1063
[Ref issue](https://github.com/empathyco/x/issues/1063)

TEST
1- [Here](https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/max-len.md#ignorestrings-true) are some examples for testing `ignoreUrls`, `ignoreStrings`, `ignoreTemplateLiterals` rules, that can be applied in, for example, `Home.vue`

2- Run eslint in your project:
run `build eslint-plugin-x`
run `pnpm install —frozen-lockfile` in x-components
run `npm run lint`  and check:
- It should ignore long urls in vue files
- It should ignore long classes, for example line 331 in Home.vue
- It should ignore icon files as ‘user-filled.vue’

[EMP-1908]: https://searchbroker.atlassian.net/browse/EMP-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ