### PR TITLE
feat: change useHybridInject so it works more like vue inject

### DIFF
--- a/packages/x-components/src/composables/use-hybrid-inject.ts
+++ b/packages/x-components/src/composables/use-hybrid-inject.ts
@@ -1,4 +1,35 @@
-import { computed, ComputedRef, inject } from 'vue';
+import { inject, isReactive, isRef, reactive, Ref, ref, UnwrapRef } from 'vue';
+import { UnwrapNestedRefs } from 'vue/types/v3-generated';
+
+/**
+ * Makes the injection reactive if it is not already.
+ *
+ * @param injection - The injection to make reactive.
+ *
+ * @returns The reactive injection.
+ * @internal
+ */
+const makeInjectionReactive = <SomeValue>(
+  injection: SomeValue | { value: SomeValue } | undefined
+): Ref<UnwrapRef<SomeValue>> | UnwrapNestedRefs<SomeValue> | SomeValue | undefined => {
+  // Check if the injection comes from XProvide and it is not already reactive.
+  if (
+    !!injection &&
+    typeof injection === 'object' &&
+    'value' in injection &&
+    (!isRef(injection) || !isReactive(injection))
+  ) {
+    const xRefValue = injection.value;
+
+    if (xRefValue && typeof xRefValue === 'object') {
+      return reactive(xRefValue);
+    } else {
+      return ref<SomeValue>(xRefValue);
+    }
+  }
+
+  return injection as SomeValue | undefined;
+};
 
 /**
  * Function to use a hybrid inject, which allows to inject a value provided by the regular provide
@@ -9,19 +40,16 @@ import { computed, ComputedRef, inject } from 'vue';
  * @returns The computed value of the injected value.
  * @public
  */
-export function useHybridInject<SomeValue>(
-  key: string,
-  defaultValue?: SomeValue
-): ComputedRef<SomeValue | undefined> {
+/* eslint-disable */
+export function useHybridInject<SomeValue>(key: string, defaultValue: SomeValue): SomeValue;
+export function useHybridInject<SomeValue>(key: string): SomeValue | undefined;
+export function useHybridInject<SomeValue>(key: string, defaultValue?: SomeValue) {
+  /* eslint-enable */
   type WrappedValue = { value: SomeValue };
 
-  return computed<SomeValue | undefined>(() => {
-    const injectedValue = defaultValue
-      ? inject<SomeValue | WrappedValue>(key, defaultValue)
-      : inject<SomeValue | WrappedValue>(key);
+  const injection = defaultValue
+    ? inject<SomeValue | WrappedValue>(key, defaultValue)
+    : inject<SomeValue | WrappedValue>(key);
 
-    return injectedValue && typeof injectedValue === 'object' && 'value' in injectedValue
-      ? injectedValue.value
-      : injectedValue;
-  });
+  return makeInjectionReactive<SomeValue>(injection);
 }

--- a/packages/x-components/src/composables/use-hybrid-inject.ts
+++ b/packages/x-components/src/composables/use-hybrid-inject.ts
@@ -42,7 +42,9 @@ const makeInjectionReactive = <SomeValue>(
  */
 /* eslint-disable */
 export function useHybridInject<SomeValue>(key: string, defaultValue: SomeValue): SomeValue;
+/** @public */
 export function useHybridInject<SomeValue>(key: string): SomeValue | undefined;
+/** @public */
 export function useHybridInject<SomeValue>(key: string, defaultValue?: SomeValue) {
   /* eslint-enable */
   type WrappedValue = { value: SomeValue };


### PR DESCRIPTION
[EMP-3636](https://searchbroker.atlassian.net/browse/EMP-3636)

# Pull request template
`useHybridInject` and vue's regular `inject` weren't behaving the same, so we made some changes in the composable.

## Motivation and context
Handling reactiveness wasn't working as expected.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Use `useHybridInject` to inject the snippet config, wrap that call in a `ref` and try to watch changes in the `filters` property when changing its array value.



[EMP-3636]: https://searchbroker.atlassian.net/browse/EMP-3636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ