### PR TITLE
fix: bus handling of a location ref

### DIFF
--- a/packages/x-components/src/composables/__tests__/use-on-display.spec.ts
+++ b/packages/x-components/src/composables/__tests__/use-on-display.spec.ts
@@ -2,8 +2,8 @@ import { ref, nextTick } from 'vue';
 import { useElementVisibility } from '@vueuse/core';
 import { TaggingRequest } from '@empathyco/x-types';
 import { useEmitDisplayEvent, useOnDisplay } from '../use-on-display';
-import { use$x } from '../use-$x';
 import { WireMetadata } from '../../wiring';
+import { bus } from '../../plugins/index';
 
 jest.mock('@vueuse/core', () => ({
   useElementVisibility: jest.fn()
@@ -12,14 +12,8 @@ jest.mock('@vueuse/core', () => ({
 const refElementVisibility = ref(false);
 (useElementVisibility as jest.Mock).mockReturnValue(refElementVisibility);
 
-jest.mock('../use-$x', () => ({
-  use$x: jest.fn()
-}));
-
-const $xEmitSpy = jest.fn();
-(use$x as jest.Mock).mockReturnValue({
-  emit: $xEmitSpy
-});
+const emitSpy = jest.fn();
+jest.spyOn(bus, 'emit' as any).mockImplementation(emitSpy);
 
 describe(`testing ${useOnDisplay.name} composable`, () => {
   beforeEach(() => {
@@ -178,8 +172,8 @@ describe(`testing ${useEmitDisplayEvent.name} composable`, () => {
 
     await toggleElementVisibility();
 
-    expect($xEmitSpy).toHaveBeenCalled();
-    expect($xEmitSpy).toHaveBeenCalledWith(
+    expect(emitSpy).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith(
       'TrackableElementDisplayed',
       {
         tagging: {
@@ -203,11 +197,11 @@ describe(`testing ${useEmitDisplayEvent.name} composable`, () => {
 
     await toggleElementVisibility();
 
-    expect($xEmitSpy).toHaveBeenCalled();
-    expect($xEmitSpy).toHaveBeenCalledWith(
+    expect(emitSpy).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith(
       'TrackableElementDisplayed',
       expect.anything(),
-      eventMetadata
+      expect.objectContaining({ ...eventMetadata })
     );
   });
 
@@ -218,7 +212,7 @@ describe(`testing ${useEmitDisplayEvent.name} composable`, () => {
     await toggleElementVisibility();
     await toggleElementVisibility();
 
-    expect($xEmitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledTimes(1);
   });
 
   it('exposes the current visibility of the element', async () => {
@@ -239,7 +233,7 @@ describe(`testing ${useEmitDisplayEvent.name} composable`, () => {
     unwatchDisplay();
 
     await toggleElementVisibility();
-    expect($xEmitSpy).not.toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/x-components/src/composables/use-on-display.ts
+++ b/packages/x-components/src/composables/use-on-display.ts
@@ -2,7 +2,7 @@ import { Ref, watch, WatchStopHandle } from 'vue';
 import { useElementVisibility } from '@vueuse/core';
 import { TaggingRequest } from '@empathyco/x-types';
 import { WireMetadata } from '../wiring';
-import { use$x } from './use-$x';
+import { useXBus } from './use-x-bus';
 
 /**
  * Composable that triggers a callback whenever the provided element appears in the viewport.
@@ -54,12 +54,16 @@ export function useEmitDisplayEvent({
   taggingRequest,
   eventMetadata = {}
 }: UseEmitDisplayEventOptions): UseOnDisplayReturn {
-  const $x = use$x();
+  const bus = useXBus();
 
   const { isElementVisible, unwatchDisplay } = useOnDisplay({
     element,
     callback: () => {
-      $x.emit('TrackableElementDisplayed', { tagging: { display: taggingRequest } }, eventMetadata);
+      bus.emit(
+        'TrackableElementDisplayed',
+        { tagging: { display: taggingRequest } },
+        eventMetadata
+      );
     }
   });
 


### PR DESCRIPTION
[EMP-3758](https://searchbroker.atlassian.net/browse/EMP-3758)

<!--Please provide a general summary of changes in the PR title -->

## Motivation and context
When using the composable use-on-display, that uses the use-bus composable underneath, ends up causing a vue error about changing the state outside a mutation. 

This is traced back to the location being injected in the bus. The composable didn’t expect the injection to be a ref, and that caused the error.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

[EMP-3758]: https://searchbroker.atlassian.net/browse/EMP-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ