### PR TITLE
feat: add the capability to reload the current search

### DIFF
--- a/packages/x-components/src/x-modules/search/events.types.ts
+++ b/packages/x-components/src/x-modules/search/events.types.ts
@@ -1,11 +1,11 @@
 import {
+  Banner,
   Facet,
+  Promoted,
+  Redirection,
   Result,
   Sort,
-  Redirection,
-  TaggingRequest,
-  Promoted,
-  Banner
+  TaggingRequest
 } from '@empathyco/x-types';
 import { InternalSearchRequest, InternalSearchResponse } from './types';
 
@@ -26,6 +26,10 @@ export interface SearchXEvents {
    * Payload: The new page number.
    */
   PageChanged: number;
+  /**
+   * Reload the current search has been requested.
+   */
+  ReloadSearchRequested: void;
   /**
    * Results have been changed.
    * Payload: The new {@link @empathyco/x-types#Result | results}.

--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -1,18 +1,18 @@
 import { isFacetFilter } from '@empathyco/x-types';
 import { setQuery } from '../../../store/utils/query.utils';
-import { setStatus } from '../../../store/utils/status-store.utils';
+import { setStatus } from '../../../store';
 import { groupItemsBy } from '../../../utils/array';
 import { mergeConfig, setConfig } from '../../../store/utils/config-store.utils';
 import { UNKNOWN_FACET_KEY } from '../../facets/store/constants';
 import {
   cancelFetchAndSaveSearchResponse,
-  fetchAndSaveSearchResponse
-} from './actions/fetch-and-save-search-response.action';
-import { fetchSearchResponse } from './actions/fetch-search-response.action';
-import { increasePageAppendingResults } from './actions/increase-page-apending-results.action';
-import { resetRequestOnRefinement } from './actions/reset-request-on-refinement.action';
+  fetchAndSaveSearchResponse,
+  fetchSearchResponse,
+  increasePageAppendingResults,
+  resetRequestOnRefinement,
+  saveSearchResponse
+} from './actions';
 import { saveOrigin } from './actions/save-origin.action';
-import { saveSearchResponse } from './actions/save-search-response.action';
 import { setUrlParams } from './actions/set-url-params.action';
 import { query } from './getters/query.getter';
 import { request } from './getters/request.getter';
@@ -45,6 +45,10 @@ export const searchXStoreModule: SearchXStoreModule = {
     },
     resetState(state) {
       Object.assign(state, resettableState());
+    },
+    resetStateForReload(state) {
+      const { query, facets, sort, page, ...resettable } = resettableState();
+      Object.assign(state, resettable);
     },
     setQuery,
     setResults(state, results) {

--- a/packages/x-components/src/x-modules/search/store/types.ts
+++ b/packages/x-components/src/x-modules/search/store/types.ts
@@ -7,17 +7,15 @@ import {
   Redirection,
   RelatedTag,
   Result,
-  Sort,
-  TaggingRequest,
   SearchRequest,
-  SearchResponse
+  SearchResponse,
+  Sort,
+  TaggingRequest
 } from '@empathyco/x-types';
 import { Dictionary } from '@empathyco/x-utils';
-import { XActionContext, XStoreModule } from '../../../store';
+import { StatusMutations, StatusState, XActionContext, XStoreModule } from '../../../store';
 import { QueryMutations, QueryState } from '../../../store/utils/query.utils';
-import { StatusMutations, StatusState } from '../../../store/utils/status-store.utils';
-import { QueryOrigin, QueryOriginInit } from '../../../types/origin';
-import { UrlParams } from '../../../types/url-params';
+import { QueryOrigin, QueryOriginInit, UrlParams } from '../../../types';
 import { SearchConfig } from '../config.types';
 import { InternalSearchRequest, WatchedInternalSearchRequest } from '../types';
 import { ConfigMutations } from '../../../store/utils/config-store.utils';
@@ -108,6 +106,11 @@ export interface SearchMutations
    * {@link searchXStoreModule} for details.
    */
   resetState(): void;
+  /**
+   * Resets the "resettable" part of the Search state like {@link SearchMutations.resetState} but
+   * maintains the values required to perform the search request again.
+   */
+  resetStateForReload(): void;
   /**
    * Sets the banners of the module.
    *

--- a/packages/x-components/src/x-modules/search/wiring.ts
+++ b/packages/x-components/src/x-modules/search/wiring.ts
@@ -1,12 +1,13 @@
-import { filterTruthyPayload, namespacedWireCommitWithoutPayload } from '../../wiring';
 import {
+  createWiring,
+  filterTruthyPayload,
   namespacedWireCommit,
+  namespacedWireCommitWithoutPayload,
   namespacedWireDispatch,
-  namespacedWireDispatchWithoutPayload
-} from '../../wiring/namespaced-wires.factory';
-import { WirePayload } from '../../wiring/wiring.types';
-import { createWiring } from '../../wiring/wiring.utils';
-import { createRawFilters } from '../../utils/filters';
+  namespacedWireDispatchWithoutPayload,
+  WirePayload
+} from '../../wiring';
+import { createRawFilters } from '../../utils';
 import { InternalSearchRequest } from './types';
 
 /**
@@ -129,6 +130,13 @@ export const setSearchPage = wireCommit('setPage');
  * @public
  */
 export const setSearchExtraParams = wireCommit('setParams');
+
+/**
+ * Resets the search state to reload the current search.
+ *
+ * @public
+ */
+export const resetStateForReloadWire = wireCommitWithoutPayload('resetStateForReload');
 
 /**
  * Resets the search state `isNoResults`.
@@ -271,6 +279,9 @@ export const searchWiring = createWiring({
   },
   ResultsChanged: {
     resetAppending
+  },
+  ReloadSearchRequested: {
+    resetStateForReloadWire
   },
   SelectedSortProvided: {
     setSort

--- a/packages/x-components/tests/e2e/reload-search.feature
+++ b/packages/x-components/tests/e2e/reload-search.feature
@@ -1,0 +1,19 @@
+Feature: Reload search
+
+  Background:
+    Given a results API with 24 results
+    And   a tracking API with a known response
+    And   no special config for layout view
+
+  Scenario Outline: 1. Search is reloaded when event is emitted
+    When  start button is clicked
+    Then  empathize should be visible
+    When  "<query>" is searched
+    Then  results page number 1 is loaded
+    And  search request contains parameter "query" with value "<query>"
+    When  event ReloadSearchRequested is emitted
+    Then  search request contains parameter "query" with value "<query>"
+
+    Examples:
+      | query |
+      | lego  |

--- a/packages/x-components/tests/e2e/reload-search/reload-search.spec.ts
+++ b/packages/x-components/tests/e2e/reload-search/reload-search.spec.ts
@@ -1,0 +1,6 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+
+When('event ReloadSearchRequested is emitted', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  cy.window().then((w: Window) => w.InterfaceX?.bus.emit('ReloadSearchRequested'));
+});


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
We need a way to *refresh* the results displayed on the search layer.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
This requirement comes from the Backroom's next functionality, boost&bury of single products by query. After boosting or burying a product, we need a way to re-do the current search and refresh the results to see the change applied.
The idea is to emit the event `ReloadSearchRequested` through the x-bus and trigger a mutation on the state that triggers the search request.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
