### PR TITLE
fix: prop type definition in BaseTeleport component

### DIFF
--- a/packages/x-components/src/components/base-teleport.vue
+++ b/packages/x-components/src/components/base-teleport.vue
@@ -13,7 +13,7 @@ export default defineComponent({
   props: {
     /** The element or css selector to which the component will be teleported. */
     target: {
-      type: [String, Element] as PropType<string | Element>,
+      type: Object as PropType<string | Element>,
       required: true,
     },
     /**

--- a/packages/x-components/src/components/base-teleport.vue
+++ b/packages/x-components/src/components/base-teleport.vue
@@ -13,7 +13,7 @@ export default defineComponent({
   props: {
     /** The element or css selector to which the component will be teleported. */
     target: {
-      type: Object as PropType<string | Element>,
+      type: [String, Object] as PropType<string | Element>,
       required: true,
     },
     /**


### PR DESCRIPTION
This pull request modifies the `target` prop in the `base-teleport.vue` component to simplify its type definition.

* [`packages/x-components/src/components/base-teleport.vue`](diffhunk://#diff-7c8ec8a6a61d1303ddabe0d9e969f7362bab23fd66b66edf7b900f8fc15e87d8L16-R16): Changed the `target` prop's type from a union of `[String, Element]` to `Object` for cleaner and more generic type handling.