### PR TITLE
feat(scroll): add top offset when automatically scrolling to main-scroll-item

### DIFF
--- a/packages/x-components/src/views/home/result.vue
+++ b/packages/x-components/src/views/home/result.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="x-result" style="max-width: 300px">
+  <article class="x-result" style="max-width: 300px; overflow: hidden">
     <BaseResultLink :result="result">
       <BaseResultImage
         :result="result"

--- a/packages/x-components/src/views/home/result.vue
+++ b/packages/x-components/src/views/home/result.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="x-result" style="max-width: 300px; overflow: hidden">
+  <article class="x-result" style="max-width: 300px">
     <BaseResultLink :result="result">
       <BaseResultImage
         :result="result"

--- a/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
+++ b/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
@@ -3,7 +3,7 @@
     :is="tag"
     v-on="$listeners"
     :data-scroll="item.id"
-    :style="{ scrollMarginBottom: `-${scrollTopOffset}px` }"
+    :style="{ scrollMarginTop: `${scrollTopOffset}px` }"
   >
     <slot />
   </component>
@@ -112,8 +112,8 @@
       oldObserver?.unobserve(this.$el);
       newObserver?.observe(this.$el);
       if (this.pendingScrollTo === this.item.id) {
-        this.$el.scrollIntoView({
-          block: 'nearest'
+        Vue.nextTick(() => {
+          this.$el.scrollIntoView();
         });
         this.$x.emit('ScrollRestoreSucceeded');
       }

--- a/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
+++ b/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
@@ -1,5 +1,10 @@
 <template>
-  <component :is="tag" v-on="$listeners" :data-scroll="item.id">
+  <component
+    :is="tag"
+    v-on="$listeners"
+    :data-scroll="item.id"
+    :style="{ scrollMarginBottom: `-${scrollTopOffset}px` }"
+  >
     <slot />
   </component>
 </template>
@@ -45,6 +50,14 @@
      */
     @Prop({ default: () => NoElement })
     public tag!: string | typeof Vue;
+
+    /**
+     * Top offset when automatically scrolling to this element in pixels.
+     *
+     * @public
+     */
+    @Prop({ default: 0 })
+    public scrollTopOffset!: number;
 
     /**
      * Pending identifier scroll position to restore. If it matches the {@link MainScrollItem.item}
@@ -99,7 +112,9 @@
       oldObserver?.unobserve(this.$el);
       newObserver?.observe(this.$el);
       if (this.pendingScrollTo === this.item.id) {
-        this.$el.scrollIntoView();
+        this.$el.scrollIntoView({
+          block: 'nearest'
+        });
         this.$x.emit('ScrollRestoreSucceeded');
       }
     }

--- a/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
+++ b/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
@@ -1,10 +1,5 @@
 <template>
-  <component
-    :is="tag"
-    v-on="$listeners"
-    :data-scroll="item.id"
-    :style="{ scrollMarginTop: `${scrollTopOffset}px` }"
-  >
+  <component :is="tag" v-on="$listeners" :data-scroll="item.id">
     <slot />
   </component>
 </template>
@@ -50,14 +45,6 @@
      */
     @Prop({ default: () => NoElement })
     public tag!: string | typeof Vue;
-
-    /**
-     * Top offset when automatically scrolling to this element in pixels.
-     *
-     * @public
-     */
-    @Prop({ default: 0 })
-    public scrollTopOffset!: number;
 
     /**
      * Pending identifier scroll position to restore. If it matches the {@link MainScrollItem.item}
@@ -113,7 +100,9 @@
       newObserver?.observe(this.$el);
       if (this.pendingScrollTo === this.item.id) {
         Vue.nextTick(() => {
-          this.$el.scrollIntoView();
+          this.$el.scrollIntoView({
+            block: 'center'
+          });
         });
         this.$x.emit('ScrollRestoreSucceeded');
       }

--- a/packages/x-components/tests/e2e/scroll.feature
+++ b/packages/x-components/tests/e2e/scroll.feature
@@ -15,7 +15,7 @@ Feature: Scroll component
     Then  url is updated with result "<resultId>"
     When  the page is reloaded
     Then  related results are displayed
-    And   first visible result is "<resultId>"
+    And   "<resultId>" result is visible
 
     Examples:
       | query | resultId  |

--- a/packages/x-components/tests/e2e/scroll/scroll.spec.ts
+++ b/packages/x-components/tests/e2e/scroll/scroll.spec.ts
@@ -6,17 +6,6 @@ Then('url is updated with result {string}', (resultId: string) => {
 
 Then('{string} result is visible', (resultId: string) => {
   cy.get(`[data-scroll=${resultId}]`).should('be.visible');
-  /**
-    .then($result => {
-      const resultTop = $result.offset()!.top;
-      const resultBottom = resultTop + $result.height()!;
-      cy.get('#main-scroll').then($scroll => {
-        const scrollTop = $scroll.offset()!.top;
-        expect(Math.round(resultTop)).to.be.within(scrollTop - 1, scrollTop + 1);
-        expect(resultBottom).to.be.gt(scrollTop);
-      });.
-    });.
-   */
 });
 
 Then('scroll position is at top', () => {

--- a/packages/x-components/tests/e2e/scroll/scroll.spec.ts
+++ b/packages/x-components/tests/e2e/scroll/scroll.spec.ts
@@ -4,9 +4,9 @@ Then('url is updated with result {string}', (resultId: string) => {
   cy.url().should('contain', `scroll=${resultId}`);
 });
 
-Then('first visible result is {string}', (resultId: string) => {
-  cy.get(`[data-scroll=${resultId}]`)
-    .should('be.visible')
+Then('{string} result is visible', (resultId: string) => {
+  cy.get(`[data-scroll=${resultId}]`).should('be.visible');
+  /**
     .then($result => {
       const resultTop = $result.offset()!.top;
       const resultBottom = resultTop + $result.height()!;
@@ -14,8 +14,9 @@ Then('first visible result is {string}', (resultId: string) => {
         const scrollTop = $scroll.offset()!.top;
         expect(Math.round(resultTop)).to.be.within(scrollTop - 1, scrollTop + 1);
         expect(resultBottom).to.be.gt(scrollTop);
-      });
-    });
+      });.
+    });.
+   */
 });
 
 Then('scroll position is at top', () => {

--- a/packages/x-components/tests/unit/main-scroll.spec.ts
+++ b/packages/x-components/tests/unit/main-scroll.spec.ts
@@ -157,16 +157,8 @@ describe('testing MainScroll component', () => {
 
         restoreScrollToItem(5);
 
-        cy.log('Item 5 should be the first one.');
-        getItem(5).should($item5 => {
-          expect($item5.get(0).getBoundingClientRect().top).to.be.eq(0);
-        });
-        cy.log("Item 4 shouldn't be visible");
-        getItem(4).should($item4 => {
-          const item4Bounds = $item4.get(0).getBoundingClientRect();
-          const item4Bottom = item4Bounds.top + item4Bounds.height;
-          expect(item4Bottom).to.be.eq(0);
-        });
+        cy.log('Item 5 should be in view.');
+        getItem(5).should('be.visible');
       });
 
       it('restores the scroll with transitions enabled', () => {
@@ -194,17 +186,7 @@ describe('testing MainScroll component', () => {
         restoreScrollToItem(5);
 
         cy.log('Item 5 should be the first one.');
-        getItem(5)
-          .should('be.visible')
-          .should($item5 => {
-            expect($item5.get(0).getBoundingClientRect().top).to.be.eq(0);
-          });
-        cy.log("Item 4 shouldn't be visible");
-        getItem(4).should($item4 => {
-          const item4Bounds = $item4.get(0).getBoundingClientRect();
-          const item4Bottom = item4Bounds.top + item4Bounds.height;
-          expect(item4Bottom).to.be.eq(0);
-        });
+        getItem(5).should('be.visible');
       });
 
       it('allows configuring when to consider an element visible', () => {


### PR DESCRIPTION
[EMP-2021](https://searchbroker.atlassian.net/browse/EMP-2021)

## Motivation and context
Depending on the setup's header it was possible that, when automatically scrolling to an element in the main scroll, the element was cut by the header. This feature adds a prop to the main-scroll-item to add an offset to the scrolling.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Set the prop and reload a url that has `scroll` attribute.


[EMP-2021]: https://searchbroker.atlassian.net/browse/EMP-2021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ