### PR TITLE
feat: Support empty params on adapter's requests

### DIFF
--- a/packages/x-adapter/src/http-clients/__tests__/fetch.http-client.spec.ts
+++ b/packages/x-adapter/src/http-clients/__tests__/fetch.http-client.spec.ts
@@ -59,6 +59,20 @@ describe('fetch httpClient testing', () => {
     expectFetchCallWith(endpoint);
   });
 
+  it('maps empty values if configured to do so', async () => {
+    await fetchHttpClient(endpoint, {
+      sendEmptyParams: true,
+      parameters: {
+        q: undefined,
+        r: '',
+        s: null,
+        t: [],
+        u: {}
+      }
+    });
+    expectFetchCallWith(`${endpoint}?r=&s=null`);
+  });
+
   it('cancels equal endpoint requests if no requestId parameter is passed', async () => {
     await Promise.all([
       expect(
@@ -182,6 +196,43 @@ describe('fetch httpClient testing', () => {
           q: 'shirt',
           extraParams: {
             lang: 'en'
+          }
+        })
+      });
+    });
+
+    it('sends empty values in the body if configured to do so', async () => {
+      await fetchHttpClient(endpoint, {
+        sendParamsInBody: true,
+        sendEmptyParams: true,
+        parameters: {
+          q: 'shirt',
+          a: undefined,
+          b: null,
+          c: '',
+          d: [],
+          extraParams: {
+            lang: 'en',
+            e: undefined,
+            f: null,
+            g: '',
+            h: [],
+            i: {}
+          }
+        }
+      });
+      expectFetchCallWith(endpoint, {
+        body: JSON.stringify({
+          q: 'shirt',
+          b: null,
+          c: '',
+          d: [],
+          extraParams: {
+            lang: 'en',
+            f: null,
+            g: '',
+            h: [],
+            i: {}
           }
         })
       });

--- a/packages/x-adapter/src/http-clients/fetch.http-client.ts
+++ b/packages/x-adapter/src/http-clients/fetch.http-client.ts
@@ -14,12 +14,22 @@ import { buildUrl, toJson } from './utils';
  */
 export const fetchHttpClient: HttpClient = (
   endpoint,
-  { id = endpoint, cancelable = true, parameters = {}, properties, sendParamsInBody = false } = {}
+  {
+    id = endpoint,
+    cancelable = true,
+    parameters = {},
+    properties,
+    sendParamsInBody = false,
+    sendEmptyParams = false
+  } = {}
 ) => {
   const signal = cancelable ? { signal: abortAndGetNewAbortSignal(id) } : {};
+  if (!sendEmptyParams) {
+    parameters = cleanEmpty(parameters);
+  }
   const flatParameters = flatObject(parameters);
-  const url = sendParamsInBody ? endpoint : buildUrl(endpoint, cleanEmpty(flatParameters));
-  const bodyParameters = sendParamsInBody ? { body: JSON.stringify(cleanEmpty(parameters)) } : {};
+  const url = sendParamsInBody ? endpoint : buildUrl(endpoint, flatParameters);
+  const bodyParameters = sendParamsInBody ? { body: JSON.stringify(parameters) } : {};
 
   return fetch(url, {
     ...properties,

--- a/packages/x-adapter/src/http-clients/types.ts
+++ b/packages/x-adapter/src/http-clients/types.ts
@@ -32,6 +32,10 @@ export interface RequestOptions {
    */
   sendParamsInBody?: boolean;
   /**
+   * A flag to always send the parameters even if their values are empty.
+   */
+  sendEmptyParams?: boolean;
+  /**
    * A list of parameters to send to the API.
    */
   parameters?: Dictionary<unknown>;


### PR DESCRIPTION
## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
From Play we need to perform Search requests that must necessarily include some specific parameters in the body, even if their values are empty (`''`).

These parameters are used to preview products and attributes boosts so the empty value tells the Search service that no boosts must be applied in the response even if they exist in the database.

This way there would be three different scenarios depending on the value of these parameters:

1. No parameters are sent -> Search must apply the boosts stored in the database (default behaviour).
2. Parameters with specific values (not empty) are sent -> Search must ignore the boosts stored in the database AND apply the ones specified in the parameters.
3. [NEW] Parameters with empty values are sent -> Search must just ignore the boosts stored in the database AND not apply anything else.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md).

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
