### PR TITLE
fix: move the display-results-provider to fix semantics sliding panel

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -370,9 +370,9 @@
                       >
                         <span data-test="semantic-queries-query">{{ query }}</span>
                       </SemanticQuery>
-                      <SlidingPanel :resetOnContentChange="false">
-                        <div class="x-flex x-gap-8">
-                          <DisplayResultProvider>
+                      <DisplayResultProvider>
+                        <SlidingPanel :resetOnContentChange="false">
+                          <div class="x-flex x-gap-8">
                             <Result
                               v-for="result in results"
                               :key="result.id"
@@ -380,9 +380,9 @@
                               style="max-width: 180px"
                               data-test="semantic-query-result"
                             />
-                          </DisplayResultProvider>
-                        </div>
-                      </SlidingPanel>
+                          </div>
+                        </SlidingPanel>
+                      </DisplayResultProvider>
                     </div>
                   </QueryPreviewList>
                 </LocationProvider>


### PR DESCRIPTION
EMP-2402

## Motivation and context
The `DisplayResultsProvider` was messing up with the sliding panel of the semantic queries and making it so it only displayed one result.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Search for a query that returns semantics (`battery` for example) and see that the carrousels have more than one item.

