### PR TITLE
refactor(empathize): OIM-747 - Remove the empty predictive box when we don't have content

### DIFF
--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, PropType, ref } from 'vue';
+  import { defineComponent, PropType, ref, computed } from 'vue';
   import { NoAnimation } from '../../../components';
   import { use$x, useDebounce } from '../../../composables';
   import { AnimationProp } from '../../../types';
@@ -61,7 +61,7 @@
       const empathizeRef = ref<HTMLDivElement>();
 
       const isOpen = ref(false);
-      const hasContent = ref(!!empathizeRef.value?.children.length);
+      const hasContent = computed(() => !!empathizeRef.value?.children?.length);
 
       /**
        * Changes the state of {@link Empathize.isOpen} assigning to it the value of `newOpen`
@@ -84,7 +84,6 @@
        * element.
        */
       function open() {
-        hasContent.value = !!empathizeRef.value?.children.length;
         if (hasContent.value) {
           changeOpen(true);
         }


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->
The actual definion check the children when is opened
But doesn't detect if the information displayed as children is removed, and the empathize remains opened

WIth the computed implemented, the reactivity works and the empathize hide/show with the changes displayed

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
