### PR TITLE
refactor: migrate cross-fade component to vue 2.7

### DIFF
--- a/packages/x-components/src/components/animations/cross-fade.vue
+++ b/packages/x-components/src/components/animations/cross-fade.vue
@@ -6,8 +6,7 @@
 </template>
 
 <script lang="ts">
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { defineComponent } from 'vue';
 
   /**
    * Renders a transition wrapping the element passed in the default slot. The transition
@@ -15,19 +14,19 @@
    *
    * @public
    */
-  @Component({
-    inheritAttrs: false
-  })
-  export default class CrossFade extends Vue {
-    /**
-     * Indicates if the transition must be applied on the initial render of the node.
-     */
-    @Prop({
-      type: Boolean,
-      default: true
-    })
-    public appear!: boolean;
-  }
+  export default defineComponent({
+    name: 'CrossFade',
+    inheritAttrs: false,
+    props: {
+      /**
+       * Indicates if the transition must be applied on the initial render of the node.
+       */
+      appear: {
+        type: Boolean,
+        default: true
+      }
+    }
+  });
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
[EMP-3381](https://searchbroker.atlassian.net/browse/EMP-3381)

# Motivation and context
For the vue 3 migration we need to migrate components to 2.7

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Follow the docs in the component to tests that the feature still works correctly


[EMP-3381]: https://searchbroker.atlassian.net/browse/EMP-3381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ