### PR TITLE
fix(history-queries-switch): migrate value to modelValue

### DIFF
--- a/packages/x-components/src/components/__tests__/base-switch.spec.ts
+++ b/packages/x-components/src/components/__tests__/base-switch.spec.ts
@@ -22,7 +22,7 @@ function renderBaseSwitch({ template, value }: RenderBaseSwitchOptions): RenderB
 describe('testing Switch component', () => {
   it('allows toggling the state', async () => {
     const { wrapper } = renderBaseSwitch({
-      template: `<BaseSwitch :modelValue="value" @change="value = !value" />`,
+      template: `<BaseSwitch :modelValue="value" @update:modelValue="value = !value" />`,
       value: false
     });
 

--- a/packages/x-components/src/components/base-switch.vue
+++ b/packages/x-components/src/components/base-switch.vue
@@ -35,7 +35,7 @@
         default: false
       }
     },
-    emits: ['change', 'update:modelValue'],
+    emits: ['update:modelValue'],
     setup(props, { emit }) {
       /**
        * Dynamic CSS classes to add to the switch component
@@ -49,7 +49,7 @@
       });
 
       /**
-       * Emits a change and input event with the desired value of the switch.
+       * Emits an event with the new value of the switch.
        *
        * @internal
        */
@@ -61,7 +61,6 @@
         };
 
         emit('update:modelValue', newValue);
-        emit('change', newValue);
       };
 
       return {
@@ -126,7 +125,7 @@ _Try clicking it to see how it changes its state_
 
 ```vue live
 <template>
-  <BaseSwitch @change="value = !value" :modelValue="value" />
+  <BaseSwitch @update:modelValue="value = !value" :modelValue="value" />
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/history-queries/components/__tests__/history-queries-switch.spec.ts
+++ b/packages/x-components/src/x-modules/history-queries/components/__tests__/history-queries-switch.spec.ts
@@ -1,7 +1,8 @@
 import { DeepPartial } from '@empathyco/x-utils';
-import { mount, VueWrapper } from '@vue/test-utils';
-import { Store } from 'vuex';
 import { HistoryQuery } from '@empathyco/x-types';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import { Store } from 'vuex';
 import { RootXStoreState } from '../../../../store/store.types';
 import { installNewXPlugin } from '../../../../__tests__/utils';
 import { getXComponentXModuleName, isXComponent } from '../../../../components/x-component.utils';
@@ -11,20 +12,20 @@ import { createHistoryQueries } from '../../../../__stubs__/index';
 import { XPlugin } from '../../../../plugins/x-plugin';
 import { resetXHistoryQueriesStateWith } from './utils';
 
-function renderHistoryQueriesSwitch({
+async function renderHistoryQueriesSwitch({
   historyQueries = createHistoryQueries('jacket', 'tshirt'),
   isEnabled = false
-}: HistoryQueriesSwitchOptions = {}): HistoryQueriesSwitchAPI {
+}: HistoryQueriesSwitchOptions = {}): Promise<HistoryQueriesSwitchAPI> {
   const store = new Store<DeepPartial<RootXStoreState>>({});
 
   const wrapper = mount(HistoryQueriesSwitch, {
     global: {
       plugins: [installNewXPlugin({ store, initialXModules: [historyQueriesXModule] })]
-    },
-    store
+    }
   });
 
   resetXHistoryQueriesStateWith(store, { isEnabled, historyQueries });
+  await nextTick();
 
   return {
     wrapper
@@ -32,15 +33,15 @@ function renderHistoryQueriesSwitch({
 }
 
 describe('testing HistoryQueriesSwitch component', () => {
-  it('is an XComponent which has an XModule', () => {
-    const { wrapper } = renderHistoryQueriesSwitch();
+  it('is an XComponent which has an XModule', async () => {
+    const { wrapper } = await renderHistoryQueriesSwitch();
 
     expect(isXComponent(wrapper.vm)).toEqual(true);
     expect(getXComponentXModuleName(wrapper.vm)).toEqual('historyQueries');
   });
 
-  it('should emit proper events when toggling its state', () => {
-    const { wrapper } = renderHistoryQueriesSwitch();
+  it('should emit proper events when toggling its state', async () => {
+    const { wrapper } = await renderHistoryQueriesSwitch();
     const enableListener = jest.fn();
     const disableListener = jest.fn();
 
@@ -58,7 +59,7 @@ describe('testing HistoryQueriesSwitch component', () => {
   });
 
   it('should emit confirm disable event if there are not history queries', async () => {
-    const { wrapper } = renderHistoryQueriesSwitch({
+    const { wrapper } = await renderHistoryQueriesSwitch({
       historyQueries: [],
       isEnabled: true
     });
@@ -66,8 +67,7 @@ describe('testing HistoryQueriesSwitch component', () => {
     XPlugin.bus.on('UserClickedConfirmDisableHistoryQueries').subscribe(listener);
 
     wrapper.trigger('click');
-
-    await new Promise(resolve => setTimeout(resolve));
+    await flushPromises();
 
     expect(listener).toHaveBeenCalledTimes(1);
     expect(XPlugin.store.state.x.historyQueries.isEnabled).toBe(false);

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries-switch.vue
@@ -1,5 +1,5 @@
 <template>
-  <BaseSwitch @change="toggle" :value="isEnabled" aria-label="Queries' history" />
+  <BaseSwitch @update:modelValue="toggle" :modelValue="isEnabled" aria-label="Queries' history" />
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
`HistoryQueriesSwitch` was not migrated correctly to Vue3 and was not working. It was required to change the `v-model` prop default name which changed in Vue3 (`value` to `modelValue`)

We are also introducing the BREAKING CHANGE of removing the event `change` in favor of the `update:modelValue` in the `BaseSwitch` component to follow the Vue3 naming.

Source: https://v3-migration.vuejs.org/breaking-changes/v-model.html

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
