### PR TITLE
fix(main-scroll): obtain observed container element reliably to work with any Vue version

### DIFF
--- a/packages/_vue3-migration-test/src/x-modules/scroll/test-scroll.vue
+++ b/packages/_vue3-migration-test/src/x-modules/scroll/test-scroll.vue
@@ -1,10 +1,11 @@
-<script setup lang="ts">
-  import MainScroll from '../../../../x-components/src/x-modules/scroll/components/main-scroll.vue';
-  import MainScrollItem from '../../../../x-components/src/x-modules/scroll/components/main-scroll-item.vue';
-  const items = Array.from({ length: 24 }, (_, index) => ({ id: `item-${index}` }));
-</script>
-
 <template>
+  <MainScroll class="CLASS-TEST" data-custom="DATA-TEST">
+    <ul class="list" data-test="scroll">
+      <MainScrollItem v-for="item in items" :key="item.id" class="item" tag="article" :item="item">
+        {{ item.id }}
+      </MainScrollItem>
+    </ul>
+  </MainScroll>
   <MainScroll>
     <ul class="list" data-test="scroll">
       <MainScrollItem v-for="item in items" :key="item.id" class="item" tag="article" :item="item">
@@ -13,6 +14,26 @@
     </ul>
   </MainScroll>
 </template>
+
+<script setup lang="ts">
+  import { useXBus } from '../../../../x-components/src/composables/use-x-bus';
+  import { XEvent } from '../../../../x-components/src/wiring/events.types';
+  import MainScroll from '../../../../x-components/src/x-modules/scroll/components/main-scroll.vue';
+  import MainScrollItem from '../../../../x-components/src/x-modules/scroll/components/main-scroll-item.vue';
+
+  const items = Array.from({ length: 24 }, (_, index) => ({ id: `item-${index}` }));
+
+  const xBus = useXBus();
+  const events: XEvent[] = [
+    'UserScrolledToElement',
+    'ScrollRestoreSucceeded',
+    'ScrollRestoreFailed'
+  ];
+  events.forEach(event => {
+    // eslint-disable-next-line no-console
+    xBus.on(event, true).subscribe(args => console.log(`${event} event ->`, args));
+  });
+</script>
 
 <style scoped lang="scss">
   .list {

--- a/packages/_vue3-migration-test/src/x-modules/scroll/test-scroll.vue
+++ b/packages/_vue3-migration-test/src/x-modules/scroll/test-scroll.vue
@@ -1,5 +1,5 @@
 <template>
-  <MainScroll class="CLASS-TEST" data-custom="DATA-TEST">
+  <MainScroll class="CUSTOM-CLASS" data-custom="CUSTOM-DATA-ATTR">
     <ul class="list" data-test="scroll">
       <MainScrollItem v-for="item in items" :key="item.id" class="item" tag="article" :item="item">
         {{ item.id }}
@@ -21,14 +21,15 @@
   import MainScroll from '../../../../x-components/src/x-modules/scroll/components/main-scroll.vue';
   import MainScrollItem from '../../../../x-components/src/x-modules/scroll/components/main-scroll-item.vue';
 
-  const items = Array.from({ length: 24 }, (_, index) => ({ id: `item-${index}` }));
-
   const xBus = useXBus();
+
+  const items = Array.from({ length: 24 }, (_, index) => ({ id: `item-${index}` }));
   const events: XEvent[] = [
     'UserScrolledToElement',
     'ScrollRestoreSucceeded',
     'ScrollRestoreFailed'
   ];
+
   events.forEach(event => {
     // eslint-disable-next-line no-console
     xBus.on(event, true).subscribe(args => console.log(`${event} event ->`, args));

--- a/packages/_vue3-migration-test/src/x-modules/scroll/x-module.ts
+++ b/packages/_vue3-migration-test/src/x-modules/scroll/x-module.ts
@@ -4,7 +4,7 @@ import { ScrollXModule } from '../../../../x-components/src/x-modules/scroll/x-m
 export const scrollXModule: PrivateXModuleOptions<ScrollXModule> = {
   storeModule: {
     state: {
-      pendingScrollTo: 'item-10'
+      pendingScrollTo: 'item-15'
     }
   }
 };

--- a/packages/x-components/src/components/no-element.ts
+++ b/packages/x-components/src/components/no-element.ts
@@ -8,7 +8,8 @@ import { useNoElementRender } from '../composables/use-no-element-render';
  * @internal
  */
 export const NoElement = defineComponent({
-  setup(props, { slots }) {
+  name: 'NoElement',
+  setup(_, { slots }) {
     return () => useNoElementRender(slots);
   }
 });

--- a/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
+++ b/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
@@ -107,6 +107,10 @@
         {
           if (rootRef.value !== null) {
             const htmlElement = isElementRef(rootRef.value) ? rootRef.value.$el : rootRef.value;
+            // eslint-disable-next-line no-console
+            console.log(isElementRef(rootRef.value));
+            // eslint-disable-next-line no-console
+            console.log(rootRef.value);
 
             oldObserver?.unobserve(htmlElement);
             newObserver?.observe(htmlElement);

--- a/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
+++ b/packages/x-components/src/x-modules/scroll/components/main-scroll-item.vue
@@ -33,67 +33,35 @@
     name: 'MainScrollItem',
     xModule: scrollXModule.name,
     props: {
-      /**
-       * The item data. Used to set the scroll identifier.
-       *
-       * @public
-       */
+      /** The item data. Used to set the scroll identifier. */
       item: {
         type: Object as PropType<Identifiable>,
         required: true
       },
-      /**
-       * The tag to render.
-       *
-       * @public
-       */
+      /** The tag to render. */
       tag: {
         type: [String, Object] as PropType<string | typeof Vue>,
         default: 'div'
       }
     },
     setup(props) {
-      type ElementRef = {
-        $el: HTMLElement;
-      };
-
       const xBus = useXBus();
 
-      /**
-       * Rendered HTML node.
-       *
-       * @public
-       */
-      const rootRef = ref<ElementRef | HTMLElement | null>(null);
+      /** Rendered HTML node. */
+      const rootRef = ref<HTMLElement>();
 
       /**
        * Pending identifier scroll position to restore. If it matches the {@link MainScrollItem} item
        * `id` property, this component should be scrolled into view.
-       *
-       * @internal
        */
       const { pendingScrollTo } = useState('scroll', ['pendingScrollTo']);
 
-      /**
-       * Observer to detect the first visible element.
-       *
-       * @internal
-       */
+      /** Observer to detect the first visible element. */
       const firstVisibleItemObserver = inject<Ref<ScrollVisibilityObserver> | null>(
         ScrollObserverKey as string,
         null
       );
-      /**
-       * Checks if a given value is an `ElementRef` object.
-       *
-       * @param value - The value to check.
-       * @returns `true` if the value is an `ElementRef` object, `false` otherwise.
-       *
-       * @internal
-       */
-      const isElementRef = (value: any): value is ElementRef => {
-        return value && value.$el instanceof HTMLElement;
-      };
+
       /**
        * Initialises the element visibility observation, stopping the previous one if it has.
        *
@@ -105,18 +73,12 @@
         oldObserver: ScrollVisibilityObserver | null
       ): void => {
         {
-          if (rootRef.value !== null) {
-            const htmlElement = isElementRef(rootRef.value) ? rootRef.value.$el : rootRef.value;
-            // eslint-disable-next-line no-console
-            console.log(isElementRef(rootRef.value));
-            // eslint-disable-next-line no-console
-            console.log(rootRef.value);
-
-            oldObserver?.unobserve(htmlElement);
-            newObserver?.observe(htmlElement);
+          if (rootRef.value) {
+            oldObserver?.unobserve(rootRef.value);
+            newObserver?.observe(rootRef.value);
             if (pendingScrollTo.value === props.item.id) {
               Vue.nextTick(() => {
-                htmlElement.scrollIntoView({
+                rootRef.value!.scrollIntoView({
                   block: 'center'
                 });
               });
@@ -126,15 +88,10 @@
         }
       };
 
-      /**
-       * Detaches the observer from the rendered element to prevent memory leaks.
-       *
-       * @internal
-       */
+      /** Detaches the observer from the rendered element to prevent memory leaks. */
       onBeforeUnmount(() => {
-        if (rootRef.value !== null) {
-          const htmlElement = isElementRef(rootRef.value) ? rootRef.value.$el : rootRef.value;
-          firstVisibleItemObserver?.value.unobserve(htmlElement);
+        if (rootRef.value) {
+          firstVisibleItemObserver?.value.unobserve(rootRef.value);
         }
       });
 
@@ -143,8 +100,6 @@
        * - Observes the rendered element to detect if it is the first visible item.
        * - If the rendered element matches the {@link MainScrollItem.pendingScrollTo}, scrolls the
        * element into the first position of the view.
-       *
-       * @internal
        */
       onMounted(() => {
         nextTick(() => {
@@ -155,7 +110,7 @@
         });
       });
 
-      return { rootRef, firstVisibleItemObserver, observeItem, isElementRef };
+      return { rootRef };
     }
   });
 </script>


### PR DESCRIPTION
Obtain observed container element reliably to work with any Vue version

With the following code, we are able to retrieve the root element of a renderless component in both Vue 2 and Vue 3:

```TS
onMounted(() => {
   containerRef.value = getCurrentInstance()?.proxy?.$el;
});
...
return () => slots.default?.()[0];
```

In Vue 2 and Vue 3:
- `slots.default?.()` -> Gives an array of `vNodes` | `[0]` Gets the `vNode` root and renders it 

IF we would return the full array of `vNodes` `return () => slots.default?.()`:
- In Vue 2: Renders the `vNodes` as it is without problem, and we can get the root element with `getCurrentInstance()?.proxy?.$el`. Only if the default slot has a single node, otherwise, Vue will throw an error 
`[Vue warn]: Multiple root nodes returned from render function. Render function should return a single root node.`
- In Vue 3: Renders the `vNodes` as a `Fragment` (because in Vue3 supports multiple root nodes) and when we do `getCurrentInstance()?.proxy?.$el` it gives a `#text` node because the root node is the `Fragment`.

One more thing, this scope will support `attrs` inheritance in both Vue versions ✌🏾 