### PR TITLE
fix(search): replace results state to append new results instead of pushing them

### DIFF
--- a/packages/x-components/src/x-modules/search/store/module.ts
+++ b/packages/x-components/src/x-modules/search/store/module.ts
@@ -41,7 +41,7 @@ export const searchXStoreModule: SearchXStoreModule = {
   },
   mutations: {
     appendResults(state, results) {
-      state.results.push(...results);
+      state.results = [...state.results, ...results];
     },
     resetState(state) {
       Object.assign(state, resettableState());


### PR DESCRIPTION
Fix issue with emitters and `no-deep` watchers for arrays in Vue3 https://v3-migration.vuejs.org/breaking-changes/watch.html
