### PR TITLE
refactor(base-event-button): migrate base-event-button component to Composition API

### DIFF
--- a/packages/_vue3-migration-test/src/App.vue
+++ b/packages/_vue3-migration-test/src/App.vue
@@ -7,7 +7,12 @@
       </RouterLink>
     </nav>
     <main>
-      <RouterView />
+      <RouterView v-slot="{ Component }">
+        <!-- Components are mounted only once with keep-alive -->
+        <KeepAlive>
+          <component :is="Component" />
+        </KeepAlive>
+      </RouterView>
     </main>
   </div>
 </template>

--- a/packages/_vue3-migration-test/src/components/index.ts
+++ b/packages/_vue3-migration-test/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './animations';
 export { default as TestBaseDropdown } from './test-base-dropdown.vue';
+export { default as TestBaseEventButton } from './test-base-event-button.vue';

--- a/packages/_vue3-migration-test/src/components/test-base-event-button.vue
+++ b/packages/_vue3-migration-test/src/components/test-base-event-button.vue
@@ -1,0 +1,25 @@
+<template>
+  <BaseEventButton @focusin="onFocusin" :events="events" data-id="$attrs working on Vue3!">
+    <span>Emit X event!</span>
+  </BaseEventButton>
+</template>
+
+<script setup lang="ts">
+  import BaseEventButton from '../../../x-components/src/components/base-event-button.vue';
+  import { use$x } from '../../../x-components/src/composables/use-$x';
+  import { XEvent, XEventsTypes } from '../../../x-components/src/wiring/events.types';
+
+  const $x = use$x();
+
+  const events: Partial<XEventsTypes> = {
+    UserClickedASort: 'price asc',
+    UserClickedPDPAddToCart: 'A012'
+  };
+
+  Object.entries(events).forEach(([event]) =>
+    // eslint-disable-next-line no-console
+    $x.on(event as XEvent, true).subscribe(args => console.log('BaseEventButton emission:', args))
+  );
+  // eslint-disable-next-line no-console
+  const onFocusin = (): void => console.log('$listeners working on Vue3!');
+</script>

--- a/packages/_vue3-migration-test/src/main.ts
+++ b/packages/_vue3-migration-test/src/main.ts
@@ -6,7 +6,7 @@ import router from './router';
 const VUE_COMPAT_MODE = Number(import.meta.env.VITE_VUE_COMPAT_MODE);
 if (VUE_COMPAT_MODE === 2) {
   configureCompat({
-    INSTANCE_LISTENERS: 'suppress-warning',
+    INSTANCE_LISTENERS: false, // https://github.com/vuejs/core/issues/4566#issuecomment-917997056
     RENDER_FUNCTION: false,
     COMPONENT_V_MODEL: false
   });

--- a/packages/_vue3-migration-test/src/main.ts
+++ b/packages/_vue3-migration-test/src/main.ts
@@ -6,7 +6,14 @@ import router from './router';
 const VUE_COMPAT_MODE = Number(import.meta.env.VITE_VUE_COMPAT_MODE);
 if (VUE_COMPAT_MODE === 2) {
   configureCompat({
-    INSTANCE_LISTENERS: false, // https://github.com/vuejs/core/issues/4566#issuecomment-917997056
+    /**
+     * Remove $attrs and $listeners when Vue 3 and `INSTANCE_LISTENERS: false`.
+     * Both $attrs and $listeners are inherited (automatically forwarded) to the root component
+     * by default:
+     * https://vuejs.org/guide/components/attrs#nested-component-inheritance
+     * https://github.com/vuejs/core/issues/4566#issuecomment-917997056.
+     */
+    INSTANCE_LISTENERS: 'suppress-warning',
     RENDER_FUNCTION: false,
     COMPONENT_V_MODEL: false
   });

--- a/packages/_vue3-migration-test/src/router.ts
+++ b/packages/_vue3-migration-test/src/router.ts
@@ -1,5 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router';
-import { TestAnimateWidth, TestBaseDropdown, TestFade } from './';
+import { TestAnimateWidth, TestBaseDropdown, TestBaseEventButton, TestFade } from './';
 
 const routes = [
   {
@@ -16,6 +16,11 @@ const routes = [
     path: '/base-dropdown',
     name: 'BaseDropdown',
     component: TestBaseDropdown
+  },
+  {
+    path: '/base-event-button',
+    name: 'BaseEventButton',
+    component: TestBaseEventButton
   }
 ];
 

--- a/packages/x-components/src/components/__tests__/base-event-button.spec.ts
+++ b/packages/x-components/src/components/__tests__/base-event-button.spec.ts
@@ -1,67 +1,79 @@
-import { forEach } from '@empathyco/x-utils';
 import { mount } from '@vue/test-utils';
+import { installNewXPlugin } from '../../__tests__/utils';
+import { XPlugin } from '../../plugins';
 import { WireMetadata } from '../../wiring/wiring.types';
 import BaseEventButton from '../base-event-button.vue';
 
-describe('testing Base Event Button Component', () => {
-  const emitSpy = jest.fn();
+function render() {
+  installNewXPlugin();
 
-  const componentWrapper = mount(BaseEventButton, {
-    propsData: {
-      events: {}
+  const wrapper = mount(
+    {
+      template: `<BaseEventButton :events="events">
+        <span class="test-msg">button text</span>
+        <i class="test-icon"></i>
+      </BaseEventButton>`,
+      components: { BaseEventButton },
+      props: ['events']
     },
-    mocks: {
-      $x: {
-        emit: emitSpy
-      }
-    },
-    slots: {
-      default: [
-        { template: '<span class="test-msg">button text</span>' },
-        { template: '<i class="test-icon"></i>' }
-      ]
+    {
+      propsData: { events: {} }
     }
-  });
-  const expectedMetadata: Omit<WireMetadata, 'moduleName'> = {
-    target: componentWrapper.element
-  };
+  );
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+  return {
+    wrapper,
+    emitSpy: jest.spyOn(XPlugin.bus, 'emit'),
+    expectedMetadata: {
+      location: 'none',
+      moduleName: null,
+      replaceable: true,
+      target: wrapper.element
+    } as WireMetadata
+  } as const;
+}
 
+describe('testing Base Event Button Component', () => {
   it('renders everything passed to its default slot', () => {
-    expect(componentWrapper.find('.test-msg').exists()).toBe(true);
-    expect(componentWrapper.find('.test-icon').exists()).toBe(true);
+    const { wrapper } = render();
+
+    expect(wrapper.find('.test-msg').exists()).toBeTruthy();
+    expect(wrapper.find('.test-icon').exists()).toBeTruthy();
   });
 
-  it('emits an event with a payload', () => {
-    componentWrapper.setProps({
-      events: { testEvent: 'testPayload' }
-    });
-    componentWrapper.trigger('click');
+  it('emits an event with a payload', async () => {
+    const { wrapper, emitSpy, expectedMetadata } = render();
 
-    expect(emitSpy).toHaveBeenCalledWith('testEvent', 'testPayload', expectedMetadata);
+    await wrapper.setProps({ events: { testEvent: 'test-payload' } });
+    await wrapper.trigger('click');
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith('testEvent', 'test-payload', expectedMetadata);
   });
 
-  it('emits an event with no payload', () => {
-    componentWrapper.setProps({ events: { testEvent: undefined } });
-    componentWrapper.trigger('click');
+  it('emits an event with no payload', async () => {
+    const { wrapper, emitSpy, expectedMetadata } = render();
 
+    await wrapper.setProps({ events: { testEvent: undefined } });
+    await wrapper.trigger('click');
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
     expect(emitSpy).toHaveBeenCalledWith('testEvent', undefined, expectedMetadata);
   });
 
-  it('emits multiple events with multiple payloads', () => {
+  it('emits multiple events with multiple payloads', async () => {
+    const { wrapper, emitSpy, expectedMetadata } = render();
+
     const events = {
       testEvent1: 'test-payload-1',
       testEvent2: 'test-payload-2',
       testEvent3: undefined
     };
-    componentWrapper.setProps({ events });
-    componentWrapper.trigger('click');
+    await wrapper.setProps({ events });
+    await wrapper.trigger('click');
 
     expect(emitSpy).toHaveBeenCalledTimes(3);
-    forEach(events, (event, payload) =>
+    Object.entries(events).forEach(([event, payload]) =>
       expect(emitSpy).toHaveBeenCalledWith(event, payload, expectedMetadata)
     );
   });

--- a/packages/x-components/src/components/animations/animate-width.vue
+++ b/packages/x-components/src/components/animations/animate-width.vue
@@ -1,5 +1,6 @@
 <template>
-  <transition v-on="$listeners" name="x-animate-width-">
+  <!-- eslint-disable-next-line vue/attributes-order -->
+  <transition v-bind="$attrs" v-on="$listeners" name="x-animate-width-">
     <!-- @slot (Required) Transition content -->
     <slot />
   </transition>

--- a/packages/x-components/src/components/animations/animate-width.vue
+++ b/packages/x-components/src/components/animations/animate-width.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition name="x-animate-width-">
+  <transition v-on="$listeners" name="x-animate-width-">
     <!-- @slot (Required) Transition content -->
     <slot />
   </transition>

--- a/packages/x-components/src/components/animations/animate-width.vue
+++ b/packages/x-components/src/components/animations/animate-width.vue
@@ -1,6 +1,5 @@
 <template>
-  <!-- eslint-disable-next-line vue/attributes-order -->
-  <transition v-bind="$attrs" v-on="$listeners" name="x-animate-width-">
+  <transition name="x-animate-width-">
     <!-- @slot (Required) Transition content -->
     <slot />
   </transition>
@@ -15,7 +14,7 @@
    * @public
    */
   export default defineComponent({
-    inheritAttrs: false
+    name: 'AnimateWidth'
   });
 </script>
 

--- a/packages/x-components/src/components/animations/animate-width.vue
+++ b/packages/x-components/src/components/animations/animate-width.vue
@@ -15,7 +15,8 @@
    * @public
    */
   export default defineComponent({
-    name: 'AnimateWidth'
+    name: 'AnimateWidth',
+    inheritAttrs: false
   });
 </script>
 

--- a/packages/x-components/src/components/animations/fade.vue
+++ b/packages/x-components/src/components/animations/fade.vue
@@ -17,6 +17,7 @@
    */
   export default defineComponent({
     name: 'Fade',
+    inheritAttrs: false,
     props: {
       /** Indicates if the transition must be applied on the initial render of the node. */
       appear: {

--- a/packages/x-components/src/components/animations/fade.vue
+++ b/packages/x-components/src/components/animations/fade.vue
@@ -1,5 +1,6 @@
 <template>
-  <transition v-on="$listeners" name="x-fade-" :appear="appear">
+  <!-- eslint-disable-next-line vue/attributes-order -->
+  <transition v-bind="$attrs" v-on="$listeners" name="x-fade-" :appear="appear">
     <!-- @slot (Required) to add content to the transition -->
     <slot />
   </transition>

--- a/packages/x-components/src/components/animations/fade.vue
+++ b/packages/x-components/src/components/animations/fade.vue
@@ -1,6 +1,5 @@
 <template>
-  <!-- eslint-disable-next-line vue/attributes-order -->
-  <transition v-bind="$attrs" v-on="$listeners" name="x-fade-" :appear="appear">
+  <transition name="x-fade-" :appear="appear">
     <!-- @slot (Required) to add content to the transition -->
     <slot />
   </transition>
@@ -17,11 +16,8 @@
    */
   export default defineComponent({
     name: 'Fade',
-    inheritAttrs: false,
     props: {
-      /**
-       * Indicates if the transition must be applied on the initial render of the node.
-       */
+      /** Indicates if the transition must be applied on the initial render of the node. */
       appear: {
         type: Boolean,
         default: true

--- a/packages/x-components/src/components/animations/fade.vue
+++ b/packages/x-components/src/components/animations/fade.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition name="x-fade-" :appear="appear">
+  <transition v-on="$listeners" name="x-fade-" :appear="appear">
     <!-- @slot (Required) to add content to the transition -->
     <slot />
   </transition>

--- a/packages/x-components/src/components/base-event-button.vue
+++ b/packages/x-components/src/components/base-event-button.vue
@@ -1,41 +1,53 @@
 <template>
-  <button v-on="$listeners" @click="emitEvents" data-test="event-button">
+  <button ref="rootRef" @click="emitEvents" data-test="event-button">
     <!-- @slot (Required) Button content with a text, an icon or both -->
     <slot />
   </button>
 </template>
 
 <script lang="ts">
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
-  import { XEvent, XEventsTypes } from '../wiring';
+  import { defineComponent, PropType, ref } from 'vue';
+  import { use$x } from '../composables/use-$x';
+  import { XEvent, XEventsTypes } from '../wiring/events.types';
 
   /**
    * Component to be reused that renders a `<button>` with the logic of emitting events to the bus
-   * on click. The events are passed as an object to prop {@link XEventsTypes}.
+   * on click. The events are passed as an object to prop {@link XEvent}.
    * The keys are the event name and the values are the payload of each event. All events are
    * emitted with its respective payload. If any event doesn't need payload a `undefined` must be
    * passed as value.
    *
    * @public
    */
-  @Component
-  export default class BaseEventButton extends Vue {
-    /**
-     * (Required) A object where the keys are the {@link XEvent} and the values
-     * are the payload of each event.
-     *
-     * @public
-     */
-    @Prop({ required: true })
-    protected events!: Partial<XEventsTypes>;
+  export default defineComponent({
+    name: 'BaseEventButton',
+    props: {
+      /** An object where the keys are the {@link XEvent} and the values are the payload. */
+      events: {
+        type: Object as PropType<Partial<XEventsTypes>>,
+        required: true
+      }
+    },
+    setup(props) {
+      const $x = use$x();
 
-    protected emitEvents(): void {
-      Object.entries(this.events).forEach(([event, payload]) => {
-        this.$x.emit(event as XEvent, payload, { target: this.$el as HTMLElement });
-      });
+      const rootRef = ref<HTMLButtonElement>();
+
+      /**
+       * Emits `events` prop to the X bus with the payload given by it.
+       */
+      function emitEvents() {
+        Object.entries(props.events).forEach(([event, payload]) =>
+          $x.emit(event as XEvent, payload, { target: rootRef.value })
+        );
+      }
+
+      return {
+        emitEvents,
+        rootRef
+      };
     }
-  }
+  });
 </script>
 
 <docs lang="mdx">

--- a/packages/x-components/src/components/base-event-button.vue
+++ b/packages/x-components/src/components/base-event-button.vue
@@ -1,5 +1,5 @@
 <template>
-  <button ref="rootRef" @click="emitEvents" data-test="event-button">
+  <button ref="rootRef" v-on="$listeners" @click="emitEvents" data-test="event-button">
     <!-- @slot (Required) Button content with a text, an icon or both -->
     <slot />
   </button>

--- a/packages/x-components/src/components/column-picker/__tests__/base-column-picker-list.spec.ts
+++ b/packages/x-components/src/components/column-picker/__tests__/base-column-picker-list.spec.ts
@@ -97,7 +97,7 @@ describe('testing Base Column Picker List', () => {
       metadata: {
         moduleName: null, // no module registered for this base component
         target: wrapper.findAll(getDataTestSelector('column-picker-button')).at(index).element,
-        location: undefined,
+        location: 'none',
         replaceable: true
       }
     });
@@ -110,7 +110,7 @@ describe('testing Base Column Picker List', () => {
       metadata: {
         moduleName: null, // no module registered for this base component
         target: wrapper.findAll(getDataTestSelector('column-picker-button')).at(index).element,
-        location: undefined,
+        location: 'none',
         replaceable: true
       }
     });

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -452,7 +452,6 @@
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
   import { animateClipPath } from '../../components/animations/animate-clip-path/animate-clip-path.factory';
-  import AnimateWidth from '../../components/animations/animate-width.vue';
   import StaggeredFadeAndSlide from '../../components/animations/staggered-fade-and-slide.vue';
   import AutoProgressBar from '../../components/auto-progress-bar.vue';
   import BaseDropdown from '../../components/base-dropdown.vue';
@@ -532,7 +531,6 @@
       infiniteScroll
     },
     components: {
-      AnimateWidth,
       DisplayEmitter,
       QueryPreviewButton,
       DisplayResultProvider,

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -452,6 +452,7 @@
   import Vue from 'vue';
   import { Component } from 'vue-property-decorator';
   import { animateClipPath } from '../../components/animations/animate-clip-path/animate-clip-path.factory';
+  import AnimateWidth from '../../components/animations/animate-width.vue';
   import StaggeredFadeAndSlide from '../../components/animations/staggered-fade-and-slide.vue';
   import AutoProgressBar from '../../components/auto-progress-bar.vue';
   import BaseDropdown from '../../components/base-dropdown.vue';
@@ -531,6 +532,7 @@
       infiniteScroll
     },
     components: {
+      AnimateWidth,
       DisplayEmitter,
       QueryPreviewButton,
       DisplayResultProvider,

--- a/packages/x-components/src/x-modules/facets/components/__tests__/clear-filters.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/__tests__/clear-filters.spec.ts
@@ -167,7 +167,7 @@ describe('testing ClearFilters component', () => {
       metadata: {
         moduleName: 'facets',
         target: wrapper.element,
-        location: undefined,
+        location: 'none',
         replaceable: true
       }
     });
@@ -188,7 +188,7 @@ describe('testing ClearFilters component', () => {
       metadata: {
         moduleName: 'facets',
         target: wrapper.element,
-        location: undefined,
+        location: 'none',
         replaceable: true
       }
     });

--- a/packages/x-components/src/x-modules/facets/components/filters/__tests__/all-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/filters/__tests__/all-filter.spec.ts
@@ -102,7 +102,7 @@ describe('testing AllFilter component', () => {
       metadata: {
         moduleName: 'facets',
         target: wrapper.element,
-        location: undefined,
+        location: 'none',
         replaceable: true
       }
     });

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/clear-history-queries.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/clear-history-queries.spec.ts
@@ -57,7 +57,7 @@ describe('testing ClearHistoryQueries component', () => {
       metadata: {
         moduleName: 'historyQueries',
         target: clearHistoryQueries.element,
-        location: undefined,
+        location: 'none',
         replaceable: true
       }
     });

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/remove-history-query.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/remove-history-query.spec.ts
@@ -30,7 +30,7 @@ describe('testing RemoveHistoryQuery component', () => {
       metadata: {
         moduleName: 'historyQueries',
         target: removeHistoryQuery.element,
-        location: undefined,
+        location: 'none',
         replaceable: true
       }
     });

--- a/packages/x-components/src/x-modules/search-box/components/__tests__/clear-search-input.spec.ts
+++ b/packages/x-components/src/x-modules/search-box/components/__tests__/clear-search-input.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { installNewXPlugin } from '../../../../__tests__/utils';
+import { XPlugin } from '../../../../plugins';
 import ClearSearchInput from '../clear-search-input.vue';
 
 describe('testing ClearSearchInput component', () => {
@@ -7,8 +8,13 @@ describe('testing ClearSearchInput component', () => {
 
   it('emits UserPressedClearSearchBoxButton event when clicked', () => {
     const clearSearchInput = mount(ClearSearchInput, { localVue });
-    const target = { target: clearSearchInput.element };
-    const emitSpy = jest.spyOn(clearSearchInput.vm.$children[0].$x, 'emit');
+    const target = {
+      location: 'none',
+      moduleName: 'searchBox',
+      replaceable: true,
+      target: clearSearchInput.element
+    };
+    const emitSpy = jest.spyOn(XPlugin.bus, 'emit');
 
     clearSearchInput.trigger('click');
 

--- a/packages/x-components/src/x-modules/search/components/__tests__/sort-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/sort-list.spec.ts
@@ -85,7 +85,7 @@ describe('testing SortList component', () => {
       metadata: {
         moduleName: 'search',
         target: getButton(2),
-        location: undefined, // TODO - Emission by BaseEventButton in the old way. `none` when use$x
+        location: 'none',
         replaceable: true
       }
     });

--- a/packages/x-components/src/x-modules/search/components/__tests__/sort-picker-list.spec.ts
+++ b/packages/x-components/src/x-modules/search/components/__tests__/sort-picker-list.spec.ts
@@ -92,7 +92,7 @@ describe('testing SortPickerList component', () => {
       metadata: {
         moduleName: 'search',
         target: getButton(2),
-        location: undefined, // TODO - Emission by BaseEventButton in the old way. `none` when use$x
+        location: 'none',
         replaceable: true
       }
     });


### PR DESCRIPTION
Migrate `base-event-button` component to Composition API

⚠️ Pending to migrate animations used in the `vue3` package to support `INSTANCE_LISTENERS: false` needed for this PR -> ✅ Solved here: https://github.com/empathyco/x/pull/1457/commits/ae291b4397284879d65f98b7ce41b88095c0069a
https://vuejs.org/guide/components/attrs#nested-component-inheritance
2nd round: Recovered `INSTANCE_LISTENERS: 'suppress-warning'` until Vue3 ecosystem integration (build and testing)

EMP-3965

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Vue 3 Migration

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [X] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [X] I have **commented** my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [X] I have added **tests** that prove my fix is effective or that my feature works.
- [X] New and existing **unit tests pass locally** with my changes.
