### PR TITLE
feat: store result info on add to cart events to be able to track checkout

### DIFF
--- a/packages/x-components/src/x-modules/tagging/components/__tests__/tagging.spec.ts
+++ b/packages/x-components/src/x-modules/tagging/components/__tests__/tagging.spec.ts
@@ -140,7 +140,7 @@ describe('testing Tagging component', () => {
     });
   });
 
-  it('emits TaggingConfigProvided when clicked result storage ttl is set using the prop', () => {
+  it('emits TaggingConfigProvided when storage ttl is set using the prop', () => {
     const { onTaggingConfigProvided } = renderTagging({ storageTTLMs: 150 });
 
     expect(onTaggingConfigProvided).toHaveBeenCalledTimes(1);
@@ -153,7 +153,7 @@ describe('testing Tagging component', () => {
     });
   });
 
-  it('emits TaggingConfigProvided when clicked result storage key is set using the prop', () => {
+  it('emits TaggingConfigProvided when storage key is set using the prop', () => {
     const { onTaggingConfigProvided } = renderTagging({ storageKey: 'id' });
 
     expect(onTaggingConfigProvided).toHaveBeenCalledTimes(1);
@@ -241,7 +241,7 @@ interface RenderTaggingOptions {
   sessionTTLMs?: number;
   /** The template to be rendered. */
   template?: string;
-  /** Time in milliseconds to keep the information for a result clicked by the user. */
+  /** Time in milliseconds to keep the information for a result. */
   storageTTLMs?: number;
   /** The id ot use for storing the information. */
   storageKey?: string;

--- a/packages/x-components/src/x-modules/tagging/components/__tests__/tagging.spec.ts
+++ b/packages/x-components/src/x-modules/tagging/components/__tests__/tagging.spec.ts
@@ -14,15 +14,15 @@ function renderTagging({
                 :consent="consent"
                 :sessionTTLMs="sessionTTLMs"
                 :queryTaggingDebounceMs="queryTaggingDebounceMs"
-                :clickedResultStorageTTLMs="clickedResultStorageTTLMs"
-                :clickedResultStorageKey="clickedResultStorageKey"
+                :storageTTLMs="storageTTLMs"
+                :storageKey="storageKey"
               />`,
   consent,
   sessionTTLMs,
   queryTaggingDebounceMs,
   snippetConsent,
-  clickedResultStorageTTLMs,
-  clickedResultStorageKey,
+  storageTTLMs,
+  storageKey,
   productId
 }: RenderTaggingOptions = {}) {
   const snippetConfig = reactive({
@@ -41,8 +41,8 @@ function renderTagging({
         'queryTaggingDebounceMs',
         'sessionTTLMs',
         'snippetConfig',
-        'clickedResultStorageTTLMs',
-        'clickedResultStorageKey'
+        'storageTTLMs',
+        'storageKey'
       ],
       template
     },
@@ -56,8 +56,8 @@ function renderTagging({
         queryTaggingDebounceMs,
         sessionTTLMs,
         snippetConfig,
-        clickedResultStorageTTLMs,
-        clickedResultStorageKey
+        storageTTLMs,
+        storageKey
       }
     }
   );
@@ -86,8 +86,8 @@ function renderTagging({
 }
 
 const defaultTaggingConfig: Partial<TaggingConfig> = {
-  clickedResultStorageTTLMs: 30000,
-  clickedResultStorageKey: 'url',
+  storageTTLMs: 30000,
+  storageKey: 'url',
   queryTaggingDebounceMs: 2000
 };
 
@@ -141,26 +141,26 @@ describe('testing Tagging component', () => {
   });
 
   it('emits TaggingConfigProvided when clicked result storage ttl is set using the prop', () => {
-    const { onTaggingConfigProvided } = renderTagging({ clickedResultStorageTTLMs: 150 });
+    const { onTaggingConfigProvided } = renderTagging({ storageTTLMs: 150 });
 
     expect(onTaggingConfigProvided).toHaveBeenCalledTimes(1);
     expect(onTaggingConfigProvided).toHaveBeenCalledWith({
       eventPayload: {
         ...defaultTaggingConfig,
-        clickedResultStorageTTLMs: 150
+        storageTTLMs: 150
       },
       metadata: stubTagginMetadata
     });
   });
 
   it('emits TaggingConfigProvided when clicked result storage key is set using the prop', () => {
-    const { onTaggingConfigProvided } = renderTagging({ clickedResultStorageKey: 'id' });
+    const { onTaggingConfigProvided } = renderTagging({ storageKey: 'id' });
 
     expect(onTaggingConfigProvided).toHaveBeenCalledTimes(1);
     expect(onTaggingConfigProvided).toHaveBeenCalledWith({
       eventPayload: {
         ...defaultTaggingConfig,
-        clickedResultStorageKey: 'id'
+        storageKey: 'id'
       },
       metadata: stubTagginMetadata
     });
@@ -169,8 +169,8 @@ describe('testing Tagging component', () => {
   // eslint-disable-next-line max-len
   it('emits TaggingConfigProvided only once when multiple tagging config are set using the props', () => {
     const { onTaggingConfigProvided } = renderTagging({
-      clickedResultStorageKey: 'id',
-      clickedResultStorageTTLMs: 150,
+      storageKey: 'id',
+      storageTTLMs: 150,
       queryTaggingDebounceMs: 150,
       sessionTTLMs: 100
     });
@@ -178,8 +178,8 @@ describe('testing Tagging component', () => {
     expect(onTaggingConfigProvided).toHaveBeenCalledTimes(1);
     expect(onTaggingConfigProvided).toHaveBeenCalledWith({
       eventPayload: {
-        clickedResultStorageKey: 'id',
-        clickedResultStorageTTLMs: 150,
+        storageKey: 'id',
+        storageTTLMs: 150,
         queryTaggingDebounceMs: 150,
         sessionTTLMs: 100
       },
@@ -242,9 +242,9 @@ interface RenderTaggingOptions {
   /** The template to be rendered. */
   template?: string;
   /** Time in milliseconds to keep the information for a result clicked by the user. */
-  clickedResultStorageTTLMs?: number;
+  storageTTLMs?: number;
   /** The id ot use for storing the information. */
-  clickedResultStorageKey?: string;
+  storageKey?: string;
   /** The id for a product. */
   productId?: string;
 }

--- a/packages/x-components/src/x-modules/tagging/components/tagging.vue
+++ b/packages/x-components/src/x-modules/tagging/components/tagging.vue
@@ -18,7 +18,7 @@
       /**
        * The TTL in milliseconds for storing the clicked result info.
        */
-      clickedResultStorageTTLMs: {
+      storageTTLMs: {
         type: Number,
         default: 30000
       },
@@ -26,7 +26,7 @@
        * The Object key of the {@link @empathyco/x-types#Result} clicked by the user
        * that will be used as id for the storage. By default, the Result url will be used.
        */
-      clickedResultStorageKey: {
+      storageKey: {
         type: String,
         default: 'url'
       },
@@ -75,8 +75,8 @@
         return {
           queryTaggingDebounceMs: props.queryTaggingDebounceMs,
           sessionTTLMs: props.sessionTTLMs as number,
-          clickedResultStorageTTLMs: props.clickedResultStorageTTLMs,
-          clickedResultStorageKey: props.clickedResultStorageKey
+          storageTTLMs: props.storageTTLMs,
+          storageKey: props.storageKey
         };
       });
 
@@ -144,13 +144,12 @@ doesn't render elements to the DOM.
 
 In this example, the `Tagging` component will emit `ConsentProvided` with payload false by default
 if the consent is not provided, the `TaggingConfigProvided` event will be emitted only if the props
-`queryTaggingDebounceMs`, `sessionDurationMs`, `clickedResultStorageTTLMs` or
-`clickedResultStorageKey`are defined.
+`queryTaggingDebounceMs`, `sessionDurationMs`, `storageTTLMs` or `storageKey`are defined.
 
 Every time the user clicks a result the information for the clicked product will be stored on the
-browser during 30 seconds which is the default value for the prop `clickedResultStorageTTLMs`. To
-distinguish the storage information for the different results the product url will be used since
-`clickedResultStorageKey` default value is 'url'.
+browser during 30 seconds which is the default value for the prop `storageTTLMs`. To distinguish the
+storage information for the different results the product url will be used since `storageKey`
+default value is 'url'.
 
 ```vue
 <template>
@@ -174,7 +173,7 @@ the product id will be used as storage key.
 
 ```vue
 <template>
-  <Tagging :clickedResultStorageTTLMs="60000" :clickedResultStorageKey="'id'" />
+  <Tagging :storageTTLMs="60000" :storageKey="'id'" />
 </template>
 
 <script>

--- a/packages/x-components/src/x-modules/tagging/components/tagging.vue
+++ b/packages/x-components/src/x-modules/tagging/components/tagging.vue
@@ -16,15 +16,16 @@
     xModule: taggingXModule.name,
     props: {
       /**
-       * The TTL in milliseconds for storing the clicked result info.
+       * The TTL in milliseconds for storing the result info.
        */
       storageTTLMs: {
         type: Number,
         default: 30000
       },
       /**
-       * The Object key of the {@link @empathyco/x-types#Result} clicked by the user
-       * that will be used as id for the storage. By default, the Result url will be used.
+       * The Object key of the {@link @empathyco/x-types#Result} clicked or added to the cart by the user
+       * that will be used as id for the storage.
+       * By default, the Result url will be used.
        */
       storageKey: {
         type: String,
@@ -146,10 +147,10 @@ In this example, the `Tagging` component will emit `ConsentProvided` with payloa
 if the consent is not provided, the `TaggingConfigProvided` event will be emitted only if the props
 `queryTaggingDebounceMs`, `sessionDurationMs`, `storageTTLMs` or `storageKey`are defined.
 
-Every time the user clicks a result the information for the clicked product will be stored on the
-browser during 30 seconds which is the default value for the prop `storageTTLMs`. To distinguish the
-storage information for the different results the product url will be used since `storageKey`
-default value is 'url'.
+Every time the user clicks a result or adds a result to the cart, the information for the product
+will be stored on the browser during 30 seconds which is the default value for the prop
+`storageTTLMs`. To distinguish the storage information for the different results the product url
+will be used since `storageKey` default value is 'url'.
 
 ```vue
 <template>
@@ -168,8 +169,8 @@ default value is 'url'.
 </script>
 ```
 
-In this example, the clicked result information will be stored on the browser during 60 seconds and
-the product id will be used as storage key.
+In this example, the clicked or added to cart result information will be stored on the browser
+during 60 seconds and the product id will be used as storage key
 
 ```vue
 <template>

--- a/packages/x-components/src/x-modules/tagging/config.types.ts
+++ b/packages/x-components/src/x-modules/tagging/config.types.ts
@@ -15,7 +15,7 @@ export interface TaggingConfig {
   sessionTTLMs: number;
 
   /**
-   * Time in milliseconds to keep the information for a result clicked by the user.
+   * Time in milliseconds to keep the information for a result.
    */
   storageTTLMs: number | null;
 

--- a/packages/x-components/src/x-modules/tagging/config.types.ts
+++ b/packages/x-components/src/x-modules/tagging/config.types.ts
@@ -17,11 +17,11 @@ export interface TaggingConfig {
   /**
    * Time in milliseconds to keep the information for a result clicked by the user.
    */
-  clickedResultStorageTTLMs: number | null;
+  storageTTLMs: number | null;
 
   /**
    * Field of the {@link @empathyco/x-types#Result | result} to use as id for storing the
    * information.
    */
-  clickedResultStorageKey: string | null;
+  storageKey: string | null;
 }

--- a/packages/x-components/src/x-modules/tagging/events.types.ts
+++ b/packages/x-components/src/x-modules/tagging/events.types.ts
@@ -24,9 +24,9 @@ export interface TaggingXEvents {
    */
   PDPIsLoaded: string;
   /**
-   * ClickedResultStorageKey has been configured to use the
+   * StorageKey has been configured to use the
    * {@link @empathyco/x-types#Result | result} url.
-   * Payload: The new clickedResultStorageKey.
+   * Payload: The new storageKey.
    */
   ResultURLTrackingEnabled: string;
   /**

--- a/packages/x-components/src/x-modules/tagging/service/__tests__/external-tagging.service.spec.ts
+++ b/packages/x-components/src/x-modules/tagging/service/__tests__/external-tagging.service.spec.ts
@@ -1,7 +1,7 @@
 import { InMemoryStorageService } from '@empathyco/x-storage-service';
 import { Store } from 'vuex';
 import { mount } from '@vue/test-utils';
-import { DefaultPDPAddToCartService } from '../pdp-add-to-cart.service';
+import { DefaultExternalTaggingService } from '../external-tagging.service';
 import { XPlugin } from '../../../../plugins/index';
 import { installNewXPlugin } from '../../../../__tests__/utils';
 import { taggingXModule } from '../../x-module';
@@ -9,14 +9,14 @@ import { RootXStoreState } from '../../../../store/index';
 import { createResultStub } from '../../../../__stubs__/index';
 import { TaggingConfig } from '../../config.types';
 
-interface PDPAddToCartServiceTestAPI {
-  service: DefaultPDPAddToCartService;
+interface ExternalTaggingServiceTestAPI {
+  service: DefaultExternalTaggingService;
   localStorageService: InMemoryStorageService;
   sessionStorageService: InMemoryStorageService;
   store: Store<RootXStoreState>;
 }
 
-function preparePDPAddToCartService(): PDPAddToCartServiceTestAPI {
+function prepareExternalTaggingService(): ExternalTaggingServiceTestAPI {
   XPlugin.resetInstance();
   XPlugin.registerXModule(taggingXModule);
   const plugin = installNewXPlugin();
@@ -26,7 +26,7 @@ function preparePDPAddToCartService(): PDPAddToCartServiceTestAPI {
   const store = XPlugin.store;
   const localStorageService = new InMemoryStorageService();
   const sessionStorageService = new InMemoryStorageService();
-  const service = new DefaultPDPAddToCartService(localStorageService, sessionStorageService);
+  const service = new DefaultExternalTaggingService(localStorageService, sessionStorageService);
 
   return {
     service,
@@ -45,7 +45,7 @@ function commitTaggingConfig(
 
 describe('testing pdp add to cart', () => {
   const { service, localStorageService, sessionStorageService, store } =
-    preparePDPAddToCartService();
+    prepareExternalTaggingService();
 
   const localSetItemSpy = jest.spyOn(localStorageService, 'setItem');
   const localRemoveItemSpy = jest.spyOn(localStorageService, 'removeItem');

--- a/packages/x-components/src/x-modules/tagging/service/__tests__/external-tagging.service.spec.ts
+++ b/packages/x-components/src/x-modules/tagging/service/__tests__/external-tagging.service.spec.ts
@@ -138,6 +138,7 @@ describe('testing pdp add to cart', () => {
       service.trackAddToCart();
 
       expect(sessionGetItemSpy).toHaveBeenCalledWith(`add-to-cart-${productPathName}`);
+      expect(sessionSetItemSpy).toHaveBeenCalledWith(`checkout-${productPathName}`, result);
       expect(storeDispatchSpy).toHaveBeenCalledWith('x/tagging/track', result.tagging?.add2cart);
 
       commitTaggingConfig(store, { storageKey: 'id', storageTTLMs });
@@ -147,6 +148,7 @@ describe('testing pdp add to cart', () => {
       service.trackAddToCart(id);
 
       expect(sessionGetItemSpy).toHaveBeenCalledWith(`add-to-cart-${id}`);
+      expect(sessionSetItemSpy).toHaveBeenCalledWith(`checkout-${id}`, result);
       expect(storeDispatchSpy).toHaveBeenCalledWith('x/tagging/track', result.tagging?.add2cart);
     });
 
@@ -156,60 +158,32 @@ describe('testing pdp add to cart', () => {
       service.trackAddToCart();
 
       expect(storeDispatchSpy).not.toHaveBeenCalledWith('x/tagging/track', expect.anything());
+      expect(sessionSetItemSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('testing the add to cart actions', () => {
-    it('stores the add to cart with the id as key and ttl', () => {
+    it('stores the add to cart with the id as key', () => {
       const storageKey = 'id';
       const storageTTLMs = 30000;
       commitTaggingConfig(store, { storageKey, storageTTLMs });
 
       service.storeAddToCart(result);
-      expect(localSetItemSpy).toHaveBeenCalledWith(`checkout-${result.id}`, result, storageTTLMs);
+      expect(sessionSetItemSpy).toHaveBeenCalledWith(`checkout-${result.id}`, result);
     });
 
-    it('stores the add to cart using the url as id and ttl', () => {
+    it('stores the add to cart using the url as id', () => {
       const storageKey = 'url';
       const storageTTLMs = 30;
       commitTaggingConfig(store, { storageKey, storageTTLMs });
 
       service.storeAddToCart(result);
-      expect(localSetItemSpy).toHaveBeenCalledWith(
-        `checkout-${productPathName}`,
-        result,
-        storageTTLMs
-      );
+      expect(sessionSetItemSpy).toHaveBeenCalledWith(`checkout-${productPathName}`, result);
 
       result.url = encodedURL;
 
       service.storeAddToCart(result);
-      expect(localSetItemSpy).toHaveBeenCalledWith(
-        `checkout-${productPathName}`,
-        result,
-        storageTTLMs
-      );
-    });
-
-    it('moves the add to cart to the session service', () => {
-      const storageKey = 'id';
-      const storageTTLMs = 30000;
-      commitTaggingConfig(store, { storageKey, storageTTLMs });
-
-      service.storeAddToCart(result);
-      service.moveToSessionStorage(result.id as string);
-      let id = `checkout-${result.id}`;
-
-      expect(localRemoveItemSpy).toHaveBeenCalledWith(id);
-      expect(sessionSetItemSpy).toHaveBeenCalledWith(id, result);
-
-      commitTaggingConfig(store, { storageKey: 'url' });
-      service.storeAddToCart(result);
-      service.moveToSessionStorage();
-      id = `checkout-${productPathName}`;
-
-      expect(localRemoveItemSpy).toHaveBeenCalledWith(id);
-      expect(sessionSetItemSpy).toHaveBeenCalledWith(id, result);
+      expect(sessionSetItemSpy).toHaveBeenCalledWith(`checkout-${productPathName}`, result);
     });
   });
 });

--- a/packages/x-components/src/x-modules/tagging/service/__tests__/pdp-add-to-cart.service.spec.ts
+++ b/packages/x-components/src/x-modules/tagging/service/__tests__/pdp-add-to-cart.service.spec.ts
@@ -74,31 +74,28 @@ describe('testing pdp add to cart', () => {
 
   describe('testing the result click actions', () => {
     it('stores the result with the id as key and ttl', () => {
-      const clickedResultStorageKey = 'id';
-      const clickedResultStorageTTLMs = 30000;
-      commitTaggingConfig(store, {
-        clickedResultStorageKey,
-        clickedResultStorageTTLMs
-      });
+      const storageKey = 'id';
+      const storageTTLMs = 30000;
+      commitTaggingConfig(store, { storageKey, storageTTLMs });
 
       service.storeResultClicked(result);
       expect(localSetItemSpy).toHaveBeenCalledWith(
         `add-to-cart-${result.id}`,
         result,
-        clickedResultStorageTTLMs
+        storageTTLMs
       );
     });
 
     it('stores the result using the url as id and ttl', () => {
-      const clickedResultStorageKey = 'url';
-      const clickedResultStorageTTLMs = 30;
-      commitTaggingConfig(store, { clickedResultStorageKey, clickedResultStorageTTLMs });
+      const storageKey = 'url';
+      const storageTTLMs = 30;
+      commitTaggingConfig(store, { storageKey, storageTTLMs });
 
       service.storeResultClicked(result);
       expect(localSetItemSpy).toHaveBeenCalledWith(
         `add-to-cart-${productPathName}`,
         result,
-        clickedResultStorageTTLMs
+        storageTTLMs
       );
 
       result.url = encodedURL;
@@ -107,14 +104,14 @@ describe('testing pdp add to cart', () => {
       expect(localSetItemSpy).toHaveBeenCalledWith(
         `add-to-cart-${productPathName}`,
         result,
-        clickedResultStorageTTLMs
+        storageTTLMs
       );
     });
 
     it('moves the result to the session service', () => {
-      const clickedResultStorageKey = 'id';
-      const clickedResultStorageTTLMs = 30000;
-      commitTaggingConfig(store, { clickedResultStorageKey, clickedResultStorageTTLMs });
+      const storageKey = 'id';
+      const storageTTLMs = 30000;
+      commitTaggingConfig(store, { storageKey, storageTTLMs });
 
       service.storeResultClicked(result);
       service.moveToSessionStorage(result.id as string);
@@ -123,7 +120,7 @@ describe('testing pdp add to cart', () => {
       expect(localRemoveItemSpy).toHaveBeenCalledWith(id);
       expect(sessionSetItemSpy).toHaveBeenCalledWith(id, result);
 
-      commitTaggingConfig(store, { clickedResultStorageKey: 'url' });
+      commitTaggingConfig(store, { storageKey: 'url' });
       service.storeResultClicked(result);
       service.moveToSessionStorage();
       id = `add-to-cart-${productPathName}`;
@@ -133,9 +130,9 @@ describe('testing pdp add to cart', () => {
     });
 
     it('dispatches the add to track tagging', () => {
-      const clickedResultStorageKey = 'url';
-      const clickedResultStorageTTLMs = 30000;
-      commitTaggingConfig(store, { clickedResultStorageKey, clickedResultStorageTTLMs });
+      const storageKey = 'url';
+      const storageTTLMs = 30000;
+      commitTaggingConfig(store, { storageKey, storageTTLMs });
       service.storeResultClicked(result);
       service.moveToSessionStorage();
       service.trackAddToCart();
@@ -143,7 +140,7 @@ describe('testing pdp add to cart', () => {
       expect(sessionGetItemSpy).toHaveBeenCalledWith(`add-to-cart-${productPathName}`);
       expect(storeDispatchSpy).toHaveBeenCalledWith('x/tagging/track', result.tagging?.add2cart);
 
-      commitTaggingConfig(store, { clickedResultStorageKey: 'id', clickedResultStorageTTLMs });
+      commitTaggingConfig(store, { storageKey: 'id', storageTTLMs });
       service.storeResultClicked(result);
       const id = result.id as string;
       service.moveToSessionStorage(id);
@@ -164,31 +161,24 @@ describe('testing pdp add to cart', () => {
 
   describe('testing the add to cart actions', () => {
     it('stores the add to cart with the id as key and ttl', () => {
-      const clickedResultStorageKey = 'id';
-      const clickedResultStorageTTLMs = 30000;
-      commitTaggingConfig(store, {
-        clickedResultStorageKey,
-        clickedResultStorageTTLMs
-      });
+      const storageKey = 'id';
+      const storageTTLMs = 30000;
+      commitTaggingConfig(store, { storageKey, storageTTLMs });
 
       service.storeAddToCart(result);
-      expect(localSetItemSpy).toHaveBeenCalledWith(
-        `checkout-${result.id}`,
-        result,
-        clickedResultStorageTTLMs
-      );
+      expect(localSetItemSpy).toHaveBeenCalledWith(`checkout-${result.id}`, result, storageTTLMs);
     });
 
     it('stores the add to cart using the url as id and ttl', () => {
-      const clickedResultStorageKey = 'url';
-      const clickedResultStorageTTLMs = 30;
-      commitTaggingConfig(store, { clickedResultStorageKey, clickedResultStorageTTLMs });
+      const storageKey = 'url';
+      const storageTTLMs = 30;
+      commitTaggingConfig(store, { storageKey, storageTTLMs });
 
       service.storeAddToCart(result);
       expect(localSetItemSpy).toHaveBeenCalledWith(
         `checkout-${productPathName}`,
         result,
-        clickedResultStorageTTLMs
+        storageTTLMs
       );
 
       result.url = encodedURL;
@@ -197,14 +187,14 @@ describe('testing pdp add to cart', () => {
       expect(localSetItemSpy).toHaveBeenCalledWith(
         `checkout-${productPathName}`,
         result,
-        clickedResultStorageTTLMs
+        storageTTLMs
       );
     });
 
     it('moves the add to cart to the session service', () => {
-      const clickedResultStorageKey = 'id';
-      const clickedResultStorageTTLMs = 30000;
-      commitTaggingConfig(store, { clickedResultStorageKey, clickedResultStorageTTLMs });
+      const storageKey = 'id';
+      const storageTTLMs = 30000;
+      commitTaggingConfig(store, { storageKey, storageTTLMs });
 
       service.storeAddToCart(result);
       service.moveToSessionStorage(result.id as string);
@@ -213,7 +203,7 @@ describe('testing pdp add to cart', () => {
       expect(localRemoveItemSpy).toHaveBeenCalledWith(id);
       expect(sessionSetItemSpy).toHaveBeenCalledWith(id, result);
 
-      commitTaggingConfig(store, { clickedResultStorageKey: 'url' });
+      commitTaggingConfig(store, { storageKey: 'url' });
       service.storeAddToCart(result);
       service.moveToSessionStorage();
       id = `checkout-${productPathName}`;

--- a/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
+++ b/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
@@ -3,14 +3,14 @@ import { Result } from '@empathyco/x-types';
 import { BrowserStorageService, StorageService } from '@empathyco/x-storage-service';
 import { RootXStoreState } from '../../../store/index';
 import { XPlugin } from '../../../plugins/index';
-import { PDPAddToCartService } from './types';
+import { ExternalTaggingService } from './types';
 
 /**
- * Default implementation for the {@link PDPAddToCartService}.
+ * Default implementation for the {@link ExternalTaggingService}.
  *
  * @public
  */
-export class DefaultPDPAddToCartService implements PDPAddToCartService {
+export class DefaultExternalTaggingService implements ExternalTaggingService {
   /**
    * Session id key to use as key in the storage for result clicks.
    *
@@ -26,9 +26,9 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
   public static readonly ADD_TO_CART_ID_KEY = 'checkout';
 
   /**
-   * Global instance of the {@link PDPAddToCartService}.
+   * Global instance of the {@link ExternalTaggingService}.
    */
-  public static instance: PDPAddToCartService = new DefaultPDPAddToCartService();
+  public static instance: ExternalTaggingService = new DefaultExternalTaggingService();
 
   public constructor(
     protected localStorageService: StorageService = new BrowserStorageService(localStorage, 'x'),
@@ -57,7 +57,7 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
    */
   storeResultClicked(result: Result): void {
     const key = result[this.storageKey as keyof Result] as string;
-    const storageId = this.getStorageId(DefaultPDPAddToCartService.RESULT_CLICKED_ID_KEY, key);
+    const storageId = this.getStorageId(DefaultExternalTaggingService.RESULT_CLICKED_ID_KEY, key);
     if (storageId) {
       this.localStorageService.setItem(storageId, result, this.storageTTLMs);
     }
@@ -73,7 +73,7 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
    */
   storeAddToCart(result: Result): void {
     const key = result[this.storageKey as keyof Result] as string;
-    const storageId = this.getStorageId(DefaultPDPAddToCartService.ADD_TO_CART_ID_KEY, key);
+    const storageId = this.getStorageId(DefaultExternalTaggingService.ADD_TO_CART_ID_KEY, key);
     if (storageId) {
       this.localStorageService.setItem(storageId, result, this.storageTTLMs);
     }
@@ -89,12 +89,15 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
    */
   moveToSessionStorage(id?: string): void {
     const storageResultClickedId = this.getStorageId(
-      DefaultPDPAddToCartService.RESULT_CLICKED_ID_KEY,
+      DefaultExternalTaggingService.RESULT_CLICKED_ID_KEY,
       id
     );
     this.transferToSessionStorage(storageResultClickedId);
 
-    const storageAddToCartId = this.getStorageId(DefaultPDPAddToCartService.ADD_TO_CART_ID_KEY, id);
+    const storageAddToCartId = this.getStorageId(
+      DefaultExternalTaggingService.ADD_TO_CART_ID_KEY,
+      id
+    );
     this.transferToSessionStorage(storageAddToCartId);
   }
 
@@ -109,8 +112,8 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
   trackAddToCart(id?: string): void {
     const storageId =
       this.storageKey === 'url'
-        ? this.getStorageId(DefaultPDPAddToCartService.RESULT_CLICKED_ID_KEY)
-        : this.getStorageId(DefaultPDPAddToCartService.RESULT_CLICKED_ID_KEY, id);
+        ? this.getStorageId(DefaultExternalTaggingService.RESULT_CLICKED_ID_KEY)
+        : this.getStorageId(DefaultExternalTaggingService.RESULT_CLICKED_ID_KEY, id);
     if (storageId) {
       const result = this.sessionStorageService.getItem<Result>(storageId);
       if (result?.tagging?.add2cart) {

--- a/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
+++ b/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
@@ -49,7 +49,7 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
 
   /**
    * Stores in the local storage the information from the Result clicked by the user
-   * in order to be able to track the add to cart later on.
+   * in order to be able to track the add to cart later on the result's PDP.
    *
    * @param result - The result to store.
    *
@@ -65,7 +65,8 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
 
   /**
    * Stores in the session storage the information from the Result added to the cart
-   * by the user in order to be able to track the checkout later on.
+   * by the user in order to be able to track the checkout later on when the checkout
+   * process has been completed by shopper.
    *
    * @param result - The result to store.
    *
@@ -98,7 +99,7 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
   }
 
   /**
-   * Checks if the session storage contains a result information for given id or the current url.
+   * Checks if the session storage contains a result information for a given id or the current url.
    * If exists, it tracks the add to cart and saves the add to cart information into session
    * storage.
    *

--- a/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
+++ b/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
@@ -75,7 +75,7 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
     const key = result[this.storageKey as keyof Result] as string;
     const storageId = this.getStorageId(DefaultExternalTaggingService.ADD_TO_CART_ID_KEY, key);
     if (storageId) {
-      this.localStorageService.setItem(storageId, result, this.storageTTLMs);
+      this.sessionStorageService.setItem(storageId, result, this.storageTTLMs);
     }
   }
 
@@ -88,17 +88,13 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
    * @public
    */
   moveToSessionStorage(id?: string): void {
-    const storageResultClickedId = this.getStorageId(
-      DefaultExternalTaggingService.RESULT_CLICKED_ID_KEY,
-      id
-    );
-    this.transferToSessionStorage(storageResultClickedId);
-
-    const storageAddToCartId = this.getStorageId(
-      DefaultExternalTaggingService.ADD_TO_CART_ID_KEY,
-      id
-    );
-    this.transferToSessionStorage(storageAddToCartId);
+    const storageId = this.getStorageId(DefaultExternalTaggingService.RESULT_CLICKED_ID_KEY, id);
+    if (storageId) {
+      const result = this.localStorageService.removeItem(storageId);
+      if (result) {
+        this.sessionStorageService.setItem(storageId, result);
+      }
+    }
   }
 
   /**
@@ -119,6 +115,7 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
       if (result?.tagging?.add2cart) {
         result.tagging.add2cart.params.location = 'pdp';
         this.store.dispatch('x/tagging/track', result.tagging.add2cart);
+        this.storeAddToCart(result);
       }
     }
   }
@@ -184,22 +181,6 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
       //eslint-disable-next-line no-console
       console.warn(`There was a problem with url ${url}`);
       return url;
-    }
-  }
-
-  /**
-   * Moves the result information from the local storage to the session storage.
-   *
-   * @param storageKey - The key of the storage to transfer.
-   *
-   * @internal
-   */
-  protected transferToSessionStorage(storageKey: string | null): void {
-    if (storageKey) {
-      const result = this.localStorageService.removeItem(storageKey);
-      if (result) {
-        this.sessionStorageService.setItem(storageKey, result);
-      }
     }
   }
 }

--- a/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
+++ b/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
@@ -64,7 +64,7 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
   }
 
   /**
-   * Stores in the local storage the information from the Result added to the cart
+   * Stores in the session storage the information from the Result added to the cart
    * by the user in order to be able to track the checkout later on.
    *
    * @param result - The result to store.
@@ -75,7 +75,7 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
     const key = result[this.storageKey as keyof Result] as string;
     const storageId = this.getStorageId(DefaultExternalTaggingService.ADD_TO_CART_ID_KEY, key);
     if (storageId) {
-      this.sessionStorageService.setItem(storageId, result, this.storageTTLMs);
+      this.sessionStorageService.setItem(storageId, result);
     }
   }
 
@@ -98,8 +98,9 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
   }
 
   /**
-   * Checks if the session storage contains a result information for given id or the current url
-   * and tracks the add to cart if exists.
+   * Checks if the session storage contains a result information for given id or the current url.
+   * If exists, it tracks the add to cart and saves the add to cart information into session
+   * storage.
    *
    * @param id - The id of the result to track.
    *

--- a/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
+++ b/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
@@ -118,9 +118,6 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
         result.tagging.add2cart.params.location = 'pdp';
         this.store.dispatch('x/tagging/track', result.tagging.add2cart);
         /**
-         * Store the add to cart information in the session storage to be able to
-         * track the checkout later on.
-         *
          * Done after tracking the add to cart to avoid tracking the checkout without
          * an add to cart, in case the tracking fails.
          */

--- a/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
+++ b/packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts
@@ -116,6 +116,13 @@ export class DefaultExternalTaggingService implements ExternalTaggingService {
       if (result?.tagging?.add2cart) {
         result.tagging.add2cart.params.location = 'pdp';
         this.store.dispatch('x/tagging/track', result.tagging.add2cart);
+        /**
+         * Store the add to cart information in the session storage to be able to
+         * track the checkout later on.
+         *
+         * Done after tracking the add to cart to avoid tracking the checkout without
+         * an add to cart, in case the tracking fails.
+         */
         this.storeAddToCart(result);
       }
     }

--- a/packages/x-components/src/x-modules/tagging/service/index.ts
+++ b/packages/x-components/src/x-modules/tagging/service/index.ts
@@ -1,2 +1,2 @@
-export * from './pdp-add-to-cart.service';
+export * from './external-tagging.service';
 export * from './types';

--- a/packages/x-components/src/x-modules/tagging/service/pdp-add-to-cart.service.ts
+++ b/packages/x-components/src/x-modules/tagging/service/pdp-add-to-cart.service.ts
@@ -39,12 +39,12 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
     return XPlugin.store;
   }
 
-  protected get clickedResultStorageKey(): string {
-    return this.store.state.x.tagging.config.clickedResultStorageKey as string;
+  protected get storageKey(): string {
+    return this.store.state.x.tagging.config.storageKey as string;
   }
 
-  protected get clickedResultStorageTTLMs(): number {
-    return this.store.state.x.tagging.config.clickedResultStorageTTLMs as number;
+  protected get storageTTLMs(): number {
+    return this.store.state.x.tagging.config.storageTTLMs as number;
   }
 
   /**
@@ -56,10 +56,10 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
    * @public
    */
   storeResultClicked(result: Result): void {
-    const key = result[this.clickedResultStorageKey as keyof Result] as string;
+    const key = result[this.storageKey as keyof Result] as string;
     const storageId = this.getStorageId(DefaultPDPAddToCartService.RESULT_CLICKED_ID_KEY, key);
     if (storageId) {
-      this.localStorageService.setItem(storageId, result, this.clickedResultStorageTTLMs);
+      this.localStorageService.setItem(storageId, result, this.storageTTLMs);
     }
   }
 
@@ -72,10 +72,10 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
    * @public
    */
   storeAddToCart(result: Result): void {
-    const key = result[this.clickedResultStorageKey as keyof Result] as string;
+    const key = result[this.storageKey as keyof Result] as string;
     const storageId = this.getStorageId(DefaultPDPAddToCartService.ADD_TO_CART_ID_KEY, key);
     if (storageId) {
-      this.localStorageService.setItem(storageId, result, this.clickedResultStorageTTLMs);
+      this.localStorageService.setItem(storageId, result, this.storageTTLMs);
     }
   }
 
@@ -108,7 +108,7 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
    */
   trackAddToCart(id?: string): void {
     const storageId =
-      this.clickedResultStorageKey === 'url'
+      this.storageKey === 'url'
         ? this.getStorageId(DefaultPDPAddToCartService.RESULT_CLICKED_ID_KEY)
         : this.getStorageId(DefaultPDPAddToCartService.RESULT_CLICKED_ID_KEY, id);
     if (storageId) {
@@ -131,7 +131,7 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
    * @internal
    */
   protected getStorageId(keyPrefix: string, id?: string): string | null {
-    if (this.clickedResultStorageKey === 'url') {
+    if (this.storageKey === 'url') {
       let url = id ?? window.location.href;
       url = url.replace(/\s|\+/g, '%20');
       const pathName = this.getPathName(url);
@@ -150,7 +150,7 @@ export class DefaultPDPAddToCartService implements PDPAddToCartService {
    * @internal
    */
   protected showWarningMessage(): void {
-    if (this.clickedResultStorageKey !== 'url') {
+    if (this.storageKey !== 'url') {
       //TODO: add here logger
       //eslint-disable-next-line no-console
       console.warn('No product id was provided but the storage was not configured to use the url');

--- a/packages/x-components/src/x-modules/tagging/service/types.ts
+++ b/packages/x-components/src/x-modules/tagging/service/types.ts
@@ -8,11 +8,19 @@ import { Result } from '@empathyco/x-types';
 export interface PDPAddToCartService {
   /**
    * Stores in the local storage the information from the Result clicked by the user
-   * in order to be able to track later on.
+   * in order to be able to track the add to cart later on.
    *
    * @param result - The result to store.
    */
   storeResultClicked(result: Result): void;
+
+  /**
+   * Stores in the local storage the information from the Result added to the cart
+   * by the user in order to be able to track the checkout later on.
+   *
+   * @param result - The result to store.
+   */
+  storeAddToCart(result: Result): void;
 
   /**
    * Checks if the local storage contains a result information for the given id and moves

--- a/packages/x-components/src/x-modules/tagging/service/types.ts
+++ b/packages/x-components/src/x-modules/tagging/service/types.ts
@@ -8,7 +8,7 @@ import { Result } from '@empathyco/x-types';
 export interface ExternalTaggingService {
   /**
    * Stores in the local storage the information from the Result clicked by the user
-   * in order to be able to track the add to cart later on.
+   * in order to be able to track the add to cart later on the result's PDP.
    *
    * @param result - The result to store.
    */
@@ -16,7 +16,8 @@ export interface ExternalTaggingService {
 
   /**
    * Stores in the session storage the information from the Result added to the cart
-   * by the user in order to be able to track the checkout later on.
+   * by the user in order to be able to track the checkout later on when the checkout
+   * process has been completed by shopper.
    *
    * @param result - The result to store.
    */
@@ -31,7 +32,7 @@ export interface ExternalTaggingService {
   moveToSessionStorage(id?: string): void;
 
   /**
-   * Checks if the session storage contains a result information for given id or the current url.
+   * Checks if the session storage contains a result information for a given id or the current url.
    * If exists, it tracks the add to cart and saves the add to cart information into session
    * storage.
    *

--- a/packages/x-components/src/x-modules/tagging/service/types.ts
+++ b/packages/x-components/src/x-modules/tagging/service/types.ts
@@ -15,7 +15,7 @@ export interface ExternalTaggingService {
   storeResultClicked(result: Result): void;
 
   /**
-   * Stores in the local storage the information from the Result added to the cart
+   * Stores in the session storage the information from the Result added to the cart
    * by the user in order to be able to track the checkout later on.
    *
    * @param result - The result to store.
@@ -31,8 +31,9 @@ export interface ExternalTaggingService {
   moveToSessionStorage(id?: string): void;
 
   /**
-   * Checks if the session storage contains a result information for given id or the current url
-   * and tracks the add to cart if exists.
+   * Checks if the session storage contains a result information for given id or the current url.
+   * If exists, it tracks the add to cart and saves the add to cart information into session
+   * storage.
    *
    * @param id - The id of the result to track.
    */

--- a/packages/x-components/src/x-modules/tagging/service/types.ts
+++ b/packages/x-components/src/x-modules/tagging/service/types.ts
@@ -5,7 +5,7 @@ import { Result } from '@empathyco/x-types';
  *
  * @public
  */
-export interface PDPAddToCartService {
+export interface ExternalTaggingService {
   /**
    * Stores in the local storage the information from the Result clicked by the user
    * in order to be able to track the add to cart later on.

--- a/packages/x-components/src/x-modules/tagging/store/emitters.ts
+++ b/packages/x-components/src/x-modules/tagging/store/emitters.ts
@@ -10,7 +10,7 @@ export const taggingEmitters = createStoreEmitters(taggingXStoreModule, {
   ConsentChanged: state => state.consent!,
   SearchTaggingReceived: state => state.queryTaggingInfo!,
   ResultURLTrackingEnabled: {
-    selector: state => state.config.clickedResultStorageKey!,
+    selector: state => state.config.storageKey!,
     filter: newValue => newValue === 'url'
   }
 });

--- a/packages/x-components/src/x-modules/tagging/store/module.ts
+++ b/packages/x-components/src/x-modules/tagging/store/module.ts
@@ -13,8 +13,8 @@ export const taggingXStoreModule: TaggingXStoreModule = {
     config: {
       sessionTTLMs: 30 * 60 * 1000,
       queryTaggingDebounceMs: 2000,
-      clickedResultStorageKey: null,
-      clickedResultStorageTTLMs: null
+      storageKey: null,
+      storageTTLMs: null
     },
     consent: null,
     noResultsTaggingEnabled: false,

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -64,6 +64,13 @@ const wirePDPAddToCartService = wireService(DefaultPDPAddToCartService.instance)
 const storeClickedResultWire = wirePDPAddToCartService('storeResultClicked');
 
 /**
+ * Stores the result added to cart on the local storage.
+ *
+ * @public
+ */
+const storeAddToCartWire = wirePDPAddToCartService('storeAddToCart');
+
+/**
  * Moves the result information from the local storage to session storage.
  *
  * @public
@@ -121,7 +128,7 @@ export const setTaggingConfig = wireCommit('mergeConfig');
 export const trackQueryWire = filter(
   wireDispatch('track'),
   ({ eventPayload, store }) =>
-    (eventPayload as TaggingRequest).params.totalHits > 0 ||
+    ((eventPayload as TaggingRequest).params.totalHits as number) > 0 ||
     !store.state.x.tagging.noResultsTaggingEnabled
 );
 
@@ -426,7 +433,8 @@ export const taggingWiring = createWiring({
   },
   UserClickedResultAddToCart: {
     trackAddToCartWire,
-    trackResultClickedWire
+    trackResultClickedWire,
+    storeAddToCartWire
   },
   UserClickedPDPAddToCart: {
     trackAddToCartFromSessionStorage

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -18,7 +18,7 @@ import { DisplayWireMetadata, Wire } from '../../wiring/wiring.types';
 import { createWiring } from '../../wiring/wiring.utils';
 import { createOrigin } from '../../utils/index';
 import { FeatureLocation } from '../../types/index';
-import { DefaultPDPAddToCartService } from './service/pdp-add-to-cart.service';
+import { DefaultExternalTaggingService } from './service/external-tagging.service';
 
 /**
  * `tagging` {@link XModuleName | XModule name}.
@@ -52,23 +52,23 @@ const wireDispatch = namespacedWireDispatch(moduleName);
 const wireSessionServiceWithoutPayload = wireServiceWithoutPayload(DefaultSessionService.instance);
 
 /**
- * Wires factory for {@link DefaultPDPAddToCartService}.
+ * Wires factory for {@link DefaultExternalTaggingService}.
  */
-const wirePDPAddToCartService = wireService(DefaultPDPAddToCartService.instance);
+const wireExternalTaggingService = wireService(DefaultExternalTaggingService.instance);
 
 /**
  * Stores the given result on the local storage.
  *
  * @public
  */
-const storeClickedResultWire = wirePDPAddToCartService('storeResultClicked');
+const storeClickedResultWire = wireExternalTaggingService('storeResultClicked');
 
 /**
  * Stores the result added to cart on the local storage.
  *
  * @public
  */
-const storeAddToCartWire = wirePDPAddToCartService('storeAddToCart');
+const storeAddToCartWire = wireExternalTaggingService('storeAddToCart');
 
 /**
  * Moves the result information from the local storage to session storage.
@@ -76,7 +76,7 @@ const storeAddToCartWire = wirePDPAddToCartService('storeAddToCart');
  * @public
  */
 const moveClickedResultToSessionWire = mapWire(
-  wirePDPAddToCartService('moveToSessionStorage'),
+  wireExternalTaggingService('moveToSessionStorage'),
   (payload: string) => {
     return payload === 'url' ? undefined : payload;
   }
@@ -87,7 +87,7 @@ const moveClickedResultToSessionWire = mapWire(
  *
  * @public
  */
-const trackAddToCartFromSessionStorage = wirePDPAddToCartService('trackAddToCart');
+const trackAddToCartFromSessionStorage = wireExternalTaggingService('trackAddToCart');
 
 /**
  * Clears the session id.


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
This pull request adds the implementation to save the result info into the SessionStorage when a result has been added to the cart. Implemented in both cases when adding a result from SERP (UserClickedResultAddToCart) and PDP (UserClickedPDPAddToCart). 

This is intended to provide the customer with the info of the results added to the cart from the Empathy experience and allow them to help us track the checkout at the moment the shopper finishes the buy. The customer must perform a request to the `result.tagging.checkout.url` providing the `result.tagging.checkout.params`.

Other important changes, as they introduce BREAKING CHANGES, include updating the property names in various files (removing the `clickedResult` prefix, as now props are not used just for clicked results) and refactoring the associated tests.

 ### ⚠️ BREAKING CHANGES: Renaming properties in Tagging module and renaming service:

* [`packages/x-components/src/x-modules/tagging/components/tagging.vue`](diffhunk://#diff-f088e75eb7ec98810f9d9ba30ecfb68d8217f5bc8fb436628e054e83bda6e23bL19-R30): Modified the property names in the `Tagging` component to use `storageTTLMs` and `storageKey` instead of `clickedResultStorageTTLMs` and `clickedResultStorageKey`. [[1]](diffhunk://#diff-f088e75eb7ec98810f9d9ba30ecfb68d8217f5bc8fb436628e054e83bda6e23bL19-R30) [[2]](diffhunk://#diff-f088e75eb7ec98810f9d9ba30ecfb68d8217f5bc8fb436628e054e83bda6e23bL78-R80) [[3]](diffhunk://#diff-f088e75eb7ec98810f9d9ba30ecfb68d8217f5bc8fb436628e054e83bda6e23bL147-R153) [[4]](diffhunk://#diff-f088e75eb7ec98810f9d9ba30ecfb68d8217f5bc8fb436628e054e83bda6e23bL172-R177)

* [`packages/x-components/src/x-modules/tagging/config.types.ts`](diffhunk://#diff-c3db7dd7c0e3215bd1769491e87e7288236ca536fbb006c0cebe6c8fd31cd1b2L18-R26): Modified the `TaggingConfig` interface to use `storageTTLMs` and `storageKey` instead of `clickedResultStorageTTLMs` and `clickedResultStorageKey`.

* [`packages/x-components/src/x-modules/tagging/events.types.ts`](diffhunk://#diff-b11c5023bf0a68f3fe5c4ac5da84a6e3cc4e5058fb30414c948b933897c5c8b2L27-R29): Updated event descriptions to use `storageKey` instead of `clickedResultStorageKey`.

* [`packages/x-components/src/x-modules/tagging/service/external-tagging.service.ts`](diffhunk://#diff-f6445ec690b3c42935eb3cf3bfda9a37fea6b6dae0952a95d40aa389a7e7084aR13): Renamed service.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: https://searchbroker.atlassian.net/browse/RST-3103

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

This PR needs to be tested from SERP and PDP when adding a result to the cart:

- SERP: Add a result to the cart and check that an item has been added to the SessionStorage containing:
`x-checkout-[result-url]` as key and an object containing the result as value.

- PDP: Click a product result and in its PDP execute `InterfaceX.addProductToCart()` and check that an item has been added to the SessionStorage containing:
`x-checkout-[result-url]` as key and an object containing the result as value.

## Checklist:

- [X] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
