### PR TITLE
feat: using setQuery util in tests that need it

### DIFF
--- a/packages/x-components/src/plugins/__tests__/x-plugin-emitters.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin-emitters.spec.ts
@@ -1,6 +1,7 @@
 import { createLocalVue } from '@vue/test-utils';
 import { default as Vue, VueConstructor } from 'vue';
 import Vuex, { Store } from 'vuex';
+import { setQuery } from '../../store/utils/query.utils';
 import { createWireFromFunction } from '../../wiring/wires.factory';
 import { XComponentsAdapterDummy } from '../../__tests__/adapter.dummy';
 import { createXModule } from '../../__tests__/utils';
@@ -35,9 +36,7 @@ const xModule = createXModule({
     },
     actions: {},
     mutations: {
-      setQuery(state, query: string): void {
-        state.query = query;
-      }
+      setQuery
     }
   }
 });

--- a/packages/x-components/src/plugins/__tests__/x-plugin.spec.ts
+++ b/packages/x-components/src/plugins/__tests__/x-plugin.spec.ts
@@ -12,6 +12,7 @@ import { installNewXPlugin } from '../../__tests__/utils';
 import { XPlugin } from '../x-plugin';
 import { PrivateXModulesOptions, XModulesOptions, XPluginOptions } from '../x-plugin.types';
 import { XDummyBus } from '../../__tests__/bus.dummy';
+import { setQuery } from '../../store/utils/query.utils';
 
 const wireToReplace: AnyWire = jest.fn();
 const wireToRemove: AnyWire = jest.fn();
@@ -364,9 +365,7 @@ describe('testing X Plugin', () => {
         }
       },
       mutations: {
-        setQuery(state, query) {
-          state.query = query;
-        }
+        setQuery
       },
       state: () => ({ query: '' })
     };

--- a/packages/x-components/src/x-modules/facets/store/types.ts
+++ b/packages/x-components/src/x-modules/facets/store/types.ts
@@ -1,6 +1,7 @@
 import { Facet, Filter, RawFilter } from '@empathyco/x-types';
 import { XActionContext, XStoreModule } from '../../../store';
 import { ConfigMutations } from '../../../store/utils/config-store.utils';
+import { QueryMutations } from '../../../store/utils/query.utils';
 
 /**
  * Facets store state.
@@ -53,7 +54,7 @@ export interface FacetsGetters {
  *
  * @public
  */
-export interface FacetsMutations extends ConfigMutations<FacetsState> {
+export interface FacetsMutations extends QueryMutations, ConfigMutations<FacetsState> {
   /**
    * Updates the state of a filter.
    *
@@ -92,12 +93,6 @@ export interface FacetsMutations extends ConfigMutations<FacetsState> {
    * @param filters - The filters to add.
    */
   setPreselectedFilters(filters: RawFilter[]): void;
-  /**
-   * Sets the {@link FacetsState.query} property.
-   *
-   * @param query - The new {@link FacetsState.query}.
-   */
-  setQuery(query: string): void;
   /**
    * Removes the facet from the {@link FacetsState.facets | facets} record.
    *

--- a/packages/x-components/src/x-modules/history-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/types.ts
@@ -82,12 +82,6 @@ export interface HistoryQueriesMutations
    */
   setSessionTimeStamp(timeStamp: number): void;
   /**
-   * Sets the {@link HistoryQueriesState.query } property.
-   *
-   * @param query - The new {@link HistoryQueriesState.query }.
-   */
-  setQuery(query: string): void;
-  /**
    * Sets the {@link HistoryQueriesState.isEnabled } property.
    *
    * @param isEnabled - The new {@link HistoryQueriesState.isEnabled }.

--- a/packages/x-components/src/x-modules/history-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/types.ts
@@ -40,7 +40,7 @@ export interface HistoryQueriesState extends QueryState {
 export interface HistoryQueriesGetters {
   /**
    * A sub-set of the {@link HistoryQueriesState.historyQueries}. If the
-   * {@link HistoryQueriesState.query} property is not empty, this list will only contain
+   * query property is not empty, this list will only contain
    * suggestions whose query matches with it.
    */
   historyQueries: HistoryQuery[];

--- a/packages/x-components/src/x-modules/history-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/types.ts
@@ -25,10 +25,7 @@ export interface HistoryQueriesState extends QueryState {
    * search sessions.
    */
   historyQueries: HistoryQuery[];
-  /**
-   * The current query for searching into the {@link HistoryQueriesState.historyQueries}.
-   */
-  query: string;
+
   /**
    * Whether the history queries are enabled or disabled.
    */

--- a/packages/x-components/src/x-modules/identifier-results/store/types.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/types.ts
@@ -71,12 +71,6 @@ export interface IdentifierResultsMutations
    * @param params - The new extra params.
    */
   setParams(params: Dictionary<unknown>): void;
-  /**
-   * Sets the query of the module, which is used to retrieve the identifier-results.
-   *
-   * @param newQuery - The new query to save to the state.
-   */
-  setQuery(newQuery: string): void;
 }
 
 /**

--- a/packages/x-components/src/x-modules/identifier-results/store/types.ts
+++ b/packages/x-components/src/x-modules/identifier-results/store/types.ts
@@ -21,8 +21,6 @@ export interface IdentifierResultsState extends StatusState, QueryState {
   origin: QueryOrigin | null;
   /** The extra params property of the state. */
   params: Dictionary<unknown>;
-  /** The internal query of the module. Used to request the identifier results. */
-  query: string;
 }
 
 /**

--- a/packages/x-components/src/x-modules/identifier-results/wiring.ts
+++ b/packages/x-components/src/x-modules/identifier-results/wiring.ts
@@ -64,7 +64,7 @@ export const clearIdentifierResultsQuery = wireCommit('setQuery', '');
 const setUrlParams = wireDispatch('saveQuery', ({ eventPayload: { query } }) => query);
 
 /**
- * Requests and stores a new set of identifier results for the {@link IdentifierResultsState.query}.
+ * Requests and stores a new set of identifier results for the query.
  *
  * @public
  */

--- a/packages/x-components/src/x-modules/next-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/types.ts
@@ -20,8 +20,6 @@ import { ConfigMutations } from '../../../store/utils/config-store.utils';
  * @public
  */
 export interface NextQueriesState extends StatusState, QueryState {
-  /** The internal query of the module. Used to request the next queries. */
-  query: string;
   /** The list of the next queries, related to the `query` property of the state. */
   nextQueries: NextQuery[];
   /** The list of the searched queries, related to the `query` property of the state. */

--- a/packages/x-components/src/x-modules/next-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/types.ts
@@ -58,12 +58,6 @@ export interface NextQueriesMutations
     QueryMutations,
     ConfigMutations<NextQueriesState> {
   /**
-   * Sets the query of the module, which is used to retrieve the next-queries.
-   *
-   * @param newQuery - The new query to save to the state.
-   */
-  setQuery(newQuery: string): void;
-  /**
    * Sets the next queries of the module.
    *
    * @param nextQueries - The new next queries to save to the state.

--- a/packages/x-components/src/x-modules/query-suggestions/store/types.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/store/types.ts
@@ -13,8 +13,6 @@ import { ConfigMutations } from '../../../store/utils/config-store.utils';
  * @public
  */
 export interface QuerySuggestionsState extends StatusState, QueryState {
-  /** The query of the query suggestions module. Used to request the suggestions. */
-  query: string;
   /** The suggestions for the query of the state. */
   suggestions: Suggestion[];
   /** The configuration of the query suggestions module. */

--- a/packages/x-components/src/x-modules/query-suggestions/store/types.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/store/types.ts
@@ -48,12 +48,6 @@ export interface QuerySuggestionsMutations
     QueryMutations,
     ConfigMutations<QuerySuggestionsState> {
   /**
-   * Sets the query of the query suggestions module.
-   *
-   * @param newQuery - The new query.
-   */
-  setQuery(newQuery: string): void;
-  /**
    * Sets the suggestions of the module.
    *
    * @param suggestions - The suggestions list.

--- a/packages/x-components/src/x-modules/query-suggestions/wiring.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/wiring.ts
@@ -84,7 +84,7 @@ export const clearQuerySuggestionsQuery = wireCommit('setQuery', '');
 const setUrlParams = wireDispatch('setUrlParams');
 
 /**
- * Requests and stores a new set of query suggestions for the {@link QuerySuggestionsState.query}.
+ * Requests and stores a new set of query suggestions for the query.
  *
  * @public
  */

--- a/packages/x-components/src/x-modules/search-box/store/types.ts
+++ b/packages/x-components/src/x-modules/search-box/store/types.ts
@@ -10,10 +10,6 @@ import { XEvent } from '../../../wiring/events.types';
  */
 export interface SearchBoxState extends QueryState {
   /**
-   * The query of the search box input.
-   */
-  query: string;
-  /**
    * The status of the search box input based on a state machine.
    */
   inputStatus: string;

--- a/packages/x-components/src/x-modules/search-box/store/types.ts
+++ b/packages/x-components/src/x-modules/search-box/store/types.ts
@@ -32,12 +32,6 @@ export interface SearchBoxGetters {
  */
 export interface SearchBoxMutations extends QueryMutations {
   /**
-   * Sets the new query of the search-box.
-   *
-   * @param newQuery - The new query of the search-box.
-   */
-  setQuery(newQuery: string): void;
-  /**
    * Sets the new input status of the search-box.
    *
    * @param inputStatus - The new {@link InputStatus} of the search-box.

--- a/packages/x-components/src/x-modules/search/store/getters/query.getter.ts
+++ b/packages/x-components/src/x-modules/search/store/getters/query.getter.ts
@@ -2,7 +2,7 @@ import { createRelatedTagsQueryGetter } from '../../../../store/utils/query.util
 import { SearchXStoreModule } from '../types';
 
 /**
- * Default implementation for the {@link SearchState.query} getter.
+ * Default implementation for the search query getter.
  *
  * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the related
  * tags' module.

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -167,12 +167,6 @@ export interface SearchMutations
    */
   setPromoteds(promoteds: Promoted[]): void;
   /**
-   * Sets the query of the module, which is used to retrieve the results.
-   *
-   * @param newQuery - The new query to save to the state.
-   */
-  setQuery(newQuery: string): void;
-  /**
    * Sets the query tagging of the module, which is used to track the query.
    *
    * @param queryTagging - The new query tagging object to save to the state.

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -50,8 +50,6 @@ export interface SearchState extends StatusState, QueryState {
   partialResults: PartialResult[];
   /** The list of the promoted, related to the `query` property of the state. */
   promoteds: Promoted[];
-  /** The internal query of the module. Used to request the search results. */
-  query: string;
   /** The query tagging used to track the search events. */
   queryTagging: TaggingRequest;
   /** The redirections associated to the `query`. */

--- a/packages/x-components/src/x-modules/semantic-queries/store/module.ts
+++ b/packages/x-components/src/x-modules/semantic-queries/store/module.ts
@@ -1,10 +1,10 @@
 import { mergeConfig, setConfig } from '../../../store/utils/config-store.utils';
+import { setQuery } from '../../../store/utils/query.utils';
 import { SemanticQueriesXStoreModule } from './types';
 import { fetchSemanticQuery } from './actions/fetch-semantic-query.action';
 import { fetchAndSaveSemanticQuery } from './actions/fetch-and-save-semantic-query.action';
 import { request } from './getters/request.getter';
 import { normalizedQuery } from './getters/normalized-query.getter';
-
 /**
  * {@link XStoreModule} For the `semantic-queries` module.
  *
@@ -32,9 +32,7 @@ export const semanticQueriesXStoreModule: SemanticQueriesXStoreModule = {
     setSemanticQueries(state, queries) {
       state.semanticQueries = queries;
     },
-    setQuery(state, query) {
-      state.query = query;
-    },
+    setQuery,
     setTotalResults(state, totalResults) {
       state.totalResults = totalResults;
     },

--- a/packages/x-components/src/x-modules/semantic-queries/store/module.ts
+++ b/packages/x-components/src/x-modules/semantic-queries/store/module.ts
@@ -5,6 +5,7 @@ import { fetchSemanticQuery } from './actions/fetch-semantic-query.action';
 import { fetchAndSaveSemanticQuery } from './actions/fetch-and-save-semantic-query.action';
 import { request } from './getters/request.getter';
 import { normalizedQuery } from './getters/normalized-query.getter';
+
 /**
  * {@link XStoreModule} For the `semantic-queries` module.
  *

--- a/packages/x-components/src/x-modules/semantic-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/semantic-queries/store/types.ts
@@ -48,10 +48,6 @@ export interface SemanticQueriesMutations
   extends QueryMutations,
     ConfigMutations<SemanticQueriesState> {
   /**
-   * Sets the {@link SemanticQueriesState.query} property.
-   */
-  setQuery(query: string): void;
-  /**
    * Sets the {@link SemanticQueriesState.totalResults} property.
    */
   setTotalResults(totalResults: number): void;

--- a/packages/x-components/src/x-modules/semantic-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/semantic-queries/store/types.ts
@@ -4,13 +4,14 @@ import { XActionContext } from '../../../store/actions.types';
 import { XStoreModule } from '../../../store/store.types';
 import { SemanticQueriesConfig } from '../config.types';
 import { ConfigMutations } from '../../../store/utils/config-store.utils';
+import { QueryMutations, QueryState } from '../../../store/utils/query.utils';
 
 /**
  * SemanticQueries store state.
  *
  * @public
  */
-export interface SemanticQueriesState {
+export interface SemanticQueriesState extends QueryState {
   /** The query sending on the request. */
   query: string;
   /** The number of the total results of the query. */
@@ -45,7 +46,9 @@ export interface SemanticQueriesGetters {
  *
  * @public
  */
-export interface SemanticQueriesMutations extends ConfigMutations<SemanticQueriesState> {
+export interface SemanticQueriesMutations
+  extends QueryMutations,
+    ConfigMutations<SemanticQueriesState> {
   /**
    * Sets the {@link SemanticQueriesState.query} property.
    */

--- a/packages/x-components/src/x-modules/semantic-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/semantic-queries/store/types.ts
@@ -12,8 +12,6 @@ import { QueryMutations, QueryState } from '../../../store/utils/query.utils';
  * @public
  */
 export interface SemanticQueriesState extends QueryState {
-  /** The query sending on the request. */
-  query: string;
   /** The number of the total results of the query. */
   totalResults: number;
   /** The request and results. */

--- a/packages/x-components/src/x-modules/url/store/types.ts
+++ b/packages/x-components/src/x-modules/url/store/types.ts
@@ -50,12 +50,6 @@ export interface UrlMutations extends QueryMutations {
    */
   setParams(params: Partial<UrlParams>): void;
   /**
-   * Sets the new query.
-   *
-   * @param query - The new query of the Url.
-   */
-  setQuery(query: string): void;
-  /**
    * Sets the related tags.
    *
    * @param relatedTags - The new related tags of the url.


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 


## Motivation and context

This task is to check in the different modules that all mutations of a query are taking advantage of the setQuery util functionality and import the setQuery & use it if necessary. I noticed that in some tests we weren't using the setQuery function

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-2424](https://searchbroker.atlassian.net/browse/EMP-2424)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:



[EMP-2424]: https://searchbroker.atlassian.net/browse/EMP-2424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ