### PR TITLE
feat: bump vue18n version

### DIFF
--- a/packages/x-archetype-utils/package.json
+++ b/packages/x-archetype-utils/package.json
@@ -56,8 +56,8 @@
     "vue": "~3.4.31"
   },
   "peerDependencies": {
-    "vue": "^2.7.0",
-    "vue-i18n": "^8.0.0"
+    "vue": "^3.4.31",
+    "vue-i18n": "^9.14.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/x-archetype-utils/package.json
+++ b/packages/x-archetype-utils/package.json
@@ -39,12 +39,12 @@
     "@empathyco/x-deep-merge": "^2.0.3-alpha.1",
     "@empathyco/x-utils": "workspace:^1.0.3-alpha.1",
     "tslib": "~2.6.0",
-    "vue-i18n": "~8.28.2"
+    "vue-i18n": "~9.14.0"
   },
   "devDependencies": {
     "@types/jest": "~27.5.0",
     "@types/node": "~18.19.0",
-    "@vue/test-utils": "~1.0.3",
+    "@vue/test-utils": "~2.4.6",
     "jest": "~27.5.0",
     "rimraf": "~3.0.2",
     "rollup": "~4.9.1",
@@ -53,7 +53,7 @@
     "rollup-plugin-typescript2": "~0.36.0",
     "ts-jest": "~27.1.0",
     "typescript": "~4.9.4",
-    "vue": "~2.7.14"
+    "vue": "~3.4.31"
   },
   "peerDependencies": {
     "vue": "^2.7.0",

--- a/packages/x-archetype-utils/rollup.config.mjs
+++ b/packages/x-archetype-utils/rollup.config.mjs
@@ -24,7 +24,13 @@ export default {
     }),
     typescript({
       clean: true,
-      useTsconfigDeclarationDir: true
+      useTsconfigDeclarationDir: true,
+      tsconfigOverride: {
+        exclude: [
+          'node_modules',
+          '**/__tests__/**',
+        ]
+      }
     })
   ]
 };

--- a/packages/x-archetype-utils/src/__tests__/i18n.plugin.spec.ts
+++ b/packages/x-archetype-utils/src/__tests__/i18n.plugin.spec.ts
@@ -1,6 +1,5 @@
 import { DeepPartial } from '@empathyco/x-utils';
-import Vue from 'vue';
-import { mount, createLocalVue, Wrapper } from '@vue/test-utils';
+import { mount, VueWrapper } from '@vue/test-utils';
 import { I18n } from '../i18n/i18n.plugin';
 import { Device, I18nOptions, Locale } from '../i18n/i18n.types';
 
@@ -24,10 +23,6 @@ describe('Test custom i18n plugin for several use cases', () => {
     i18nOptions: Partial<I18nOptions<DeepPartial<Messages>>> = {},
     key = 'testComponent.title'
   ): Promise<RenderComponentAPI> {
-    const TestComponent = Vue.component('testComponent', {
-      template: `<div>{{ $t("${key}") }}</div>`
-    });
-    const localVue = createLocalVue();
     const i18n = await I18n.create({
       locale: 'en',
       messages: {
@@ -43,11 +38,19 @@ describe('Test custom i18n plugin for several use cases', () => {
       fallbackLocale: 'en',
       ...i18nOptions
     });
-    localVue.use(i18n);
     const setLocale = i18n.setLocale.bind(i18n);
     const setLocaleDevice = i18n.setDevice.bind(i18n);
 
-    const wrapper = mount(TestComponent, { localVue, i18n: i18n.vueI18n });
+    const wrapper = mount(
+      {
+        template: `<div>{{ $t("${key}") }}</div>`
+      },
+      {
+        global: {
+          plugins: [i18n]
+        }
+      }
+    );
     return { wrapper, setLocale, setLocaleDevice };
   }
 
@@ -158,7 +161,7 @@ describe('Test custom i18n plugin for several use cases', () => {
 });
 
 interface RenderComponentAPI {
-  wrapper: Wrapper<Vue>;
+  wrapper: VueWrapper;
   setLocale: (newLocale: Locale) => Promise<void>;
   setLocaleDevice: (newDevice: Device) => Promise<void>;
 }

--- a/packages/x-archetype-utils/src/i18n/i18n.plugin.ts
+++ b/packages/x-archetype-utils/src/i18n/i18n.plugin.ts
@@ -50,10 +50,10 @@ export class I18n<SomeMessages> {
    * @param vue - The Vue instance.
    */
   install(vue: App): void {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     this.vueI18n = createI18n({
       locale: this.locale,
       silentFallbackWarn: true,
+      messages: this.currentMessages ? ({ [this.locale]: this.currentMessages } as any) : {},
       missing: (_, key: string) => {
         return (
           this.getMessageWithDotsInKey(key) ??

--- a/packages/x-archetype-utils/src/i18n/i18n.plugin.ts
+++ b/packages/x-archetype-utils/src/i18n/i18n.plugin.ts
@@ -54,7 +54,7 @@ export class I18n<SomeMessages> {
     this.vueI18n = createI18n({
       locale: this.locale,
       silentFallbackWarn: true,
-      missing: (locale, key: string) => {
+      missing: (_, key: string) => {
         return (
           this.getMessageWithDotsInKey(key) ??
           `[i18n] Key '${key}' is missing for locale: '${this.locale}'`

--- a/packages/x-archetype-utils/src/i18n/i18n.types.ts
+++ b/packages/x-archetype-utils/src/i18n/i18n.types.ts
@@ -1,5 +1,5 @@
-import VueI18n from 'vue-i18n';
 import { DeepPartial } from '@empathyco/x-utils';
+import { type I18n } from 'vue-i18n';
 
 /** Supported locales. */
 export type Locale = string;
@@ -46,7 +46,7 @@ export interface I18nOptions<SomeMessages> {
  */
 export interface I18nAPI {
   /** The Vue I18n instance that should be passed to the root Vue component. */
-  readonly vueI18n: Readonly<VueI18n>;
+  readonly vueI18n: Readonly<I18n>;
   /**
    * Sets the new locale.
    *

--- a/packages/x-archetype-utils/src/i18n/i18n.types.ts
+++ b/packages/x-archetype-utils/src/i18n/i18n.types.ts
@@ -1,5 +1,5 @@
 import { DeepPartial } from '@empathyco/x-utils';
-import { type I18n } from 'vue-i18n';
+import { I18n as VueI18n } from 'vue-i18n';
 
 /** Supported locales. */
 export type Locale = string;
@@ -46,7 +46,7 @@ export interface I18nOptions<SomeMessages> {
  */
 export interface I18nAPI {
   /** The Vue I18n instance that should be passed to the root Vue component. */
-  readonly vueI18n: Readonly<I18n>;
+  readonly vueI18n: Readonly<VueI18n>;
   /**
    * Sets the new locale.
    *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,8 +352,8 @@ importers:
         specifier: ~2.6.0
         version: 2.6.0
       vue-i18n:
-        specifier: ~8.28.2
-        version: 8.28.2(vue@2.7.14)
+        specifier: ~9.14.0
+        version: 9.14.0(vue@3.4.31)
     devDependencies:
       '@types/jest':
         specifier: ~27.5.0
@@ -362,8 +362,8 @@ importers:
         specifier: ~18.19.0
         version: 18.19.0
       '@vue/test-utils':
-        specifier: ~1.0.3
-        version: 1.0.3(vue-template-compiler@2.7.16)(vue@2.7.14)
+        specifier: ~2.4.6
+        version: 2.4.6
       jest:
         specifier: ~27.5.0
         version: 27.5.0(ts-node@10.9.2)
@@ -389,8 +389,8 @@ importers:
         specifier: ~4.9.4
         version: 4.9.4
       vue:
-        specifier: ~2.7.14
-        version: 2.7.14
+        specifier: ~3.4.31
+        version: 3.4.31(typescript@4.9.4)
 
   packages/x-bus:
     dependencies:
@@ -2365,6 +2365,27 @@ packages:
     resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
     engines: {node: '>=6.9.0'}
     dev: true
+
+  /@intlify/core-base@9.14.0:
+    resolution: {integrity: sha512-zJn0imh9HIsZZUtt9v8T16PeVstPv6bP2YzlrYJwoF8F30gs4brZBwW2KK6EI5WYKFi3NeqX6+UU4gniz5TkGg==}
+    engines: {node: '>= 16'}
+    dependencies:
+      '@intlify/message-compiler': 9.14.0
+      '@intlify/shared': 9.14.0
+    dev: false
+
+  /@intlify/message-compiler@9.14.0:
+    resolution: {integrity: sha512-sXNsoMI0YsipSXW8SR75drmVK56tnJHoYbPXUv2Cf9lz6FzvwsosFm6JtC1oQZI/kU+n7qx0qRrEWkeYFTgETA==}
+    engines: {node: '>= 16'}
+    dependencies:
+      '@intlify/shared': 9.14.0
+      source-map-js: 1.2.0
+    dev: false
+
+  /@intlify/shared@9.14.0:
+    resolution: {integrity: sha512-r+N8KRQL7LgN1TMTs1A2svfuAU0J94Wu9wWdJVJqYsoMMLIeJxrPjazihfHpmJqfgZq0ah3Y9Q4pgWV2O90Fyg==}
+    engines: {node: '>= 16'}
+    dev: false
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -4440,6 +4461,7 @@ packages:
       '@babel/parser': 7.25.3
       postcss: 8.4.40
       source-map: 0.6.1
+    dev: true
 
   /@vue/compiler-sfc@2.7.16:
     resolution: {integrity: sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==}
@@ -4784,19 +4806,6 @@ packages:
 
   /@vue/shared@3.4.35:
     resolution: {integrity: sha512-hvuhBYYDe+b1G8KHxsQ0diDqDMA8D9laxWZhNAjE83VZb5UDaXl9Xnz7cGdDSyiHM90qqI/CyGMcpBpiDy6VVQ==}
-    dev: true
-
-  /@vue/test-utils@1.0.3(vue-template-compiler@2.7.16)(vue@2.7.14):
-    resolution: {integrity: sha512-mmsKXZSGfvd0bH05l4SNuczZ2MqlJH2DWhiul5wJXFxbf/gRRd2UL4QZgozEMQ30mRi9i4/+p4JJat8S4Js64Q==}
-    peerDependencies:
-      vue: 2.x
-      vue-template-compiler: ^2.x
-    dependencies:
-      dom-event-types: 1.1.0
-      lodash: 4.17.21
-      pretty: 2.0.0
-      vue: 2.7.14
-      vue-template-compiler: 2.7.16(vue@2.7.14)
     dev: true
 
   /@vue/test-utils@2.4.6:
@@ -6026,15 +6035,6 @@ packages:
       yargs: 17.7.2
     dev: true
 
-  /condense-newlines@0.2.1:
-    resolution: {integrity: sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: 2.0.1
-      is-whitespace: 0.3.0
-      kind-of: 3.2.2
-    dev: true
-
   /confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
     dev: false
@@ -7078,10 +7078,6 @@ packages:
 
   /dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
-    dev: true
-
-  /dom-event-types@1.1.0:
-    resolution: {integrity: sha512-jNCX+uNJ3v38BKvPbpki6j5ItVlnSqVV6vDWGS6rExzCMjsc39frLjm1n91o6YaKK6AZl0wLloItW6C6mr61BQ==}
     dev: true
 
   /dom-serializer@1.4.1:
@@ -8405,13 +8401,6 @@ packages:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
     dev: true
 
-  /extend-shallow@2.0.1:
-    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extendable: 0.1.1
-    dev: true
-
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     dev: true
@@ -9497,10 +9486,6 @@ packages:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
 
-  /is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-    dev: true
-
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -9548,11 +9533,6 @@ packages:
     dependencies:
       acorn: 7.4.1
       object-assign: 4.1.1
-    dev: true
-
-  /is-extendable@0.1.1:
-    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /is-extglob@2.1.1:
@@ -9744,11 +9724,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /is-whitespace@0.3.0:
-    resolution: {integrity: sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -10664,13 +10639,6 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
-
-  /kind-of@3.2.2:
-    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-buffer: 1.1.6
-    dev: true
 
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -12340,7 +12308,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.18'}
     dependencies:
       lru-cache: 10.4.3
-      minipass: 6.0.2
+      minipass: 7.1.2
     dev: true
 
   /path-type@3.0.0:
@@ -13011,15 +12979,6 @@ packages:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
-    dev: true
-
-  /pretty@2.0.0:
-    resolution: {integrity: sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      condense-newlines: 0.2.1
-      extend-shallow: 2.0.1
-      js-beautify: 1.15.1
     dev: true
 
   /proc-log@2.0.1:
@@ -14131,6 +14090,7 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map@0.7.3:
     resolution: {integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==}
@@ -15570,12 +15530,16 @@ packages:
       vue: 3.4.31(typescript@4.9.4)
     dev: false
 
-  /vue-i18n@8.28.2(vue@2.7.14):
-    resolution: {integrity: sha512-C5GZjs1tYlAqjwymaaCPDjCyGo10ajUphiwA922jKt9n7KPpqR7oM1PCwYzhB/E7+nT3wfdG3oRre5raIT1rKA==}
+  /vue-i18n@9.14.0(vue@3.4.31):
+    resolution: {integrity: sha512-LxmpRuCt2rI8gqU+kxeflRZMQn4D5+4M3oP3PWZdowW/ePJraHqhF7p4CuaME52mUxdw3Mmy2yAUKgfZYgCRjA==}
+    engines: {node: '>= 16'}
     peerDependencies:
-      vue: ^2
+      vue: ^3.0.0
     dependencies:
-      vue: 2.7.14
+      '@intlify/core-base': 9.14.0
+      '@intlify/shared': 9.14.0
+      '@vue/devtools-api': 6.5.1
+      vue: 3.4.31(typescript@4.9.4)
     dev: false
 
   /vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.4.31):
@@ -15631,16 +15595,6 @@ packages:
       - supports-color
     dev: true
 
-  /vue-template-compiler@2.7.16(vue@2.7.14):
-    resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
-    peerDependencies:
-      vue: ~2.7.14
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
-      vue: 2.7.14
-    dev: true
-
   /vue-template-compiler@2.7.16(vue@2.7.16):
     resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
     peerDependencies:
@@ -15685,6 +15639,7 @@ packages:
     dependencies:
       '@vue/compiler-sfc': 2.7.14
       csstype: 3.1.3
+    dev: true
 
   /vue@2.7.16:
     resolution: {integrity: sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==}


### PR DESCRIPTION
Updates vue related deps for `@empathyco/x-archetype-utils`. This package contains the custom i18n plugin used in x-archetype. 

Update vue18n to 9.14.0 and make the necessary adjustments.

BREAKING CHANGE: This package now is only compatible with vue 3