### PR TITLE
fix(tagging): query tagging and send session param

### DIFF
--- a/packages/x-components/src/x-modules/tagging/components/__tests__/tagging.spec.ts
+++ b/packages/x-components/src/x-modules/tagging/components/__tests__/tagging.spec.ts
@@ -88,7 +88,8 @@ function renderTagging({
 
 const defaultTaggingConfig: Partial<TaggingConfig> = {
   clickedResultStorageTTLMs: 30000,
-  clickedResultStorageKey: 'url'
+  clickedResultStorageKey: 'url',
+  queryTaggingDebounceMs: 2000
 };
 
 const stubTagginMetadata: WireMetadata = {

--- a/packages/x-components/src/x-modules/tagging/components/tagging.vue
+++ b/packages/x-components/src/x-modules/tagging/components/tagging.vue
@@ -37,11 +37,17 @@
       /**
        * The debounce time in milliseconds to track the query.
        */
-      queryTaggingDebounceMs: Number,
+      queryTaggingDebounceMs: {
+        type: Number,
+        default: 2000
+      },
       /**
        * The consent to be emitted.
        */
-      consent: Boolean
+      consent: {
+        type: Boolean,
+        default: null
+      }
     },
     setup(props) {
       const xBus = useXBus();
@@ -67,7 +73,7 @@
        */
       const taggingConfig = computed<TaggingConfig>(() => {
         return {
-          queryTaggingDebounceMs: props.queryTaggingDebounceMs as number,
+          queryTaggingDebounceMs: props.queryTaggingDebounceMs,
           sessionTTLMs: props.sessionTTLMs as number,
           clickedResultStorageTTLMs: props.clickedResultStorageTTLMs,
           clickedResultStorageKey: props.clickedResultStorageKey


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
`queryTaggingDebounceMs` was always being initialized to undefined and that's why query tagging was not working properly when there were semantics. Also, session param was not being sent in the tagging because the `consent` was always set as null.

The solution to these problems is to set a default value for these variables in the `tagging.vue` component.

Next steps: 
- Update x-components in archetype
- Update x-components in my-motive-marketplace
- Update x-components in bigbuy
- Update x-components in primor
- Check if there are more repos with this bug

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Check if query tagging and consent work in a customer (f.e. archetype).

