### PR TITLE
refactor(render-function): clear void calls

### DIFF
--- a/packages/x-components/src/components/display-emitter.vue
+++ b/packages/x-components/src/components/display-emitter.vue
@@ -50,7 +50,7 @@
        * because Vue2 only allows a single root node. Then, `getCurrentInstance()?.proxy?.$el` to
        * retrieve the HTML element in both versions.
        */
-      return () => slots.default?.()[0] ?? h();
+      return () => slots.default?.()[0] ?? '';
     }
   });
 </script>

--- a/packages/x-components/src/components/result/result-variants-provider.vue
+++ b/packages/x-components/src/components/result/result-variants-provider.vue
@@ -128,7 +128,7 @@
         { immediate: true }
       );
 
-      return () => slots.default?.({ result: resultToProvide.value })[0] ?? h();
+      return () => slots.default?.({ result: resultToProvide.value })[0] ?? '';
     }
   });
 </script>

--- a/packages/x-components/src/composables/use-no-element-render.ts
+++ b/packages/x-components/src/composables/use-no-element-render.ts
@@ -10,8 +10,8 @@ import { h, SetupContext, VNode } from 'vue';
  */
 export function useNoElementRender(
   slots: { [key: string]: VNode[] | undefined } | SetupContext['slots']
-): VNode | VNode[] {
+): VNode | VNode[] | string {
   const defaultSlotContent = typeof slots.default === 'function' ? slots.default() : slots.default;
 
-  return defaultSlotContent ?? h();
+  return defaultSlotContent ?? '';
 }

--- a/packages/x-components/src/views/home/display-result-provider.vue
+++ b/packages/x-components/src/views/home/display-result-provider.vue
@@ -16,7 +16,7 @@
         }
       });
 
-      return () => slots.default?.()[0] ?? h();
+      return () => slots.default?.()[0] ?? '';
     }
   });
 </script>

--- a/packages/x-components/src/x-modules/extra-params/components/renderless-extra-param.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/renderless-extra-param.vue
@@ -37,7 +37,7 @@
         xBus.emit('UserChangedExtraParams', { [props.name]: newValue });
       }
 
-      return () => slots.default?.({ value, updateValue })[0] ?? h();
+      return () => slots.default?.({ value, updateValue })[0] ?? '';
     }
   });
 </script>

--- a/packages/x-components/src/x-modules/facets/components/lists/exclude-filters-with-no-results.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/exclude-filters-with-no-results.vue
@@ -44,7 +44,7 @@
       );
       provide('filters', filtersWithResults);
 
-      return () => slots.default?.({ filters: filtersWithResults.value }) ?? h();
+      return () => slots.default?.({ filters: filtersWithResults.value }) ?? '';
     }
   });
 </script>

--- a/packages/x-components/src/x-modules/facets/components/lists/sorted-filters.vue
+++ b/packages/x-components/src/x-modules/facets/components/lists/sorted-filters.vue
@@ -52,7 +52,7 @@
       });
       provide('filters', sortedFilters);
 
-      return () => slots.default?.({ filters: sortedFilters.value }) ?? h();
+      return () => slots.default?.({ filters: sortedFilters.value }) ?? '';
     }
   });
 </script>

--- a/packages/x-components/src/x-modules/scroll/components/main-scroll.vue
+++ b/packages/x-components/src/x-modules/scroll/components/main-scroll.vue
@@ -203,7 +203,7 @@
        * because Vue2 only allows a single root node. Then, `getCurrentInstance()?.proxy?.$el` to
        * retrieve the HTML element in both versions.
        */
-      return () => slots.default?.()[0] ?? h();
+      return () => slots.default?.()[0] ?? '';
     }
   });
 </script>


### PR DESCRIPTION
## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

The `h()` render function requires 1-3 arguments. As the empty `h()` intends to render "nothing", returning an empty string has the same effect.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [X] Other. Specify: https://github.com/empathyco/x/tree/vue3-update-rc

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
