### PR TITLE
fix: set query in facets module from selecting a query preview

### DIFF
--- a/packages/x-components/src/x-modules/facets/wiring.ts
+++ b/packages/x-components/src/x-modules/facets/wiring.ts
@@ -171,10 +171,7 @@ export const setSelectedFiltersFromPreview = wireCommit(
  *
  * @public
  */
-export const setQueryFromPreview = wireCommit(
-  'setQuery',
-  ({ eventPayload: { query } }) => query
-);
+export const setQueryFromPreview = wireCommit('setQuery', ({ eventPayload: { query } }) => query);
 
 /**
  * Wiring configuration for the {@link FacetsXModule | facets module}.

--- a/packages/x-components/src/x-modules/facets/wiring.ts
+++ b/packages/x-components/src/x-modules/facets/wiring.ts
@@ -157,13 +157,23 @@ const clearStickyFilters = filter<XEventPayload<'SearchResponseChanged'>>(
 );
 
 /**
- * Sets the filters of the facets module from a selectedQueryPreview's filters.
+ * Sets the filters of the facets module from a queryPreview's filters.
  *
  * @public
  */
 export const setSelectedFiltersFromPreview = wireCommit(
   'setFilters',
   ({ eventPayload: { filters } }) => (filters ? createRawFilters(filters) : [])
+);
+
+/**
+ * Sets the query of the facets module from a queryPreview.
+ *
+ * @public
+ */
+export const setQueryFromPreview = wireCommit(
+  'setQuery',
+  ({ eventPayload: { query } }) => query
 );
 
 /**
@@ -218,6 +228,7 @@ export const facetsWiring = createWiring({
     clearStickyFilters
   },
   UserAcceptedAQueryPreview: {
+    setQueryFromPreview,
     setSelectedFiltersFromPreview
   }
 });


### PR DESCRIPTION
EMP-2407

## Motivation and context
The query of the facets module wasn't being updated when a query preview was selected and that caused probles with the events from the emitters not having the correct `oldValue`.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Click a query preview with filters (`cortina` for example) and search for something that doesn't have results (a spellchecked query, `pantlon` for example). Only the spellcheck message should appear. Check removing the new wire and two messages appear doing the same.
