### PR TITLE
fix: reset scroll on ExtraParamsChanged by default

### DIFF
--- a/packages/x-components/src/components/scroll/scroll.mixin.ts
+++ b/packages/x-components/src/components/scroll/scroll.mixin.ts
@@ -63,6 +63,7 @@ export default class ScrollMixin extends Vue {
       'SelectedFiltersChanged',
       'SelectedFiltersForRequestChanged',
       'SelectedRelatedTagsChanged',
+      'ExtraParamsChanged',
       'UserChangedExtraParams'
     ]
   })


### PR DESCRIPTION
https://jira.kroger.com/jira/browse/DCPPERS-12567

<!--Please provide a general summary of changes in the PR title -->

## Motivation and context

In the [Playboard](https://github.com/empathyco/playboard), we use the `ExtraParams` component (wrapped [here](https://github.com/empathyco/playboard/blob/main/packages/playboard-core/src/components/x/x-extra-params.component.vue#L2)). We often modify these `extraParams` programmatically.

We recently discovered a "bug" that the scroll of the `ResultList`(which we also use) wasn't getting reseted, causing and extra request to the search endpoint (for the second page or results) and the incorrect results displayed in the list 😢

The `ScrollMixin` component was already "listening" to the `UserChangedExtraParams` event (triggered by `RenderlessExtraParam`) and resetting the scroll of the scrollable element, but it wasn't "listening" to the `ExtraParamsChanged` event (triggered by `ExtraParams`).

This PR basically adds `ExtraParamsChanged` to the "default" list of events that should cause the scroll to be reseted.


- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

I tested this manually by adding the following to `packages/x-components/src/views/home/Home.vue`:

```
<template>
             ...
            <ExtraParams :values="extraParams" />
            <button @click="extraParams.a = extraParams.a + 1">Change extraParams</button>
            ...
</template>

<script>
    ...,
    components: {
      ...,
      ExtraParams
    },
    data() {
      return {
        extraParams: {
          a: 0
        }
      }
    }
<script>

```

**Without this fix (aka HOW TO REPRODUCE the issue):**
  - Search for "dress"
  - Scroll down a couple of "pages"
  - Click the "Change extraParams" buttons
  - Scroll of the list of results doesn't change and new results are fetched

**With this fix:**
  - Search for "dress"
  - Scroll down a couple of "pages"
  - Click the "Change extraParams" buttons
  - List of results is scrolled to the top and new results are fetched

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works
- [x] New and existing **unit tests pass locally** with my changes.
