### PR TITLE
feature: Make Main Modal events configurable via props

### DIFF
--- a/packages/x-components/src/components/modals/main-modal.vue
+++ b/packages/x-components/src/components/modals/main-modal.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent } from 'vue';
+  import { defineComponent, PropType } from 'vue';
   import { AnimationProp } from '../../types/animation-prop';
   import { XEvent } from '../../wiring/events.types';
   import BaseEventsModal from './base-events-modal.vue';
@@ -38,41 +38,34 @@
         type: AnimationProp
       },
       /**
+       * Events to listen for closing the main modal.
+       */
+      closeEvents: {
+        type: Array as PropType<XEvent[]>,
+        default: () => ['UserClickedCloseX', 'UserClickedOutOfMainModal']
+      },
+      /**
        * Determines if the focused element changes to one inside the modal when it opens. Either the
        * first element with a positive tabindex or just the first focusable element.
        */
       focusOnOpen: {
         type: Boolean,
         default: false
-      }
-    },
-    setup() {
+      },
       /**
        * Events to listen for opening the main modal.
-       *
-       * @internal
        */
-      const openEvents: XEvent[] = ['UserClickedOpenX', 'UserOpenXProgrammatically'];
-
-      /**
-       * Events to listen for closing the main modal.
-       *
-       * @internal
-       */
-      const closeEvents: XEvent[] = ['UserClickedCloseX', 'UserClickedOutOfMainModal'];
-
+      openEvents: {
+        type: Array as PropType<XEvent[]>,
+        default: () => ['UserClickedOpenX', 'UserOpenXProgrammatically']
+      },
       /**
        * Event to be emitted by the modal when clicked out of its content.
-       *
-       * @internal
        */
-      const outOfModalClickEvent: XEvent = 'UserClickedOutOfMainModal';
-
-      return {
-        openEvents,
-        closeEvents,
-        outOfModalClickEvent
-      };
+      outOfModalClickEvent: {
+        type: (String as PropType<XEvent>) || null,
+        default: 'UserClickedOutOfMainModal'
+      }
     }
   });
 </script>
@@ -121,6 +114,45 @@ The `contentClass` prop can be used to add classes to the modal content.
   <div>
     <OpenMainModal>Open X</OpenMainModal>
     <MainModal contentClass="x-bg-neutral-75">
+      <CloseMainModal>Close X</CloseMainModal>
+    </MainModal>
+  </div>
+</template>
+
+<script>
+  import { MainModal, CloseMainModal, OpenMainModal } from '@empathyco/x-components';
+
+  export default {
+    name: 'MainModalDemo',
+    components: {
+      MainModal,
+      CloseMainModal,
+      OpenMainModal
+    }
+  };
+</script>
+```
+
+### Customizing the modal events
+
+The modal events can be customized by changing its props values:
+
+- To add or subtract events to open or close the modal,
+- To modify or remove the default
+  [`UserClickedOutOfMainModal`](https://github.com/empathyco/x/blob/main/packages/x-components/src/wiring/events.types.ts)
+  that the modal emits.
+
+In this example, we are changing the `openEvents` prop to add another event, and removing the event
+that the modal would emit when the user clicks out of the modal.
+
+```vue live
+<template>
+  <div>
+    <OpenMainModal>Open X</OpenMainModal>
+    <MainModal
+      :openEvents="['UserClickedOpenX', 'UserOpenXProgrammatically', 'MyCustomXEvent']"
+      :outOfModalClickEvent="null"
+    >
       <CloseMainModal>Close X</CloseMainModal>
     </MainModal>
   </div>


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Currently, when some customers want to implement features without leaving the search engine (ex. opening pop-ups), their flow is broken due to the `UserClickedOutOfMainModal` event being fired.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
A recent example is Tous, trying to open a modal when the add2Cart button is clicked, or Carrefour, with their wishlist integration. 

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [x] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
1. in `Home.vue`:
```
<MainModal
      :animation="modalAnimation"
      :openEvents="['UserClickedOpenX', 'UserOpenXProgrammatically', 'MyCustomXEvent']"
      :outOfModalClickEvent="null"
    >.........</MainModal>
```
2. Check devTools events' props are updated accordingly.
3. Change change `x-modal` styles to check that clicking out of the modal doesn't close it, + query & results are not being cleared (so the `UserClickedOutOfMainModal` event is not being fired):
```
.x-modal {
    width: 60% !important;
    left: 615px !important;
  }
```

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
