### PR TITLE
build: use vue latest version as peer dependency

### DIFF
--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -85,7 +85,7 @@
     "vue-global-events": "~3.0.1"
   },
   "peerDependencies": {
-    "vue": "~3.4.31",
+    "vue": "^3.5.12",
     "vuex": "4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request includes a minor update to the `packages/x-components/package.json` file to ensure compatibility with the latest version of Vue.

Dependencies update:

* [`packages/x-components/package.json`](diffhunk://#diff-a01ad56f8bacdc7b865e92dfbad7968f847e98320952533ce6c6db4b479deec0L88-R88): Updated the `vue` peer dependency from version `~3.4.31` to `^3.5.12` to support newer versions of Vue.