### PR TITLE
feat: migrate base-switch to use defineComponent sintax

### DIFF
--- a/packages/x-components/src/components/base-switch.vue
+++ b/packages/x-components/src/components/base-switch.vue
@@ -14,8 +14,21 @@
   import { defineComponent, ref } from 'vue';
   import { VueCSSClasses } from '../utils/types';
 
+  /**
+   * Basic switch component to handle boolean values. This component receives
+   * its selected state using a prop, and emits a Vue event whenever the user
+   * clicks it.
+   *
+   * @public
+   */
+
   export default defineComponent({
     name: 'BaseSwitch',
+    /**
+     * The selected value of the switch.
+     *
+     * @public
+     */
     props: {
       value: {
         type: Boolean,
@@ -24,10 +37,22 @@
     },
     emits: ['change', 'input'],
     setup(props, { emit }) {
+      /**
+       * Dynamic CSS classes to add to the switch component
+       * depending on its internal state.
+       *
+       * @returns A boolean dictionary with dynamic CSS classes.
+       * @internal
+       */
       const cssClasses = ref<VueCSSClasses>({
         'x-switch--is-selected x-selected': props.value
       });
 
+      /**
+       * Emits a change and input event with the desired value of the switch.
+       *
+       * @internal
+       */
       const toggle = (): void => {
         const newValue = !props.value;
         cssClasses.value = {

--- a/packages/x-components/src/components/base-switch.vue
+++ b/packages/x-components/src/components/base-switch.vue
@@ -22,7 +22,7 @@
         required: true
       }
     },
-    emits: ['change'],
+    emits: ['change', 'input'],
     setup(props, { emit }) {
       const cssClasses = ref<VueCSSClasses>({
         'x-switch--is-selected x-selected': props.value
@@ -34,6 +34,8 @@
           'x-switch--is-selected': newValue,
           'x-selected': newValue
         };
+
+        emit('input', newValue);
         emit('change', newValue);
       };
 

--- a/packages/x-components/src/components/base-switch.vue
+++ b/packages/x-components/src/components/base-switch.vue
@@ -11,53 +11,38 @@
 </template>
 
 <script lang="ts">
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { defineComponent, ref } from 'vue';
   import { VueCSSClasses } from '../utils/types';
 
-  /**
-   * Basic switch component to handle boolean values. This component receives
-   * its selected state using a prop, and emits a Vue event whenever the user
-   * clicks it.
-   *
-   * @public
-   */
-  @Component({
-    model: {
-      event: 'change'
-    }
-  })
-  export default class BaseSwitch extends Vue {
-    /**
-     * The selected value of the switch.
-     *
-     * @public
-     */
-    @Prop({ required: true })
-    public value!: boolean;
+  export default defineComponent({
+    name: 'BaseSwitch',
+    props: {
+      value: {
+        type: Boolean,
+        required: true
+      }
+    },
+    emits: ['change'],
+    setup(props, { emit }) {
+      const cssClasses = ref<VueCSSClasses>({
+        'x-switch--is-selected x-selected': props.value
+      });
 
-    /**
-     * Dynamic CSS classes to add to the switch component
-     * depending on its internal state.
-     *
-     * @returns A boolean dictionary with dynamic CSS classes.
-     * @internal
-     */
-    protected get cssClasses(): VueCSSClasses {
+      const toggle = (): void => {
+        const newValue = !props.value;
+        cssClasses.value = {
+          'x-switch--is-selected': newValue,
+          'x-selected': newValue
+        };
+        emit('change', newValue);
+      };
+
       return {
-        'x-switch--is-selected x-selected': this.value
+        cssClasses,
+        toggle
       };
     }
-
-    /**
-     * Emits a change event with the desired value of the switch.
-     *
-     * @internal
-     */
-    protected toggle(): void {
-      this.$emit('change', !this.value);
-    }
-  }
+  });
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
In order to migrate X components to vue3, we need to use the 2.7 sintax.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, [EMP-3376](https://searchbroker.atlassian.net/browse/EMP-3376?atlOrigin=eyJpIjoiMmQ2N2JlNGFkYmRkNGE4ZDkzZDVjNDYzMGY2OTgzYTMiLCJwIjoiaiJ9)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

You can use this test component to see if the switch still works correctly (review the import of the component according to your context)
```
<template>
  <div>
    <BaseSwitch @change="value = !value" :value="value" />
  </div>
</template>

<script>
  import { BaseSwitch } from '../../components';

  export default {
    name: 'BaseSwitchDemo',
    components: {
      BaseSwitch
    },
    data() {
      return {
        value: false
      };
    }
  };
</script>
```
Also test the v-model sintax:   `<BaseSwitch v-model="value" />`


[EMP-3376]: https://searchbroker.atlassian.net/browse/EMP-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ