### PR TITLE
fix(history-queries): ensuring history-queries x-module registration before using components

### DIFF
--- a/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/clear-history-queries.vue
@@ -18,7 +18,6 @@
   import { VueCSSClasses } from '../../../utils/types';
   import { XEventsTypes } from '../../../wiring/events.types';
   import { historyQueriesXModule } from '../x-module';
-  import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import { useState } from '../../../composables/use-state';
 
   /**
@@ -35,8 +34,6 @@
       BaseEventButton
     },
     setup() {
-      useRegisterXModule(historyQueriesXModule);
-
       /**
        * The whole history queries.
        *

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
@@ -10,7 +10,6 @@
   import { historyQueriesXModule } from '../x-module';
   import { isArrayEmpty } from '../../../utils/array';
   import { use$x } from '../../../composables/use-$x';
-  import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import { useState } from '../../../composables/use-state';
 
   /**
@@ -26,8 +25,6 @@
       BaseSwitch
     },
     setup() {
-      useRegisterXModule(historyQueriesXModule);
-
       const $x = use$x();
 
       /**

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -50,7 +50,6 @@
   import { defineComponent } from 'vue';
   import BaseSuggestions from '../../../components/suggestions/base-suggestions.vue';
   import { historyQueriesXModule } from '../x-module';
-  import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import { useGetter } from '../../../composables/use-getter';
   import HistoryQuery from './history-query.vue';
 
@@ -70,8 +69,6 @@
     },
     inheritAttrs: false,
     setup() {
-      useRegisterXModule(historyQueriesXModule);
-
       /**
        * The filtered list of history queries.
        *

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -45,7 +45,6 @@
   import { XEventsTypes } from '../../../wiring/events.types';
   import { historyQueriesXModule } from '../x-module';
   import { useGetter } from '../../../composables/use-getter';
-  import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import RemoveHistoryQuery from './remove-history-query.vue';
 
   /**
@@ -76,8 +75,6 @@
     },
     emits: ['click'],
     setup(props) {
-      useRegisterXModule(historyQueriesXModule);
-
       /**
        * The normalized query of the history-queries module.
        *

--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -66,7 +66,6 @@
   import { historyQueriesXModule } from '../x-module';
   import { AnimationProp } from '../../../types/index';
   import { useState } from '../../../composables/use-state';
-  import { useRegisterXModule } from '../../../composables/use-register-x-module';
   import HistoryQuery from './history-query.vue';
 
   /**
@@ -110,8 +109,6 @@
       queriesListClass: String
     },
     setup(props) {
-      useRegisterXModule(historyQueriesXModule);
-
       /**
        * The list of history queries.
        *

--- a/packages/x-components/src/x-modules/history-queries/components/remove-history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/remove-history-query.vue
@@ -15,7 +15,6 @@
   import BaseEventButton from '../../../components/base-event-button.vue';
   import { XEventsTypes } from '../../../wiring/events.types';
   import { historyQueriesXModule } from '../x-module';
-  import { useRegisterXModule } from '../../../composables/use-register-x-module';
 
   /**
    * Button that when it is pressed emits the
@@ -42,8 +41,6 @@
       }
     },
     setup(props) {
-      useRegisterXModule(historyQueriesXModule);
-
       /**
        * The event handler that will be triggered when clicking on the clear history query button.
        *

--- a/packages/x-components/src/x-modules/history-queries/x-module.ts
+++ b/packages/x-components/src/x-modules/history-queries/x-module.ts
@@ -1,3 +1,4 @@
+import { XPlugin } from '../../plugins/x-plugin';
 import { XModule } from '../x-modules.types';
 import { historyQueriesEmitters } from './store/emitters';
 import { historyQueriesXStoreModule } from './store/module';
@@ -23,3 +24,5 @@ export const historyQueriesXModule: HistoryQueriesXModule = {
   storeEmitters: historyQueriesEmitters,
   wiring: historyQueriesWiring
 };
+
+XPlugin.registerXModule(historyQueriesXModule);


### PR DESCRIPTION
## Precedents
- `xComponentMixin(historyQueriesXModule)` mixin is executed as soon as the component is imported, before mounting it.
- `useRegisterXModule(historyQueriesXModule)` composable is executed once the component is mounted.
- Sometimes in setups, we need to check some state values before mounting the component (`v-if`). So using the composable, the `XModule` has not been registered when the check is executed because the component has not been mounted yet.

## How can we ensure the `XModule` registration?
Registering it as soon as we can, in the `XModule` creation itself.

## Key concepts to understand why it works

- Every component must have an import of its `XModule` to assign the `xModule` name to itself.
> A module code is evaluated only the first time when imported.
If the same module is imported into multiple other modules, its code is executed only once, upon the first import. Then its exports are given to all further importers
https://javascript.info/modules-intro#a-module-code-is-evaluated-only-the-first-time-when-imported

## Workflow example

1. In a setup, we import a `xModule` component: `import { HistoryQueries } from '@empathyco/x-components/history-queries';`
2. `HistoryQueries` component imports the module `import { historyQueriesXModule } from '../x-module'` to assign the `xModule` name to the component `xModule: historyQueriesXModule.name`
3. In the `xModule` JS file, we register the component itself after creating it `XPlugin.registerXModule(historyQueriesXModule);`
4. The registration is done as soon as the ES module is imported, and it is only executed and registered the first time the `xModule` is imported (with the mixin or composable, the registration was tried once per component)

## tl;dr

`xModule` registration now is done at the same time an X component is imported, and we can guarantee the store module is registered before mounting the component.
We just need to remember to assign the `xModule` name to each x-component `xModule: historyQueriesXModule.name`