### PR TITLE
feat(use-x-bus): unsubscribe from bus events when component is unmounted

### DIFF
--- a/packages/_vue3-migration-test/src/App.vue
+++ b/packages/_vue3-migration-test/src/App.vue
@@ -7,12 +7,7 @@
       </RouterLink>
     </nav>
     <main>
-      <RouterView v-slot="{ Component }">
-        <!-- Components are mounted only once with keep-alive -->
-        <KeepAlive>
-          <component :is="Component" />
-        </KeepAlive>
-      </RouterView>
+      <RouterView />
     </main>
   </div>
 </template>

--- a/packages/_vue3-migration-test/src/components/test-base-event-button.vue
+++ b/packages/_vue3-migration-test/src/components/test-base-event-button.vue
@@ -22,6 +22,7 @@
     // eslint-disable-next-line no-console
     _$x.on(event as XEvent, true).subscribe(args => console.log('BaseEventButton emission:', args))
   );
+
   // eslint-disable-next-line no-console
   const onFocusin = (): void => console.log('$listeners working on Vue3!');
 </script>

--- a/packages/x-components/src/components/column-picker/base-column-picker-dropdown.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-dropdown.vue
@@ -88,7 +88,7 @@
       watch(providedSelectedColumns, emitColumnsNumberProvided);
       watch(selectedColumns, emitUpdateModelValue);
 
-      $x.on('ColumnsNumberProvided').subscribe(column => (selectedColumns.value = column));
+      $x.on('ColumnsNumberProvided', false).subscribe(column => (selectedColumns.value = column));
 
       /**
        * Synchronizes the columns number before mounting the component. If the real number of selected

--- a/packages/x-components/src/components/column-picker/base-column-picker-list.vue
+++ b/packages/x-components/src/components/column-picker/base-column-picker-list.vue
@@ -98,7 +98,7 @@
       watch(providedSelectedColumns, emitColumnsNumberProvided);
       watch(selectedColumns, emitUpdateModelValue);
 
-      $x.on('ColumnsNumberProvided').subscribe(column => (selectedColumns.value = column));
+      $x.on('ColumnsNumberProvided', false).subscribe(column => (selectedColumns.value = column));
 
       /**
        * Synchronizes the columns number before mounting the component. If the real number of selected

--- a/packages/x-components/src/components/global-x-bus.vue
+++ b/packages/x-components/src/components/global-x-bus.vue
@@ -1,16 +1,12 @@
 <script lang="ts">
-  import { reduce } from '@empathyco/x-utils';
-  import { Observable, Subscription } from 'rxjs';
-  import { EventPayload, SubjectPayload } from '@empathyco/x-bus';
-  import { defineComponent, onBeforeUnmount } from 'vue';
+  import { defineComponent } from 'vue';
   import { XEventListeners } from '../x-installer/api/api.types';
-  import { WireMetadata } from '../wiring/wiring.types';
-  import { XEventsTypes } from '../wiring/events.types';
+  import { XEvent } from '../wiring/events.types';
   import { useNoElementRender } from '../composables/use-no-element-render';
   import { useXBus } from '../composables/use-x-bus';
 
   /**
-   * This component helps subscribing to any {@link XEvent} with custom callbacks using Vue
+   * This component helps to subscribe to any {@link XEvent} with custom callbacks using Vue
    * listeners API.
    *
    * @public
@@ -22,29 +18,12 @@
 
       /**
        * Handles a subscription to all the events provided in the listeners with the function that
-       * will execute the callback. Also unsubscribes on beforeDestroy.
-       *
-       * @internal
+       * will execute the callback.
        */
-      const subscription = reduce(
-        listeners as XEventListeners,
-        (subscription, eventName, callback) => {
-          subscription.add(
-            (
-              xBus.on(eventName, true) as unknown as Observable<
-                SubjectPayload<EventPayload<XEventsTypes, typeof eventName>, WireMetadata>
-              >
-            ).subscribe(({ eventPayload, metadata }) => {
-              callback(eventPayload as never, metadata);
-            })
-          );
-          return subscription;
-        },
-        new Subscription()
-      );
-
-      onBeforeUnmount(() => {
-        subscription.unsubscribe();
+      Object.entries(listeners as XEventListeners).forEach(([eventName, callback]) => {
+        xBus.on(eventName as XEvent, true).subscribe(({ eventPayload, metadata }) => {
+          callback(eventPayload as never, metadata);
+        });
       });
     },
     render() {

--- a/packages/x-components/src/composables/use-$x.ts
+++ b/packages/x-components/src/composables/use-$x.ts
@@ -1,5 +1,5 @@
-import { UseAliasAPI, useAliasApi } from './use-alias-api';
-import { useXBus, UseXBusAPI } from './use-x-bus';
+import { useAliasApi } from './use-alias-api';
+import { useXBus } from './use-x-bus';
 
 /**
  * Function which returns the `$x` object from the current component instance.
@@ -8,16 +8,8 @@ import { useXBus, UseXBusAPI } from './use-x-bus';
  *
  * @public
  */
-export function use$x(): UseXComponentAPI {
+export function use$x() {
   const xAliasAPI = useAliasApi();
   const xBusAPI = useXBus();
   return Object.assign(xAliasAPI, xBusAPI);
 }
-
-/**
- * The XComponentAPI exposes access to the {@link @empathyco/x-bus#XBus}, and store aliases to the
- * components.
- *
- * @public
- */
-export interface UseXComponentAPI extends UseXBusAPI, UseAliasAPI {}

--- a/packages/x-components/src/composables/use-x-bus.ts
+++ b/packages/x-components/src/composables/use-x-bus.ts
@@ -1,52 +1,71 @@
-import Vue, { getCurrentInstance, inject, Ref } from 'vue';
-import { XBus } from '@empathyco/x-bus';
+import { Subscription } from 'rxjs';
+import Vue, { getCurrentInstance, inject, isRef, onBeforeUnmount, Ref } from 'vue';
+import { EventPayload, SubjectPayload, XBus } from '@empathyco/x-bus';
 import { XEvent, XEventPayload, XEventsTypes } from '../wiring/events.types';
 import { WireMetadata } from '../wiring/wiring.types';
 import { getRootXComponent, getXComponentXModuleName } from '../components/x-component.utils';
 import { FeatureLocation } from '../types/origin';
-import { PropsWithType } from '../utils/types';
 import { XPlugin } from '../plugins/x-plugin';
 import { bus as xBus } from '../plugins/x-bus';
 
+interface PrivateExtendedVueComponent extends Vue {
+  xComponent?: Vue;
+}
+
 /**
- * Composable which injects the current location,
- * returns the `on` and `emit` functions from the `XBus`, applying location
- * and component metadata.
+ * Composable which injects the current location, returns the `on` and `emit` functions
+ * using the bus and applying component metadata. Also unsubscribe from events when components is
+ * unmounted.
  *
  * @remarks This composable tries to use the `XPlugin` bus and catches the exception thrown
  * by the `XPlugin` if it was not instantiated and uses the default `xBus` as fallback.
  *
  * @returns An object with the `on` and `emit` functions.
  */
-export function useXBus(): UseXBusAPI {
+export function useXBus() {
   const injectedLocation = inject<Ref<FeatureLocation> | FeatureLocation>('location', 'none');
 
-  const currentComponent: PrivateExtendedVueComponent | undefined | null =
-    getCurrentInstance()?.proxy;
-  const currentXComponent = getRootXComponent(currentComponent ?? null);
-  if (currentComponent && currentXComponent) {
-    currentComponent.xComponent = currentXComponent;
+  const component = getCurrentInstance()?.proxy;
+  const xComponent = getRootXComponent(component ?? null);
+  if (component && xComponent) {
+    (component as PrivateExtendedVueComponent).xComponent = xComponent;
   }
+
   let bus: XBus<XEventsTypes, WireMetadata>;
   try {
     bus = XPlugin.bus;
   } catch (error) {
     bus = xBus;
   }
+
+  const subscription = new Subscription();
+  onBeforeUnmount(() => {
+    subscription.unsubscribe();
+  });
+
   return {
-    on: bus.on.bind(bus),
+    on: <Event extends XEvent, Metadata extends boolean>(event: Event, withMetadata: Metadata) => {
+      type Payload = EventPayload<XEventsTypes, Event>;
+      const observable = bus.on(event, withMetadata);
+
+      return {
+        subscribe: (
+          callback: (
+            payload: Metadata extends true ? SubjectPayload<Payload, WireMetadata> : Payload
+          ) => void
+          // Cast to any because bus.on doesn't infer conditional type referencing `withMetadata`
+        ) => subscription.add(observable.subscribe(callback as any))
+      };
+    },
     emit: <Event extends XEvent>(
       event: Event,
       payload?: XEventPayload<Event>,
       metadata: Omit<WireMetadata, 'moduleName'> = {}
     ) => {
-      const location =
-        typeof injectedLocation === 'object' && 'value' in injectedLocation
-          ? injectedLocation.value
-          : injectedLocation;
+      const location = isRef(injectedLocation) ? injectedLocation.value : injectedLocation;
 
-      bus.emit(event, payload!, createWireMetadata(metadata, currentComponent, location));
-      currentXComponent?.$emit(event, payload);
+      xComponent?.$emit(event, payload); // TODO - Pending to deprecate
+      return bus.emit(event, payload!, createWireMetadata(metadata, component, location));
     }
   };
 }
@@ -81,23 +100,4 @@ function createWireMetadata(
       }
     }
   );
-}
-
-interface PrivateExtendedVueComponent extends Vue {
-  xComponent?: Vue | undefined;
-}
-
-export interface UseXBusAPI {
-  /* eslint-disable jsdoc/require-description-complete-sentence */
-  /** {@inheritDoc XBus.(on:1)} */
-  on: XBus<XEventsTypes, WireMetadata>['on'];
-  /** {@inheritDoc XBus.(emit:1)} */
-  emit(event: PropsWithType<XEventsTypes, void>): void;
-  /** {@inheritDoc XBus.(emit:2)} */
-  emit<Event extends XEvent>(
-    event: Event,
-    payload: XEventPayload<Event>,
-    metadata?: Omit<WireMetadata, 'moduleName' | 'origin' | 'location'>
-  ): void;
-  /* eslint-enable jsdoc/require-description-complete-sentence */
 }

--- a/packages/x-components/src/views/pdp.vue
+++ b/packages/x-components/src/views/pdp.vue
@@ -13,10 +13,9 @@
 </template>
 
 <script lang="ts">
-  import { merge } from 'rxjs';
-  import { delay } from 'rxjs/operators';
-  import { defineComponent, onUnmounted, ref } from 'vue';
+  import { defineComponent, ref } from 'vue';
   import { use$x } from '../composables/use-$x';
+  import { XEvent } from '../wiring';
   import { Tagging } from '../x-modules/tagging';
 
   export default defineComponent({
@@ -29,13 +28,12 @@
       const addProductToCart = (): void => window.InterfaceX?.addProductToCart();
 
       const showAddToCartButton = ref(false);
-      const resultURLTrackingEnabled$ = $x.on('ResultURLTrackingEnabled');
-      const pdpIsLoaded$ = $x.on('PDPIsLoaded');
-      const subscription = merge(resultURLTrackingEnabled$, pdpIsLoaded$)
-        .pipe(delay(500)) // emulate loading time for customer PDP
-        .subscribe(() => (showAddToCartButton.value = true));
-
-      onUnmounted(() => subscription.unsubscribe());
+      setTimeout(() => {
+        const events: XEvent[] = ['ResultURLTrackingEnabled', 'PDPIsLoaded'];
+        events.forEach(event =>
+          $x.on(event, false).subscribe(() => (showAddToCartButton.value = true))
+        );
+      }, 500); // emulate loading time for customer PDP
 
       return {
         addProductToCart,

--- a/packages/x-components/src/x-modules/search/components/banners-list.vue
+++ b/packages/x-components/src/x-modules/search/components/banners-list.vue
@@ -17,9 +17,7 @@
 
 <script lang="ts">
   import { Banner } from '@empathyco/x-types';
-  import { computed, ComputedRef, defineComponent, inject, provide, ref, Ref } from 'vue';
-  import { Observable } from 'rxjs';
-  import { EventPayload, SubjectPayload } from '@empathyco/x-bus';
+  import { computed, ComputedRef, defineComponent, inject, isRef, provide, ref, Ref } from 'vue';
   import ItemsList from '../../../components/items-list.vue';
   import { FeatureLocation } from '../../../types/origin';
   import { ListItem } from '../../../utils/types';
@@ -29,8 +27,6 @@
   import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import { useState } from '../../../composables/use-state';
   import { LIST_ITEMS_KEY } from '../../../components/decorators/injection.consts';
-  import { WireMetadata } from '../../../wiring/wiring.types';
-  import { XEventsTypes } from '../../../wiring/events.types';
 
   /**
    * It renders a {@link ItemsList} list of banners from {@link SearchState.banners} by
@@ -82,10 +78,7 @@
         'location',
         undefined
       );
-      const location =
-        typeof injectedLocation === 'object' && 'value' in injectedLocation
-          ? injectedLocation.value
-          : injectedLocation;
+      const location = isRef(injectedLocation) ? injectedLocation.value : injectedLocation;
 
       /**
        * Number of columns the grid is being divided into.
@@ -102,13 +95,9 @@
        *
        * @internal
        */
-      (
-        $x.on('RenderedColumnsNumberChanged', true) as unknown as Observable<
-          SubjectPayload<EventPayload<XEventsTypes, keyof XEventsTypes>, WireMetadata>
-        >
-      ).subscribe(({ eventPayload, metadata }) => {
+      $x.on('RenderedColumnsNumberChanged', true).subscribe(({ eventPayload, metadata }) => {
         if (metadata.location === location) {
-          columnsNumber.value = eventPayload as number;
+          columnsNumber.value = eventPayload;
         }
       });
 


### PR DESCRIPTION
`useXBus.on` function registers the subscriptions itself to be able to unsubscribe once the component is unmounted.
`useXBus.emit` now returns the emission promise.

Highlights: 
- No more needed `KeepAlive` in the `_vue3` package since components doesn't have active subscriptions once the component is unmounted.
-  Now, the boolean `withMetada` is required `$x.on('ColumnsNumberProvided', false)`. It is because improve type safe when `$x.on` and conditional metadata
- `useXbus` has improved the type infer. No more needed type assertions to retrieve payload with or without `metadata`. Like: https://github.com/empathyco/x/compare/EMP-4083-usexbus-unmounted?expand=1#diff-1c8a891163d5ec75f3348e5d88e9c5a8560fc77b7d7b3ee9f682be58ae209d90R23 or https://github.com/empathyco/x/compare/EMP-4083-usexbus-unmounted?expand=1#diff-1b602dc109cfb36aa80b79eab7803c7ee38818376457049a42eca050108aa746R98
- No more `rxjs` in Vue components because now `observable` or `subscription` are not returned in the `useXBus` composable ✌🏾 

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->
- [X] Open issue. If applicable, link: EMP-4083

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Vue 3 migration

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`

## Checklist:

- [X] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [X] I have **commented** my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [X] My changes generate **no new warnings**.
- [X] I have added **tests** that prove my fix is effective or that my feature works.
- [X] New and existing **unit tests pass locally** with my changes.
