### PR TITLE
Query Previews stop requesting when one fails

### DIFF
--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview-list.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview-list.spec.ts
@@ -86,9 +86,7 @@ describe('testing QueryPreviewList', () => {
     expect(queryPreviews.at(1).text()).toEqual('jeans - Sick jeans');
   });
 
-  // TODO Uncomment when the 'error' event is fixed. EMP-3402 task
-  // eslint-disable-next-line jest/no-commented-out-tests
-  /*it('hides queries with no results', async () => {
+  it('hides queries with no results', async () => {
     const { getQueryPreviewItemWrappers, reRender } = renderQueryPreviewList({
       queriesPreviewInfo: [{ query: 'noResults' }, { query: 'shoes' }],
       results: { noResults: [], shoes: [createResultStub('Crazy shoes')] }
@@ -127,7 +125,7 @@ describe('testing QueryPreviewList', () => {
     queryPreviews = getQueryPreviewItemWrappers();
     expect(queryPreviews.wrappers).toHaveLength(1);
     expect(queryPreviews.at(0).text()).toEqual('shoes - Crazy shoes');
-  });*/
+  });
 });
 
 interface RenderQueryPreviewListOptions {


### PR DESCRIPTION
[EMP-3403](https://searchbroker.atlassian.net/browse/EMP-3402)

Just uncommented the tests that should fail and now they are passing, also tested with another query with no results, `fbguadjrhvgw`.
I have compared my local branch (`feature/EMP-3079-allow-queries-preview-with-same-query-but-different-filters-or-params`) which was not updated with the [last changes that were merged](https://github.com/empathyco/x/pull/1392):

Here is a screenshot: On the left side the code in the updated branch, on the right side my local & not updated branch (where tests failed):
![Captura de pantalla 2024-02-07 a les 11 46 30](https://github.com/empathyco/x/assets/21217131/6f0a7815-839f-41d1-b308-5ee74e040097)

 It seems that the reactivity was broken as the query preview key variable was not reassigned, so there weren't new queries to make more requests. Setting the key as a computed property was the solution.
 
@diegopf or @CachedaCodes ping me if you need my local & not updated branch pushed or ping me to check this together 🙏 



[EMP-3403]: https://searchbroker.atlassian.net/browse/EMP-3403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ