### PR TITLE
feat(x-installer): extend domElement type to allow ShadowRoot

### DIFF
--- a/packages/x-components/src/x-installer/x-installer/types.ts
+++ b/packages/x-components/src/x-installer/x-installer/types.ts
@@ -30,7 +30,11 @@ export interface InstallXOptions<API extends XAPI = XAPI> extends XPluginOptions
    * An Element | string | function to indicate the HTML element that will contain the Vue
    * application. If it isn't passed, the {@link XInstaller} will create the target element.
    */
-  domElement?: Element | string | ((snippetConfig: NormalisedSnippetConfig) => Element | string);
+  domElement?:
+    | Element
+    | ShadowRoot
+    | string
+    | ((snippetConfig: NormalisedSnippetConfig) => Element | ShadowRoot | string);
   /**
    * The XPlugin which will be installed. If not passed, an instance of {@link XPlugin} will be
    * installed.

--- a/packages/x-components/src/x-installer/x-installer/x-installer.ts
+++ b/packages/x-components/src/x-installer/x-installer/x-installer.ts
@@ -289,13 +289,13 @@ export class XInstaller {
    * returns an Element or element selector to use.
    * If it is not present, a new <div> Element is created and appended to the body.
    *
-   * @param domElement - {@link InstallXOptions.domElement | Element, string or function} Used
-   * to mount the Vue Application.
+   * @param domElement - {@link InstallXOptions.domElement} Element, ShadowRoot, string or function
+   * used to mount the Vue Application.
    *
-   * @returns The Element to use as mounting target for the Vue Application.
+   * @returns The Element or ShadowRoot to use as mounting target for the Vue Application.
    * @internal
    */
-  protected getMountingTarget(domElement?: InstallXOptions['domElement']): Element {
+  protected getMountingTarget(domElement?: InstallXOptions['domElement']): Element | ShadowRoot {
     if (isFunction(domElement)) {
       domElement = domElement(this.snippetConfig!);
     }


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.

## Motivation and context
Vue 3 mount diferent that vue 2. [Mounted application does not replace the element](https://v3-migration.vuejs.org/breaking-changes/mount-changes#mounted-application-does-not-replace-the-element) so we should allow `shadowRoot` to avoid unnecessary wrappers.

Vue2:
<img width="471" alt="image" src="https://github.com/user-attachments/assets/a4e7ac20-3514-4cb9-9a9e-cb9c139f9a51">

Vue3:
![image](https://github.com/user-attachments/assets/163de6e6-35bc-4708-be16-9f805c2b19f5)
![image](https://github.com/user-attachments/assets/5b19906a-f304-4289-947f-e7d5d46388f6)

Current vue3 archetype
![image](https://github.com/user-attachments/assets/52265e6d-2747-496d-aa23-fcec88b537de)

To fix this, lets start fixing the types to allow shadow root as `domElement`.


- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
