### PR TITLE
refactor: migrate location-provider component to vue 2.7

### DIFF
--- a/packages/x-components/src/components/location-provider.vue
+++ b/packages/x-components/src/components/location-provider.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Prop, Provide, Component } from 'vue-property-decorator';
-  import { NoElement } from '../components/no-element';
+  import { defineComponent, PropType, provide, toRef } from 'vue';
   import { FeatureLocation } from '../types';
+  import { useNoElementRender } from '../composables/index';
 
   /**
    * Location Provider component.
@@ -9,17 +9,25 @@
    *
    * @public
    */
-  @Component
-  export default class LocationProvider extends NoElement {
-    /**
-     * The {@link FeatureLocation} to provide.
-     *
-     * @public
-     */
-    @Prop({ required: true })
-    @Provide()
-    protected location!: FeatureLocation;
-  }
+  export default defineComponent({
+    name: 'LocationProvider',
+    props: {
+      location: {
+        type: String as PropType<FeatureLocation>
+      }
+    },
+    setup(props, { slots }) {
+      const locationFeature = toRef(props, 'location');
+      /**
+       * The {@link FeatureLocation} to provide.
+       *
+       * @public
+       */
+      provide('location', locationFeature);
+
+      return () => useNoElementRender(slots);
+    }
+  });
 </script>
 
 <docs lang="mdx">

--- a/packages/x-components/src/components/location-provider.vue
+++ b/packages/x-components/src/components/location-provider.vue
@@ -13,7 +13,8 @@
     name: 'LocationProvider',
     props: {
       location: {
-        type: String as PropType<FeatureLocation>
+        type: String as PropType<FeatureLocation>,
+        required: true
       }
     },
     setup(props, { slots }) {

--- a/packages/x-components/src/components/location-provider.vue
+++ b/packages/x-components/src/components/location-provider.vue
@@ -12,19 +12,19 @@
   export default defineComponent({
     name: 'LocationProvider',
     props: {
+      /**
+       * The {@link FeatureLocation} to provide.
+       *
+       * @public
+       */
       location: {
         type: String as PropType<FeatureLocation>,
         required: true
       }
     },
     setup(props, { slots }) {
-      const locationFeature = toRef(props, 'location');
-      /**
-       * The {@link FeatureLocation} to provide.
-       *
-       * @public
-       */
-      provide('location', locationFeature);
+      const featureLocation = toRef(props, 'location');
+      provide('location', featureLocation);
 
       return () => useNoElementRender(slots);
     }


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->
[EMP-3541](https://searchbroker.atlassian.net/browse/EMP-3541)
## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->
For the vue 3 migration we need to migrate components to 2.7

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: [EMP-3541](https://searchbroker.atlassian.net/browse/EMP-3541)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Follow the docs in the component to tests that the feature still works correctly



[EMP-3541]: https://searchbroker.atlassian.net/browse/EMP-3541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMP-3541]: https://searchbroker.atlassian.net/browse/EMP-3541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ