### PR TITLE
refactor(use-getter): improve type inference while keeping old signature

### DIFF
--- a/packages/x-components/src/composables/__tests__/use-getter.spec.ts
+++ b/packages/x-components/src/composables/__tests__/use-getter.spec.ts
@@ -1,4 +1,3 @@
-import type { ExtractGetters } from '../../x-modules/x-modules.types'
 import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import { installNewXPlugin } from '../../__tests__/utils'
@@ -6,11 +5,11 @@ import { XPlugin } from '../../plugins'
 import { historyQueriesXModule } from '../../x-modules/history-queries/x-module'
 import { useGetter } from '../use-getter'
 
-function render(modulePaths: (keyof ExtractGetters<'historyQueries'>)[]) {
+function render() {
   const component = defineComponent({
     xModule: historyQueriesXModule.name,
     setup: () => {
-      const historyQueriesGetter = useGetter('historyQueries', modulePaths)
+      const historyQueriesGetter = useGetter('historyQueries')
       return { historyQueriesGetter }
     },
     template: `<div/>`,
@@ -29,18 +28,12 @@ function render(modulePaths: (keyof ExtractGetters<'historyQueries'>)[]) {
 
 describe('testing useGetter composable', () => {
   it('maps store getters', async () => {
-    const { storageKey, historyQueries } = render(['storageKey', 'historyQueries'])
+    const { storageKey, historyQueries } = render()
     expect(storageKey.value).toEqual('history-queries')
     expect(historyQueries.value).toHaveLength(0)
 
     await XPlugin.store.dispatch('x/historyQueries/addQueryToHistory', 'chorizo')
 
     expect(historyQueries.value).toHaveLength(1)
-  })
-
-  it('does not return not requested getters', () => {
-    const { storageKey, historyQueries } = render(['storageKey'])
-    expect(storageKey).toBeDefined()
-    expect(historyQueries).toBeUndefined()
   })
 })

--- a/packages/x-components/src/composables/use-getter.ts
+++ b/packages/x-components/src/composables/use-getter.ts
@@ -1,28 +1,43 @@
 import type { Dictionary } from '@empathyco/x-utils'
 import type { ComputedRef } from 'vue'
+import type { RootXStoreState } from '../store/index'
 import type { ExtractGetters, XModuleName } from '../x-modules/x-modules.types'
 import { computed } from 'vue'
+import { useStore } from 'vuex'
 import { getGetterPath } from '../plugins/index'
-import { useStore } from './use-store'
+
+interface UseGetter {
+  /** @deprecated Use the single-argument overload instead. */
+  <Module extends XModuleName, Getters = keyof ExtractGetters<Module> & string[]>(
+    module: Module,
+    getters: Getters,
+  ): Dictionary<ComputedRef>
+
+  /**
+   * Preferred. Use this signature for better type inference and future compatibility.
+   */
+  <Module extends XModuleName, Getters = ExtractGetters<Module>>(
+    module: Module,
+  ): { [P in keyof Getters]: ComputedRef<Getters[P]> }
+}
 
 /**
- * Function which returns the requested getters as a dictionary of getters.
+ * Function which returns the requested getter's properties as a dictionary.
  *
  * @param module - The {@link XModuleName} of the getter.
- * @param getters - List of getters names.
  * @returns The requested getters from the module.
  * @public
  */
-export function useGetter<
+export const useGetter: UseGetter = function useGetter<
   Module extends XModuleName,
-  GetterName extends keyof ExtractGetters<Module> & string,
->(module: Module, getters: GetterName[]): Dictionary<ComputedRef> {
-  const store = useStore()
-
-  return getters.reduce<Dictionary<ComputedRef>>((getterDictionary, getterName) => {
-    const getterPath = getGetterPath(module, getterName)
-    // eslint-disable-next-line ts/no-unsafe-return,ts/no-unsafe-member-access
-    getterDictionary[getterName] = computed(() => store.getters[getterPath])
-    return getterDictionary
-  }, {})
+  Getters = ExtractGetters<Module>,
+>(module: Module): { [P in keyof Getters]: ComputedRef<Getters[P]> } {
+  const store = useStore<RootXStoreState>()
+  return new Proxy({} as { [P in keyof Getters]: ComputedRef<Getters[P]> }, {
+    get(_obj, getterName) {
+      const path = getGetterPath(module, getterName as keyof ExtractGetters<Module>)
+      // eslint-disable-next-line ts/no-unsafe-member-access,ts/no-unsafe-return
+      return computed(() => store.getters[path as typeof getterName])
+    },
+  })
 }

--- a/packages/x-components/src/x-modules/facets/components/facets/facets.vue
+++ b/packages/x-components/src/x-modules/facets/components/facets/facets.vue
@@ -56,7 +56,7 @@
 <script lang="ts">
 import type { Facet } from '@empathyco/x-types'
 import type { Dictionary } from '@empathyco/x-utils'
-import type { ComputedRef, PropType } from 'vue'
+import type { PropType } from 'vue'
 import { map, objectFilter } from '@empathyco/x-utils'
 import { computed, defineComponent } from 'vue'
 import { useGetter } from '../../../../composables/use-getter'
@@ -121,11 +121,7 @@ export default defineComponent({
   },
   setup(props, { slots }) {
     const { selectedFiltersByFacet } = useFacets(props)
-
-    const { facets } = useGetter('facets', ['facets']) as {
-      /** Dictionary of facets in the state. */
-      facets: ComputedRef<Record<Facet['id'], Facet>>
-    }
+    const { facets } = useGetter('facets')
 
     /**
      * The facets to be rendered after filtering {@link Facets.facets} by

--- a/packages/x-components/src/x-modules/facets/components/filters/all-filter.vue
+++ b/packages/x-components/src/x-modules/facets/components/filters/all-filter.vue
@@ -17,10 +17,8 @@
 
 <script lang="ts">
 import type { Facet } from '@empathyco/x-types'
-import type { Dictionary } from '@empathyco/x-utils'
-import type { ComputedRef, PropType } from 'vue'
+import type { PropType } from 'vue'
 import type { XEventsTypes } from '../../../../wiring/events.types'
-import type { FiltersByFacet } from '../../store'
 import { computed, defineComponent } from 'vue'
 import BaseEventButton from '../../../../components/base-event-button.vue'
 import { useGetter } from '../../../../composables/use-getter'
@@ -51,10 +49,7 @@ export default defineComponent({
   },
   setup(props) {
     /** The getter of the selectedFiltersByFacet. */
-    const { selectedFiltersByFacet }: Dictionary<ComputedRef<FiltersByFacet>> = useGetter(
-      'facets',
-      ['selectedFiltersByFacet'],
-    )
+    const { selectedFiltersByFacet } = useGetter('facets')
 
     /**
      * The event that will be emitted when the all filter button is clicked.

--- a/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-queries.vue
@@ -72,7 +72,7 @@ export default defineComponent({
      *
      * @internal
      */
-    const { historyQueriesWithResults } = useGetter('historyQueries', ['historyQueriesWithResults'])
+    const { historyQueriesWithResults } = useGetter('historyQueries')
 
     return {
       historyQueriesWithResults,

--- a/packages/x-components/src/x-modules/history-queries/components/history-query.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/history-query.vue
@@ -81,7 +81,7 @@ export default defineComponent({
      *
      * @internal
      */
-    const query = useGetter('historyQueries', ['normalizedQuery']).normalizedQuery
+    const query = useGetter('historyQueries').normalizedQuery
 
     /**
      * The list of events that are going to be emitted when the suggestion button is pressed.

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
@@ -9,7 +9,7 @@
 
 <script lang="ts">
 import type { Result } from '@empathyco/x-types'
-import type { ComputedRef, PropType } from 'vue'
+import type { PropType } from 'vue'
 import { computed, defineComponent } from 'vue'
 import { useGetter } from '../../../composables/use-getter'
 import { useState } from '../../../composables/use-state'
@@ -49,9 +49,7 @@ export default defineComponent({
      *
      * @public
      */
-    const identifierHighlightRegexp: ComputedRef<RegExp> = useGetter('identifierResults', [
-      'identifierHighlightRegexp',
-    ]).identifierHighlightRegexp
+    const identifierHighlightRegexp = useGetter('identifierResults').identifierHighlightRegexp
 
     /**
      * Highlights the matching part of the identifier result with the query from the state.

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries-list.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
-import type { NextQuery } from '@empathyco/x-types'
-import type { ComputedRef, Ref } from 'vue'
+import type { Ref } from 'vue'
 import type { ListItem } from '../../../utils/types'
 import type { NextQueriesGroup } from '../types'
 import { computed, defineComponent, h, inject, provide } from 'vue'
@@ -61,9 +60,7 @@ export default defineComponent({
     const { query, status } = useState('nextQueries')
 
     /** The state next queries. */
-    const nextQueries: ComputedRef<NextQuery[]> = useGetter('nextQueries', [
-      'nextQueries',
-    ]).nextQueries
+    const nextQueries = useGetter('nextQueries').nextQueries
 
     /** Injected query, updated when the related request(s) have succeeded. */
     const injectedQuery = inject<Ref<string>>(QUERY_KEY as string)

--- a/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-queries.vue
@@ -81,7 +81,7 @@ export default defineComponent({
      *
      * @internal
      */
-    const stateNextQueries = useGetter('nextQueries', ['nextQueries']).nextQueries
+    const stateNextQueries = useGetter('nextQueries').nextQueries
 
     /**.
      * The list of next queries finally rendered

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -58,7 +58,7 @@ export default defineComponent({
      *
      * @internal
      */
-    const { popularSearches } = useGetter('popularSearches', ['popularSearches'])
+    const { popularSearches } = useGetter('popularSearches')
 
     return { popularSearches }
   },

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestion.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestion.vue
@@ -44,7 +44,7 @@ export default defineComponent({
   },
   setup(props) {
     /** The normalized query of the query-suggestions module. */
-    const query = useGetter('querySuggestions', ['normalizedQuery']).normalizedQuery
+    const query = useGetter('querySuggestions').normalizedQuery
 
     /**
      * Emits {@link QuerySuggestionsXEvents.UserSelectedAQuerySuggestion} with the suggestion as

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
@@ -50,7 +50,7 @@ export default defineComponent({
   components: { BaseSuggestions, QuerySuggestion },
   setup() {
     /** The module's list of suggestions. */
-    const { querySuggestions } = useGetter('querySuggestions', ['querySuggestions'])
+    const { querySuggestions } = useGetter('querySuggestions')
 
     return { suggestions: querySuggestions }
   },

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -100,9 +100,7 @@ export default defineComponent({
     itemClass: String,
   },
   setup(props) {
-    const storedRelatedTags: ComputedRef<RelatedTagModel[]> = useGetter('relatedTags', [
-      'relatedTags',
-    ]).relatedTags
+    const storedRelatedTags: ComputedRef<RelatedTagModel[]> = useGetter('relatedTags').relatedTags
 
     const relatedTags = computed((): RelatedTagModel[] =>
       storedRelatedTags.value.slice(0, props.maxItemsToRender),

--- a/packages/x-components/src/x-modules/semantic-queries/components/semantic-query.vue
+++ b/packages/x-components/src/x-modules/semantic-queries/components/semantic-query.vue
@@ -45,8 +45,8 @@ export default defineComponent({
     },
   },
   setup(props) {
-    /** The normalized query of the semantic queries module. */
-    const query = useGetter('semanticQueries', ['normalizedQuery']).normalizedQuery
+    /** The normalized query of the semantic queries' module. */
+    const query = useGetter('semanticQueries').normalizedQuery
 
     /** The list of events that are going to be emitted when the button is pressed. */
     const suggestionSelectedEvents = {


### PR DESCRIPTION
## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
It simplifies usage and reduces the risk of typos in path names.

***Before:***
Only properties explicitly passed in the paths array were available.

***After:***
Full getters access with accurate typings and autocompletion.

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [x] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

***Test***
* Check the getters information is correctly received by components that use them.
* Check the old signature is still available: use the old way (specifying paths) on any file using getters to check that it still works, but also is informed as a `@deprecated` TS signature. 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
