### PR TITLE
fix(extra-params): give more priority to values prop over params state in the ExtraParamsProvided payload

### DIFF
--- a/packages/x-components/src/x-modules/extra-params/components/__tests__/extra-params.spec.ts
+++ b/packages/x-components/src/x-modules/extra-params/components/__tests__/extra-params.spec.ts
@@ -6,7 +6,7 @@ import { getXComponentXModuleName, isXComponent } from '../../../../components';
 import { XPlugin } from '../../../../plugins';
 import { WirePayload } from '../../../../wiring';
 import ExtraParams from '../extra-params.vue';
-import { useState } from '../../../../composables/index';
+import { useState } from '../../../../composables';
 
 jest.mock('../../../../composables/use-state', () => ({
   useState: jest.fn().mockReturnValue({

--- a/packages/x-components/src/x-modules/extra-params/components/__tests__/extra-params.spec.ts
+++ b/packages/x-components/src/x-modules/extra-params/components/__tests__/extra-params.spec.ts
@@ -1,35 +1,60 @@
 import { Dictionary } from '@empathyco/x-utils';
-import { mount, VueWrapper } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
 import { installNewXPlugin } from '../../../../__tests__/utils';
 import { getXComponentXModuleName, isXComponent } from '../../../../components';
 import { XPlugin } from '../../../../plugins';
 import { WirePayload } from '../../../../wiring';
-import { extraParamsXModule } from '../../x-module';
 import ExtraParams from '../extra-params.vue';
+import { useState } from '../../../../composables/index';
+
+jest.mock('../../../../composables/use-state', () => ({
+  useState: jest.fn().mockReturnValue({
+    params: ref({})
+  })
+}));
+
+function renderExtraParams(values: Dictionary<unknown>) {
+  const wrapper = mount(ExtraParams, {
+    props: { values },
+    global: { plugins: [installNewXPlugin()] }
+  });
+
+  return { wrapper };
+}
 
 describe('testing extra params component', () => {
-  function renderExtraParams(values: Dictionary<unknown>): RenderExtraParamsApi {
-    XPlugin.resetInstance();
-    XPlugin.registerXModule(extraParamsXModule);
-
-    const wrapper = mount(ExtraParams, {
-      props: {
-        values
-      },
-      global: {
-        plugins: [installNewXPlugin()]
-      }
-    });
-
-    return {
-      wrapper
-    };
-  }
-
   it('is an XComponent which has an XModule', () => {
     const { wrapper } = renderExtraParams({ warehouse: 1234 });
+
     expect(isXComponent(wrapper.vm)).toEqual(true);
     expect(getXComponentXModuleName(wrapper.vm)).toEqual('extraParams');
+  });
+
+  it('emits the ExtraParamsProvided event on init with params state and props values', () => {
+    // Set extra-params in the store to check values prop has more priority in the merge
+    (useState as jest.Mock).mockReturnValueOnce({
+      params: ref({ area: 'gijon', currency: 'EUR' })
+    });
+    renderExtraParams({ area: 'uk', lang: 'en' });
+
+    const extraParamsInitializedCallback = jest.fn();
+    XPlugin.bus.on('ExtraParamsInitialized', true).subscribe(extraParamsInitializedCallback);
+    expect(extraParamsInitializedCallback).toHaveBeenCalledTimes(1);
+    expect(extraParamsInitializedCallback).toHaveBeenCalledWith<[WirePayload<Dictionary<unknown>>]>(
+      {
+        eventPayload: { area: 'uk', lang: 'en' },
+        metadata: { moduleName: 'extraParams', location: 'none', replaceable: true }
+      }
+    );
+
+    const extraParamsProvidedCallback = jest.fn();
+    XPlugin.bus.on('ExtraParamsProvided', true).subscribe(extraParamsProvidedCallback);
+    expect(extraParamsProvidedCallback).toHaveBeenCalledTimes(1);
+    expect(extraParamsProvidedCallback).toHaveBeenCalledWith<[WirePayload<Dictionary<unknown>>]>({
+      eventPayload: { area: 'uk', lang: 'en', currency: 'EUR' },
+      metadata: { moduleName: 'extraParams', location: 'none', replaceable: true }
+    });
   });
 
   it('emits the ExtraParamsProvided event when the values change', async () => {
@@ -53,8 +78,3 @@ describe('testing extra params component', () => {
     expect(extraParamsProvidedCallback).toHaveBeenCalledTimes(2);
   });
 });
-
-interface RenderExtraParamsApi {
-  /** The wrapper for the extra params component. */
-  wrapper: VueWrapper;
-}

--- a/packages/x-components/src/x-modules/extra-params/components/extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/extra-params.vue
@@ -26,7 +26,7 @@
       const $x = use$x();
 
       $x.emit('ExtraParamsInitialized', { ...props.values });
-      $x.emit('ExtraParamsProvided', { ...props.values, ...params.value });
+      $x.emit('ExtraParamsProvided', { ...params.value, ...props.values });
 
       watch(
         () => props.values,


### PR DESCRIPTION
# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
This PR gives more priority to the `values` prop over `params` state in the `ExtraParamsProvided` payload

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

MotiveMarket renders the `ExtraParams` component with each area changing, passing a new `values` prop each time. The store state has already `params` of the previous `area`, so emits `ExtraParamsProvided` XEvent with old `area` because in the merge, `params` from the state has more priority.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify: