### PR TITLE
feat: Migrate filters components to Composition API

### DIFF
--- a/packages/_vue3-migration-test/src/x-modules/facets/components/test-filters.vue
+++ b/packages/_vue3-migration-test/src/x-modules/facets/components/test-filters.vue
@@ -28,12 +28,69 @@
       </label>
     </SimpleFilter>
   </div>
+  <br />
+  <hr />
+  <br />
+  <h2>Number Range Filter</h2>
+  <NumberRangeFilter
+    :clickEvents="{ UserClickedANumberRangeFilter: filterNumber }"
+    :filter="filterNumber"
+    :cssClasses="innerCssClasses"
+  />
+  <br />
+  <hr />
+  <br />
+  <h2>Editable Number Range Filter</h2>
+  <EditableNumberRangeFilter
+    :filter="filterEditNumber"
+    :hasClearButton="false"
+    :class="innerCssClasses"
+    :inputsClass="'my-inputs-class'"
+    :buttonsClass="'my-buttons-class'"
+  />
+  <EditableNumberRangeFilter
+    :filter="filterEditNumber"
+    :class="innerCssClasses"
+    #default="{
+      min,
+      max,
+      setMin,
+      setMax,
+      emitUserModifiedFilter,
+      clearValues,
+      hasError,
+      isAnyRange
+    }"
+  >
+    <button @click="emitUserModifiedFilter">✅ Apply!</button>
+    <button @click="clearValues">🗑 Clear!</button>
+    <input @change="setMin($event.target.value)" :value="!isAnyRange ? min : null" />
+    <input @change="setMax($event.target.value)" :value="max" />
+    <div v-if="hasError" class="has-error">⚠️ Invalid range values</div>
+  </EditableNumberRangeFilter>
+  <br />
+  <hr />
+  <br />
+  <h2>Hierarchical Filter</h2>
+  <HierarchicalFilter :cssClasses="innerCssClasses" :filter="filterHierarchical">
+    <template #label>
+      <span class="custom-class">{{ filterHierarchical.label }}</span>
+    </template>
+  </HierarchicalFilter>
 </template>
 
 <script setup lang="ts">
-  import { SimpleFilter as SimpleFilterModel } from '@empathyco/x-types';
+  import {
+    SimpleFilter as SimpleFilterModel,
+    NumberRangeFilter as NumberRangeFilterModel,
+    EditableNumberRangeFilter as EditableNumberRangeFilterModel,
+    HierarchicalFilter as HierarchicalFilterModel
+  } from '@empathyco/x-types';
   import { computed, ref, Ref } from 'vue';
   import SimpleFilter from '../../../../../x-components/src/x-modules/facets/components/filters/simple-filter.vue';
+  import NumberRangeFilter from '../../../../../x-components/src/x-modules/facets/components/filters/number-range-filter.vue';
+  import EditableNumberRangeFilter from '../../../../../x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue';
+  import HierarchicalFilter from '../../../../../x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue';
 
   const filter: Ref<SimpleFilterModel> = ref({
     modelName: 'SimpleFilter',
@@ -44,13 +101,48 @@
     selected: false
   });
 
+  const filterNumber: Ref<NumberRangeFilterModel> = ref({
+    id: `price:1-10`,
+    modelName: 'NumberRangeFilter',
+    label: `From 1 to 10`,
+    facetId: 'price',
+    range: {
+      min: 1,
+      max: 10
+    },
+    selected: false
+  });
+
+  const filterEditNumber: Ref<EditableNumberRangeFilterModel> = ref({
+    facetId: 'age',
+    id: 'age:primary',
+    label: 'primary',
+    modelName: 'EditableNumberRangeFilter',
+    range: {
+      min: null,
+      max: null
+    },
+    selected: false
+  });
+
+  const filterHierarchical: Ref<HierarchicalFilterModel> = ref({
+    id: `categories:men`,
+    modelName: 'HierarchicalFilter',
+    label: `men`,
+    facetId: 'categories',
+    parentId: null,
+    totalResults: 10,
+    children: [],
+    selected: false
+  });
+
   const innerCssClasses = computed(() => [
     'MOT-CUSTOM',
     { 'MOT-CUSTOM--SELECTED': filter.value.selected }
   ]);
 </script>
 
-<style>
+<style lang="scss">
   .MOT-CUSTOM--SELECTED {
     background-color: greenyellow;
   }

--- a/packages/_vue3-migration-test/src/x-modules/facets/components/test-filters.vue
+++ b/packages/_vue3-migration-test/src/x-modules/facets/components/test-filters.vue
@@ -143,7 +143,8 @@
 </script>
 
 <style lang="scss">
-  .MOT-CUSTOM--SELECTED {
+  .MOT-CUSTOM--SELECTED,
+  .x-selected {
     background-color: greenyellow;
   }
 </style>

--- a/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
+++ b/packages/x-components/src/x-modules/facets/components/filters/__tests__/editable-number-range-filter.spec.ts
@@ -1,7 +1,7 @@
 import { EditableNumberRangeFilter, RangeValue } from '@empathyco/x-types';
 import { DeepPartial } from '@empathyco/x-utils';
 import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
-import Vue from 'vue';
+import Vue, { Ref, ref } from 'vue';
 import Vuex, { Store } from 'vuex';
 // eslint-disable-next-line max-len
 import { createEditableNumberRangeFilter } from '../../../../../__stubs__/filters-stubs.factory';
@@ -34,13 +34,12 @@ function renderEditableNumberRangeFilter({
     />
   `,
   range,
-  filter = createEditableNumberRangeFilter('age', range),
+  filter = ref(createEditableNumberRangeFilter('age', range)),
   isInstant = false,
   hasClearButton = true,
   buttonsClass,
   inputsClass
 }: EditableNumberRangeFilterOptions = {}): EditableNumberRangeFilterAPI {
-  Vue.observable(filter);
   const localVue = createLocalVue();
   localVue.use(Vuex);
   const store = new Store<DeepPartial<RootXStoreState>>({});
@@ -343,7 +342,7 @@ interface EditableNumberRangeFilterOptions {
    * The {@link @empathyco/x-types#EditableNumberRangeFilter | EditableNumberRangeFilter} object
    * to be passed to the component.
    */
-  filter?: EditableNumberRangeFilter;
+  filter?: Ref<EditableNumberRangeFilter>;
   /** `hasClearButton` property to init the component. */
   hasClearButton?: boolean;
   /** `isInstant` property to init the component. */
@@ -364,7 +363,7 @@ interface EditableNumberRangeFilterAPI {
   /** Clear button wrapper. */
   clearButtonWrapper: Wrapper<Vue>;
   /** The filter passed to the component. */
-  filter: EditableNumberRangeFilter;
+  filter: Ref<EditableNumberRangeFilter>;
   /** Filter component wrapper. */
   filterWrapper: Wrapper<Vue>;
   /** Max input element wrapper. */

--- a/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
@@ -313,7 +313,7 @@
        * @internal
        */
       watch(
-        () => range.value,
+        range,
         () => {
           if (props.isInstant) {
             emitUserModifiedFilter();

--- a/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
@@ -246,9 +246,7 @@
        *
        * @internal
        */
-      const parseRangeValue = (value: number) => {
-        return isNaN(value) ? null : value;
-      };
+      const parseRangeValue = (value: number) => (isNaN(value) ? null : value);
 
       /**
        * `min` setter.

--- a/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/editable-number-range-filter.vue
@@ -86,12 +86,9 @@
     EditableNumberRangeFilter as EditableNumberRangeFilterModel,
     RangeValue
   } from '@empathyco/x-types';
-  import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-  import { VueCSSClasses } from '../../../../utils/types';
+  import { defineComponent, PropType, watch, ref, Ref, computed } from 'vue';
   import { facetsXModule } from '../../x-module';
-  import { xComponentMixin } from '../../../../components/x-component.mixin';
-  import { XOn } from '../../../../components';
-  import { dynamicPropsMixin } from '../../../../components/dynamic-props.mixin';
+  import { use$x } from '../../../../composables';
 
   /**
    * Renders an editable number range filter. It has two input fields to handle min and max values,
@@ -108,219 +105,241 @@
    *
    * @public
    */
-  @Component({
-    mixins: [xComponentMixin(facetsXModule), dynamicPropsMixin(['inputsClass', 'buttonsClass'])]
-  })
-  export default class EditableNumberRangeFilter extends Vue {
-    /**
-     * Component min value.
-     *
-     * @internal
-     */
-    protected min: RangeValue['min'] = null;
-    /**
-     * Component max value.
-     *
-     * @internal
-     */
-    protected max: RangeValue['max'] = null;
+  export default defineComponent({
+    name: 'EditableNumberRangeFilter',
+    xModule: facetsXModule.name,
+    props: {
+      /**
+       * The filter data to render and edit.
+       *
+       * @public
+       */
+      filter: {
+        type: Object as PropType<EditableNumberRangeFilterModel>,
+        required: true
+      },
+      /**
+       * If `instant` prop is true, the needed events are emitted immediately; else, apply button is
+       * rendered to confirm to do it. False by default.
+       *
+       * @public
+       */
+      isInstant: Boolean,
+      /**
+       * If `clear` prop is true, clear button, which sets to null component min and max values, is
+       * rendered. True by default.
+       *
+       * @public
+       */
+      hasClearButton: {
+        type: Boolean,
+        default: true
+      },
+      /** Class inherited by content element. */
+      inputsClass: String,
+      /** Class inherited by content element. */
+      buttonsClass: String
+    },
+    setup: function (props) {
+      const $x = use$x();
 
-    /**
-     * The filter data to render and edit.
-     *
-     * @public
-     */
-    @Prop({ required: true })
-    public filter!: EditableNumberRangeFilterModel;
+      const rangeFilterMin = 'minimum amount';
+      const rangeFilterMax = 'maximum amount';
+      /**
+       * Component min value.
+       *
+       * @internal
+       */
+      const min: Ref<RangeValue['min']> = ref(null);
+      /**
+       * Component max value.
+       *
+       * @internal
+       */
+      const max: Ref<RangeValue['max']> = ref(null);
 
-    /**
-     * If `instant` prop is true, the needed events are emitted immediately; else, apply button is
-     * rendered to confirm to do it. False by default.
-     *
-     * @public
-     */
-    @Prop({ default: false })
-    public isInstant!: boolean;
+      /**
+       * Returns {@link @empathyco/x-types#RangeValue} with component min and max
+       * values.
+       *
+       * @returns Range value object with component values.
+       *
+       * @internal
+       */
+      const range = computed((): RangeValue => {
+        return { min: min.value, max: max.value };
+      });
 
-    /**
-     * If `clear` prop is true, clear button, which sets to null component min and max values, is
-     * rendered. True by default.
-     *
-     * @public
-     */
-    @Prop({ default: true })
-    public hasClearButton!: boolean;
+      /**
+       * It checks if component min and max values are valid.
+       *
+       * @returns True if there is any error in the component min and max values.
+       *
+       * @internal
+       */
+      const hasError = computed(
+        () => min.value !== null && max.value !== null && min.value > max.value
+      );
 
-    /**
-     * It watches the filter range values passed as property and updates component range values if
-     * they change.
-     *
-     * @param newRange - New range value.
-     *
-     * @internal
-     */
-    @Watch('filter.range', { immediate: true, deep: true })
-    onFilterChanged(newRange: RangeValue): void {
-      this.min = newRange.min;
-      this.max = newRange.max;
+      /**
+       * It checks if component min and max values are different from the ones within the filter
+       * provided as property.
+       *
+       * @returns True if they are different.
+       *
+       * @internal
+       */
+      const areValuesDifferent = computed(
+        () => min.value !== props.filter.range.min || max.value !== props.filter.range.max
+      );
+
+      /**
+       * Dynamic CSS classes.
+       *
+       * @returns Object which contains dynamic CSS classes.
+       *
+       * @internal
+       */
+      const cssClasses = computed(() => {
+        return { 'x-editable-number-range-filter--error': hasError.value };
+      });
+
+      /**
+       * Checks if the range of the filter allows any value, which happens when the min is
+       * null or 0 and the max is null.
+       *
+       * @returns True if the range of the filter allows any value.
+       *
+       * @internal
+       */
+      const isAnyRange = computed(() => !min.value && max.value === null);
+
+      /**
+       * It returns true if the property `hasClearButton` is true and there are values to clear.
+       *
+       * @returns True if the clear button has to be rendered.
+       *
+       * @internal
+       */
+      const renderClearButton = computed(() => props.hasClearButton && !isAnyRange.value);
+
+      /**
+       * It emits {@link FacetsXEvents.UserModifiedEditableNumberRangeFilter} event if there are no
+       * errors and component `min` and `max` values are different than `filter.range` ones.
+       *
+       * @internal
+       */
+      const emitUserModifiedFilter = () => {
+        if (!hasError.value && areValuesDifferent.value) {
+          $x.emit('UserModifiedEditableNumberRangeFilter', {
+            ...props.filter,
+            range: range.value
+          });
+        }
+      };
+
+      /**
+       * It returns the number if possible or null otherwise.
+       *
+       * @param value - Value.
+       * @returns The element value as a number if possible or null.
+       *
+       * @internal
+       */
+      const parseRangeValue = (value: number) => {
+        return isNaN(value) ? null : value;
+      };
+
+      /**
+       * `min` setter.
+       *
+       * @param value - The component `min` value to be set.
+       *
+       * @internal
+       */
+      const setMin = (value: number) => {
+        min.value = parseRangeValue(value);
+      };
+
+      /**
+       * `max` setter.
+       *
+       * @param value - The component `max` value to be set.
+       *
+       * @internal
+       */
+      const setMax = (value: number) => {
+        max.value = parseRangeValue(value);
+      };
+
+      /**
+       * It sets component `min` and `max` values to null , and it emits the change if component is
+       * working in instant mode.
+       *
+       * @internal
+       */
+      const clearValues = () => {
+        min.value = null;
+        max.value = null;
+      };
+
+      /**
+       * It resets the min/max range values to null if the
+       * {@link FacetsXEvents.UserClickedClearAllFilters} event is fired.
+       *
+       * @public
+       */
+      $x.on('UserClickedClearAllFilters', false).subscribe(clearValues);
+
+      /**
+       * It watches the filter range values passed as property and updates component range values if
+       * they change.
+       *
+       * @param newRange - New range value.
+       *
+       * @internal
+       */
+      watch(
+        () => props.filter.range,
+        (newRange: RangeValue) => {
+          min.value = newRange.min;
+          max.value = newRange.max;
+        },
+        { immediate: true, deep: true }
+      );
+
+      /**
+       * It watches range values in order to emit the event with the change if `isInstant`
+       * property is true.
+       *
+       * @internal
+       */
+      watch(
+        () => range.value,
+        () => {
+          if (props.isInstant) {
+            emitUserModifiedFilter();
+          }
+        },
+        { deep: true }
+      );
+
+      return {
+        rangeFilterMin,
+        rangeFilterMax,
+        cssClasses,
+        min,
+        max,
+        setMin,
+        setMax,
+        emitUserModifiedFilter,
+        clearValues,
+        hasError,
+        isAnyRange,
+        renderClearButton
+      };
     }
-
-    /**
-     * It watches range values in order to emit the event with the change if `isInstant`
-     * property is true.
-     *
-     * @internal
-     */
-    @Watch('range', { deep: true })
-    protected instantEmitUserModifiedFilter(): void {
-      if (this.isInstant) {
-        this.emitUserModifiedFilter();
-      }
-    }
-
-    /**
-     * It resets the min/max range values to null if the
-     * {@link FacetsXEvents.UserClickedClearAllFilters} event is fired.
-     *
-     * @public
-     */
-    @XOn('UserClickedClearAllFilters')
-    resetRanges(): void {
-      this.clearValues();
-    }
-
-    /**
-     * Dynamic CSS classes.
-     *
-     * @returns Object which contains dynamic CSS classes.
-     *
-     * @internal
-     */
-    protected get cssClasses(): VueCSSClasses {
-      return { 'x-editable-number-range-filter--error': this.hasError };
-    }
-
-    /**
-     * Returns {@link @empathyco/x-types#RangeValue} with component min and max
-     * values.
-     *
-     * @returns Range value object with component values.
-     *
-     * @internal
-     */
-    protected get range(): RangeValue {
-      return { min: this.min, max: this.max };
-    }
-
-    /**
-     * It returns true if the property `hasClearButton` is true and there are values to clear.
-     *
-     * @returns True if the clear button has to be rendered.
-     *
-     * @internal
-     */
-    protected get renderClearButton(): boolean {
-      return this.hasClearButton && !this.isAnyRange;
-    }
-
-    /**
-     * It checks if component min and max values are valid.
-     *
-     * @returns True if there is any error in the component min and max values.
-     *
-     * @internal
-     */
-    protected get hasError(): boolean {
-      return this.min !== null && this.max !== null && this.min > this.max;
-    }
-
-    /**
-     * It checks if component min and max values are different from the ones within the filter
-     * provided as property.
-     *
-     * @returns True if they are different.
-     *
-     * @internal
-     */
-    protected get areValuesDifferent(): boolean {
-      return this.min !== this.filter.range.min || this.max !== this.filter.range.max;
-    }
-
-    /**
-     * Checks if the range of the filter allows any value, which happens when the min is
-     * null or 0 and the max is null.
-     *
-     * @returns True if the range of the filter allows any value.
-     *
-     * @internal
-     */
-    protected get isAnyRange(): boolean {
-      return !this.min && this.max === null;
-    }
-
-    /**
-     * It returns the number if possible or null otherwise.
-     *
-     * @param value - Value.
-     * @returns The element value as a number if possible or null.
-     *
-     * @internal
-     */
-    protected parseRangeValue(value: number): number | null {
-      return isNaN(value) ? null : value;
-    }
-
-    /**
-     * `min` setter.
-     *
-     * @param value - The component `min` value to be set.
-     *
-     * @internal
-     */
-    protected setMin(value: number): void {
-      this.min = this.parseRangeValue(value);
-    }
-
-    /**
-     * `max` setter.
-     *
-     * @param value - The component `max` value to be set.
-     *
-     * @internal
-     */
-    protected setMax(value: number): void {
-      this.max = this.parseRangeValue(value);
-    }
-
-    /**
-     * It sets component `min` and `max` values to null , and it emits the change if component is
-     * working in instant mode.
-     *
-     * @internal
-     */
-    protected clearValues(): void {
-      this.min = null;
-      this.max = null;
-    }
-
-    /**
-     * It emits {@link FacetsXEvents.UserModifiedEditableNumberRangeFilter} event if there are no
-     * errors and component `min` and `max` values are different than `filter.range` ones.
-     *
-     * @internal
-     */
-    protected emitUserModifiedFilter(): void {
-      if (!this.hasError && this.areValuesDifferent) {
-        this.$x.emit('UserModifiedEditableNumberRangeFilter', {
-          ...this.filter,
-          range: this.range
-        });
-      }
-    }
-
-    protected rangeFilterMin = 'minimum amount';
-    protected rangeFilterMax = 'maximum amount';
-  }
+  });
 </script>
 
 <style lang="scss">

--- a/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/hierarchical-filter.vue
@@ -2,10 +2,9 @@
   <div class="x-hierarchical-filter-container" data-test="hierarchical-filter-container">
     <RenderlessFilter
       v-slot="{ filter, clickFilter, cssClasses, isDisabled }"
-      :class="innerCssClasses"
+      :cssClasses="innerCssClasses"
       :clickEvents="innerClickEvents"
       :filter="filter"
-      class="x-hierarchical-filter"
     >
       <!--
         @slot The content to render inside the button.
@@ -144,6 +143,7 @@
        * @internal
        */
       const innerCssClasses = computed(() => [
+        'x-hierarchical-filter',
         { 'x-hierarchical-filter--is-partially-selected': isPartiallySelected.value },
         { 'x-hierarchical-filter--is-selected': props.filter.selected },
         { 'x-facet-filter--is-partially-selected': isPartiallySelected.value },

--- a/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
@@ -1,8 +1,8 @@
 <template>
   <RenderlessFilter
     v-slot="{ filter, clickFilter, cssClasses, isDisabled }"
-    :class="cssClasses"
-    :clickEvents="_clickEvents"
+    :class="innerCssClasses"
+    :clickEvents="innerClickEvents"
     :filter="filter"
     class="x-number-range-filter"
   >
@@ -42,11 +42,9 @@
 </template>
 
 <script lang="ts">
-  import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { computed, defineComponent, PropType } from 'vue';
   import { NumberRangeFilter as NumberRangeFilterModel } from '@empathyco/x-types';
-  import { xComponentMixin } from '../../../../components';
-  import { VueCSSClasses } from '../../../../utils/types';
+  import { Dictionary } from '@empathyco/x-utils';
   import { XEventsTypes } from '../../../../wiring/events.types';
   import { facetsXModule } from '../../x-module';
   import RenderlessFilter from './renderless-filter.vue';
@@ -56,48 +54,57 @@
    *
    * @public
    */
-  @Component({
+  export default defineComponent({
+    name: 'NumberRangeFilter',
+    xModule: facetsXModule.name,
     components: { RenderlessFilter },
-    mixins: [xComponentMixin(facetsXModule)]
-  })
-  export default class NumberRangeFilter extends Vue {
-    /** The filter data to render. */
-    @Prop({ required: true })
-    public filter!: NumberRangeFilterModel;
+    props: {
+      /** The filter data to render. */
+      filter: {
+        type: Object as PropType<NumberRangeFilterModel>,
+        required: true
+      },
+      /**
+       * Additional events, with their payload, to emit when the filter is clicked.
+       *
+       * @public
+       */
+      clickEvents: Object as PropType<Partial<XEventsTypes>>,
+      /** Inheritance CSS classes. */
+      cssClasses: {
+        type: Array as PropType<(string | Dictionary<boolean>)[]>,
+        default: () => []
+      }
+    },
+    setup: function (props: any) {
+      /**
+       * The {@link XEventsTypes} to emit.
+       *
+       * @returns The events to emit when clicked.
+       * @internal
+       */
+      const innerClickEvents = computed(() => ({
+        UserClickedANumberRangeFilter: props.filter,
+        ...props.clickEvents
+      }));
 
-    /**
-     * Additional events, with their payload, to emit when the filter is clicked.
-     *
-     * @public
-     */
-    @Prop()
-    public clickEvents?: Partial<XEventsTypes>;
+      /**
+       * Dynamic CSS classes to apply to the component.
+       *
+       * @returns The dynamic CSS classes to apply to the component.
+       * @internal
+       */
+      const innerCssClasses = computed(() => [
+        { 'x-number-range-filter--is-selected': props.filter.selected },
+        ...props.cssClasses
+      ]);
 
-    /**
-     * The {@link XEventsTypes} to emit.
-     *
-     * @returns The events to emit when clicked.
-     * @internal
-     */
-    protected get _clickEvents(): Partial<XEventsTypes> {
       return {
-        UserClickedANumberRangeFilter: this.filter,
-        ...this.clickEvents
+        innerClickEvents,
+        innerCssClasses
       };
     }
-
-    /**
-     * Dynamic CSS classes to apply to the component.
-     *
-     * @returns The dynamic CSS classes to apply to the component.
-     * @internal
-     */
-    protected get cssClasses(): VueCSSClasses {
-      return {
-        'x-number-range-filter--is-selected': this.filter.selected
-      };
-    }
-  }
+  });
 </script>
 
 <docs lang="mdx">

--- a/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/number-range-filter.vue
@@ -1,10 +1,9 @@
 <template>
   <RenderlessFilter
     v-slot="{ filter, clickFilter, cssClasses, isDisabled }"
-    :class="innerCssClasses"
+    :cssClasses="innerCssClasses"
     :clickEvents="innerClickEvents"
     :filter="filter"
-    class="x-number-range-filter"
   >
     <!--
       @slot The control element to render
@@ -95,6 +94,7 @@
        * @internal
        */
       const innerCssClasses = computed(() => [
+        'x-number-range-filter',
         { 'x-number-range-filter--is-selected': props.filter.selected },
         ...props.cssClasses
       ]);


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

```
feat(filters)!: migrate editableNumberRangeFilter, hierarchicalFilter and numberRangeFilter to composition API

BREAKING-CHANGE: use cssClasses prop to pass classes through the component in Vue 3 instead of class or :class when using hierarchicalFilter or numberRangeFilter components
```

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
