### PR TITLE
fix: refactor snippet-config-extra-params to use watchers preventing false event firing

### DIFF
--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -5,7 +5,7 @@
 <script lang="ts">
   import { forEach, Dictionary } from '@empathyco/x-utils';
   import Vue from 'vue';
-  import { Component, Inject, Prop } from 'vue-property-decorator';
+  import { Component, Inject, Prop, Watch } from 'vue-property-decorator';
   import { xComponentMixin } from '../../../components/x-component.mixin';
   import { SnippetConfig } from '../../../x-installer/api/api.types';
   import { extraParamsXModule } from '../x-module';
@@ -48,16 +48,21 @@
      *
      * @internal
      */
-    protected get extraParams(): Dictionary<unknown> {
-      const newExtraParams = {};
+    protected extraParams: Dictionary<unknown> = {};
 
+    /**
+     * Updates the extraParams object when the snippet config or the values prop changes.
+     *
+     * @internal
+     */
+    @Watch('snippetConfig', { deep: true, immediate: true })
+    @Watch('values', { deep: true, immediate: true })
+    syncExtraParams(): void {
       forEach({ ...this.values, ...this.snippetConfig }, (name, value) => {
         if (!this.excludedExtraParams.includes(name)) {
-          this.$set(newExtraParams, name, value);
+          this.$set(this.extraParams, name, value);
         }
       });
-
-      return newExtraParams;
     }
 
     /**


### PR DESCRIPTION

## Motivation and context
The component `SnippetConfigExtraParams` was causing the firing of the event `ExtraParamsProvided` when the snippet config changed, even if the extra params didn't actually change. This PR changes the logic from a computed property to two watchers, preventing the bug.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Check that updating a parameter in the snippet config with `InterfaceX.setSnippetConfig` that is exclueded from the extra params doesn't fire `ExtraParamsProvided`.
