### PR TITLE
feat(rollup): update replace config to align CSS injector with Vue 3

### DIFF
--- a/packages/x-archetype-utils/src/build/rollup/rollup.config.ts
+++ b/packages/x-archetype-utils/src/build/rollup/rollup.config.ts
@@ -1,7 +1,8 @@
 export const rollupCssInjectorConfig = {
   replace: {
     // Replace X CSS injector by our custom one.
-    'injectCss(css);': 'window.xCSSInjector.addStyle(css);',
+    'export default injectCss;':
+      'export default (css) => window.xCSSInjector.addStyle({ source: css });',
     delimiters: ['', '']
   },
   styles: {

--- a/packages/x-archetype-utils/src/build/rollup/rollup.config.ts
+++ b/packages/x-archetype-utils/src/build/rollup/rollup.config.ts
@@ -1,7 +1,7 @@
 export const rollupCssInjectorConfig = {
   replace: {
     // Replace X CSS injector by our custom one.
-    'addStyle(id, style);': 'window.xCSSInjector.addStyle(style);',
+    'injectCss(css);': 'window.xCSSInjector.addStyle(css);',
     delimiters: ['', '']
   },
   styles: {


### PR DESCRIPTION
Replace `injectCss` X function for `(css) => window.xCSSInjector.addStyle({ source: css });` anonymous function at setup build time. The anonymous function executes the custom CSS injector `xCSSInjector` to inject styles.

![Screenshot 2024-09-03 at 5 23 47 PM](https://github.com/user-attachments/assets/acf39dcf-1da6-4743-8986-7a9e4dfa93b8)
Setup build example with `ShadowRoot` activated

![Screenshot 2024-09-03 at 5 26 06 PM](https://github.com/user-attachments/assets/499e3717-26c7-400c-beb9-1b702c98ef50)
Setup bundle example