### PR TITLE
feature(composables): create useNoElementRender composable

### DIFF
--- a/packages/x-components/src/composables/__tests__/use-no-element-render.spec.ts
+++ b/packages/x-components/src/composables/__tests__/use-no-element-render.spec.ts
@@ -1,0 +1,79 @@
+import Vue, { ComponentOptions, defineComponent } from 'vue';
+import { mount, Wrapper } from '@vue/test-utils';
+import { Dictionary } from '@empathyco/x-utils';
+import { useNoElementRender } from '../use-no-element-render';
+import { getDataTestSelector } from '../../__tests__/utils';
+
+const renderUseNoElementRender = ({
+  slots,
+  component
+}: RenderUseNoElementRenderOptions = {}): Wrapper<Vue> => {
+  const wrapper = mount(
+    component ??
+      (defineComponent({
+        render() {
+          return useNoElementRender(this.$slots);
+        }
+      }) as ComponentOptions<Vue>),
+    {
+      slots
+    }
+  );
+
+  return wrapper;
+};
+
+describe('testing useNoElementRender composable', () => {
+  it('renders as empty if there are no slots', () => {
+    let wrapper = renderUseNoElementRender();
+
+    expect(wrapper.html()).toBe('');
+
+    wrapper = renderUseNoElementRender({
+      slots: {
+        nonDefault: '<div data-test="non-default-slot"></div>'
+      }
+    });
+
+    expect(wrapper.html()).toBe('');
+  });
+
+  it('renders the default slot if there is any', () => {
+    const wrapper = renderUseNoElementRender({
+      slots: {
+        default: '<div data-test="default-slot"></div>',
+        nonDefault: '<div data-test="non-default-slot"></div>'
+      }
+    });
+
+    expect(wrapper.find(getDataTestSelector('default-slot')).exists()).toBe(true);
+  });
+
+  it('also works from the `setup` function', () => {
+    const component = defineComponent({
+      setup(_, { slots }) {
+        return () => useNoElementRender(slots);
+      }
+    });
+
+    let wrapper = renderUseNoElementRender({
+      component
+    });
+
+    expect(wrapper.html()).toBe('');
+
+    wrapper = renderUseNoElementRender({
+      slots: {
+        default: '<div data-test="default-slot"></div>'
+      },
+      component
+    });
+
+    expect(wrapper.find(getDataTestSelector('default-slot')).exists()).toBe(true);
+  });
+});
+
+type RenderUseNoElementRenderOptions = {
+  slots?: Dictionary<string>;
+  component?: ComponentOptions<Vue>;
+};

--- a/packages/x-components/src/composables/index.ts
+++ b/packages/x-components/src/composables/index.ts
@@ -1,4 +1,5 @@
 export * from './create-use-device.composable';
+export * from './use-no-element-render';
 export * from './use-$x';
 export * from './use-register-x-module';
 export * from './use-on-display';

--- a/packages/x-components/src/composables/use-no-element-render.ts
+++ b/packages/x-components/src/composables/use-no-element-render.ts
@@ -6,6 +6,8 @@ import { VNode } from 'vue/types/vnode';
  *
  * @param slots - The slots object from the component.
  * @returns The result of the rendering function to use.
+ *
+ * @public
  */
 export function useNoElementRender(
   slots: { [key: string]: VNode[] | undefined } | SetupContext['slots']

--- a/packages/x-components/src/composables/use-no-element-render.ts
+++ b/packages/x-components/src/composables/use-no-element-render.ts
@@ -1,0 +1,17 @@
+import { h, SetupContext } from 'vue';
+import { VNode } from 'vue/types/vnode';
+
+/**
+ * Returns a render function that returns the default slot or nothing if it's not defined.
+ *
+ * @param slots - The slots object from the component.
+ * @returns The result of the rendering function to use.
+ */
+export function useNoElementRender(
+  slots: { [key: string]: VNode[] | undefined } | SetupContext['slots']
+): VNode {
+  const defaultSlotContent =
+    typeof slots.default === 'function' ? slots.default()?.[0] : slots.default?.[0];
+
+  return defaultSlotContent ?? h();
+}


### PR DESCRIPTION
[EMP-3540](https://searchbroker.atlassian.net/browse/EMP-3540)

## Motivation and context
Vue 3 is removing the ability to extend Vue components and replacing it with composables. Due to this, components like `LocationProvider` need a way to use the NoElement rendering. We have to create a composable for that.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Create a clone component of `NoElement` and implement the composable instead. Test that the component behaves the same as the other one.


[EMP-3540]: https://searchbroker.atlassian.net/browse/EMP-3540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ