### PR TITLE
fix(queryPreviewList): repeated query loading issue

### DIFF
--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview-list.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview-list.spec.ts
@@ -162,6 +162,26 @@ describe('testing QueryPreviewList', () => {
     expect(queryPreviews.wrappers).toHaveLength(1);
     expect(queryPreviews.at(0).text()).toEqual('shoes - Crazy shoes');
   });
+
+  it('load next batch when it contains duplicates', async () => {
+    const { getQueryPreviewItemWrappers, reRender, wrapper } = renderQueryPreviewList({
+      queriesPreviewInfo: [{ query: 'shirt' }, { query: 'jeans' }],
+      results: {
+        shirt: [createResultStub('Cool shirt')],
+        jeans: [createResultStub('Sick jeans')],
+        dress: [createResultStub('cool dress ')]
+      }
+    });
+    await reRender();
+    let queryPreviews = getQueryPreviewItemWrappers();
+    expect(queryPreviews.wrappers).toHaveLength(2);
+    wrapper.setProps({
+      queriesPreviewInfo: [{ query: 'shirt' }, { query: 'jeans' }, { query: 'dress' }]
+    });
+    await reRender();
+    queryPreviews = getQueryPreviewItemWrappers();
+    expect(queryPreviews.wrappers).toHaveLength(3);
+  });
 });
 
 interface RenderQueryPreviewListOptions {

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview-list.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview-list.vue
@@ -157,7 +157,11 @@
         queries,
         (newQueries: string[], oldQueries: string[] | undefined) => {
           if (newQueries.toString() !== oldQueries?.toString()) {
-            queriesStatus.value = {};
+            for (const key of Object.keys(queriesStatus.value)) {
+              if (!newQueries.includes(key)) {
+                delete queriesStatus.value[key];
+              }
+            }
             loadNext();
           }
         },


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

This PR addresses a bug in the `QueryPreviewList` component that prevents it from loading the next list of queries if the new collection partially overlaps with the previous one. The issue occurs due to the resetting of the `queriesStatus`, which causes queries that were already loaded to get stuck in a loading state. This prevents the necessary actions from being triggered to load the remaining queries.


## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
Added a unit test for this scenario and it can be tested manually by changing using some queries to preview and then adding a new one to the collection:

```ts
      let queriesPreviewInfo: QueryPreviewInfo[] = [{ query: 't-shirt' }];
      
      queriesPreviewInfo = [{query: 't-shirt'}, {query: 'jeans'}];
```

Tests performed according to [testing guidelines](./contributing/tests.md): 

