### PR TITLE
feat: update result information in the QPs

### DIFF
--- a/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
@@ -165,7 +165,7 @@ describe('results with variants', () => {
     expect(emitSpy).toHaveBeenCalledTimes(1);
     expect(emitSpy).toHaveBeenCalledWith(
       'UserSelectedAResultVariant',
-      { result, variant: variants[0], level: 0 },
+      { result, variant: variants[0], level: 0, queryPreviewHash: null },
       expect.anything()
     );
   });

--- a/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
+++ b/packages/x-components/src/components/result/__tests__/result-variants-provider-and-selector.spec.ts
@@ -33,7 +33,8 @@ const result = createResultStub('jacket', { variants });
 const render = ({
   template = '<ResultVariantSelector/>',
   result = {},
-  autoSelectDepth = Number.POSITIVE_INFINITY
+  autoSelectDepth = Number.POSITIVE_INFINITY,
+  queryPreviewHash = null as string | null
 } = {}) => {
   installNewXPlugin();
   const emitSpy = jest.spyOn(XPlugin.bus, 'emit');
@@ -49,6 +50,9 @@ const render = ({
     components: {
       ResultVariantsProvider,
       ResultVariantSelector
+    },
+    provide: {
+      queryPreviewHash
     },
     data: () => ({
       result,
@@ -166,6 +170,25 @@ describe('results with variants', () => {
     expect(emitSpy).toHaveBeenCalledWith(
       'UserSelectedAResultVariant',
       { result, variant: variants[0], level: 0, queryPreviewHash: null },
+      expect.anything()
+    );
+  });
+
+  it('emits UserSelectedAResultVariant event when a variant from a query preview is selected', async () => {
+    const { wrapper, emitSpy } = render({
+      result,
+      autoSelectDepth: 0,
+      queryPreviewHash: 'abcd'
+    });
+
+    const button = wrapper.find(getDataTestSelector('variant-button'));
+
+    await button.trigger('click');
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith(
+      'UserSelectedAResultVariant',
+      { result, variant: variants[0], level: 0, queryPreviewHash: 'abcd' },
       expect.anything()
     );
   });

--- a/packages/x-components/src/components/result/result-variants-provider.vue
+++ b/packages/x-components/src/components/result/result-variants-provider.vue
@@ -1,5 +1,16 @@
 <script lang="ts">
-  import { defineComponent, ref, computed, watch, provide, Ref, PropType, h } from 'vue';
+  import {
+    defineComponent,
+    ref,
+    computed,
+    watch,
+    provide,
+    Ref,
+    PropType,
+    h,
+    inject,
+    ComputedRef
+  } from 'vue';
   import { Result, ResultVariant } from '@empathyco/x-types';
   import {
     RESULT_WITH_VARIANTS_KEY,
@@ -56,6 +67,13 @@
       const selectedVariants = ref<ResultVariant[]>([]);
 
       /**
+       * It injects the queryPreviewHash provided by a query-preview.
+       *
+       * @internal
+       */
+      const queryPreviewHash = inject<ComputedRef<string> | null>('queryPreviewHash', null);
+
+      /**
        * Selects a variant of the result.
        * When called, it slices the array of selected variants to remove the selected child variants.
        * Emits the {@link XEventsTypes.UserSelectedAResultVariant} when called.
@@ -68,7 +86,12 @@
           return;
         }
         selectedVariants.value.splice(level, Number.POSITIVE_INFINITY, variant);
-        xBus.emit('UserSelectedAResultVariant', { variant, level, result: result.value });
+        xBus.emit('UserSelectedAResultVariant', {
+          variant,
+          level,
+          result: result.value,
+          queryPreviewHash
+        });
       }
 
       /**

--- a/packages/x-components/src/wiring/events.types.ts
+++ b/packages/x-components/src/wiring/events.types.ts
@@ -1,4 +1,5 @@
 import { Result, ResultVariant, Suggestion } from '@empathyco/x-types';
+import { ComputedRef } from 'vue';
 import { ExtractPayload } from '../store/store.types';
 import { ArrowKey, PropsWithType } from '../utils';
 import { DeviceXEvents } from '../x-modules/device';
@@ -200,10 +201,15 @@ export interface XEventsTypes
   UserReachedEmpathizeTop: void;
   /**
    * The user selected a result variant.
-   * Payload: And object containing the result, the selected variant and the level of the selected
-   * variant.
+   * Payload: And object containing the result, the selected variant, the level of the selected
+   * variant and the query preview hash.
    */
-  UserSelectedAResultVariant: { result: Result; variant: ResultVariant; level: number };
+  UserSelectedAResultVariant: {
+    result: Result;
+    variant: ResultVariant;
+    level: number;
+    queryPreviewHash: ComputedRef<string> | null;
+  };
   /**
    * User selected any kind of suggestion (query-suggestion, popular-search...)
    * Payload: The {@link @empathyco/x-types#Suggestion | suggestion} that the user selected.

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -159,6 +159,8 @@
         return getHashFromQueryPreviewInfo(props.queryPreviewInfo);
       });
 
+      provide('queryPreviewHash', queryPreviewHash);
+
       /**
        * Gets from the state the results preview of the query preview.
        *

--- a/packages/x-components/src/x-modules/queries-preview/store/module.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/module.ts
@@ -56,6 +56,14 @@ export const queriesPreviewXStoreModule: QueriesPreviewXStoreModule = {
           Vue.delete(state.queriesPreview, queryPreviewHash);
         }
       }
+    },
+    updateAQueryPreviewResult(state, { result, queryPreviewHash }) {
+      const queryPreviewResult = state.queriesPreview[queryPreviewHash.value].results.find(
+        resultPreview => resultPreview.id === result.id
+      );
+      if (queryPreviewResult) {
+        Object.assign(queryPreviewResult, result);
+      }
     }
   },
   actions: {

--- a/packages/x-components/src/x-modules/queries-preview/store/module.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/module.ts
@@ -58,7 +58,7 @@ export const queriesPreviewXStoreModule: QueriesPreviewXStoreModule = {
       }
     },
     updateAQueryPreviewResult(state, { result, queryPreviewHash }) {
-      const queryPreviewResult = state.queriesPreview[queryPreviewHash.value].results.find(
+      const queryPreviewResult = state.queriesPreview[queryPreviewHash.value]?.results.find(
         resultPreview => resultPreview.id === result.id
       );
       if (queryPreviewResult) {

--- a/packages/x-components/src/x-modules/queries-preview/store/types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/types.ts
@@ -1,5 +1,6 @@
 import { Result, SearchRequest, SearchResponse, TaggingRequest } from '@empathyco/x-types';
 import { Dictionary } from '@empathyco/x-utils';
+import { ComputedRef } from 'vue';
 import { XActionContext } from '../../../store/actions.types';
 import { XStoreModule } from '../../../store/store.types';
 import { RequestStatus, StatusState } from '../../../store/utils/status-store.utils';
@@ -133,6 +134,20 @@ export interface QueriesPreviewMutations extends ConfigMutations<QueriesPreviewS
   }: {
     queryPreviewHash: string;
     cache: boolean;
+  }): void;
+  /**
+   * Updates a result with new fields.
+   *
+   * @param QueryPreviewResultPayload - Information needed to update a query preview result.
+   * result is an object that contains at least an id, and the properties to modify.
+   * queryPreviewHash is the query preview key to find the QueryPreview saved in the state.
+   */
+  updateAQueryPreviewResult({
+    result,
+    queryPreviewHash
+  }: {
+    result: Result;
+    queryPreviewHash: ComputedRef<string>;
   }): void;
 }
 


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Currently, if we are working with results with variants, we cannot update the result information when switching variants in the preview queries.

That's why it was necessary to carry out this task, which involves modifying the payload of the UserSelectedAResultVariant event to send the hash of the preview query of the result to be modified, and creating a mutation in the queriesPreview module to update the result with the new information.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [EMP-4683](https://searchbroker.atlassian.net/browse/EMP-4683)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Try in primor setup to install this x version locally and change variants in a query preview result.

And add this code in the `plugin.options.ts`:
```
queriesPreview: {
      wiring: {
        UserSelectedAResultVariant: {
          updateResultVariantWire
        }
      }
    },
```

```
const updateResultVariantWire = createWireFromFunction<XEventPayload<'UserSelectedAResultVariant'>>(
  ({ store, eventPayload }) => {
    const resultFromEvent = { ...eventPayload.result };
    const variantSelected = eventPayload.variant;
    const queryPreviewHash = eventPayload.queryPreviewHash;

    if (resultFromEvent) {
      const updateResult = {
        ...resultFromEvent,
        price: {
          value: variantSelected.salePrice,
          originalValue: variantSelected.originalPrice,
          hasDiscount:
            variantSelected.salePrice < (variantSelected.originalPrice ?? variantSelected.salePrice)
        },
        discountPct: variantSelected.discountPct,
        variantValue: variantSelected.variantValue,
        images: [variantSelected.imageLink],
        url: variantSelected.link ?? resultFromEvent.url,
        hexadecimalCode: variantSelected.hexadecimalCode,
        variantAttributeId: variantSelected.variantAttributeId,
        variantOptionId: variantSelected.variantOptionId
      };
      if (queryPreviewHash) {
        store.commit('x/queriesPreview/updateAQueryPreviewResult', {
          result: updateResult,
          queryPreviewHash
        });
      } else {
        store.commit('x/search/updateResult', updateResult);
      }
    }
  }
);
```
## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[EMP-4683]: https://searchbroker.atlassian.net/browse/EMP-4683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ