### PR TITLE
fix(scroll): scroll direction inconsistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 **/tests/e2e/videos/
 **/tests/e2e/screenshots/
+**/tests/e2e/downloads/
 
 # local env files
 .env.local

--- a/packages/x-components/.gitignore
+++ b/packages/x-components/.gitignore
@@ -8,6 +8,7 @@
 
 /tests/e2e/videos/
 /tests/e2e/screenshots/
+/tests/e2e/downloads/
 
 # local env files
 .env.local

--- a/packages/x-components/cypress.config.ts
+++ b/packages/x-components/cypress.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     supportFile: 'tests/support/index.ts',
     fixturesFolder: 'tests/e2e/fixtures',
     screenshotsFolder: 'tests/e2e/screenshots',
+    downloadsFolder: 'tests/e2e/downloads',
     experimentalRunAllSpecs: true,
     screenshotOnRunFailure: false,
     video: false,

--- a/packages/x-components/src/components/scroll/use-scroll.ts
+++ b/packages/x-components/src/components/scroll/use-scroll.ts
@@ -113,9 +113,9 @@ export function useScroll(
    */
   const storeScrollData = () => {
     if (scrollEl.value) {
-      currentPosition.value = scrollEl.value.scrollTop;
       scrollHeight.value = scrollEl.value.scrollHeight;
       clientHeight.value = scrollEl.value.clientHeight;
+      currentPosition.value = scrollEl.value.scrollTop;
     }
   };
 

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -102,7 +102,10 @@
     <MainModal :animation="modalAnimation">
       <MultiColumnMaxWidthLayout class="x-bg-neutral-0">
         <template #header-middle>
-          <div class="x-flex x-flex-col x-gap-16 x-items-stretch x-flex-auto">
+          <div
+            class="x-flex x-flex-col x-gap-16 x-items-stretch x-flex-auto"
+            :data-test="`main-scroll-${mainScrollDirection}`"
+          >
             <div class="x-input-group x-input-group-lead x-rounded-sm">
               <div class="x-input x-search-input-placeholder-container x-flex">
                 <SearchInputPlaceholder :messages="searchInputPlaceholderMessages" />
@@ -477,6 +480,7 @@
   import ChevronUp from '../../components/icons/chevron-up.vue';
   import CrossIcon from '../../components/icons/cross.vue';
   import { use$x } from '../../composables/use-$x';
+  import { useState } from '../../composables/use-state';
   import { infiniteScroll } from '../../directives/infinite-scroll';
   import ExperienceControls from '../../x-modules/experience-controls/components/experience-controls.vue';
   import Grid2Col from '../../components/icons/grid-2-col.vue';
@@ -613,6 +617,9 @@
       const sortValues = ['', 'price asc', 'price desc'];
       const isAnyQueryLoadedInPreview = useQueriesPreview().isAnyQueryLoadedInPreview;
 
+      const scrollData = useState('scroll', ['data']).data;
+      const mainScrollDirection = computed(() => scrollData.value['main-scroll']?.direction);
+
       const controls: ComputedRef<HomeControls> = computed(() => {
         return {
           searchInput: {
@@ -682,7 +689,8 @@
         queries,
         toggleE2EAdapter,
         controls,
-        x: use$x()
+        x: use$x(),
+        mainScrollDirection
       };
     }
   });

--- a/packages/x-components/tests/e2e/scroll.feature
+++ b/packages/x-components/tests/e2e/scroll.feature
@@ -101,3 +101,24 @@ Feature: Scroll component
     Examples:
       | query1 | resultId  | store |
       | lego   | result-12 | Italy |
+
+  Scenario Outline: 7. Scroll direction is updated properly
+    When  start button is clicked
+    Then  empathize should be visible
+    When  "<query1>" is searched
+    Then  related results are displayed
+    When  scrolling to bottom
+    Then  scroll direction is DOWN
+    When  scrolling to top
+    Then  scroll direction is UP
+    When  scrolling down to result "<resultId>"
+    And   the page is reloaded
+    Then  related results are displayed
+    When  scrolling to bottom
+    Then  scroll direction is DOWN
+    When  scrolling to top
+    Then  scroll direction is UP
+
+    Examples:
+      | query1 | resultId  |
+      | lego   | result-8 |

--- a/packages/x-components/tests/e2e/scroll/scroll.spec.ts
+++ b/packages/x-components/tests/e2e/scroll/scroll.spec.ts
@@ -1,4 +1,4 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
 Then('url is updated with result {string}', (resultId: string) => {
   cy.url().should('contain', `scroll=${resultId}`);
@@ -12,4 +12,28 @@ Then('scroll position is at top', () => {
   cy.get('#main-scroll').should(scrollContainer => {
     expect(scrollContainer.scrollTop()).to.equal(0);
   });
+});
+
+When('scrolling to top', () => {
+  cy.get('#main-scroll').scrollTo('top', {
+    easing: 'swing',
+    duration: 1000,
+    ensureScrollable: true
+  });
+});
+
+When('scrolling to bottom', () => {
+  cy.get('#main-scroll').scrollTo('bottom', {
+    easing: 'swing',
+    duration: 1000,
+    ensureScrollable: true
+  });
+});
+
+Then('scroll direction is UP', () => {
+  cy.getByDataTest('main-scroll-UP').should('exist');
+});
+
+Then('scroll direction is DOWN', () => {
+  cy.getByDataTest('main-scroll-DOWN').should('exist');
 });


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
After the Vue3 upgrade the `useScroll` composable created a inconsistency in the scroll direction prop in the `useScroll` instance and the scroll direction prop in the Vuex store.

## Explanation:

When scrolling, the data in `useScroll` is updated via the `storeScrollData` method, which updates values on `currentPosition` and `clientHeight`. For the first scroll event, the behavior is described below:

In **Vue2** the running order was:

1. Callback of `clientHeight` watch, which blocks updates on scroll direction because `isClientHeightChanging` is set to `true`.
2. Callback of `currentPosition` watch, skipped due to `isClientHeightChanging` = true.

But in **Vue3** the running order is:

1. Callback of `currentPosition` watch, because in the running order of `storeScrollData` currentPosition is mutated first. Then `isClientHeightChanging` is false, so it mutates `scrollDirection`
2. Callback of `clientHeight` watch, which blocks updates on scroll direction because `isClientHeightChanging` is set to `true`.
3. Callback of `scrollDirection` watch, skipped due to `isClientHeightChanging` = true. So the event is not emitted and the store keeps the original value not the current one.

## Consequences:

In the x-archetype, it is used the `useHasScrollPastThreshold` composable which relies on the scroll direction of the store. It is used in this case to collapse the subheader of the desktop and mobile layouts. Those subheaders were not hidden due to this bug.

## How it is fixed:

Changing the running order of the `storeScrollData` mutating first the `clientHeight`, it is ensured that the data is consistent between the composable and the store.

**Before:**

https://github.com/user-attachments/assets/6c3605df-97cf-4188-b07d-104c4f8ab1df

**After:**

https://github.com/user-attachments/assets/82cefb86-5d9a-4211-b857-0e7423b736a1

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [X] Other. Specify: https://github.com/empathyco/x/tree/vue3-update-rc

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [X] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [X] I have performed a **self-review** on my own code.
- [X] I have **commented** my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [X] My changes generate **no new warnings**.
- [X] I have added **tests** that prove my fix is effective or that my feature works.
- [X] New and existing **unit tests pass locally** with my changes.
