### PR TITLE
refactor: migrate snippet-callbacks to vue 2.7

### DIFF
--- a/packages/x-components/jest.setup.ts
+++ b/packages/x-components/jest.setup.ts
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom/extend-expect';
+import { XDummyBus } from './src/__tests__/bus.dummy';
 
 window.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
   unobserve: jest.fn(),
   disconnect: jest.fn()
+}));
+
+// Dummy bus so ReplaySubject doesn't mess with unitary tests
+jest.mock('./src/plugins/x-bus', () => ({
+  bus: new XDummyBus()
 }));

--- a/packages/x-components/src/__tests__/bus.dummy.ts
+++ b/packages/x-components/src/__tests__/bus.dummy.ts
@@ -1,5 +1,6 @@
 import { Dictionary } from '@empathyco/x-utils';
-import { EmittedData, EventPayload, XPriorityBus } from '@empathyco/x-bus';
+import { EmittedData, EventPayload, SubjectPayload, XPriorityBus } from '@empathyco/x-bus';
+import { Subject } from 'rxjs';
 import { WireMetadata, XEventsTypes } from '../wiring';
 
 export class XDummyBus<
@@ -20,5 +21,11 @@ export class XDummyBus<
     emitter.next(emittedPayload);
 
     return Promise.resolve({ event, ...emittedPayload });
+  }
+
+  createEmitter<SomeEvent extends keyof SomeEvents>(event: SomeEvent): void {
+    this.emitters[event] = new Subject<
+      SubjectPayload<EventPayload<SomeEvents, SomeEvent>, SomeMetadata>
+    >();
   }
 }

--- a/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
+++ b/packages/x-components/src/components/__tests__/snippet-callbacks.spec.ts
@@ -3,6 +3,7 @@ import { installNewXPlugin } from '../../__tests__/utils';
 import { baseSnippetConfig } from '../../views/base-config';
 import { XEventListeners } from '../../x-installer/api/api.types';
 import SnippetCallbacks from '../snippet-callbacks.vue';
+import { bus } from '../../plugins/index';
 
 function renderSnippetCallbacks({
   callbacks = {}
@@ -24,14 +25,14 @@ describe('testing SnippetCallbacks component', () => {
   it('executes a callback injected from the snippetConfig', () => {
     const acceptedAQueryCallback = jest.fn(payload => payload);
     const clickedColumnPickerCallback = jest.fn(payload => payload);
-    const { wrapper } = renderSnippetCallbacks({
+    renderSnippetCallbacks({
       callbacks: {
         UserAcceptedAQuery: acceptedAQueryCallback,
         UserClickedColumnPicker: clickedColumnPickerCallback
       }
     });
 
-    wrapper.vm.$x.emit('UserAcceptedAQuery', 'lego');
+    bus.emit('UserAcceptedAQuery', 'lego');
 
     expect(acceptedAQueryCallback).toHaveBeenCalledTimes(1);
     expect(acceptedAQueryCallback).toHaveBeenCalledWith('lego', {
@@ -42,7 +43,7 @@ describe('testing SnippetCallbacks component', () => {
 
     expect(clickedColumnPickerCallback).not.toHaveBeenCalled();
 
-    wrapper.vm.$x.emit('UserClickedColumnPicker', 1);
+    bus.emit('UserClickedColumnPicker', 1);
 
     expect(acceptedAQueryCallback).toHaveBeenCalledTimes(1);
 
@@ -57,7 +58,7 @@ describe('testing SnippetCallbacks component', () => {
   it('emits a SnippetCallbackExecuted event when a callback is executed', () => {
     const acceptedAQueryCallback = jest.fn((payload: string) => payload + '1');
     const clickedColumnPickerCallback = jest.fn((payload: number) => payload + 1);
-    const { wrapper } = renderSnippetCallbacks({
+    renderSnippetCallbacks({
       callbacks: {
         UserAcceptedAQuery: acceptedAQueryCallback,
         UserClickedColumnPicker: clickedColumnPickerCallback
@@ -65,9 +66,9 @@ describe('testing SnippetCallbacks component', () => {
     });
 
     const eventSpy = jest.fn();
-    wrapper.vm.$x.on('SnippetCallbackExecuted').subscribe(eventSpy);
+    bus.on('SnippetCallbackExecuted').subscribe(eventSpy);
 
-    wrapper.vm.$x.emit('UserAcceptedAQuery', 'playmobil');
+    bus.emit('UserAcceptedAQuery', 'playmobil');
     expect(eventSpy).toHaveBeenCalledTimes(1);
     expect(eventSpy).toHaveBeenCalledWith({
       event: 'UserAcceptedAQuery',
@@ -76,7 +77,7 @@ describe('testing SnippetCallbacks component', () => {
       metadata: expect.any(Object)
     });
 
-    wrapper.vm.$x.emit('UserClickedColumnPicker', 3);
+    bus.emit('UserClickedColumnPicker', 3);
     expect(eventSpy).toHaveBeenCalledTimes(2);
     expect(eventSpy).toHaveBeenCalledWith({
       event: 'UserClickedColumnPicker',

--- a/packages/x-components/src/components/snippet-callbacks.vue
+++ b/packages/x-components/src/components/snippet-callbacks.vue
@@ -40,7 +40,7 @@
        *
        */
       const eventListeners = computed<XEventListeners>(() => {
-        const callbacks = snippetConfig.value?.callbacks;
+        const callbacks = snippetConfig?.callbacks;
 
         return callbacks
           ? map(callbacks, (eventName, callback) => {


### PR DESCRIPTION
[EMP-3380](https://searchbroker.atlassian.net/browse/EMP-3380)

## Motivation and context
Migrate snippet callbacks to vue 2.7.
Dummy bus for the jest tests was created to prevent issues with the rxjs RepeatSubject.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-3380](https://searchbroker.atlassian.net/browse/EMP-3380)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?
Tests suite has been updated for this migration.