### PR TITLE
ci: sync install workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,7 +4,7 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-18.16.0-chrome-112.0.5615.121-1-ff-112.0.1-edge-112.0.1722.48-1@sha256:78ca118a3ac93a551e43d6c6fe3e31e6f2f4bb034b56627be56005229bfc1790
+      image: cypress/browsers:node-22.14.0-chrome-135.0.7049.84-1-ff-137.0.1-edge-135.0.3179.54-1@sha256:55119cf831abaff1d4a66cfcdcd617a9dedf5a6183ec2272e24bf657db5f1ce5
       # https://github.com/cypress-io/github-action#firefox Cypress FF image needs this user permissions to be able to install dependencies
       options: --user 1001
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,14 +13,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Install pnpm because it is not included in our container image
-      - name: install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-        with:
-          version: 9.15.9
-
-      - name: install dependencies
-        run: pnpm install
+      - name: Install
+        uses: ./.github/actions/install
 
       - name: configure git user
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-18.16.0-chrome-112.0.5615.121-1-ff-112.0.1-edge-112.0.1722.48-1@sha256:78ca118a3ac93a551e43d6c6fe3e31e6f2f4bb034b56627be56005229bfc1790
+      image: cypress/browsers:node-22.14.0-chrome-135.0.7049.84-1-ff-137.0.1-edge-135.0.3179.54-1@sha256:55119cf831abaff1d4a66cfcdcd617a9dedf5a6183ec2272e24bf657db5f1ce5
       # https://github.com/cypress-io/github-action#firefox Cypress FF image needs this user permissions to be able to install dependencies
       options: --user 1001
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,14 +22,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      # Install pnpm because it is not included in our container image
-      - name: install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-        with:
-          version: 9.15.9
-
-      - name: install dependencies
-        run: pnpm install
+      - name: Install
+        uses: ./.github/actions/install
 
       - name: lint packages
         run: pnpm run lint:check

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -29,14 +29,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      # Install pnpm because it is not included in our container image
-      - name: install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-        with:
-          version: 9.15.9
-
-      - name: install dependencies
-        run: pnpm install
+      - name: Install
+        uses: ./.github/actions/install
 
       - name: execute release-alpha action
         uses: ./.github/actions/release-alpha

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -10,7 +10,7 @@ jobs:
   release-alpha:
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-18.16.0-chrome-112.0.5615.121-1-ff-112.0.1-edge-112.0.1722.48-1@sha256:78ca118a3ac93a551e43d6c6fe3e31e6f2f4bb034b56627be56005229bfc1790
+      image: cypress/browsers:node-22.14.0-chrome-135.0.7049.84-1-ff-137.0.1-edge-135.0.3179.54-1@sha256:55119cf831abaff1d4a66cfcdcd617a9dedf5a6183ec2272e24bf657db5f1ce5
       # https://github.com/cypress-io/github-action#firefox Cypress FF image needs this user permissions to be able to install dependencies
       options: --user 1001
 


### PR DESCRIPTION
- Sync `install` workflows for release.
- Upgrade Docker container of release workflows to use `node@22`