### PR TITLE
feat(search): handle display tagging from search response

### DIFF
--- a/packages/x-adapter-platform/src/__tests__/__fixtures__/search.response.ts
+++ b/packages/x-adapter-platform/src/__tests__/__fixtures__/search.response.ts
@@ -101,6 +101,8 @@ export const platformSearchResponse = {
       }
     ],
     tagging: {
+      display:
+        'https://api.staging.empathy.co/tagging/v1/track/empathy/display?q=jeans&lang=en&scope=desktop&totalHits=686&page=1&origin=url%3Aexternal&filtered=true&spellcheck=false',
       query:
         'https://api.staging.empathy.co/tagging/v1/track/empathy/query?q=jeans&lang=en&scope=desktop&totalHits=686&page=1&origin=url%3Aexternal&filtered=true&spellcheck=false'
     },

--- a/packages/x-adapter-platform/src/mappers/__tests__/url.spec.ts
+++ b/packages/x-adapter-platform/src/mappers/__tests__/url.spec.ts
@@ -1,4 +1,8 @@
-import { extractUrlParameters, getDisplayClickTagging, getTaggingInfoFromUrl } from '../url.utils';
+import {
+  extractUrlParameters,
+  getDisplayTaggingInfoFromUrl,
+  getTaggingInfoFromUrl
+} from '../url.utils';
 
 describe('url utils methods tests', () => {
   describe('extractUrlParameters', () => {
@@ -45,14 +49,14 @@ describe('url utils methods tests', () => {
 
   describe('getDisplayClickTagging', () => {
     it('should not break when dealing with bad urls', () => {
-      expect(getDisplayClickTagging('null')).toStrictEqual({
+      expect(getDisplayTaggingInfoFromUrl('null')).toStrictEqual({
         url: 'null',
         params: { displayId: 'no_query', follow: false }
       });
     });
 
     it('should retrieve the tagging info from the url, replacing q with displayId', () => {
-      const { url, params } = getDisplayClickTagging(
+      const { url, params } = getDisplayTaggingInfoFromUrl(
         'https://api.empathy.co/?q=chips&env=mobile&lang=english&lang=spanish'
       );
       expect(url).toBe('https://api.empathy.co/');
@@ -65,7 +69,7 @@ describe('url utils methods tests', () => {
     });
 
     it('should set no_query tagging info when no q param exist as in topclicked response', () => {
-      const { url, params } = getDisplayClickTagging(
+      const { url, params } = getDisplayTaggingInfoFromUrl(
         'https://api.empathy.co/?env=mobile&lang=english&lang=spanish'
       );
       expect(url).toBe('https://api.empathy.co/');

--- a/packages/x-adapter-platform/src/mappers/responses/__tests__/__snapshots__/search-response.mapper.spec.ts.snap
+++ b/packages/x-adapter-platform/src/mappers/responses/__tests__/__snapshots__/search-response.mapper.spec.ts.snap
@@ -30,6 +30,20 @@ Object {
       "url": "https://assets.empathy.co/",
     },
   ],
+  "displayTagging": Object {
+    "params": Object {
+      "filtered": "true",
+      "follow": false,
+      "lang": "en",
+      "origin": "url:external",
+      "page": "1",
+      "q": "jeans",
+      "scope": "desktop",
+      "spellcheck": "false",
+      "totalHits": "686",
+    },
+    "url": "https://api.staging.empathy.co/tagging/v1/track/empathy/display",
+  },
   "facets": Array [
     Object {
       "filters": Array [

--- a/packages/x-adapter-platform/src/mappers/responses/__tests__/__snapshots__/search-response.mapper.spec.ts.snap
+++ b/packages/x-adapter-platform/src/mappers/responses/__tests__/__snapshots__/search-response.mapper.spec.ts.snap
@@ -32,12 +32,12 @@ Object {
   ],
   "displayTagging": Object {
     "params": Object {
+      "displayId": "jeans",
       "filtered": "true",
       "follow": false,
       "lang": "en",
       "origin": "url:external",
       "page": "1",
-      "q": "jeans",
       "scope": "desktop",
       "spellcheck": "false",
       "totalHits": "686",

--- a/packages/x-adapter-platform/src/mappers/url.utils.ts
+++ b/packages/x-adapter-platform/src/mappers/url.utils.ts
@@ -28,7 +28,7 @@ export function getTaggingInfoFromUrl(taggingUrl: string): TaggingRequest {
  *
  * @public
  */
-export function getDisplayClickTagging(displayTaggingUrl: string): TaggingRequest {
+export function getDisplayTaggingInfoFromUrl(displayTaggingUrl: string): TaggingRequest {
   const displayClickTagging = getTaggingInfoFromUrl(displayTaggingUrl);
   const displayClickTaggingParams = displayClickTagging.params;
 

--- a/packages/x-adapter-platform/src/mappers/url.utils.ts
+++ b/packages/x-adapter-platform/src/mappers/url.utils.ts
@@ -29,13 +29,13 @@ export function getTaggingInfoFromUrl(taggingUrl: string): TaggingRequest {
  * @public
  */
 export function getDisplayTaggingInfoFromUrl(displayTaggingUrl: string): TaggingRequest {
-  const displayClickTagging = getTaggingInfoFromUrl(displayTaggingUrl);
-  const displayClickTaggingParams = displayClickTagging.params;
+  const displayTagging = getTaggingInfoFromUrl(displayTaggingUrl);
+  const displayTaggingParams = displayTagging.params;
 
-  displayClickTaggingParams.displayId = displayClickTaggingParams.q ?? 'no_query';
-  delete displayClickTaggingParams.q;
+  displayTaggingParams.displayId = displayTaggingParams.q ?? 'no_query';
+  delete displayTaggingParams.q;
 
-  return displayClickTagging;
+  return displayTagging;
 }
 
 /**

--- a/packages/x-adapter-platform/src/schemas/models/result.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/result.schema.ts
@@ -1,6 +1,6 @@
 import { createMutableSchema } from '@empathyco/x-adapter';
 import { Result } from '@empathyco/x-types';
-import { getDisplayClickTagging, getTaggingInfoFromUrl } from '../../mappers/url.utils';
+import { getDisplayTaggingInfoFromUrl, getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformResult } from '../../types/models/result.model';
 
 /**
@@ -36,7 +36,7 @@ export const resultSchema = createMutableSchema<PlatformResult, Result>({
       add2cart: ({ add2cart }) => getTaggingInfoFromUrl(add2cart),
       checkout: ({ checkout }) => getTaggingInfoFromUrl(checkout),
       click: ({ click }) => getTaggingInfoFromUrl(click),
-      displayClick: ({ displayClick }) => getDisplayClickTagging(displayClick)
+      displayClick: ({ displayClick }) => getDisplayTaggingInfoFromUrl(displayClick)
     }
   }
 });

--- a/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
@@ -1,6 +1,6 @@
 import { createMutableSchema } from '@empathyco/x-adapter';
 import { SearchResponse } from '@empathyco/x-types';
-import { getTaggingInfoFromUrl } from '../../mappers/url.utils';
+import { getDisplayTaggingInfoFromUrl, getTaggingInfoFromUrl } from '../../mappers/url.utils';
 import { PlatformSearchResponse } from '../../types/responses/search-response.model';
 import { bannerSchema } from '../models/banner.schema';
 import { facetSchema } from '../models/facet.schema';
@@ -42,5 +42,5 @@ export const searchResponseSchema = createMutableSchema<PlatformSearchResponse, 
     $subSchema: partialResultsSchema
   },
   queryTagging: ({ catalog }) => getTaggingInfoFromUrl(catalog?.tagging?.query),
-  displayTagging: ({ catalog }) => getTaggingInfoFromUrl(catalog?.tagging?.display)
+  displayTagging: ({ catalog }) => getDisplayTaggingInfoFromUrl(catalog?.tagging?.display)
 });

--- a/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/responses/search-response.schema.ts
@@ -41,5 +41,6 @@ export const searchResponseSchema = createMutableSchema<PlatformSearchResponse, 
     $path: 'catalog.partials',
     $subSchema: partialResultsSchema
   },
-  queryTagging: ({ catalog }) => getTaggingInfoFromUrl(catalog?.tagging?.query)
+  queryTagging: ({ catalog }) => getTaggingInfoFromUrl(catalog?.tagging?.query),
+  displayTagging: ({ catalog }) => getTaggingInfoFromUrl(catalog?.tagging?.display)
 });

--- a/packages/x-adapter-platform/src/types/responses/search-response.model.ts
+++ b/packages/x-adapter-platform/src/types/responses/search-response.model.ts
@@ -22,6 +22,7 @@ export interface PlatformSearchResponse {
     partials: PlatformPartialResult[];
     tagging: {
       query: string;
+      display: string;
     };
   };
   direct: {

--- a/packages/x-components/src/__stubs__/empty-search-response-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/empty-search-response-stubs.factory.ts
@@ -17,6 +17,10 @@ export function getEmptySearchResponseStub(): SearchResponse {
       params: {},
       url: ''
     },
+    displayTagging: {
+      params: {},
+      url: ''
+    },
     redirections: [],
     results: [],
     spellcheck: '',

--- a/packages/x-components/src/__stubs__/search-response-stubs.factory.ts
+++ b/packages/x-components/src/__stubs__/search-response-stubs.factory.ts
@@ -20,6 +20,7 @@ export function getSearchResponseStub(): SearchResponse {
     partialResults: [],
     promoteds: getPromotedsStub(),
     queryTagging: getTaggingResponseStub(),
+    displayTagging: getTaggingResponseStub(),
     redirections: getRedirectionsStub(),
     results: getResultsStub(),
     spellcheck: '',

--- a/packages/x-components/src/adapter/mocked-responses.ts
+++ b/packages/x-components/src/adapter/mocked-responses.ts
@@ -221,6 +221,10 @@ export function createSearchResponse(partial?: Partial<SearchResponse>): SearchR
       url: `${trackEndpoint}/query`,
       params: { page: 1 }
     },
+    displayTagging: {
+      url: `${trackEndpoint}/display`,
+      params: { page: 1 }
+    },
     spellcheck: '',
     ...partial
   };

--- a/packages/x-components/src/x-modules/search/store/actions/save-search-response.action.ts
+++ b/packages/x-components/src/x-modules/search/store/actions/save-search-response.action.ts
@@ -20,7 +20,8 @@ export const saveSearchResponse: SearchXStoreModule['actions']['saveSearchRespon
     totalResults,
     spellcheck,
     redirections,
-    queryTagging
+    queryTagging,
+    displayTagging
   }
 ) => {
   if (totalResults === 0) {
@@ -50,6 +51,11 @@ export const saveSearchResponse: SearchXStoreModule['actions']['saveSearchRespon
   if (queryTagging) {
     commit('setQueryTagging', queryTagging);
   }
+
+  if (displayTagging) {
+    commit('setDisplayTagging', displayTagging);
+  }
+
   commit('setTotalResults', totalResults);
   commit('setSpellcheck', spellcheck ?? '');
 };

--- a/packages/x-components/src/x-modules/search/store/emitters.ts
+++ b/packages/x-components/src/x-modules/search/store/emitters.ts
@@ -28,6 +28,7 @@ export const searchEmitters = createStoreEmitters(searchXStoreModule, {
         partialResults: state.partialResults,
         promoteds: state.promoteds,
         queryTagging: state.queryTagging,
+        displayTagging: state.displayTagging,
         redirections: state.redirections,
         results: state.results,
         spellcheck: state.spellcheckedQuery,

--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -106,6 +106,9 @@ export const searchXStoreModule: SearchXStoreModule = {
     setQueryTagging(state, queryTagging) {
       state.queryTagging = queryTagging;
     },
+    setDisplayTagging(state, displayTagging) {
+      state.displayTagging = displayTagging;
+    },
     updateResult(state, result) {
       const stateResult = state.results.find(stateResult => result.id === stateResult.id);
       if (stateResult) {
@@ -151,6 +154,10 @@ export function resettableState() {
     isAppendResults: false,
     redirections: [],
     queryTagging: {
+      url: '',
+      params: {}
+    },
+    displayTagging: {
       url: '',
       params: {}
     }

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -52,6 +52,8 @@ export interface SearchState extends StatusState, QueryState {
   promoteds: Promoted[];
   /** The query tagging used to track the search events. */
   queryTagging: TaggingRequest;
+  /** The display tagging used to track the search events. */
+  displayTagging: TaggingRequest;
   /** The redirections associated to the `query`. */
   redirections: Redirection[];
   /** The list of the related tags, related to the `query` property of the state. */
@@ -172,6 +174,12 @@ export interface SearchMutations
    * @param queryTagging - The new query tagging object to save to the state.
    */
   setQueryTagging(queryTagging: TaggingRequest): void;
+  /**
+   * Sets the display tagging of the module.
+   *
+   * @param displayTagging - The new display tagging object to save to the state.
+   */
+  setDisplayTagging(DisplayTagging: TaggingRequest): void;
   /**
    * Sets the redirection of the module.
    *

--- a/packages/x-types/src/response/search-response.model.ts
+++ b/packages/x-types/src/response/search-response.model.ts
@@ -17,6 +17,7 @@ export interface SearchResponse {
   partialResults?: PartialResult[];
   promoteds?: Promoted[];
   queryTagging?: TaggingRequest;
+  displayTagging?: TaggingRequest;
   redirections?: Redirection[];
   results: Result[];
   spellcheck?: string;


### PR DESCRIPTION
[EMP-3239](https://searchbroker.atlassian.net/browse/EMP-3239)

## Motivation and context
A new field for the display tagging will be added to the search response to be used on the recommendations. This PR handles that new field for the search response types and the search module.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

[EMP-3239]: https://searchbroker.atlassian.net/browse/EMP-3239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ