### PR TITLE
chore(deps): update renovate rules

### DIFF
--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -118,7 +118,6 @@
     "postcss": "8.4.12",
     "postcss-dir-pseudo-class": "7.0.0",
     "postcss-logical": "4.0.2",
-    "prettier-plugin-tailwindcss": "0.6.11",
     "rimraf": "3.0.2",
     "rollup": "4.9.1",
     "rollup-plugin-copy": "3.5.0",

--- a/packages/x-tailwindcss/package.json
+++ b/packages/x-tailwindcss/package.json
@@ -50,7 +50,6 @@
     "autoprefixer": "10.4.4",
     "postcss": "8.4.12",
     "postcss-import": "16.1.0",
-    "prettier-plugin-tailwindcss": "0.6.11",
     "rimraf": "3.0.2",
     "rollup": "4.9.1",
     "rollup-plugin-typescript2": "0.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,9 +388,6 @@ importers:
       postcss-logical:
         specifier: 4.0.2
         version: 4.0.2
-      prettier-plugin-tailwindcss:
-        specifier: 0.6.11
-        version: 0.6.11(prettier@3.5.3)
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
@@ -526,9 +523,6 @@ importers:
       postcss-import:
         specifier: 16.1.0
         version: 16.1.0(postcss@8.4.12)
-      prettier-plugin-tailwindcss:
-        specifier: 0.6.11
-        version: 0.6.11(prettier@3.5.3)
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
@@ -8513,7 +8507,7 @@ snapshots:
       '@cucumber/ci-environment': 10.0.1
       '@cucumber/cucumber-expressions': 17.1.0
       '@cucumber/gherkin': 28.0.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@22.0.0))(@cucumber/messages@24.1.0)
       '@cucumber/gherkin-utils': 9.0.0
       '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -8553,7 +8547,7 @@ snapshots:
       yaml: 2.7.1
       yup: 1.2.0
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@22.0.0))(@cucumber/messages@24.1.0)':
     dependencies:
       '@cucumber/gherkin': 28.0.0
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)

--- a/renovate.json
+++ b/renovate.json
@@ -3,40 +3,16 @@
   "extends": ["github>empathyco/.github:frontend"],
   "packageRules": [
     {
-      "matchPackageNames": ["@vue/test-utils"],
-      "groupName": null,
-      "allowedVersions": "< 2"
-    },
-    {
-      "matchPackageNames": ["vue"],
-      "allowedVersions": "< 3"
-    },
-    {
       "matchPackageNames": ["vuex"],
-      "allowedVersions": "< 4"
-    },
-    {
-      "matchPackageNames": ["vue-router"],
-      "allowedVersions": "< 4"
-    },
-    {
-      "matchPackageNames": ["vue-global-events"],
-      "allowedVersions": "< 2"
-    },
-    {
-      "matchPackageNames": ["vue-i18n"],
-      "allowedVersions": "< 9"
+      "allowedVersions": "< 4.1",
+      "description": "4.1 has a bug: https://github.com/empathyco/motive-x/pull/640#issuecomment-2714822157"
     },
     {
       "extends": ["monorepo:react"],
       "enabled": false
     },
     {
-      "enabled": false,
-      "matchPackageNames": ["/^@types/react*/"]
-    },
-    {
-      "matchPackageNames": ["prettier-plugin-tailwindcss"],
+      "matchPackageNames": ["/^@types/react*/"],
       "enabled": false
     }
   ]


### PR DESCRIPTION


<!--Please provide a general summary of changes in the PR title -->

# Pull request template

Remove outdated renovate rules.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [x] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
