### PR TITLE
feat: bump packages versions

### DIFF
--- a/packages/x-archetype-utils/package.json
+++ b/packages/x-archetype-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@empathyco/x-archetype-utils",
-  "version": "1.1.0-alpha.2",
+  "version": "2.0.0-alpha.0",
   "description": "Utilities for x-archetype",
   "author": "Empathy Systems Corporation S.L.",
   "license": "Apache-2.0",

--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@empathyco/x-components",
-  "version": "5.0.0-alpha.81",
+  "version": "6.0.0-alpha.0",
   "description": "Empathy X Components",
   "author": "Empathy Systems Corporation S.L.",
   "license": "Apache-2.0",


### PR DESCRIPTION
BREAKING CHANGE:

 @empathyco/x-components v6 and @empathyco/x-archetype-utils v2 are only compatible with Vue 3 and if you are looking for the Vue 2 versions, take look at the main brach.