### PR TITLE
fix: make arrays reactive with ref in useHybridInject

### DIFF
--- a/packages/x-components/src/composables/use-hybrid-inject.ts
+++ b/packages/x-components/src/composables/use-hybrid-inject.ts
@@ -21,7 +21,7 @@ const makeInjectionReactive = <SomeValue>(
   ) {
     const xRefValue = injection.value;
 
-    if (xRefValue && typeof xRefValue === 'object') {
+    if (xRefValue && typeof xRefValue === 'object' && !Array.isArray(xRefValue)) {
       return reactive(xRefValue);
     } else {
       return ref<SomeValue>(xRefValue);


### PR DESCRIPTION
[EMP-3798](https://searchbroker.atlassian.net/browse/EMP-3798)

## Motivation and context
useHybridInject doesn’t work well with arrays, we need to add a check to make list dynamic using ref

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:


[EMP-3798]: https://searchbroker.atlassian.net/browse/EMP-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ