### PR TITLE
feat: migrating base-rating component using defineComponent sintax

### DIFF
--- a/packages/x-components/src/components/base-rating.vue
+++ b/packages/x-components/src/components/base-rating.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent } from 'vue';
+  import { computed, defineComponent } from 'vue';
   import StarIcon from './icons/star.vue';
 
   /**
@@ -58,7 +58,7 @@
         default: 5
       }
     },
-    computed: {
+    setup(props) {
       /**
        * Calculates the width of the filled elements wrapper.
        *
@@ -66,9 +66,10 @@
        *
        * @internal
        */
-      calculateFilledWrapperWidth(): string {
-        return this.value < 0 ? '0%' : `${(this.value * 100) / this.max}%`;
-      },
+      const calculateFilledWrapperWidth = computed(() => {
+        return props.value < 0 ? '0%' : `${(props.value * 100) / props.max}%`;
+      });
+
       /**
        * Creates the aria label for accessibility purpose.
        *
@@ -76,9 +77,14 @@
        *
        * @internal
        */
-      ariaLabel(): string {
-        return `${this.value}/${this.max}`;
-      }
+      const ariaLabel = computed(() => {
+        return `${props.value}/${props.max}`;
+      });
+
+      return {
+        calculateFilledWrapperWidth,
+        ariaLabel
+      };
     }
   });
 </script>

--- a/packages/x-components/src/components/base-rating.vue
+++ b/packages/x-components/src/components/base-rating.vue
@@ -24,8 +24,7 @@
 </template>
 
 <script lang="ts">
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { defineComponent } from 'vue';
   import StarIcon from './icons/star.vue';
 
   /**
@@ -34,49 +33,54 @@
    *
    * @public
    */
-  @Component({
+  export default defineComponent({
+    name: 'BaseRating',
     components: {
       DefaultIcon: StarIcon
+    },
+    props: {
+      /**
+       * Numeric value used to calculates the width of the filled elements.
+       *
+       * @public
+       */
+      value: {
+        type: Number,
+        required: true
+      },
+      /**
+       * Maximum number of elements to paint.
+       *
+       * @public
+       */
+      max: {
+        type: Number,
+        default: 5
+      }
+    },
+    computed: {
+      /**
+       * Calculates the width of the filled elements wrapper.
+       *
+       * @returns The % of the wrapper width.
+       *
+       * @internal
+       */
+      calculateFilledWrapperWidth(): string {
+        return this.value < 0 ? '0%' : `${(this.value * 100) / this.max}%`;
+      },
+      /**
+       * Creates the aria label for accessibility purpose.
+       *
+       * @returns The aria label.
+       *
+       * @internal
+       */
+      ariaLabel(): string {
+        return `${this.value}/${this.max}`;
+      }
     }
-  })
-  export default class BaseRating extends Vue {
-    /**
-     * Numeric value used to calculates the width of the filled elements.
-     *
-     * @public
-     */
-    @Prop({ required: true })
-    protected value!: number;
-    /**
-     * Maximum number of elements to paint.
-     *
-     * @public
-     */
-    @Prop({ default: 5 })
-    protected max!: number;
-
-    /**
-     * Calculates the width of the filled elements wrapper.
-     *
-     * @returns The % of the wrapper width.
-     *
-     * @internal
-     */
-    protected get calculateFilledWrapperWidth(): string {
-      return this.value < 0 ? '0%' : `${(this.value * 100) / this.max}%`;
-    }
-
-    /**
-     * Creates the aria label for accessibility purpose.
-     *
-     * @returns The aria label.
-     *
-     * @internal
-     */
-    protected get ariaLabel(): string {
-      return `${this.value}/${this.max}`;
-    }
-  }
+  });
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
In order to migrate X components to vue3, we need to use the 2.7 sintax.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-3377](https://searchbroker.atlassian.net/browse/EMP-3377?atlOrigin=eyJpIjoiYjFiNWEwYmZjNDBlNDA3YTk3MWQ4N2U5MTEzYTllY2IiLCJwIjoiaiJ9)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

Tested using this component in a test view: https://docs.empathy.co/develop-empathy-platform/ui-reference/components/base-components/x-components.base-rating.html


[EMP-3377]: https://searchbroker.atlassian.net/browse/EMP-3377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ