### PR TITLE
fix: replace extra divs with `NoElement`

### DIFF
--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="items.length > 0">
+  <NoElement>
     <!--
       @slot Next queries list layout.
         @binding {SearchItem[]} items - Next queries groups plus the injected list items to
@@ -13,7 +13,7 @@
         </template>
       </ItemsList>
     </slot>
-  </div>
+  </NoElement>
 </template>
 
 <script lang="ts">
@@ -33,6 +33,7 @@
   import { use$x } from '../../../composables/use-$x';
   import { useGetter } from '../../../composables/use-getter';
   import { useRegisterXModule } from '../../../composables/use-register-x-module';
+  import { NoElement } from '../../../components/no-element';
 
   /**
    * Component that inserts groups of next queries in different positions of the injected search
@@ -43,7 +44,8 @@
   export default defineComponent({
     name: 'NextQueriesList',
     components: {
-      ItemsList
+      ItemsList,
+      NoElement
     },
     xModule: nextQueriesXModule.name,
     props: {

--- a/packages/x-components/src/x-modules/scroll/components/main-scroll.vue
+++ b/packages/x-components/src/x-modules/scroll/components/main-scroll.vue
@@ -1,7 +1,7 @@
 <template>
-  <div ref="rootRef" :class="dynamicClasses">
-    <slot />
-  </div>
+  <NoElement :class="dynamicClasses">
+    <slot ref="rootRef" />
+  </NoElement>
 </template>
 <script lang="ts">
   import { computed, defineComponent, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue';
@@ -11,6 +11,7 @@
   import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import { useState } from '../../../composables/use-state';
   import { useXBus } from '../../../composables/use-x-bus';
+  import { NoElement } from '../../../components/no-element';
   import { ScrollObserverKey } from './scroll.const';
   import { ScrollVisibilityObserver } from './scroll.types';
 
@@ -25,6 +26,9 @@
    */
   export default defineComponent({
     name: 'MainScroll',
+    components: {
+      NoElement
+    },
     xModule: scrollXModule.name,
     props: {
       /**

--- a/packages/x-components/src/x-modules/search/components/banners-list.vue
+++ b/packages/x-components/src/x-modules/search/components/banners-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="items.length > 0">
+  <NoElement>
     <!--
       @slot Customized BannersList layout.
         @binding {Banner[]} items - Banners plus the injected list items to render.
@@ -12,7 +12,7 @@
         </template>
       </ItemsList>
     </slot>
-  </div>
+  </NoElement>
 </template>
 
 <script lang="ts">
@@ -27,6 +27,7 @@
   import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import { useState } from '../../../composables/use-state';
   import { LIST_ITEMS_KEY } from '../../../components/decorators/injection.consts';
+  import { NoElement } from '../../../components/no-element';
 
   /**
    * It renders a {@link ItemsList} list of banners from {@link SearchState.banners} by
@@ -43,7 +44,8 @@
   export default defineComponent({
     name: 'BannersList',
     components: {
-      ItemsList
+      ItemsList,
+      NoElement
     },
     xModule: searchXModule.name,
     props: {

--- a/packages/x-components/src/x-modules/search/components/promoteds-list.vue
+++ b/packages/x-components/src/x-modules/search/components/promoteds-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="items.length > 0">
+  <NoElement>
     <!--
       @slot Customized Promoteds List layout.
         @binding {Promoted[]} items - Promoteds plus the injected list items to render.
@@ -12,7 +12,7 @@
         </template>
       </ItemsList>
     </slot>
-  </div>
+  </NoElement>
 </template>
 
 <script lang="ts">
@@ -26,6 +26,7 @@
   import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import { useState } from '../../../composables/use-state';
   import { LIST_ITEMS_KEY } from '../../../components/decorators/injection.consts';
+  import { NoElement } from '../../../components/no-element';
 
   /**
    * It renders a {@link ItemsList} of promoteds from {@link SearchState.promoteds} by default
@@ -43,7 +44,8 @@
   export default defineComponent({
     name: 'PromotedsList',
     components: {
-      ItemsList
+      ItemsList,
+      NoElement
     },
     xModule: searchXModule.name,
     props: {

--- a/packages/x-components/src/x-modules/search/components/results-list.vue
+++ b/packages/x-components/src/x-modules/search/components/results-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="items.length > 0">
+  <NoElement>
     <!--
       @slot Customize ResultsList.
         @binding {Result[]} items - Results to render.
@@ -12,7 +12,7 @@
         </template>
       </ItemsList>
     </slot>
-  </div>
+  </NoElement>
 </template>
 
 <script lang="ts">
@@ -30,6 +30,7 @@
   import { useRegisterXModule, useState } from '../../../composables';
   import { searchXModule } from '../x-module';
   import { useXBus } from '../../../composables/use-x-bus';
+  import { NoElement } from '../../../components/no-element';
 
   /**
    * It renders a {@link ItemsList} list with the results from {@link SearchState.results} by
@@ -45,7 +46,8 @@
   export default defineComponent({
     name: 'ResultsList',
     components: {
-      ItemsList
+      ItemsList,
+      NoElement
     },
     xModule: searchXModule.name,
     directives: { 'infinite-scroll': infiniteScroll },


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Replace extra divs with `NoElement` component from the components of the following list:
- `BannersList`
- `PromotedsList`
- `ResultsList`
- `NextQueriesList`
- `MainScroll` --> we are having problems with this extra div in the archetype (the subheader is not being collapsed because the scroll module is not saving data).

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

