### PR TITLE
fix(x-tailwindcss): rename `.selected` classes by `.x-selected` like the rest of plugin classes

### DIFF
--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/default.ts
@@ -38,7 +38,7 @@ export function buttonDefault(helpers: TailwindHelpers) {
 
     ...buttonSizes(helpers).md,
 
-    '&.selected': {
+    '&.x-selected': {
       backgroundColor: `var(--button-color-75,${theme('x.colors.neutral.100')})`,
       borderColor: `var(--button-color-75,${theme('x.colors.neutral.100')})`,
 

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/disabled.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/disabled.ts
@@ -22,7 +22,7 @@ export function buttonDisabled(helpers: TailwindHelpers) {
       cursor: 'not-allowed',
       ...disabledStyles,
 
-      '&.selected': {
+      '&.x-selected': {
         ...disabledStyles,
       },
     },

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/ghost.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/ghost.ts
@@ -13,7 +13,7 @@ export function buttonGhost(helpers: TailwindHelpers) {
   const { theme } = helpers
   return {
     ghost: deepMerge(noBackground(helpers), backgroundOnHover(helpers), {
-      '&.selected': {
+      '&.x-selected': {
         borderColor: theme('x.colors.neutral.10'),
         backgroundColor: theme('x.colors.neutral.10'),
         color: `var(--button-color-75,${theme('x.colors.neutral.90')})`,

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/link.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/link.ts
@@ -23,7 +23,7 @@ export function buttonLink(helpers: TailwindHelpers) {
       ...noHorizontalPadding(helpers),
       ...noBackground(helpers),
 
-      '&.selected': {
+      '&.x-selected': {
         borderColor: 'transparent',
         backgroundColor: 'transparent',
         color: `var(--button-color-75,${theme('x.colors.neutral.100')})`,

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/outlined.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/outlined.ts
@@ -23,7 +23,7 @@ export function buttonOutlined(helpers: TailwindHelpers) {
         color: theme('x.colors.neutral.0'),
       },
 
-      '&.selected': {
+      '&.x-selected': {
         borderColor: `var(--button-color-50,${theme('x.colors.neutral.90')})`,
         backgroundColor: `var(--button-color-50,${theme('x.colors.neutral.90')})`,
         color: theme('x.colors.neutral.0'),

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/tight.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/button/tight.ts
@@ -13,7 +13,7 @@ export function buttonTight(helpers: TailwindHelpers) {
   const { theme } = helpers
   return {
     tight: deepMerge(noBackground(helpers), noHorizontalPadding(helpers), {
-      '&.selected': {
+      '&.x-selected': {
         borderColor: 'transparent',
         backgroundColor: 'transparent',
         color: `var(--button-color-75,${theme('x.colors.neutral.100')})`,

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/facet-filter/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/facet-filter/default.ts
@@ -37,7 +37,7 @@ export function facetFilterDefault(helpers: TailwindHelpers) {
       color: `var(--filter-color-50, ${theme('x.colors.neutral.50')})`,
     },
 
-    '&.selected': {
+    '&.x-selected': {
       fontWeight: theme('x.fontWeight.bold'),
       letterSpacing: theme('x.letterSpacing.xs'),
       color: `var(--filter-color-50, ${theme('x.colors.neutral.90')})`,

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/facet-filter/ghost.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/facet-filter/ghost.ts
@@ -24,7 +24,7 @@ export function facetFilterGhost(helpers: TailwindHelpers) {
         backgroundColor: theme('x.colors.neutral.10'),
         color: theme('x.colors.neutral.90'),
       },
-      '&.selected': {
+      '&.x-selected': {
         fontWeight: theme('x.fontWeight.regular'),
         color: `var(--filter-color-75)`,
         letterSpacing: theme('x.letterSpacing.md'),

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/facet-filter/simple.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/facet-filter/simple.ts
@@ -15,7 +15,7 @@ export function facetFilterSimple(helpers: TailwindHelpers) {
         color: theme('x.colors.neutral.90'),
         opacity: '.6',
       },
-      '&.selected': {
+      '&.x-selected': {
         fontWeight: theme('x.fontWeight.regular'),
         letterSpacing: theme('x.letterSpacing.md'),
 

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/facet-filter/underline.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/facet-filter/underline.ts
@@ -18,7 +18,7 @@ export function facetFilterUnderline(helpers: TailwindHelpers) {
           borderColor: 'transparent',
         },
       },
-      '&.selected': {
+      '&.x-selected': {
         fontWeight: theme('x.fontWeight.regular'),
         letterSpacing: theme('x.letterSpacing.md'),
       },

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/default.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/default.ts
@@ -53,7 +53,7 @@ export function tagDefault(helpers: TailwindHelpers) {
     ...tagSizes(helpers).md,
     ...disabledStyles,
 
-    '&.selected': {
+    '&.x-selected': {
       borderColor: `var(--tag-color-75, ${theme('x.colors.neutral.90')})`,
       borderWidth: theme('x.spacing.2'),
       color: theme('x.colors.neutral.90'),

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/ghost.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/ghost.ts
@@ -33,7 +33,7 @@ export function tagGhost(helpers: TailwindHelpers) {
 
       ...disabledStyles,
 
-      '&.selected': {
+      '&.x-selected': {
         borderColor: 'transparent',
         color: `var(--tag-color-75, ${theme('x.colors.neutral.90')})`,
         fontWeight: theme('x.fontWeight.bold'),

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/outlined.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/outlined.ts
@@ -33,7 +33,7 @@ export function tagOutlined(helpers: TailwindHelpers) {
       ...hoverStyles,
       ...disabledStyles,
 
-      '&.selected': {
+      '&.x-selected': {
         backgroundColor: `var(--tag-color-25, ${theme('x.colors.neutral.10')})`,
         borderColor: `var(--tag-color-75, ${theme('x.colors.neutral.75')})`,
         borderWidth: theme('x.spacing.1'),

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/solid.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/solid.ts
@@ -32,7 +32,7 @@ export function tagSolid(helpers: TailwindHelpers) {
 
       ...disabledStyles,
 
-      '&.selected': {
+      '&.x-selected': {
         backgroundColor: `var(--tag-color-75, ${theme('x.colors.neutral.90')})`,
         borderColor: `var(--tag-color-75, ${theme('x.colors.neutral.90')})`,
         color: theme('x.colors.neutral.0'),

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/tight.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/components/tag/tight.ts
@@ -34,7 +34,7 @@ export function tagTight(helpers: TailwindHelpers) {
       ...hoverStyles,
       ...disabledStyles,
 
-      '&.selected': {
+      '&.x-selected': {
         borderColor: 'transparent',
         color: `var(--tag-color-75, ${theme('x.colors.neutral.90')})`,
         fontWeight: theme('x.fontWeight.bold'),

--- a/packages/x-tailwindcss/src/x-tailwind-plugin/plugin.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/plugin.ts
@@ -41,7 +41,7 @@ export default plugin.withOptions(
       /* Add utilities */
       helpers.addUtilities(utilities(helpers), { respectPrefix: false })
       /* Add variant to selected */
-      helpers.addVariant('selected', '&.selected')
+      helpers.addVariant('selected', '&.x-selected')
     }
   },
   () => {


### PR DESCRIPTION
In this PR and breaking change https://github.com/empathyco/x/pull/1658, every X class was refactored to be prefixed with `x-` like `x-tag`, but the `.selected` was forgotten to prefix. Given a compiled selector `.x-tag.selected` but it is a X modified, and it is used like `.x-tag.x-selected`.