### PR TITLE
feat(query-preview): use deep equal to compare request

### DIFF
--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -35,7 +35,7 @@
 <script lang="ts">
   import Vue from 'vue';
   import { Component, Prop, Inject, Watch } from 'vue-property-decorator';
-  import { Dictionary } from '@empathyco/x-utils';
+  import { deepEqual, Dictionary } from '@empathyco/x-utils';
   import { SearchRequest, Result } from '@empathyco/x-types';
   import { State } from '../../../components/decorators/store.decorators';
   import { LIST_ITEMS_KEY } from '../../../components/decorators/injection.consts';
@@ -206,7 +206,7 @@
       this.$watch(
         () => this.queryPreviewRequest,
         (newRequest, oldRequest) => {
-          if (JSON.stringify(newRequest) !== JSON.stringify(oldRequest)) {
+          if (!deepEqual(newRequest, oldRequest)) {
             this.emitQueryPreviewRequestUpdated(newRequest);
           }
         }


### PR DESCRIPTION
EMP-2124

## Motivation and context
With the new deepEqual we can compare the requests from the query preview component more accurately.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 
Try a query with semantic queries + query preview and test everything still works the same (the "cortina" query preview works)

