### PR TITLE
fix(url-handler): replace '+' with '%20' in url parameters only

### DIFF
--- a/packages/x-components/src/x-modules/url/components/url-handler.vue
+++ b/packages/x-components/src/x-modules/url/components/url-handler.vue
@@ -173,7 +173,8 @@
           deleteUrlParameters(newUrl);
           setUrlParameters(newUrl, newUrlParams);
 
-          newUrl.href = newUrl.href.replace(/\+/g, '%20');
+          // Normalize '+' characters into '%20' for spaces in url params.
+          newUrl.search = newUrl.search.replace(/\+/g, '%20');
 
           if (newUrl.href !== window.location.href) {
             historyMethod({ ...window.history.state }, document.title, newUrl.href);


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template

Fix url-handler logic to replace '+' with '%20' in query parameters only. Before was in full url.

Current `url-handler` is too invasive and modifies the full url, for example:
https://coallagourmet.com/a+b/ → https://coallagourmet.com/a%20b/

Relax a bit to modify only all the query params (not only ours 😢) instead of the full URL.

## Motivation and context

Client affected by the bug: https://searchbroker.atlassian.net/browse/RST-3053

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
