### PR TITLE
feat: make reference selector reactive

### DIFF
--- a/packages/x-components/src/components/modals/base-modal.vue
+++ b/packages/x-components/src/components/modals/base-modal.vue
@@ -97,7 +97,7 @@
       /** Boolean to delay the leave animation until it has completed. */
       const isWaitingForLeave = ref(false);
       /** The reference element to use to find the modal's position. */
-      let referenceElement: HTMLElement;
+      let referenceElement: HTMLElement | undefined;
 
       /** Disables the scroll of both the body and the window. */
       function disableScroll() {
@@ -211,13 +211,24 @@
 
         resizeObserver = new ResizeObserver(debouncedUpdatePosition);
 
-        if (props.referenceSelector) {
-          const element = document.querySelector(props.referenceSelector) as HTMLElement;
-          if (element) {
-            referenceElement = element;
-            resizeObserver.observe(element);
-          }
-        }
+        watch(
+          () => props.referenceSelector,
+          () => {
+            resizeObserver.disconnect();
+
+            if (props.referenceSelector) {
+              const element = document.querySelector(props.referenceSelector) as HTMLElement;
+              if (element) {
+                referenceElement = element;
+                resizeObserver.observe(element);
+              }
+            } else {
+              referenceElement = undefined;
+              debouncedUpdatePosition();
+            }
+          },
+          { immediate: true }
+        );
       });
 
       onBeforeUnmount(() => {

--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -110,7 +110,7 @@
         </label>
       </li>
     </ul>
-    <MainModal :animation="modalAnimation">
+    <MainModal :animation="modalAnimation" :referenceSelector="referenceSelector">
       <MultiColumnMaxWidthLayout class="x-bg-neutral-0">
         <template #header-middle>
           <div
@@ -518,7 +518,7 @@
 
 <script lang="ts">
   /* eslint-disable max-len */
-  import { computed, ComputedRef, defineComponent, provide } from 'vue';
+  import { computed, ComputedRef, defineComponent, provide, ref } from 'vue';
   import { RelatedPrompt } from '@empathyco/x-types';
   import { animateClipPath } from '../../components/animations/animate-clip-path/animate-clip-path.factory';
   import StaggeredFadeAndSlide from '../../components/animations/staggered-fade-and-slide.vue';
@@ -675,6 +675,7 @@
       const selectedColumns = 4;
       const sortValues = ['', 'price asc', 'price desc'];
       const isAnyQueryLoadedInPreview = useQueriesPreview().isAnyQueryLoadedInPreview;
+      const referenceSelector = ref();
 
       const scrollData = useState('scroll', ['data']).data;
       const mainScrollDirection = computed(() => scrollData.value['main-scroll']?.direction);
@@ -773,7 +774,8 @@
         x,
         mainScrollDirection,
         relatedPromptsQueriesPreviewInfo,
-        selectedPrompt
+        selectedPrompt,
+        referenceSelector
       };
     }
   });


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Include the possibility to update the `referenceSelector`, which determines the position of the empathy modal.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
