### PR TITLE
feat(sliding-panel): migrate sliding-panel component to composition API

### DIFF
--- a/packages/_vue3-migration-test/src/components/index.ts
+++ b/packages/_vue3-migration-test/src/components/index.ts
@@ -3,3 +3,4 @@ export { default as TestBaseColumnPickerDropdown } from './column-picker/test-ba
 export { default as TestBaseColumnPickerList } from './column-picker/test-base-column-picker-list.vue';
 export { default as TestBaseDropdown } from './test-base-dropdown.vue';
 export { default as TestBaseEventButton } from './test-base-event-button.vue';
+export { default as TestSlidingPanel } from './test-sliding-panel.vue';

--- a/packages/_vue3-migration-test/src/components/test-sliding-panel.vue
+++ b/packages/_vue3-migration-test/src/components/test-sliding-panel.vue
@@ -1,0 +1,16 @@
+<template>
+  <SlidingPanel style="width: 300px">
+    <span v-for="item in items" :key="item">Item {{ item }}</span>
+  </SlidingPanel>
+  <button @click="updateItems">Update items</button>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import SlidingPanel from '../../../x-components/src/components/sliding-panel.vue';
+
+  const items = ref<number[]>([]);
+
+  const updateItems = () => (items.value = [...Array(Math.floor(Math.random() * 100)).keys()]);
+  updateItems();
+</script>

--- a/packages/_vue3-migration-test/src/router.ts
+++ b/packages/_vue3-migration-test/src/router.ts
@@ -16,7 +16,8 @@ import {
   TestSortList,
   TestSortPickerList,
   TestBaseScroll,
-  TestSearchBox
+  TestSearchBox,
+  TestSlidingPanel
 } from './';
 
 const routes = [
@@ -64,6 +65,11 @@ const routes = [
     path: '/base-column-picker-list',
     name: 'BaseColumnPickerList',
     component: TestBaseColumnPickerList
+  },
+  {
+    path: '/sliding-panel',
+    name: 'SlidingPanel',
+    component: TestSlidingPanel
   },
   {
     path: '/facets',

--- a/packages/x-components/src/components/dynamic-props.mixin.ts
+++ b/packages/x-components/src/components/dynamic-props.mixin.ts
@@ -19,7 +19,7 @@ import { ExtendedVue } from 'vue/types/vue';
  *   }
  * ```
  * @returns Mixin for the component.
- *
+ * @deprecated Use props.
  */
 export function dynamicPropsMixin<PropNames extends string>(
   propNames: PropNames[]

--- a/packages/x-components/src/x-modules/facets/components/lists/sliced-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/sliced-filters.vue
@@ -69,28 +69,19 @@
        * @public
        */
       filters: Array as PropType<Filter[]>,
-
       /**
        * This prop is used in the `HierarchicalFilter` component and only in that case. It is necessary
        * to make the `renderedFilters` to return only the filters of each level of the hierarchy.
-       *
-       * @public
        */
       parentId: {
         type: String as PropType<Filter['id']>,
         required: false
       },
-
-      /**
-       * The maximum number of filters to show.
-       *
-       * @public
-       */
+      /** The maximum number of filters to show. */
       max: {
         type: Number,
         required: true
       },
-
       buttonClass: String
     },
     emits: ['click:show-less', 'click:show-more'],


### PR DESCRIPTION
Migrate sliding-panel component to composition API.
Last component using `@Debounce` decorator.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link: EMP-4087

## Type of change
<!-- Indicate the type of change involved in the PR -->
- Vue 3 migration

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- `Main`

## How has this been tested?

`_vue3` playground and `x-components` serve

## Checklist:

- My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- I have performed a **self-review** on my own code.
- I have **commented** my code, particularly in hard-to-understand areas.
- I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- My changes generate **no new warnings**.
- I have added **tests** that prove my fix is effective or that my feature works.
- New and existing **unit tests pass locally** with my changes.
