### PR TITLE
ci: allow to select branch to release from

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,5 +1,11 @@
 name: Release alpha version on demand
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to release from'
+        required: true
+        default: 'main'
 jobs:
   release-alpha:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

Small change to be able to select the branch to release from. This will allow us to create a release from the vue 3 RC branch and do proper testing in the archetype or other setups.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:
