### PR TITLE
fix(infinite-scroll): getting xBus from XPlugin instead useXBus composable

### DIFF
--- a/packages/x-components/src/directives/infinite-scroll.ts
+++ b/packages/x-components/src/directives/infinite-scroll.ts
@@ -1,5 +1,5 @@
 import { Directive } from 'vue';
-import { useXBus } from '../composables/use-x-bus';
+import { XPlugin } from '../plugins';
 
 const VIEWPORT_ID = 'viewport';
 
@@ -82,7 +82,7 @@ export const infiniteScroll: Directive<HTMLElement, { margin: number }> = {
      */
     const rootMargin = `1000000% 0px ${margin}px 0px`;
     const root = getRoot(element, id);
-    const xBus = useXBus();
+    const xBus = XPlugin.bus;
 
     state[id] = new IntersectionObserver(
       ([entry]) => {


### PR DESCRIPTION
Getting xBus from `XPlugin` instead `useXBus` composable.

As it is a directive and not a component, the composable uses `inject` and `onBeforeUnmount` which are not allowed out of component context, throwing the following warnings

![Screenshot 2024-08-02 at 2 27 18 PM](https://github.com/user-attachments/assets/a3ebbe80-8698-439e-bd77-2b0cd8081535)