### PR TITLE
fix: send origin in query tagging

### DIFF
--- a/packages/x-components/src/components/base-event-button.vue
+++ b/packages/x-components/src/components/base-event-button.vue
@@ -9,7 +9,7 @@
   import { defineComponent, PropType, ref } from 'vue';
   import { use$x } from '../composables/use-$x';
   import { XEvent, XEventsTypes } from '../wiring/events.types';
-  import { QueryFeature } from '../types/origin';
+  import { WireMetadata } from '../wiring/index';
 
   /**
    * Component to be reused that renders a `<button>` with the logic of emitting events to the bus
@@ -29,12 +29,12 @@
         required: true
       },
       /**
-       * The origin property for the request on each query preview.
+       * The metadata property for the request on each query preview.
        *
        * @public
        */
-      queryFeature: {
-        type: String as PropType<QueryFeature>
+      metadata: {
+        type: Object as PropType<Omit<WireMetadata, 'moduleName'>>
       }
     },
     setup(props) {
@@ -47,7 +47,7 @@
        */
       function emitEvents() {
         Object.entries(props.events).forEach(([event, payload]) =>
-          $x.emit(event as XEvent, payload, { target: rootRef.value, feature: props.queryFeature })
+          $x.emit(event as XEvent, payload, { target: rootRef.value, ...props.metadata })
         );
       }
 

--- a/packages/x-components/src/components/base-event-button.vue
+++ b/packages/x-components/src/components/base-event-button.vue
@@ -9,6 +9,7 @@
   import { defineComponent, PropType, ref } from 'vue';
   import { use$x } from '../composables/use-$x';
   import { XEvent, XEventsTypes } from '../wiring/events.types';
+  import { QueryFeature } from '../types/origin';
 
   /**
    * Component to be reused that renders a `<button>` with the logic of emitting events to the bus
@@ -26,6 +27,14 @@
       events: {
         type: Object as PropType<Partial<XEventsTypes>>,
         required: true
+      },
+      /**
+       * The origin property for the request on each query preview.
+       *
+       * @public
+       */
+      queryFeature: {
+        type: String as PropType<QueryFeature>
       }
     },
     setup(props) {
@@ -38,7 +47,7 @@
        */
       function emitEvents() {
         Object.entries(props.events).forEach(([event, payload]) =>
-          $x.emit(event as XEvent, payload, { target: rootRef.value })
+          $x.emit(event as XEvent, payload, { target: rootRef.value, feature: props.queryFeature })
         );
       }
 

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -270,6 +270,7 @@
                       <QueryPreviewButton
                         class="x-w-fit x-button-xl x-button-ghost"
                         :queryPreviewInfo="queryPreviewInfo"
+                        :queryFeature="'customer'"
                       >
                         {{ `${queryPreviewInfo.query} (${totalResults})` }}
                       </QueryPreviewButton>

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -270,7 +270,7 @@
                       <QueryPreviewButton
                         class="x-w-fit x-button-xl x-button-ghost"
                         :queryPreviewInfo="queryPreviewInfo"
-                        :queryFeature="'customer'"
+                        :metadata="{ feature: 'customer' }"
                       >
                         {{ `${queryPreviewInfo.query} (${totalResults})` }}
                       </QueryPreviewButton>

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview-button.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview-button.vue
@@ -2,6 +2,7 @@
   <BaseEventButton
     v-on="$listeners"
     :events="events"
+    :queryFeature="queryFeature"
     class="x-query-preview-button x-button"
     data-test="query-preview-button"
   >
@@ -19,6 +20,7 @@
   import { BaseEventButton } from '../../../components';
   import { queriesPreviewXModule } from '../x-module';
   import { useState } from '../../../composables/use-state';
+  import { QueryFeature } from '../../../types/origin';
 
   /**
    * Component containing an event button that emits
@@ -42,6 +44,14 @@
       queryPreviewInfo: {
         type: Object as PropType<QueryPreviewInfo>,
         required: true
+      },
+      /**
+       * The origin property for the request on each query preview.
+       *
+       * @public
+       */
+      queryFeature: {
+        type: String as PropType<QueryFeature>
       }
     },
     setup(props) {

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview-button.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview-button.vue
@@ -2,7 +2,7 @@
   <BaseEventButton
     v-on="$listeners"
     :events="events"
-    :queryFeature="queryFeature"
+    :metadata="metadata"
     class="x-query-preview-button x-button"
     data-test="query-preview-button"
   >
@@ -20,7 +20,7 @@
   import { BaseEventButton } from '../../../components';
   import { queriesPreviewXModule } from '../x-module';
   import { useState } from '../../../composables/use-state';
-  import { QueryFeature } from '../../../types/origin';
+  import { WireMetadata } from '../../../wiring/index';
 
   /**
    * Component containing an event button that emits
@@ -46,12 +46,12 @@
         required: true
       },
       /**
-       * The origin property for the request on each query preview.
+       * The metadata property for the request on each query preview.
        *
        * @public
        */
-      queryFeature: {
-        type: String as PropType<QueryFeature>
+      metadata: {
+        type: Object as PropType<Omit<WireMetadata, 'moduleName'>>
       }
     },
     setup(props) {


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
When you click on a brand recommendation, the origin param is not included in the query tagging. That's because the `BaseEventButton` used on the `QueryPreviewButton` component emits `UserAcceptedAQueryPreview` event without any feature param in the metadata so that the origin couldn't be created.

To fix it, we are going to pass the origin through a prop and it will be added to the event metadata.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [RST-1853](https://searchbroker.atlassian.net/browse/RST-1853)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Click on a brand recommendation and check if the origin `customer:no_query` is sent in the query tagging.

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[RST-1853]: https://searchbroker.atlassian.net/browse/RST-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ