### PR TITLE
feat(tagging): send query event when a result from a QP is clicked

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -277,7 +277,6 @@
                             <Result
                               v-for="result in results"
                               :key="result.id"
-                              @click="emitTracking(queryTagging)"
                               :result="result"
                               style="max-width: 180px"
                             />

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -250,7 +250,13 @@
                 <QueryPreviewList
                   :debounceTimeMs="250"
                   :queriesPreviewInfo="queriesPreviewInfo"
-                  #default="{ queryPreviewInfo, totalResults, results, displayTagging }"
+                  #default="{
+                    queryPreviewInfo,
+                    totalResults,
+                    results,
+                    displayTagging,
+                    queryTagging
+                  }"
                   data-test="brand-recommendation"
                   :persistInCache="true"
                 >
@@ -265,16 +271,19 @@
                       >
                         {{ `${queryPreviewInfo.query} (${totalResults})` }}
                       </QueryPreviewButton>
-                      <SlidingPanel :resetOnContentChange="false">
-                        <div class="x-flex x-gap-8">
-                          <Result
-                            v-for="result in results"
-                            :key="result.id"
-                            :result="result"
-                            style="max-width: 180px"
-                          />
-                        </div>
-                      </SlidingPanel>
+                      <DisplayResultProvider :queryTagging="queryTagging">
+                        <SlidingPanel :resetOnContentChange="false">
+                          <div class="x-flex x-gap-8">
+                            <Result
+                              v-for="result in results"
+                              :key="result.id"
+                              @click="emitTracking(queryTagging)"
+                              :result="result"
+                              style="max-width: 180px"
+                            />
+                          </div>
+                        </SlidingPanel>
+                      </DisplayResultProvider>
                     </div>
                   </DisplayEmitter>
                 </QueryPreviewList>

--- a/packages/x-components/src/views/home/display-result-provider.vue
+++ b/packages/x-components/src/views/home/display-result-provider.vue
@@ -20,13 +20,10 @@
       }
     },
     setup(props) {
-      provide('resultClickExtraEvents', [
-        'UserClickedADisplayResult',
-        'UserClickedADisplayResultWithQuery'
-      ]);
+      provide('resultClickExtraEvents', ['UserClickedADisplayResult']);
 
       provide('resultLinkMetadataPerEvent', {
-        UserClickedADisplayResultWithQuery: {
+        UserClickedADisplayResult: {
           queryTagging: props.queryTagging
         }
       });

--- a/packages/x-components/src/views/home/display-result-provider.vue
+++ b/packages/x-components/src/views/home/display-result-provider.vue
@@ -5,17 +5,31 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent } from 'vue';
+  import { defineComponent, PropType, provide } from 'vue';
+  import { TaggingRequest } from '@empathyco/x-types';
   import { NoElement } from '../../components/no-element';
 
   export default defineComponent({
     components: {
       NoElement
     },
-    provide() {
-      return {
-        resultClickExtraEvents: ['UserClickedADisplayResult']
-      };
+    props: {
+      queryTagging: {
+        type: Object as PropType<TaggingRequest>,
+        required: false
+      }
+    },
+    setup(props) {
+      provide('resultClickExtraEvents', [
+        'UserClickedADisplayResult',
+        'UserClickedADisplayResultWithQuery'
+      ]);
+
+      provide('resultLinkMetadataPerEvent', {
+        UserClickedADisplayResultWithQuery: {
+          queryTagging: props.queryTagging
+        }
+      });
     }
   });
 </script>

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -114,12 +114,6 @@ export interface XEventsTypes
    */
   UserClickedADisplayResult: Result;
   /**
-   * The user has clicked on a display result.
-   * Payload: The {@link @empathyco/x-types#Result | result} that the user clicked.
-   * Metadata: The queryTagging of the query of the clicked result.
-   */
-  UserClickedADisplayResultWithQuery: Result;
-  /**
    * The user clicked the button to close the events modal.
    * Payload: none.
    */

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -114,6 +114,12 @@ export interface XEventsTypes
    */
   UserClickedADisplayResult: Result;
   /**
+   * The user has clicked on a display result.
+   * Payload: The {@link @empathyco/x-types#Result | result} that the user clicked.
+   * Metadata: The queryTagging of the query of the clicked result.
+   */
+  UserClickedADisplayResultWithQuery: Result;
+  /**
    * The user clicked the button to close the events modal.
    * Payload: none.
    */

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -12,6 +12,7 @@
       :results="queryPreviewResults.results"
       :totalResults="queryPreviewResults.totalResults"
       :displayTagging="queryPreviewResults.displayTagging"
+      :queryTagging="queryPreviewResults.queryTagging"
     >
       <ul data-test="query-preview" class="x-query-preview">
         <li

--- a/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
@@ -83,6 +83,15 @@ describe('testing queries preview module actions', () => {
             totalHits: '789'
           },
           url: 'https://api.empathybroker.com/tagging/v1/track/query'
+        },
+        queryTagging: {
+          params: {
+            follow: false,
+            lang: 'es',
+            q: 'lego',
+            totalHits: '789'
+          },
+          url: 'https://api.empathybroker.com/tagging/v1/track/query'
         }
       };
 

--- a/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
@@ -38,7 +38,8 @@ export const fetchAndSaveQueryPreview: QueriesPreviewXStoreModule['actions']['fe
           status: 'success',
           totalResults: response?.totalResults ?? 0,
           instances: 1,
-          displayTagging: response?.displayTagging ?? undefined
+          displayTagging: response?.displayTagging ?? undefined,
+          queryTagging: response?.queryTagging ?? undefined
         });
       })
       .catch(error => {

--- a/packages/x-components/src/x-modules/queries-preview/store/types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/types.ts
@@ -23,6 +23,8 @@ export interface QueryPreviewItem extends StatusState {
   results: Result[];
   /** Display tagging info. */
   displayTagging?: TaggingRequest;
+  /** Query tagging info. */
+  queryTagging?: TaggingRequest;
   /** The total number of results for the search query. */
   totalResults: number;
   /** The number of instances showing the query preview .*/

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -128,11 +128,28 @@ export const setQueryTaggingInfo = moduleDebounce(
 );
 
 /**
+ * Sets the tagging state of the query tagging info using.
+ *
+ * @public
+ */
+export const setQueryTaggingFromQueryPreview = wireCommit(
+  'setQueryTaggingInfo',
+  ({ metadata: { queryTagging } }) => queryTagging as TaggingRequest
+);
+
+/**
  * Tracks the tagging of the result.
  *
  * @public
  */
 export const trackResultClickedWire = createTrackWire('click');
+
+/**
+ * Tracks the tagging of the query of the clicked result.
+ *
+ * @public
+ */
+export const trackQueryResultClickWire = createTrackQueryWire('query');
 
 /**
  * Tracks the tagging of the banner.
@@ -180,6 +197,22 @@ export function createTrackWire(property: keyof Tagging): Wire<Taggable> {
     ({ eventPayload: { tagging }, metadata: { ignoreInModules } }) =>
       !!tagging?.[property] && !ignoreInModules?.includes(moduleName)
   );
+}
+
+/**
+ * Factory helper to create a wire for the track of a taggable element.
+ *
+ * @param property - Key of the tagging object to track.
+ * @returns A new wire for the query of the taggable element.
+ *
+ * @public
+ */
+export function createTrackQueryWire(property: keyof Tagging): Wire<Taggable> {
+  return wireDispatch('track', ({ eventPayload: { tagging }, metadata: { queryTagging } }) => {
+    const taggingInfo: TaggingRequest = tagging[property];
+    taggingInfo.params = (queryTagging as TaggingRequest).params;
+    return taggingInfo;
+  });
 }
 
 /**
@@ -255,5 +288,9 @@ export const taggingWiring = createWiring({
   },
   UserClickedADisplayResult: {
     trackDisplayClickedWire
+  },
+  UserClickedADisplayResultWithQuery: {
+    setQueryTaggingFromQueryPreview,
+    trackQueryResultClickWire
   }
 });

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -145,13 +145,6 @@ export const setQueryTaggingFromQueryPreview = wireCommit(
 export const trackResultClickedWire = createTrackWire('click');
 
 /**
- * Tracks the tagging of the query of the clicked result.
- *
- * @public
- */
-export const trackQueryResultClickWire = createTrackQueryWire('query');
-
-/**
  * Tracks the tagging of the banner.
  *
  * @public
@@ -197,22 +190,6 @@ export function createTrackWire(property: keyof Tagging): Wire<Taggable> {
     ({ eventPayload: { tagging }, metadata: { ignoreInModules } }) =>
       !!tagging?.[property] && !ignoreInModules?.includes(moduleName)
   );
-}
-
-/**
- * Factory helper to create a wire for the track of a taggable element.
- *
- * @param property - Key of the tagging object to track.
- * @returns A new wire for the query of the taggable element.
- *
- * @public
- */
-export function createTrackQueryWire(property: keyof Tagging): Wire<Taggable> {
-  return wireDispatch('track', ({ eventPayload: { tagging }, metadata: { queryTagging } }) => {
-    const taggingInfo: TaggingRequest = tagging[property];
-    taggingInfo.params = (queryTagging as TaggingRequest).params;
-    return taggingInfo;
-  });
 }
 
 /**
@@ -290,7 +267,6 @@ export const taggingWiring = createWiring({
     trackDisplayClickedWire
   },
   UserClickedADisplayResultWithQuery: {
-    setQueryTaggingFromQueryPreview,
-    trackQueryResultClickWire
+    setQueryTaggingFromQueryPreview
   }
 });

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -264,9 +264,7 @@ export const taggingWiring = createWiring({
     trackBannerClickedWire
   },
   UserClickedADisplayResult: {
-    trackDisplayClickedWire
-  },
-  UserClickedADisplayResultWithQuery: {
+    trackDisplayClickedWire,
     setQueryTaggingFromQueryPreview
   }
 });


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Carrousel previews are tagged with a new event “displayclicked” but this info doesn’t impact the CTR or Findability metric therefore queries are growing but CTR and Findability are suffering.
When a user clicks on a product in the carousel the query event with the origin has to be sent and the click and displayClick events.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-3521](https://searchbroker.atlassian.net/browse/EMP-3521)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Click on a result of a query preview. The first time you click on a result in one carousel 3 events should be sent (click, displayClick and query). Suppose you click on another result of the same carousel, only 2 events will be sent (click and displayClick). In that case, the tagging module has stored the queryTaggingInfo of the carousel. If you try to click in another carousel, the 3 events will be sent again.

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[EMP-3521]: https://searchbroker.atlassian.net/browse/EMP-3521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ