### PR TITLE
Feature: Modify use-$x composable

### DIFF
--- a/packages/x-components/src/composables/use-$x.ts
+++ b/packages/x-components/src/composables/use-$x.ts
@@ -11,8 +11,7 @@ import { useXBus, UseXBusAPI } from './use-x-bus';
 export function use$x(): UseXComponentAPI {
   const xAliasAPI = useAliasApi();
   const xBusAPI = useXBus();
-  const $x = Object.assign(xAliasAPI, xBusAPI);
-  return $x;
+  return Object.assign(xAliasAPI, xBusAPI);
 }
 
 /**

--- a/packages/x-components/src/composables/use-$x.ts
+++ b/packages/x-components/src/composables/use-$x.ts
@@ -1,5 +1,6 @@
-import { getCurrentInstance } from 'vue';
 import { XComponentAPI } from '../plugins';
+import { useAliasApi } from './use-alias-api';
+import { useXBus } from './use-x-bus';
 
 /**
  * Function which returns the `$x` object from the current component instance.
@@ -9,5 +10,8 @@ import { XComponentAPI } from '../plugins';
  * @public
  */
 export function use$x(): XComponentAPI {
-  return (getCurrentInstance()?.proxy as unknown as { $x: XComponentAPI }).$x;
+  const xAliasAPI = useAliasApi();
+  const xBusAPI = useXBus();
+  const $x = Object.assign(xAliasAPI, xBusAPI);
+  return $x;
 }

--- a/packages/x-components/src/composables/use-$x.ts
+++ b/packages/x-components/src/composables/use-$x.ts
@@ -1,6 +1,5 @@
-import { XComponentAPI } from '../plugins';
-import { useAliasApi } from './use-alias-api';
-import { useXBus } from './use-x-bus';
+import { UseAliasAPI, useAliasApi } from './use-alias-api';
+import { useXBus, UseXBusAPI } from './use-x-bus';
 
 /**
  * Function which returns the `$x` object from the current component instance.
@@ -9,9 +8,17 @@ import { useXBus } from './use-x-bus';
  *
  * @public
  */
-export function use$x(): XComponentAPI {
+export function use$x(): UseXComponentAPI {
   const xAliasAPI = useAliasApi();
   const xBusAPI = useXBus();
   const $x = Object.assign(xAliasAPI, xBusAPI);
   return $x;
 }
+
+/**
+ * The XComponentAPI exposes access to the {@link @empathyco/x-bus#XBus}, and store aliases to the
+ * components.
+ *
+ * @public
+ */
+export interface UseXComponentAPI extends UseXBusAPI, UseAliasAPI {}

--- a/packages/x-components/src/composables/use-alias-api.ts
+++ b/packages/x-components/src/composables/use-alias-api.ts
@@ -23,7 +23,7 @@ import { useStore } from './use-store';
  *
  * @internal
  */
-export function useAliasApi(this: any): UseAliasAPI {
+export function useAliasApi(): UseAliasAPI {
   const queryModules = [
     'facets',
     'searchBox',

--- a/packages/x-components/src/composables/use-alias-api.ts
+++ b/packages/x-components/src/composables/use-alias-api.ts
@@ -158,7 +158,7 @@ export interface UseAliasAPI {
   /** The {@link DeviceXModule} detected device. */
   readonly device: string | null;
   /** The {@link FacetsXModule} facets. */
-  readonly facets: ReadonlyArray<Facet>;
+  readonly facets: Record<Facet['id'], Facet>;
   /** The {@link HistoryQueriesXModule} history queries matching the query. */
   readonly historyQueries: ReadonlyArray<HistoryQuery>;
   /** The {@link HistoryQueriesXModule} history queries with 1 or more results. */

--- a/packages/x-components/src/composables/use-x-bus.ts
+++ b/packages/x-components/src/composables/use-x-bus.ts
@@ -73,7 +73,7 @@ interface PrivateExtendedVueComponent extends Vue {
   xComponent?: Vue | undefined;
 }
 
-interface UseXBusAPI {
+export interface UseXBusAPI {
   /* eslint-disable jsdoc/require-description-complete-sentence */
   /** {@inheritDoc XBus.(on:1)} */
   on: XBus<XEventsTypes, WireMetadata>['on'];


### PR DESCRIPTION
## Motivation and context
The xPlugin is responsible for creating the $x in every component instance through the [xplugin.mixin](https://github.com/empathyco/x/blob/main/packages/x-components/src/plugins/x-plugin.mixin.ts#L52+55). Currently the use$x composable is just returning a reference to this property. In order to get rid of this mixin we need that the use$x is able to create and return the same $x API.

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: [EMP-3656](https://searchbroker.atlassian.net/browse/EMP-3656)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?
Browse along all the app & make sure: 
* All modules are registered on init
* All features are working as expected

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
