### PR TITLE
fix(history-queries): selected filters now working for legacy history queries saved in storage without them

### DIFF
--- a/packages/x-components/src/x-modules/facets/wiring.ts
+++ b/packages/x-components/src/x-modules/facets/wiring.ts
@@ -173,7 +173,7 @@ export const setSelectedFiltersFromPreview = wireCommit(
  */
 export const setFiltersFromHistoryQueries = wireCommit(
   'setFilters',
-  ({ eventPayload: { selectedFilters } }) => selectedFilters
+  ({ eventPayload: { selectedFilters } }) => selectedFilters ?? []
 );
 
 /**

--- a/packages/x-components/src/x-modules/history-queries/store/actions/load-history-queries-from-browser-storage.action.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/actions/load-history-queries-from-browser-storage.action.ts
@@ -13,7 +13,6 @@ import { HistoryQueriesXStoreModule } from '../types';
 // eslint-disable-next-line max-len
 export const loadHistoryQueriesFromBrowserStorage: HistoryQueriesXStoreModule['actions']['loadHistoryQueriesFromBrowserStorage'] =
   ({ commit, getters }) => {
-    const historyQueries =
-      localStorageService.getItem<HistoryQuery[] | HistoryQuery>(getters.storageKey) ?? [];
-    commit('setHistoryQueries', [historyQueries].flat());
+    const historyQueries = localStorageService.getItem<HistoryQuery[]>(getters.storageKey) ?? [];
+    commit('setHistoryQueries', historyQueries);
   };

--- a/packages/x-components/src/x-modules/history-queries/store/actions/load-history-queries-from-browser-storage.action.ts
+++ b/packages/x-components/src/x-modules/history-queries/store/actions/load-history-queries-from-browser-storage.action.ts
@@ -13,6 +13,7 @@ import { HistoryQueriesXStoreModule } from '../types';
 // eslint-disable-next-line max-len
 export const loadHistoryQueriesFromBrowserStorage: HistoryQueriesXStoreModule['actions']['loadHistoryQueriesFromBrowserStorage'] =
   ({ commit, getters }) => {
-    const historyQueries = localStorageService.getItem<HistoryQuery[]>(getters.storageKey) ?? [];
-    commit('setHistoryQueries', historyQueries);
+    const historyQueries =
+      localStorageService.getItem<HistoryQuery[] | HistoryQuery>(getters.storageKey) ?? [];
+    commit('setHistoryQueries', [historyQueries].flat());
   };

--- a/packages/x-components/src/x-modules/search/wiring.ts
+++ b/packages/x-components/src/x-modules/search/wiring.ts
@@ -219,9 +219,9 @@ export const setSearchSelectedFiltersFromPreview = wireCommit(
  *
  * @public
  */
-export const setSearchSelectedFiltersFromPreviewable = wireCommit(
+export const setSearchSelectedFiltersFromHistoryQuery = wireCommit(
   'setSelectedFilters',
-  ({ eventPayload: { selectedFilters } }) => selectedFilters
+  ({ eventPayload: { selectedFilters } }) => selectedFilters ?? []
 );
 
 /**
@@ -294,6 +294,6 @@ export const searchWiring = createWiring({
     setSearchExtraParams
   },
   UserSelectedAHistoryQuery: {
-    setSearchSelectedFiltersFromPreviewable
+    setSearchSelectedFiltersFromHistoryQuery
   }
 });


### PR DESCRIPTION
## Motivation and context
Legacy HQ (history queries stored in the local storage before the new `selectedFilters` feature was created) caused an error because clicking on them resulted in the utility `groupBy` being called with `undefined`.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Check if you have any legacy HQ in the local storage or create one by removing the `selectedFilters` field from an existing one and the select it.
