### PR TITLE
feature(composable): create utility composable useHybridInject

### DIFF
--- a/packages/x-components/src/components/animations/cross-fade.vue
+++ b/packages/x-components/src/components/animations/cross-fade.vue
@@ -6,8 +6,7 @@
 </template>
 
 <script lang="ts">
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { defineComponent } from 'vue';
 
   /**
    * Renders a transition wrapping the element passed in the default slot. The transition
@@ -15,19 +14,19 @@
    *
    * @public
    */
-  @Component({
-    inheritAttrs: false
-  })
-  export default class CrossFade extends Vue {
-    /**
-     * Indicates if the transition must be applied on the initial render of the node.
-     */
-    @Prop({
-      type: Boolean,
-      default: true
-    })
-    public appear!: boolean;
-  }
+  export default defineComponent({
+    name: 'CrossFade',
+    inheritAttrs: false,
+    props: {
+      /**
+       * Indicates if the transition must be applied on the initial render of the node.
+       */
+      appear: {
+        type: Boolean,
+        default: true
+      }
+    }
+  });
 </script>
 
 <style lang="scss" scoped>

--- a/packages/x-components/src/composables/index.ts
+++ b/packages/x-components/src/composables/index.ts
@@ -5,3 +5,4 @@ export * from './use-on-display';
 export * from './use-store';
 export * from './use-state';
 export * from './use-getter';
+export * from './use-hybrid-inject';

--- a/packages/x-components/src/composables/use-hybrid-inject.ts
+++ b/packages/x-components/src/composables/use-hybrid-inject.ts
@@ -1,0 +1,26 @@
+import { computed, ComputedRef, inject } from 'vue';
+
+/**
+ * Function to use a hybrid inject, which allows to inject a value provided by the regular provide
+ * of vue  or by the XProvide decorator.
+ *
+ * @param key - The key of the value to inject.
+ * @param defaultValue - The default value to use if the value is not provided.
+ * @returns The computed value of the injected value.
+ */
+export function useHybridInject<SomeValue>(
+  key: string,
+  defaultValue?: SomeValue
+): ComputedRef<SomeValue | undefined> {
+  type WrappedValue = { value: SomeValue };
+
+  return computed<SomeValue | undefined>(() => {
+    const injectedValue = defaultValue
+      ? inject<SomeValue | WrappedValue>(key, defaultValue)
+      : inject<SomeValue | WrappedValue>(key);
+
+    return injectedValue && typeof injectedValue === 'object' && 'value' in injectedValue
+      ? injectedValue.value
+      : injectedValue;
+  });
+}

--- a/packages/x-components/src/composables/use-hybrid-inject.ts
+++ b/packages/x-components/src/composables/use-hybrid-inject.ts
@@ -7,6 +7,7 @@ import { computed, ComputedRef, inject } from 'vue';
  * @param key - The key of the value to inject.
  * @param defaultValue - The default value to use if the value is not provided.
  * @returns The computed value of the injected value.
+ * @public
  */
 export function useHybridInject<SomeValue>(
   key: string,

--- a/packages/x-components/src/composables/use-hybrid-inject.ts
+++ b/packages/x-components/src/composables/use-hybrid-inject.ts
@@ -2,7 +2,7 @@ import { computed, ComputedRef, inject } from 'vue';
 
 /**
  * Function to use a hybrid inject, which allows to inject a value provided by the regular provide
- * of vue  or by the XProvide decorator.
+ * of vue or by the XProvide decorator.
  *
  * @param key - The key of the value to inject.
  * @param defaultValue - The default value to use if the value is not provided.


### PR DESCRIPTION
[EMP-3558](https://searchbroker.atlassian.net/browse/EMP-3558)

## Motivation and context
The regular vue 3 `inject` doesn't work with the `XProvide`, so this utility composable functions as a stepping stone for the migration between the two. It works with any of them and it should be removed when the migration to vue 3 is completed.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Create a injected test vue component and a provider test vue component. Wrap the injected test component in the provider. Now, the injected test component should use the composable and the provider component should do the providing.
Create the provider component so it uses the `@XProvider` decorator and has a dynamic property that provides to its children (for example, a property that changes with a button). The injected test component should pick it up correctly and change dynamically. Then, do the same but with `defineComponent` and the vue 3 `provide`.

Unit tests not created due to this being a utility that will be removed in the future.


[EMP-3558]: https://searchbroker.atlassian.net/browse/EMP-3558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ