### PR TITLE
ci: remove lint and test steps

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -22,12 +22,6 @@ jobs:
       - name: install dependencies
         run: pnpm install
 
-      - name: lint packages
-        run: pnpm run lint
-
-      - name: test packages
-        run: pnpm run test
-
       - name: configure git user
         run: |
           git config --local user.email "x@empathy.co"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,5 +1,6 @@
 name: Prepare stable release
 on: [workflow_dispatch]
+description: Warning - Be sure that last chore commit has a green pipeline before lauhching this workflow
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
@@ -21,6 +22,12 @@ jobs:
 
       - name: install dependencies
         run: pnpm install
+
+      - name: lint packages
+        run: pnpm run lint
+
+      - name: test packages
+        run: pnpm run test
 
       - name: configure git user
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,6 +1,5 @@
 name: Prepare stable release
 on: [workflow_dispatch]
-description: Warning - Be sure that last chore commit has a green pipeline before lauhching this workflow
 jobs:
   prepare-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,12 +23,6 @@ jobs:
       - name: install dependencies
         run: pnpm install
 
-      - name: lint packages
-        run: pnpm run lint
-
-      - name: test packages
-        run: pnpm run test
-
       - name: configure git user
         run: |
           git config --local user.email "x@empathy.co"


### PR DESCRIPTION
This PR removes the test and lint steps from the workflow for creating a new stable release. Currently, these steps run on every push and PR. Since the prepare release workflow is launched against the main branch, where these steps have already been executed, there's no need to run them again, especially considering this workflow will only create a PR and this new PR will execute them.