### PR TITLE
Fix:  Next Queries not being calculated when using Related Tags

### DIFF
--- a/packages/x-components/src/x-modules/next-queries/store/__tests__/getters.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/__tests__/getters.spec.ts
@@ -2,7 +2,11 @@ import { NextQueriesRequest } from '@empathyco/x-types';
 import { map } from '@empathyco/x-utils';
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
-import { createHistoryQueries, getNextQueriesStub } from '../../../../__stubs__';
+import {
+  createHistoryQueries,
+  createRelatedTagStub,
+  getNextQueriesStub
+} from '../../../../__stubs__';
 import { nextQueriesXStoreModule } from '../module';
 import { NextQueriesState } from '../types';
 import { resetNextQueriesStateWith } from './utils';
@@ -46,6 +50,29 @@ describe('testing next queries module getters', () => {
       resetNextQueriesStateWith(store, { query: ' ' });
       expect(store.getters[gettersKeys.request]).toBeNull();
     });
+
+    // eslint-disable-next-line max-len
+    it('should return a request object with a query concatenated with a related tag if there is so', () => {
+      resetNextQueriesStateWith(store, {
+        query: 'novela',
+        relatedTags: [createRelatedTagStub('novela', 'policíaca')],
+        config: {
+          maxItemsToRequest: 5
+        },
+        params: {
+          catalog: 'es'
+        }
+      });
+
+      expect(store.getters[gettersKeys.request]).toEqual<NextQueriesRequest>({
+        query: 'novela policíaca',
+        rows: 5,
+        start: 0,
+        extraParams: {
+          catalog: 'es'
+        }
+      });
+    });
   });
 
   describe(`${gettersKeys.nextQueries} getter`, () => {
@@ -75,6 +102,24 @@ describe('testing next queries module getters', () => {
         }
       });
       expect(store.getters[gettersKeys.nextQueries]).toEqual(nextQueries);
+    });
+  });
+
+  describe(`${gettersKeys.query} getter`, () => {
+    it('returns the query when there are no selected related tags', () => {
+      resetNextQueriesStateWith(store, {
+        query: 'novela',
+        relatedTags: []
+      });
+      expect(store.getters.query).toEqual('novela');
+    });
+
+    it('returns the query and the selected related tags concatenated', () => {
+      resetNextQueriesStateWith(store, {
+        query: 'novela',
+        relatedTags: [createRelatedTagStub('novela negra', 'negra')]
+      });
+      expect(store.getters.query).toEqual('novela negra');
     });
   });
 });

--- a/packages/x-components/src/x-modules/next-queries/store/getters/next-queries-query.getter.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/getters/next-queries-query.getter.ts
@@ -1,0 +1,16 @@
+import { createRelatedTagsQueryGetter } from '../../../../store/utils/query.utils';
+import { NextQueriesXStoreModule } from '../types';
+
+/**
+ * Default implementation for the next-queries query getter.
+ *
+ * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the related
+ * tags' module.
+ *
+ * @returns The query with the selected related tags concatenated.
+ *
+ * @public
+ */
+export const query: NextQueriesXStoreModule['getters']['query'] = createRelatedTagsQueryGetter({
+  getRelatedTags: state => state.relatedTags
+});

--- a/packages/x-components/src/x-modules/next-queries/store/getters/request.getter.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/getters/request.getter.ts
@@ -5,16 +5,18 @@ import { NextQueriesXStoreModule } from '../types';
  *
  * @param state - Current {@link https://vuex.vuejs.org/guide/state.html | state} of the next
  * queries module.
+ * @param getters - Current {@link https://vuex.vuejs.org/guide/getters.html | getters} of the
+ * search module.
+ *
  * @returns The next queries request to fetch data from the API.
  *
  * @public
  */
-export const request: NextQueriesXStoreModule['getters']['request'] = ({
-  query,
-  config,
-  params
-}) => {
-  return query.trim()
+export const request: NextQueriesXStoreModule['getters']['request'] = (
+  { config, params },
+  { query }
+) => {
+  return query
     ? {
         query,
         rows: config.maxItemsToRequest,

--- a/packages/x-components/src/x-modules/next-queries/store/index.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/index.ts
@@ -4,5 +4,6 @@ export * from './actions/set-query-from-last-history-query.action';
 export * from './emitters';
 export { request as nextQueriesRequest } from './getters/request.getter';
 export * from './getters/next-queries.getter';
+export * from './getters/next-queries-query.getter';
 export * from './module';
 export * from './types';

--- a/packages/x-components/src/x-modules/next-queries/store/module.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/module.ts
@@ -11,6 +11,7 @@ import { setUrlParams } from './actions/set-url-params.action';
 import { fetchNextQueryPreview } from './actions/fetch-next-query-preview.action';
 import { fetchAndSaveNextQueryPreview } from './actions/fetch-and-save-next-query-preview.action';
 import { nextQueries } from './getters/next-queries.getter';
+import { query } from './getters/next-queries-query.getter';
 import { request } from './getters/request.getter';
 import { NextQueriesXStoreModule } from './types';
 
@@ -37,7 +38,8 @@ export const nextQueriesXStoreModule: NextQueriesXStoreModule = {
   }),
   getters: {
     request,
-    nextQueries
+    nextQueries,
+    query
   },
   mutations: {
     setQuery,

--- a/packages/x-components/src/x-modules/next-queries/store/module.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/module.ts
@@ -24,6 +24,7 @@ export const nextQueriesXStoreModule: NextQueriesXStoreModule = {
     query: '',
     nextQueries: [],
     searchedQueries: [],
+    relatedTags: [],
     status: 'initial',
     config: {
       maxItemsToRequest: 20,
@@ -45,6 +46,9 @@ export const nextQueriesXStoreModule: NextQueriesXStoreModule = {
     },
     setSearchedQueries(state, searchedQueries) {
       state.searchedQueries = searchedQueries;
+    },
+    setRelatedTags(state, relatedTags) {
+      state.relatedTags = relatedTags;
     },
     setStatus,
     setParams(state, params) {

--- a/packages/x-components/src/x-modules/next-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/types.ts
@@ -49,6 +49,8 @@ export interface NextQueriesGetters {
   request: NextQueriesRequest | null;
   /** List of next queries that have not been searched before. */
   nextQueries: NextQuery[];
+  /** The combination of the query and the selected related tags. */
+  query: string;
 }
 
 /**

--- a/packages/x-components/src/x-modules/next-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/types.ts
@@ -3,7 +3,8 @@ import {
   NextQuery,
   NextQueriesRequest,
   SearchResponse,
-  PreviewResults
+  PreviewResults,
+  RelatedTag
 } from '@empathyco/x-types';
 import { Dictionary } from '@empathyco/x-utils';
 import { XActionContext, XStoreModule } from '../../../store';
@@ -25,6 +26,8 @@ export interface NextQueriesState extends StatusState, QueryState {
   /** The list of the searched queries, related to the `query` property of the state. */
   //TODO Changes to uses the base extended class Previewable or what we decide.
   searchedQueries: HistoryQuery[];
+  /** The list of the related tags, related to the `query` property of the state. */
+  relatedTags: RelatedTag[];
   /** Configuration options of the next queries module. */
   config: NextQueriesConfig;
   /** The extra params property of the state. */
@@ -69,6 +72,12 @@ export interface NextQueriesMutations
    * @param searchedQueries - The searched queries to save to the state.
    */
   setSearchedQueries(searchedQueries: HistoryQuery[]): void;
+  /**
+   * Sets the related tags of the module.
+   *
+   * @param relatedTags - The new related tags to save to the state.
+   */
+  setRelatedTags(relatedTags: RelatedTag[]): void;
   /**
    * Sets the extra params of the module.
    *

--- a/packages/x-components/src/x-modules/next-queries/wiring.ts
+++ b/packages/x-components/src/x-modules/next-queries/wiring.ts
@@ -50,7 +50,7 @@ export const setNextQueriesQuery = wireCommit('setQuery');
  *
  * @public
  */
-export const setRelatedTags = wireCommit('setRelatedTags');
+export const setNextQueriesRelatedTags = wireCommit('setRelatedTags');
 
 /**
  * Sets the next queries state `query` with a selectedQueryPreview's query.
@@ -144,7 +144,7 @@ export const nextQueriesWiring = createWiring({
     setNextQueriesQuery
   },
   SelectedRelatedTagsChanged: {
-    setRelatedTags
+    setNextQueriesRelatedTags
   },
   SessionHistoryQueriesChanged: {
     setSearchedQueries,

--- a/packages/x-components/src/x-modules/next-queries/wiring.ts
+++ b/packages/x-components/src/x-modules/next-queries/wiring.ts
@@ -46,6 +46,13 @@ const wireDispatch: NamespacedWireDispatch<typeof moduleName> = namespacedWireDi
 export const setNextQueriesQuery = wireCommit('setQuery');
 
 /**
+ * Sets the next queries state `relatedTags`.
+ *
+ * @public
+ */
+export const setRelatedTags = wireCommit('setRelatedTags');
+
+/**
  * Sets the next queries state `query` with a selectedQueryPreview's query.
  *
  * @public
@@ -135,6 +142,9 @@ export const nextQueriesWiring = createWiring({
   },
   UserAcceptedAQuery: {
     setNextQueriesQuery
+  },
+  SelectedRelatedTagsChanged: {
+    setRelatedTags
   },
   SessionHistoryQueriesChanged: {
     setSearchedQueries,


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.
Make Next Queries requests take into account when a query is selected along with a related tag:
* Make NQ `storeModule` have a RTs array in the state to save the selected RTs
* Make NQ `storeModule` have a mutation to update the RTs in the state
* Make NQ `storeModule` have a query getter to concat the query with the RTs (if selected)
* Make NQ `request` use the query getter.
* Make NQ wiring react to the event `SelectedRelatedTagsChanged` & call `setRelatedTags` mutation

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
Currently, the Next Queries module doesn’t take into account the selected related tags. This creates some weird scenarios like having NQ when searching for novela negra but not having NQ when searching for `novela` and then selecting the RT `negra`

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: [EMP-3653](https://searchbroker.atlassian.net/browse/EMP-3653)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
Test in [CDL](https://github.com/empathyco/x-cdl-next):
**Use a local build of x-components & `env=live` to test**
- Test: `?env=live&query=novela%20negra`
- Test: `?env=live&query=novela` + select the “negra” RT
**Then:** 
- Next queries state has an RT array with the RT saved
- A NQ request has been done & given the same results searching for the full query “novela negra” as searching for “novela” and then, selecting the “negra” RT

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.


[EMP-3597]: https://searchbroker.atlassian.net/browse/EMP-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EMP-3653]: https://searchbroker.atlassian.net/browse/EMP-3653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ