### PR TITLE
fix: Snippet config extra params reactivity

### DIFF
--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -35,25 +35,16 @@
     },
     setup(props) {
       const snippetConfig = inject('snippetConfig') as SnippetConfig;
-      const extraParams = ref<Record<string, unknown>>({});
-      const initialExtraParams = ref<Record<string, unknown>>({});
+      const extraParams = ref<Record<string, any>>({});
 
       watch(
         [() => snippetConfig, () => props.values],
         () => {
-          const newExtraParams: Record<string, unknown> = {};
-
           forEach({ ...props.values, ...snippetConfig }, (name, value) => {
-            if (!props.excludedExtraParams.includes(name)) {
-              newExtraParams[name] = value;
+            if (!props.excludedExtraParams.includes(name) && extraParams.value[name] !== value) {
+              extraParams.value = { ...extraParams.value, [name]: value };
             }
           });
-
-          // Check if extraParams are really changing to avoid event emission if they don't
-          if (JSON.stringify(newExtraParams) !== JSON.stringify(initialExtraParams.value)) {
-            extraParams.value = newExtraParams;
-            initialExtraParams.value = newExtraParams;
-          }
         },
         {
           deep: true,

--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -35,16 +35,25 @@
     },
     setup(props) {
       const snippetConfig = inject('snippetConfig') as SnippetConfig;
-      const extraParams = ref({});
+      const extraParams = ref<Record<string, unknown>>({});
+      const initialExtraParams = ref<Record<string, unknown>>({});
 
       watch(
         [() => snippetConfig, () => props.values],
         () => {
+          const newExtraParams: Record<string, unknown> = {};
+
           forEach({ ...props.values, ...snippetConfig }, (name, value) => {
             if (!props.excludedExtraParams.includes(name)) {
-              extraParams.value = { ...extraParams.value, [name]: value };
+              newExtraParams[name] = value;
             }
           });
+
+          // Check if extraParams are really changing to avoid event emission if they don't
+          if (JSON.stringify(newExtraParams) !== JSON.stringify(initialExtraParams.value)) {
+            extraParams.value = newExtraParams;
+            initialExtraParams.value = newExtraParams;
+          }
         },
         {
           deep: true,


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
This PR checks if the extra params object has really changed to avoid unnecessary event emissions. 

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
In some customers, when a snippetConfig callback is executed, `ExtraParamsProvided` and `ExtraParamsChanged` events are fired even if they have not changed (and, as a consequence all the rest of the chained events that react to ExtraParamsChanged event emission). 

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: [RST-2269](https://searchbroker.atlassian.net/browse/RST-2269)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->
An [open PR](https://github.com/empathyco/x-primor/pull/143) can be used to see the implementation when a callback is executed & check: 
* No events are emitted if the `extraParams` object has not changed
* No unnecessary endpoint calls (regarding chained events).

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.


[RST-2269]: https://searchbroker.atlassian.net/browse/RST-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ