### PR TITLE
fix: avoid breaking ssr builds

### DIFF
--- a/packages/x-components/build/tools/inject-css.js
+++ b/packages/x-components/build/tools/inject-css.js
@@ -5,9 +5,11 @@
  * @params css - CSS code.
  */
 function injectCss(css) {
-  const el = document.createElement('style');
-  el.textContent = css;
-  document.head.appendChild(el);
+  if (document) {
+    const el = document.createElement('style');
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
 }
 
 export default injectCss;


### PR DESCRIPTION
This PR enhances our default css injector to prevent it from breaking builds in SSR mode where the document object might not be available