### PR TITLE
fix(tagging): fix e2e test when a display result has no queryTagging

### DIFF
--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -7,7 +7,7 @@ import {
 import { namespacedDebounce } from '../../wiring/namespaced-wires.operators';
 import { wireService, wireServiceWithoutPayload } from '../../wiring/wires.factory';
 import { filter, mapWire } from '../../wiring/wires.operators';
-import { DisplayWireMetadata, Wire } from '../../wiring/wiring.types';
+import { AnyWire, DisplayWireMetadata, Wire } from '../../wiring/wiring.types';
 import { createWiring } from '../../wiring/wiring.utils';
 import { createOrigin } from '../../utils/index';
 import { FeatureLocation } from '../../types/index';
@@ -132,10 +132,7 @@ export const setQueryTaggingInfo = moduleDebounce(
  *
  * @public
  */
-export const setQueryTaggingFromQueryPreview = wireCommit(
-  'setQueryTaggingInfo',
-  ({ metadata: { queryTagging } }) => queryTagging as TaggingRequest
-);
+export const setQueryTaggingFromQueryPreview = createSetQueryTaggingFromQueryPreview();
 
 /**
  * Tracks the tagging of the result.
@@ -216,6 +213,23 @@ export function createTrackDisplayWire(property: keyof Tagging): Wire<Taggable> 
       return taggingInfo;
     }),
     ({ eventPayload: { tagging } }) => !!tagging?.[property]
+  );
+}
+
+/**
+ * Factory helper to create a wire for set the queryTagging.
+ *
+ * @returns A new wire for the query of a result of a queryPreview.
+ *
+ * @public
+ */
+export function createSetQueryTaggingFromQueryPreview(): AnyWire {
+  return filter(
+    wireCommit(
+      'setQueryTaggingInfo',
+      ({ metadata: { queryTagging } }) => queryTagging as TaggingRequest
+    ),
+    ({ metadata: { queryTagging } }) => !!queryTagging
   );
 }
 

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -7,7 +7,7 @@ import {
 import { namespacedDebounce } from '../../wiring/namespaced-wires.operators';
 import { wireService, wireServiceWithoutPayload } from '../../wiring/wires.factory';
 import { filter, mapWire } from '../../wiring/wires.operators';
-import { AnyWire, DisplayWireMetadata, Wire } from '../../wiring/wiring.types';
+import { DisplayWireMetadata, Wire } from '../../wiring/wiring.types';
 import { createWiring } from '../../wiring/wiring.utils';
 import { createOrigin } from '../../utils/index';
 import { FeatureLocation } from '../../types/index';
@@ -217,13 +217,13 @@ export function createTrackDisplayWire(property: keyof Tagging): Wire<Taggable> 
 }
 
 /**
- * Factory helper to create a wire for set the queryTagging.
+ * Factory helper to create a wire to set the queryTagging.
  *
  * @returns A new wire for the query of a result of a queryPreview.
  *
  * @public
  */
-export function createSetQueryTaggingFromQueryPreview(): AnyWire {
+export function createSetQueryTaggingFromQueryPreview(): Wire<Taggable> {
   return filter(
     wireCommit(
       'setQueryTaggingInfo',


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Fix test e2e when we click on a displayed result that has no `queryTagging`. For example semantics.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
Tagging test must pass

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
