### PR TITLE
feat: make `useXBus` get bus from `XPlugin`

### DIFF
--- a/packages/x-components/src/__tests__/utils.ts
+++ b/packages/x-components/src/__tests__/utils.ts
@@ -182,21 +182,23 @@ function mergeStates<State extends Dictionary>(
 }
 
 /**
- * Makes a clean install of the {@link XPlugin} into the passed Vue object.
+ * Makes a clean installation of the {@link XPlugin} into the passed Vue object.
  * This also resets the bus, and all the hardcoded dependencies of the XPlugin.
  *
  * @param options - The options for installing the {@link XPlugin}. The
  * {@link XComponentsAdapterDummy}  is added by default.
  * @param localVue - A clone of the Vue constructor to isolate tests.
+ * @param bus - The event bus to use.
  * If not provided, one will be created.
  * @returns An array containing the `xPlugin` singleton and the `localVue` and objects.
  */
 export function installNewXPlugin(
   options: Partial<XPluginOptions> = {},
-  localVue: typeof Vue = createLocalVue()
+  localVue: typeof Vue = createLocalVue(),
+  bus = new XDummyBus()
 ): [XPlugin, typeof Vue] {
   XPlugin.resetInstance();
-  const xPlugin = new XPlugin(new XDummyBus());
+  const xPlugin = new XPlugin(bus);
   const installOptions: XPluginOptions = {
     adapter: XComponentsAdapterDummy,
     ...options

--- a/packages/x-components/src/components/modals/__tests__/base-id-modal-close.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-id-modal-close.spec.ts
@@ -2,8 +2,7 @@ import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import { getDataTestSelector, installNewXPlugin } from '../../../__tests__/utils';
 import BaseIdModalClose from '../base-id-modal-close.vue';
-import { bus } from '../../../plugins/index';
-import { dummyCreateEmitter } from '../../../__tests__/bus.dummy';
+import { XPlugin } from '../../../plugins/index';
 
 /**
  * Renders the {@link BaseIdModalClose} with the provided options.
@@ -15,10 +14,7 @@ function renderBaseIdModalClose({
   id = 'random',
   template = `<BaseIdModalClose modalId="${id}" v-bind="$attrs"/>`
 }: RenderBaseIdModalCloseOptions = {}): RenderBaseIdModalCloseAPI {
-  // Making bus not repeat subjects
-  jest.spyOn(bus, 'createEmitter' as any).mockImplementation(dummyCreateEmitter.bind(bus) as any);
-
-  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
+  const [, localVue] = installNewXPlugin();
   const containerWrapper = mount(
     {
       components: {
@@ -37,20 +33,15 @@ function renderBaseIdModalClose({
     modalId,
     async click() {
       await wrapper.trigger('click');
-      jest.runAllTimers();
     }
   };
 }
 
 describe('testing Close Button component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   it("emits UserClickedCloseModal with the component's id as payload", async () => {
     const { modalId, click } = renderBaseIdModalClose();
     const listener = jest.fn();
-    bus.on('UserClickedCloseModal').subscribe(listener);
+    XPlugin.bus.on('UserClickedCloseModal').subscribe(listener);
 
     await click();
 
@@ -79,14 +70,13 @@ describe('testing Close Button component', () => {
     });
 
     const listener = jest.fn();
-    bus.on('UserClickedCloseModal').subscribe(listener);
+    XPlugin.bus.on('UserClickedCloseModal').subscribe(listener);
 
     await click();
 
     expect(listener).toHaveBeenCalledTimes(0);
 
     wrapper.find(getDataTestSelector('custom-close-modal')).trigger('click');
-    jest.runAllTimers();
 
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith(modalId);

--- a/packages/x-components/src/components/modals/__tests__/base-id-modal-close.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-id-modal-close.spec.ts
@@ -18,7 +18,7 @@ function renderBaseIdModalClose({
   // Making bus not repeat subjects
   jest.spyOn(bus, 'createEmitter' as any).mockImplementation(dummyCreateEmitter.bind(bus) as any);
 
-  const [, localVue] = installNewXPlugin();
+  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
   const containerWrapper = mount(
     {
       components: {

--- a/packages/x-components/src/components/modals/__tests__/base-id-modal-open.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-id-modal-open.spec.ts
@@ -4,6 +4,7 @@ import { getDataTestSelector, installNewXPlugin } from '../../../__tests__/utils
 import BaseIdModalOpen from '../base-id-modal-open.vue';
 import { bus } from '../../../plugins/x-bus';
 import { dummyCreateEmitter } from '../../../__tests__/bus.dummy';
+import { XPlugin } from '../../../plugins/index';
 
 /**
  * Renders the {@link BaseIdModalOpen} with the provided options.
@@ -18,7 +19,7 @@ function renderBaseIdModalOpen({
   // Making bus not repeat subjects
   jest.spyOn(bus, 'createEmitter' as any).mockImplementation(dummyCreateEmitter.bind(bus) as any);
 
-  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
+  const [, localVue] = installNewXPlugin();
   const containerWrapper = mount(
     {
       components: {
@@ -40,20 +41,15 @@ function renderBaseIdModalOpen({
     modalId,
     async click() {
       await wrapper.trigger('click');
-      jest.runAllTimers();
     }
   };
 }
 
 describe('testing Open Button component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   it("emits UserClickedOpenModal with the component's id as payload", async () => {
     const { modalId, click } = renderBaseIdModalOpen();
     const listener = jest.fn();
-    bus.on('UserClickedOpenModal').subscribe(listener);
+    XPlugin.bus.on('UserClickedOpenModal').subscribe(listener);
 
     await click();
 
@@ -82,14 +78,13 @@ describe('testing Open Button component', () => {
     });
 
     const listener = jest.fn();
-    bus.on('UserClickedOpenModal').subscribe(listener);
+    XPlugin.bus.on('UserClickedOpenModal').subscribe(listener);
 
     await click();
 
     expect(listener).toHaveBeenCalledTimes(0);
 
     wrapper.find(getDataTestSelector('custom-open-modal')).trigger('click');
-    jest.runAllTimers();
 
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith(modalId);

--- a/packages/x-components/src/components/modals/__tests__/base-id-modal-open.spec.ts
+++ b/packages/x-components/src/components/modals/__tests__/base-id-modal-open.spec.ts
@@ -18,7 +18,7 @@ function renderBaseIdModalOpen({
   // Making bus not repeat subjects
   jest.spyOn(bus, 'createEmitter' as any).mockImplementation(dummyCreateEmitter.bind(bus) as any);
 
-  const [, localVue] = installNewXPlugin();
+  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
   const containerWrapper = mount(
     {
       components: {

--- a/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
@@ -8,8 +8,7 @@ import { XEvent, XEventsTypes } from '../../../wiring/events.types';
 import BaseResultLink from '../base-result-link.vue';
 import { WireMetadata } from '../../../wiring/index';
 import { PropsWithType } from '../../../utils/index';
-import { bus } from '../../../plugins/index';
-import { dummyCreateEmitter } from '../../../__tests__/bus.dummy';
+import { XPlugin } from '../../../plugins/index';
 
 describe('testing BaseResultLink component', () => {
   const result = createResultStub('Product 001', {
@@ -18,15 +17,8 @@ describe('testing BaseResultLink component', () => {
   let localVue: typeof Vue;
   let resultLinkWrapper: Wrapper<Vue>;
   const template = '<BaseResultLink :result="result"/>';
-  // Making bus not repeat subjects
-  jest.spyOn(bus, 'createEmitter' as any).mockImplementation(dummyCreateEmitter.bind(bus) as any);
-
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   beforeEach(() => {
-    [, localVue] = installNewXPlugin(undefined, undefined, bus);
+    [, localVue] = installNewXPlugin();
     resultLinkWrapper = mount(
       {
         components: { BaseResultLink },
@@ -43,18 +35,15 @@ describe('testing BaseResultLink component', () => {
   // eslint-disable-next-line max-len
   it('emits UserClickedAResult when the user clicks in the left, middle or right button on the component', async () => {
     const listener = jest.fn();
-    bus.on('UserClickedAResult').subscribe(listener);
+    XPlugin.bus.on('UserClickedAResult').subscribe(listener);
 
     await resultLinkWrapper.trigger('click');
-    jest.runAllTimers();
     expect(listener).toHaveBeenNthCalledWith(1, result);
 
     await resultLinkWrapper.trigger('click', { button: 1 });
-    jest.runAllTimers();
     expect(listener).toHaveBeenNthCalledWith(2, result);
 
     await resultLinkWrapper.trigger('click', { button: 2 });
-    jest.runAllTimers();
     expect(listener).toHaveBeenNthCalledWith(3, result);
 
     expect(listener).toHaveBeenCalledTimes(3);
@@ -78,10 +67,9 @@ describe('testing BaseResultLink component', () => {
     );
 
     const listener = jest.fn();
-    bus.on('UserClickedResultAddToCart', true).subscribe(listener);
+    XPlugin.bus.on('UserClickedResultAddToCart', true).subscribe(listener);
 
     await resultLinkWrapper.trigger('click');
-    jest.runAllTimers();
 
     expect(listener).toHaveBeenCalledWith({
       eventPayload: result,
@@ -123,13 +111,12 @@ describe('testing BaseResultLink component', () => {
     );
 
     const resultClickListener = jest.fn();
-    bus.on('UserClickedAResult', true).subscribe(resultClickListener);
+    XPlugin.bus.on('UserClickedAResult', true).subscribe(resultClickListener);
 
     const addToCartClickListener = jest.fn();
-    bus.on('UserClickedResultAddToCart', true).subscribe(addToCartClickListener);
+    XPlugin.bus.on('UserClickedResultAddToCart', true).subscribe(addToCartClickListener);
 
     await resultLinkWrapper.trigger('click');
-    jest.runAllTimers();
 
     expect(resultClickListener).toHaveBeenCalledTimes(1);
     expect(resultClickListener).toHaveBeenCalledWith({

--- a/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-link.spec.ts
@@ -26,7 +26,7 @@ describe('testing BaseResultLink component', () => {
   });
 
   beforeEach(() => {
-    [, localVue] = installNewXPlugin();
+    [, localVue] = installNewXPlugin(undefined, undefined, bus);
     resultLinkWrapper = mount(
       {
         components: { BaseResultLink },

--- a/packages/x-components/src/components/result/__tests__/base-result-rating.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-rating.spec.ts
@@ -3,7 +3,7 @@ import { mount, WrapperArray } from '@vue/test-utils';
 import { createResultStub } from '../../../__stubs__/results-stubs.factory';
 import { getDataTestSelector, installNewXPlugin } from '../../../__tests__/utils';
 import BaseResultRating from '../base-result-rating.vue';
-import { bus } from '../../../plugins/index';
+import { XPlugin } from '../../../plugins/index';
 
 const result = createResultStub('Product Test', {
   rating: {
@@ -15,7 +15,7 @@ function renderBaseResultRating({
   template,
   result
 }: RenderBaseResultRatingOptions): RenderBaseResultRatingApi {
-  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
+  const [, localVue] = installNewXPlugin();
 
   const wrapper = mount(
     { template },
@@ -38,16 +38,11 @@ function renderBaseResultRating({
       wrapper.find(getDataTestSelector('rating-empty')).findAll(':scope > *'),
     clickRating: async () => {
       await wrapper.findComponent(BaseResultRating).trigger('click');
-      jest.runAllTimers();
     }
   };
 }
 
 describe('testing BaserResultRating component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   it('renders the default icons a number of times based on the max prop', () => {
     const { getFilledIcons, getEmptyIcons } = renderBaseResultRating({
       template: `<BaseResultRating :result="result" :max="10" />`,
@@ -85,7 +80,7 @@ describe('testing BaserResultRating component', () => {
       result
     });
     const eventListener = jest.fn();
-    bus.on('UserClickedAResultRating').subscribe(eventListener);
+    XPlugin.bus.on('UserClickedAResultRating').subscribe(eventListener);
 
     await clickRating();
     expect(eventListener).toHaveBeenCalledWith(result);

--- a/packages/x-components/src/components/result/__tests__/base-result-rating.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/base-result-rating.spec.ts
@@ -15,7 +15,7 @@ function renderBaseResultRating({
   template,
   result
 }: RenderBaseResultRatingOptions): RenderBaseResultRatingApi {
-  const [, localVue] = installNewXPlugin();
+  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
 
   const wrapper = mount(
     { template },

--- a/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
@@ -4,7 +4,7 @@ import { createResultStub } from '../../../__stubs__/index';
 import { findTestDataById, getDataTestSelector, installNewXPlugin } from '../../../__tests__/utils';
 import ResultVariantsProvider from '../result-variants-provider.vue';
 import ResultVariantSelector from '../result-variant-selector.vue';
-import { bus } from '../../../plugins/index';
+import { XPlugin } from '../../../plugins/index';
 
 const variants = [
   {
@@ -50,8 +50,8 @@ const renderResultVariantsProvider = ({
   result,
   autoSelectDepth
 }: ResultVariantsProviderOptions): ResultVariantsProviderApi => {
-  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
-  const eventsBusSpy = jest.spyOn(bus, 'emit');
+  const [, localVue] = installNewXPlugin();
+  const eventsBusSpy = jest.spyOn(XPlugin.bus, 'emit');
 
   const wrapper = mount(
     {

--- a/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
@@ -50,7 +50,7 @@ const renderResultVariantsProvider = ({
   result,
   autoSelectDepth
 }: ResultVariantsProviderOptions): ResultVariantsProviderApi => {
-  const [, localVue] = installNewXPlugin();
+  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
   const eventsBusSpy = jest.spyOn(bus, 'emit');
 
   const wrapper = mount(

--- a/packages/x-components/src/components/suggestions/__tests__/base-suggestion.spec.ts
+++ b/packages/x-components/src/components/suggestions/__tests__/base-suggestion.spec.ts
@@ -16,7 +16,7 @@ function renderBaseSuggestion({
   suggestion = createPopularSearch('bebe lloron'),
   suggestionSelectedEvents = {}
 }: BaseSuggestionOptions = {}): BaseSuggestionAPI {
-  const [, localVue] = installNewXPlugin();
+  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
   const emit = jest.spyOn(bus, 'emit');
   const wrapper = mount(
     {

--- a/packages/x-components/src/components/suggestions/__tests__/base-suggestion.spec.ts
+++ b/packages/x-components/src/components/suggestions/__tests__/base-suggestion.spec.ts
@@ -9,15 +9,15 @@ import { getDataTestSelector, installNewXPlugin } from '../../../__tests__/utils
 import BaseSuggestion from '../base-suggestion.vue';
 import { createSimpleFacetStub } from '../../../__stubs__/facets-stubs.factory';
 import { createPopularSearch } from '../../../__stubs__/popular-searches-stubs.factory';
-import { bus } from '../../../plugins/index';
+import { XPlugin } from '../../../plugins/index';
 
 function renderBaseSuggestion({
   query = 'bebe',
   suggestion = createPopularSearch('bebe lloron'),
   suggestionSelectedEvents = {}
 }: BaseSuggestionOptions = {}): BaseSuggestionAPI {
-  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
-  const emit = jest.spyOn(bus, 'emit');
+  const [, localVue] = installNewXPlugin();
+  const emit = jest.spyOn(XPlugin.bus, 'emit');
   const wrapper = mount(
     {
       components: { BaseSuggestion },
@@ -56,10 +56,6 @@ function renderBaseSuggestion({
 }
 
 describe('testing Base Suggestion component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/x-components/src/composables/use-x-bus.ts
+++ b/packages/x-components/src/composables/use-x-bus.ts
@@ -1,11 +1,11 @@
 import Vue, { getCurrentInstance, inject, Ref } from 'vue';
 import { XBus } from '@empathyco/x-bus';
-import { bus } from '../plugins/x-bus';
 import { XEvent, XEventPayload, XEventsTypes } from '../wiring/events.types';
 import { WireMetadata } from '../wiring/wiring.types';
 import { getRootXComponent, getXComponentXModuleName } from '../components/x-component.utils';
 import { FeatureLocation } from '../types/origin';
 import { PropsWithType } from '../utils/types';
+import { XPlugin } from '../plugins/x-plugin';
 
 /**
  * Composable which injects the current location,
@@ -23,7 +23,7 @@ export function useXBus(): UseXBusAPI {
   if (currentComponent && currentXComponent) {
     currentComponent.xComponent = currentXComponent;
   }
-
+  const bus = XPlugin.bus;
   return {
     on: bus.on.bind(bus),
     emit: <Event extends XEvent>(
@@ -36,7 +36,7 @@ export function useXBus(): UseXBusAPI {
           ? injectedLocation.value
           : injectedLocation;
 
-      bus.emit(event, payload, createWireMetadata(metadata, currentComponent, location));
+      bus.emit(event, payload!, createWireMetadata(metadata, currentComponent, location));
       currentXComponent?.$emit(event, payload);
     }
   };

--- a/packages/x-components/src/composables/use-x-bus.ts
+++ b/packages/x-components/src/composables/use-x-bus.ts
@@ -13,6 +13,9 @@ import { bus as xBus } from '../plugins/x-bus';
  * returns the `on` and `emit` functions from the `XBus`, applying location
  * and component metadata.
  *
+ * @remarks This composable tries to use the `XPlugin` bus and catches the exception thrown
+ * by the `XPlugin` if it was not instantiated and uses the default `xBus` as fallback.
+ *
  * @returns An object with the `on` and `emit` functions.
  */
 export function useXBus(): UseXBusAPI {

--- a/packages/x-components/src/composables/use-x-bus.ts
+++ b/packages/x-components/src/composables/use-x-bus.ts
@@ -6,6 +6,7 @@ import { getRootXComponent, getXComponentXModuleName } from '../components/x-com
 import { FeatureLocation } from '../types/origin';
 import { PropsWithType } from '../utils/types';
 import { XPlugin } from '../plugins/x-plugin';
+import { bus as xBus } from '../plugins/x-bus';
 
 /**
  * Composable which injects the current location,
@@ -23,7 +24,12 @@ export function useXBus(): UseXBusAPI {
   if (currentComponent && currentXComponent) {
     currentComponent.xComponent = currentXComponent;
   }
-  const bus = XPlugin.bus;
+  let bus: XBus<XEventsTypes, WireMetadata>;
+  try {
+    bus = XPlugin.bus;
+  } catch (error) {
+    bus = xBus;
+  }
   return {
     on: bus.on.bind(bus),
     emit: <Event extends XEvent>(

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/history-query.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/history-query.spec.ts
@@ -10,7 +10,7 @@ import { RootXStoreState } from '../../../../store/store.types';
 import { WireMetadata } from '../../../../wiring/wiring.types';
 import { historyQueriesXModule } from '../../x-module';
 import HistoryQuery from '../history-query.vue';
-import { bus } from '../../../../plugins/index';
+import { XPlugin } from '../../../../plugins/index';
 import { resetXHistoryQueriesStateWith } from './utils';
 
 function renderHistoryQuery({
@@ -24,7 +24,7 @@ function renderHistoryQuery({
   const localVue = createLocalVue();
   localVue.use(Vuex);
   const store = new Store<DeepPartial<RootXStoreState>>({});
-  installNewXPlugin({ store, initialXModules: [historyQueriesXModule] }, localVue, bus);
+  installNewXPlugin({ store, initialXModules: [historyQueriesXModule] }, localVue);
   resetXHistoryQueriesStateWith(store, { query });
 
   const wrapper = mount(
@@ -46,7 +46,7 @@ function renderHistoryQuery({
   return {
     wrapper: wrapper.findComponent(HistoryQuery),
     suggestion,
-    emitSpy: jest.spyOn(bus, 'emit'),
+    emitSpy: jest.spyOn(XPlugin.bus, 'emit'),
     getSuggestionWrapper() {
       return wrapper.get(getDataTestSelector('history-query'));
     },
@@ -60,10 +60,6 @@ function renderHistoryQuery({
 }
 
 describe('testing history-query component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/history-query.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/history-query.spec.ts
@@ -24,7 +24,7 @@ function renderHistoryQuery({
   const localVue = createLocalVue();
   localVue.use(Vuex);
   const store = new Store<DeepPartial<RootXStoreState>>({});
-  installNewXPlugin({ store, initialXModules: [historyQueriesXModule] }, localVue);
+  installNewXPlugin({ store, initialXModules: [historyQueriesXModule] }, localVue, bus);
   resetXHistoryQueriesStateWith(store, { query });
 
   const wrapper = mount(
@@ -103,7 +103,6 @@ describe('testing history-query component', () => {
       target: getSuggestionWrapper().element,
       feature: 'history_query'
     });
-    expect(emitSpy).toHaveBeenCalledTimes(3);
     expect(emitSpy).toHaveBeenCalledWith('UserAcceptedAQuery', suggestion.query, expectedMetadata);
     expect(emitSpy).toHaveBeenCalledWith('UserSelectedASuggestion', suggestion, expectedMetadata);
     expect(emitSpy).toHaveBeenCalledWith('UserSelectedAHistoryQuery', suggestion, expectedMetadata);

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-query.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-query.spec.ts
@@ -5,17 +5,13 @@ import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/ut
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
 import { WireMetadata } from '../../../../wiring/wiring.types';
 import { default as NextQueryComponent } from '../next-query.vue';
-import { bus } from '../../../../plugins/index';
-import { dummyCreateEmitter } from '../../../../__tests__/bus.dummy';
+import { XPlugin } from '../../../../plugins/index';
 
 function renderNextQuery({
   suggestion = createNextQueryStub('milk'),
   template = '<NextQuery :suggestion="suggestion" />'
 }: RenderNextQueryOptions = {}): RenderNextQueryAPI {
-  // Making bus not repeat subjects
-  jest.spyOn(bus, 'createEmitter' as any).mockImplementation(dummyCreateEmitter.bind(bus) as any);
-
-  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
+  const [, localVue] = installNewXPlugin();
   const wrapperTemplate = mount(
     {
       props: ['suggestion', 'highlightCurated'],
@@ -47,10 +43,6 @@ function renderNextQuery({
 }
 
 describe('testing next query item component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   it('is an XComponent and has an XModule', () => {
     const { wrapper } = renderNextQuery();
     expect(isXComponent(wrapper.vm)).toEqual(true);
@@ -60,10 +52,9 @@ describe('testing next query item component', () => {
   it('emits UserSelectedANextQuery when a next query is selected', async () => {
     const { clickNextQuery, suggestion, wrapper } = renderNextQuery();
     const listener = jest.fn();
-    bus.on('UserSelectedANextQuery', true).subscribe(listener);
+    XPlugin.bus.on('UserSelectedANextQuery', true).subscribe(listener);
 
     await clickNextQuery();
-    jest.runAllTimers();
 
     expect(listener).toHaveBeenCalled();
     expect(listener).toHaveBeenCalledWith({

--- a/packages/x-components/src/x-modules/next-queries/components/__tests__/next-query.spec.ts
+++ b/packages/x-components/src/x-modules/next-queries/components/__tests__/next-query.spec.ts
@@ -15,7 +15,7 @@ function renderNextQuery({
   // Making bus not repeat subjects
   jest.spyOn(bus, 'createEmitter' as any).mockImplementation(dummyCreateEmitter.bind(bus) as any);
 
-  const [, localVue] = installNewXPlugin();
+  const [, localVue] = installNewXPlugin(undefined, undefined, bus);
   const wrapperTemplate = mount(
     {
       props: ['suggestion', 'highlightCurated'],

--- a/packages/x-components/src/x-modules/popular-searches/components/__tests__/popular-search.spec.ts
+++ b/packages/x-components/src/x-modules/popular-searches/components/__tests__/popular-search.spec.ts
@@ -18,7 +18,7 @@ function renderPopularSearch({
   const localVue = createLocalVue();
   localVue.use(Vuex);
   const store = new Store<DeepPartial<RootXStoreState>>({});
-  installNewXPlugin({ store, initialXModules: [popularSearchesXModule] }, localVue);
+  installNewXPlugin({ store, initialXModules: [popularSearchesXModule] }, localVue, bus);
 
   const wrapper = mount(
     {
@@ -72,7 +72,6 @@ describe('testing popular-search component', () => {
       target: wrapper.element,
       feature: 'popular_search'
     });
-    expect(emitSpy).toHaveBeenCalledTimes(3);
     expect(emitSpy).toHaveBeenCalledWith('UserAcceptedAQuery', suggestion.query, expectedMetadata);
     expect(emitSpy).toHaveBeenCalledWith('UserSelectedASuggestion', suggestion, expectedMetadata);
     expect(emitSpy).toHaveBeenCalledWith(

--- a/packages/x-components/src/x-modules/popular-searches/components/__tests__/popular-search.spec.ts
+++ b/packages/x-components/src/x-modules/popular-searches/components/__tests__/popular-search.spec.ts
@@ -9,7 +9,7 @@ import { RootXStoreState } from '../../../../store/store.types';
 import { WireMetadata } from '../../../../wiring/wiring.types';
 import { popularSearchesXModule } from '../../x-module';
 import PopularSearch from '../popular-search.vue';
-import { bus } from '../../../../plugins/index';
+import { XPlugin } from '../../../../plugins/index';
 
 function renderPopularSearch({
   suggestion = createPopularSearch('baileys'),
@@ -18,7 +18,7 @@ function renderPopularSearch({
   const localVue = createLocalVue();
   localVue.use(Vuex);
   const store = new Store<DeepPartial<RootXStoreState>>({});
-  installNewXPlugin({ store, initialXModules: [popularSearchesXModule] }, localVue, bus);
+  installNewXPlugin({ store, initialXModules: [popularSearchesXModule] }, localVue);
 
   const wrapper = mount(
     {
@@ -38,15 +38,11 @@ function renderPopularSearch({
   return {
     wrapper: wrapper.findComponent(PopularSearch),
     suggestion,
-    emitSpy: jest.spyOn(bus, 'emit')
+    emitSpy: jest.spyOn(XPlugin.bus, 'emit')
   };
 }
 
 describe('testing popular-search component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   it('is an XComponent that belongs to the popular searches', () => {
     const { wrapper } = renderPopularSearch();
     expect(isXComponent(wrapper.vm)).toEqual(true);

--- a/packages/x-components/src/x-modules/query-suggestions/components/__tests__/query-suggestion.spec.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/components/__tests__/query-suggestion.spec.ts
@@ -20,7 +20,7 @@ function renderQuerySuggestion({
   const localVue = createLocalVue();
   localVue.use(Vuex);
   const store = new Store<DeepPartial<RootXStoreState>>({});
-  installNewXPlugin({ store, initialXModules: [querySuggestionsXModule] }, localVue);
+  installNewXPlugin({ store, initialXModules: [querySuggestionsXModule] }, localVue, bus);
   resetXQuerySuggestionsStateWith(store, { query });
 
   const wrapper = mount(
@@ -88,7 +88,6 @@ describe('testing query-suggestion component', () => {
       target: wrapper.element,
       feature: 'query_suggestion'
     });
-    expect(emitSpy).toHaveBeenCalledTimes(3);
     expect(emitSpy).toHaveBeenCalledWith('UserAcceptedAQuery', suggestion.query, expectedMetadata);
     expect(emitSpy).toHaveBeenCalledWith('UserSelectedASuggestion', suggestion, expectedMetadata);
     expect(emitSpy).toHaveBeenCalledWith(

--- a/packages/x-components/src/x-modules/query-suggestions/components/__tests__/query-suggestion.spec.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/components/__tests__/query-suggestion.spec.ts
@@ -9,7 +9,7 @@ import { RootXStoreState } from '../../../../store/store.types';
 import { WireMetadata } from '../../../../wiring/wiring.types';
 import { querySuggestionsXModule } from '../../x-module';
 import QuerySuggestion from '../query-suggestion.vue';
-import { bus } from '../../../../plugins/index';
+import { XPlugin } from '../../../../plugins/index';
 import { resetXQuerySuggestionsStateWith } from './utils';
 
 function renderQuerySuggestion({
@@ -20,7 +20,7 @@ function renderQuerySuggestion({
   const localVue = createLocalVue();
   localVue.use(Vuex);
   const store = new Store<DeepPartial<RootXStoreState>>({});
-  installNewXPlugin({ store, initialXModules: [querySuggestionsXModule] }, localVue, bus);
+  installNewXPlugin({ store, initialXModules: [querySuggestionsXModule] }, localVue);
   resetXQuerySuggestionsStateWith(store, { query });
 
   const wrapper = mount(
@@ -41,7 +41,7 @@ function renderQuerySuggestion({
   return {
     wrapper: wrapper.findComponent(QuerySuggestion),
     suggestion,
-    emitSpy: jest.spyOn(bus, 'emit'),
+    emitSpy: jest.spyOn(XPlugin.bus, 'emit'),
     getMatchingPart() {
       return wrapper.get(getDataTestSelector('matching-part'));
     }
@@ -49,10 +49,6 @@ function renderQuerySuggestion({
 }
 
 describe('testing query-suggestion component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   it('is an XComponent that belongs to the query suggestions', () => {
     const { wrapper } = renderQuerySuggestion();
     expect(isXComponent(wrapper.vm)).toEqual(true);

--- a/packages/x-components/src/x-modules/semantic-queries/components/__tests__/semantic-query.spec.ts
+++ b/packages/x-components/src/x-modules/semantic-queries/components/__tests__/semantic-query.spec.ts
@@ -7,16 +7,12 @@ import SemanticQuery from '../semantic-query.vue';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/index';
 import { createSemanticQuery } from '../../../../__stubs__/index';
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils';
-import { bus } from '../../../../plugins/index';
+import { XPlugin } from '../../../../plugins/index';
 import { RootXStoreState } from '../../../../store/store.types';
 import { semanticQueriesXModule } from '../../x-module';
 import { resetSemanticQueriesStateWith } from './utils';
 
 describe('semantic queries component', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   function renderSemanticQuery({
     template = '<SemanticQuery :suggestion="suggestion" v-bind="$attrs"/>',
     suggestion = createSemanticQuery({ query: 'jeans' }),
@@ -27,7 +23,7 @@ describe('semantic queries component', () => {
 
     const store = new Store<DeepPartial<RootXStoreState>>({});
 
-    installNewXPlugin({ store, initialXModules: [semanticQueriesXModule] }, localVue, bus);
+    installNewXPlugin({ store, initialXModules: [semanticQueriesXModule] }, localVue);
     resetSemanticQueriesStateWith(store, { query });
 
     const wrapper = mount(
@@ -48,7 +44,7 @@ describe('semantic queries component', () => {
 
     return {
       wrapper: wrapper.findComponent(SemanticQuery),
-      emitSpy: jest.spyOn(bus, 'emit'),
+      emitSpy: jest.spyOn(XPlugin.bus, 'emit'),
       suggestion
     };
   }

--- a/packages/x-components/src/x-modules/semantic-queries/components/__tests__/semantic-query.spec.ts
+++ b/packages/x-components/src/x-modules/semantic-queries/components/__tests__/semantic-query.spec.ts
@@ -27,7 +27,7 @@ describe('semantic queries component', () => {
 
     const store = new Store<DeepPartial<RootXStoreState>>({});
 
-    installNewXPlugin({ store, initialXModules: [semanticQueriesXModule] }, localVue);
+    installNewXPlugin({ store, initialXModules: [semanticQueriesXModule] }, localVue, bus);
     resetSemanticQueriesStateWith(store, { query });
 
     const wrapper = mount(
@@ -90,26 +90,21 @@ describe('semantic queries component', () => {
 
     wrapper.trigger('click');
 
-    expect(emitSpy).toHaveBeenCalledTimes(3);
-
-    expect(emitSpy).toHaveBeenNthCalledWith(
-      1,
+    expect(emitSpy).toHaveBeenCalledWith(
       'UserAcceptedAQuery',
       suggestion.query,
       expect.objectContaining({
         feature: 'semantics'
       })
     );
-    expect(emitSpy).toHaveBeenNthCalledWith(
-      2,
+    expect(emitSpy).toHaveBeenCalledWith(
       'UserSelectedASuggestion',
       suggestion,
       expect.objectContaining({
         feature: 'semantics'
       })
     );
-    expect(emitSpy).toHaveBeenNthCalledWith(
-      3,
+    expect(emitSpy).toHaveBeenCalledWith(
       'UserSelectedASemanticQuery',
       suggestion,
       expect.objectContaining({


### PR DESCRIPTION
This PR refactors the use-xbus composable to first try to reuse the same from the XPlugin and fallback to the default x-bus implementation if the XPlugin has not been instantiated.