### PR TITLE
feat(xcontrols): create skeleton adapter

### DIFF
--- a/packages/x-adapter-platform/src/endpoint-adapters/experience-controls.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/experience-controls.endpoint-adapter.ts
@@ -1,0 +1,22 @@
+import { endpointAdapterFactory } from '@empathyco/x-adapter';
+
+/**.
+ * Default adapter for the experience controls endpoint.
+ *
+ * TODO: change RequestMapper and ResponseMapper
+ *
+ * @public
+ */
+export const experienceControlsEndpointAdapter = endpointAdapterFactory<any, any>({
+  endpoint:
+    'https://config-service.internal.test.empathy.co/public/configs' +
+    '?service=xcontrols&instance={extraParams.instance}',
+  requestMapper: undefined,
+  responseMapper: undefined,
+  defaultRequestOptions: {
+    id: 'experience-controls',
+    parameters: {
+      internal: true
+    }
+  }
+});

--- a/packages/x-adapter-platform/src/platform.adapter.ts
+++ b/packages/x-adapter-platform/src/platform.adapter.ts
@@ -9,6 +9,7 @@ import { identifierResultsEndpointAdapter } from './endpoint-adapters/identifier
 import { taggingEndpointAdapter } from './endpoint-adapters/tagging.endpoint-adapter';
 import { querySuggestionsEndpointAdapter } from './endpoint-adapters/query-suggestions.endpoint-adapter';
 import { semanticQueriesEndpointAdapter } from './endpoint-adapters/semantic-queries.endpoint-adapter';
+import { experienceControlsEndpointAdapter } from './endpoint-adapters/experience-controls.endpoint-adapter';
 /* eslint-enable max-len */
 
 /**
@@ -25,5 +26,6 @@ export const platformAdapter: PlatformAdapter = {
   relatedTags: relatedTagsEndpointAdapter,
   identifierResults: identifierResultsEndpointAdapter,
   tagging: taggingEndpointAdapter,
-  semanticQueries: semanticQueriesEndpointAdapter
+  semanticQueries: semanticQueriesEndpointAdapter,
+  experienceControls: experienceControlsEndpointAdapter
 };

--- a/packages/x-adapter-platform/src/types/platform-adapter.types.ts
+++ b/packages/x-adapter-platform/src/types/platform-adapter.types.ts
@@ -35,4 +35,5 @@ export interface PlatformAdapter extends XComponentsAdapter {
   identifierResults: ExtendableEndpointAdapter<IdentifierResultsRequest, IdentifierResultsResponse>;
   semanticQueries: ExtendableEndpointAdapter<SemanticQueriesRequest, SemanticQueriesResponse>;
   tagging: ExtendableEndpointAdapter<TaggingRequest, void>;
+  experienceControls: ExtendableEndpointAdapter<any, any>;
 }

--- a/packages/x-components/src/__tests__/adapter.dummy.ts
+++ b/packages/x-components/src/__tests__/adapter.dummy.ts
@@ -9,5 +9,6 @@ export const XComponentsAdapterDummy: XComponentsAdapter = {
   relatedTags: jest.fn(),
   search: jest.fn(),
   semanticQueries: jest.fn(),
-  tagging: jest.fn()
+  tagging: jest.fn(),
+  experienceControls: jest.fn()
 };

--- a/packages/x-components/src/__tests__/utils.ts
+++ b/packages/x-components/src/__tests__/utils.ts
@@ -45,6 +45,7 @@ interface MockedAdapterFeatures {
   search: SearchResponse;
   semanticQueries: SemanticQueriesResponse;
   tagging: void;
+  experienceControls: undefined;
 }
 
 /**
@@ -158,7 +159,8 @@ export function getMockedAdapter(
     relatedTags: getMockedAdapterFunction(responseFeatures?.relatedTags!),
     search: getMockedAdapterFunction(responseFeatures?.search!),
     semanticQueries: getMockedAdapterFunction(responseFeatures?.semanticQueries!),
-    tagging: getMockedAdapterFunction(undefined)
+    tagging: getMockedAdapterFunction(undefined),
+    experienceControls: getMockedAdapterFunction(undefined)
     /* eslint-enable @typescript-eslint/no-non-null-asserted-optional-chain */
   };
 }

--- a/packages/x-components/src/adapter/e2e-adapter.ts
+++ b/packages/x-components/src/adapter/e2e-adapter.ts
@@ -53,5 +53,6 @@ export const e2eAdapter: XComponentsAdapter = {
     defaultRequestOptions: {
       properties: { keepalive: true }
     }
-  })
+  }),
+  experienceControls: mockEndpointAdapter('experience-controls')
 };

--- a/packages/x-types/src/x-components-adapter.model.ts
+++ b/packages/x-types/src/x-components-adapter.model.ts
@@ -31,4 +31,5 @@ export interface XComponentsAdapter {
   identifierResults: EndpointAdapter<IdentifierResultsRequest, IdentifierResultsResponse>;
   tagging: EndpointAdapter<TaggingRequest, void>;
   semanticQueries: EndpointAdapter<SemanticQueriesRequest, SemanticQueriesResponse>;
+  experienceControls: EndpointAdapter<void, void>;
 }


### PR DESCRIPTION
# Pull request template
## Motivation and context
We need a skeleton for create the adapter. We have put `undefined` as a type for `requestMapper` and `responseMapper`. Also in `XComponentsAdapter` we put `void`, we know that these types have to be changed  

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [feature/EMP-1940-create-skeleton-adapter](https://searchbroker.atlassian.net/browse/EMP-1940)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [X] Other. Specify: [feature/EMP-1939-create-endpoint-gather-xperience-controls-adapter](https://github.com/empathyco/x/tree/feature/EMP-1939-create-endpoint-gather-xperience-controls-configuration)

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [X] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [X] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [X] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
