### PR TITLE
refactor(noElement): use the full array of VNodes from the default slot

### DIFF
--- a/packages/x-components/src/components/global-x-bus.vue
+++ b/packages/x-components/src/components/global-x-bus.vue
@@ -17,7 +17,7 @@
    */
   export default defineComponent({
     name: 'GlobalXBus',
-    setup(_, { listeners }) {
+    setup(_, { listeners, slots }) {
       const xBus = useXBus();
 
       /**
@@ -46,9 +46,8 @@
       onBeforeUnmount(() => {
         subscription.unsubscribe();
       });
-    },
-    render() {
-      return useNoElementRender(this.$slots);
+
+      return () => useNoElementRender(slots);
     }
   });
 </script>

--- a/packages/x-components/src/components/no-element.ts
+++ b/packages/x-components/src/components/no-element.ts
@@ -8,7 +8,7 @@ import { useNoElementRender } from '../composables/use-no-element-render';
  * @internal
  */
 export const NoElement = defineComponent({
-  render() {
-    return useNoElementRender(this.$slots);
+  setup(props, { slots }) {
+    return () => useNoElementRender(slots);
   }
 });

--- a/packages/x-components/src/composables/__tests__/use-no-element-render.spec.ts
+++ b/packages/x-components/src/composables/__tests__/use-no-element-render.spec.ts
@@ -11,8 +11,8 @@ const renderUseNoElementRender = ({
   const wrapper = mount(
     component ??
       (defineComponent({
-        render() {
-          return useNoElementRender(this.$slots);
+        setup(props, { slots }) {
+          return () => useNoElementRender(slots);
         }
       }) as ComponentOptions<Vue>),
     {

--- a/packages/x-components/src/composables/use-no-element-render.ts
+++ b/packages/x-components/src/composables/use-no-element-render.ts
@@ -11,9 +11,8 @@ import { VNode } from 'vue/types/vnode';
  */
 export function useNoElementRender(
   slots: { [key: string]: VNode[] | undefined } | SetupContext['slots']
-): VNode {
-  const defaultSlotContent =
-    typeof slots.default === 'function' ? slots.default()?.[0] : slots.default?.[0];
+): VNode | VNode[] {
+  const defaultSlotContent = typeof slots.default === 'function' ? slots.default() : slots.default;
 
   return defaultSlotContent ?? h();
 }

--- a/packages/x-components/src/x-modules/facets/components/preselected-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/preselected-filters.vue
@@ -28,7 +28,7 @@
         default: () => []
       }
     },
-    setup(props) {
+    setup(props, { slots }) {
       const xBus = useXBus();
 
       /**
@@ -67,9 +67,8 @@
        * computed prop changes.
        */
       watch(preselectedFilters, emitPreselectedFilters, { immediate: true });
-    },
-    render() {
-      return useNoElementRender(this.$slots);
+
+      return () => useNoElementRender(slots);
     }
   });
 </script>


### PR DESCRIPTION
This PR refactors the `useNoElementRender` composable to return the full VNodes array from the default slot, instead of just the first VNode. The former approach only works for Vue 2 where components can only have one single root node. However, Vue 3 allows having multiple root nodes for a component and it will break the `NoElement` usage. 

Thanks to the composition API is posible to use a render function that returns multiple VNodes via the return of the setup method. See [declaring render functions](https://vuejs.org/guide/extras/render-function#declaring-render-functions)
Once this PR is merged we could rollback some changes from #1460 and save the extra div that were needed here for `BannersList`, `ResultsList`, `PromotedsList` and `NextQueriesList`