### PR TITLE
feat: refactor RPs types and send toolingDisplayClick when a prompt is selected

### DIFF
--- a/packages/x-adapter-platform/src/endpoint-adapters/related-prompts.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/related-prompts.endpoint-adapter.ts
@@ -1,6 +1,8 @@
-import { endpointAdapterFactory } from '@empathyco/x-adapter';
+import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter';
 import { RelatedPromptsRequest, RelatedPromptsResponse } from '@empathyco/x-types';
 import { relatedPromptsResponseMapper } from '../mappers/responses/related-prompts-response.mapper';
+import { relatedPromptsRequestMapper } from '../mappers/index';
+import { getBeaconServiceUrl } from './utils';
 
 /**
  * Default adapter for the related prompt endpoint.
@@ -12,8 +14,9 @@ export const relatedPromptsEndpointAdapter = endpointAdapterFactory<
   RelatedPromptsRequest,
   RelatedPromptsResponse
 >({
-  endpoint: 'https://beacon-api.internal.test.empathy.co/relatedprompts/empathy?',
-  requestMapper: ({ query }) => ({ query, lang: 'es' }),
+  endpoint: from =>
+    interpolate(`${getBeaconServiceUrl(from)}/relatedprompts/{extraParams.instance}`, from),
+  requestMapper: relatedPromptsRequestMapper,
   responseMapper: relatedPromptsResponseMapper,
   defaultRequestOptions: {
     id: 'related-prompts',

--- a/packages/x-adapter-platform/src/endpoint-adapters/related-prompts.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/related-prompts.endpoint-adapter.ts
@@ -1,8 +1,6 @@
-import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter';
+import { endpointAdapterFactory } from '@empathyco/x-adapter';
 import { RelatedPromptsRequest, RelatedPromptsResponse } from '@empathyco/x-types';
 import { relatedPromptsResponseMapper } from '../mappers/responses/related-prompts-response.mapper';
-import { relatedPromptsRequestMapper } from '../mappers/index';
-import { getBeaconServiceUrl } from './utils';
 
 /**
  * Default adapter for the related prompt endpoint.
@@ -14,9 +12,8 @@ export const relatedPromptsEndpointAdapter = endpointAdapterFactory<
   RelatedPromptsRequest,
   RelatedPromptsResponse
 >({
-  endpoint: from =>
-    interpolate(`${getBeaconServiceUrl(from)}/relatedprompts/{extraParams.instance}`, from),
-  requestMapper: relatedPromptsRequestMapper,
+  endpoint: 'https://beacon-api.internal.test.empathy.co/relatedprompts/empathy?',
+  requestMapper: ({ query }) => ({ query, lang: 'es' }),
   responseMapper: relatedPromptsResponseMapper,
   defaultRequestOptions: {
     id: 'related-prompts',

--- a/packages/x-adapter-platform/src/schemas/models/related-prompt.schema.ts
+++ b/packages/x-adapter-platform/src/schemas/models/related-prompt.schema.ts
@@ -46,6 +46,7 @@ export const relatedPromptSchema = createMutableSchema<PlatformRelatedPrompt, Re
   toolingDisplayTagging: ({ tagging }) => getTaggingInfoFromUrl(tagging.toolingDisplay),
   tagging: {
     toolingDisplayTagging: ({ tagging }) => getTaggingInfoFromUrl(tagging.toolingDisplay),
+    toolingDisplayClickTagging: ({ tagging }) => getTaggingInfoFromUrl(tagging.toolingDisplayClick),
     nextQueriesTagging: {
       $path: 'nextQueries',
       $subSchema: nextQueriesRelatedPromptsSchema,

--- a/packages/x-adapter-platform/src/types/models/related-prompt.model.ts
+++ b/packages/x-adapter-platform/src/types/models/related-prompt.model.ts
@@ -19,6 +19,7 @@ export interface PlatformRelatedPrompt {
  */
 export interface PlatformRelatedPromptTagging {
   toolingDisplay: string;
+  toolingDisplayClick: string;
   nextQueries: Dictionary<PlatformRelatedPromptNextQueriesTagging>;
 }
 

--- a/packages/x-components/src/components/display-click-provider.vue
+++ b/packages/x-components/src/components/display-click-provider.vue
@@ -5,10 +5,15 @@
   import { computed, defineComponent, provide } from 'vue';
   import { use$x } from '../composables/index';
   import { DisplayWireMetadata } from '../wiring/index';
+  import type { ResultFeature } from '../types/index';
 
   export default defineComponent({
     name: 'DisplayClickProvider',
     props: {
+      resultFeature: {
+        type: String as PropType<ResultFeature>,
+        required: true
+      },
       ignoreResultClickEvent: {
         type: Boolean,
         default: false
@@ -34,6 +39,7 @@
 
       const displayClickMetadata = computed<Partial<DisplayWireMetadata>>(() => ({
         displayOriginalQuery: x.query.search,
+        feature: props.resultFeature,
         queryTagging: props.queryTagging,
         toolingTagging: props.toolingDisplayTagging,
         toolingAdd2CartTagging: props.toolingAdd2CartTagging

--- a/packages/x-components/src/x-modules/related-prompts/components/related-prompts-tag-list.vue
+++ b/packages/x-components/src/x-modules/related-prompts/components/related-prompts-tag-list.vue
@@ -260,7 +260,10 @@
           });
         }
 
-        x.emit('UserSelectedARelatedPrompt', selectedIndex);
+        x.emit('UserSelectedARelatedPrompt', selectedIndex, {
+          relatedPrompt: relatedPrompts.value[selectedIndex],
+          selectedPrompt: selectedPromptIndex.value
+        });
       };
 
       const onBeforeEnter = (el: Element) => {

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -1,4 +1,11 @@
-import { Result, SemanticQuery, Taggable, Tagging, TaggingRequest } from '@empathyco/x-types';
+import {
+  RelatedPrompt,
+  Result,
+  SemanticQuery,
+  Taggable,
+  Tagging,
+  TaggingRequest
+} from '@empathyco/x-types';
 import { DefaultSessionService } from '@empathyco/x-utils';
 import {
   namespacedWireCommit,
@@ -189,6 +196,14 @@ export const trackToolingDisplayClickedWire = createTrackToolingDisplayWire();
 export const trackToolingAdd2CartWire = createTrackToolingAdd2CartWire();
 
 /**
+ * Performs a track of a clicked related prompt.
+ *
+ * @public
+ */
+export const trackRelatedPromptToolingDisplayClickWire =
+  createTrackRelatedPromptToolingDisplayClickWire();
+
+/**
  * Performs a track of a display element appearing.
  *
  * @public
@@ -314,7 +329,7 @@ export function createTrackToolingDisplayWire(): Wire<Taggable> {
 }
 
 /**
- * Factory helper to create a wire for the track of the tooling display click.
+ * Factory helper to create a wire for the track of the tooling display add to cart.
  *
  * @returns A new wire for the tooling display add to cart of the taggable element.
  *
@@ -331,6 +346,30 @@ export function createTrackToolingAdd2CartWire(): Wire<Taggable> {
       return taggingInfo;
     }),
     ({ metadata }) => !!metadata?.toolingAdd2CartTagging
+  );
+}
+
+/**
+ * Factory helper to create a wire for the track of the tooling display click in a related prompt.
+ *
+ * @returns A new wire for the tooling display click of the taggable element.
+ *
+ * @public
+ */
+export function createTrackRelatedPromptToolingDisplayClickWire() {
+  return filter(
+    wireDispatch('track', ({ metadata }) => {
+      const relatedPrompt = metadata.relatedPrompt as RelatedPrompt;
+      const taggingInfo: TaggingRequest = relatedPrompt.tagging
+        ?.toolingDisplayClickTagging as TaggingRequest;
+
+      taggingInfo.params.productId = 'EXPAND';
+      taggingInfo.params.title = relatedPrompt.suggestionText;
+      taggingInfo.params.url = 'none';
+
+      return taggingInfo;
+    }),
+    ({ metadata }) => metadata?.selectedPrompt === -1
   );
 }
 
@@ -410,5 +449,8 @@ export const taggingWiring = createWiring({
   },
   UserClickedARelatedPromptAdd2Cart: {
     trackToolingAdd2CartWire
+  },
+  UserSelectedARelatedPrompt: {
+    trackRelatedPromptToolingDisplayClickWire
   }
 });

--- a/packages/x-types/src/query-signals/related-prompt.model.ts
+++ b/packages/x-types/src/query-signals/related-prompt.model.ts
@@ -8,7 +8,7 @@ import { TaggingRequest } from '../request/index';
  */
 export interface RelatedPrompt extends NamedModel<'RelatedPrompt'> {
   /** The next queries related to the prompt. */
-  relatedPromptNextQueries: RelatedPromptNextQuery[];
+  relatedPromptNextQueries?: RelatedPromptNextQuery[];
   /** The queries of the next queries related to the prompt. */
   nextQueries: string[];
   /** The prompt. */
@@ -20,6 +20,7 @@ export interface RelatedPrompt extends NamedModel<'RelatedPrompt'> {
   /** Related prompt tagging. */
   tagging?: {
     toolingDisplayTagging?: TaggingRequest;
+    toolingDisplayClickTagging?: TaggingRequest;
     nextQueriesTagging?: RelatedPromptNextQuery[];
   };
 }

--- a/packages/x-types/src/schemas/related-prompt.schema.ts
+++ b/packages/x-types/src/schemas/related-prompt.schema.ts
@@ -13,6 +13,7 @@ export const RelatedPromptSchema: RelatedPrompt = {
   toolingDisplayTagging: TaggingRequestSchema,
   tagging: {
     toolingDisplayTagging: TaggingRequestSchema,
+    toolingDisplayClickTagging: TaggingRequestSchema,
     nextQueriesTagging: expect.any(Array)
   }
 };


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
The click on a related prompt wants to be tracked, so I have modified the related-prompts types to save the new tagging event and I have also modified the wiring of the tagging to listen to the `UserSelectedARelatedPrompt` event and track the click on the prompt. 

As a prompt is not a result, to track this click, we are going to use a "fake" click, I mean, use the toolingDisplayClick url/structure, and instead of replacing the `productId`, `title` and `url` fields with the result information, we are going to use values previous discuss with the data team.

This is the contract: 
```
      taggingInfo.params.productId = 'EXPAND';
      taggingInfo.params.title = relatedPrompt.suggestionText;
      taggingInfo.params.url = 'none';
```

_**NOTE**: Before merging, rollback `related-prompts.endpoint-adapter.ts` file._

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
