### PR TITLE
feat: sent the correct totalHits value when RPs are displayed in no-r…

### DIFF
--- a/packages/x-components/src/x-modules/related-prompts/components/related-prompts-tag-list.vue
+++ b/packages/x-components/src/x-modules/related-prompts/components/related-prompts-tag-list.vue
@@ -80,7 +80,7 @@
 
 <script lang="ts">
 import type { PropType } from 'vue'
-import { computed, defineComponent, ref } from 'vue'
+import { computed, defineComponent, onBeforeUnmount, ref } from 'vue'
 import DisplayEmitter from '../../../components/display-emitter.vue'
 import SlidingPanel from '../../../components/sliding-panel.vue'
 import { use$x, useState } from '../../../composables'
@@ -318,6 +318,10 @@ export default defineComponent({
     // style after it finishes
     x.on('SearchRequestChanged', false).subscribe(() => {
       resetTransitionStyle([])
+    })
+
+    onBeforeUnmount(() => {
+      x.emit('RelatedPromptsUnmounted')
     })
 
     return {

--- a/packages/x-components/src/x-modules/related-prompts/events.types.ts
+++ b/packages/x-components/src/x-modules/related-prompts/events.types.ts
@@ -1,4 +1,4 @@
-import type { RelatedPromptsRequest, Result } from '@empathyco/x-types'
+import type { RelatedPrompt, RelatedPromptsRequest, Result } from '@empathyco/x-types'
 
 /**
  * Dictionary of the events of RelatedPrompts XModule, where each key is the event name,
@@ -38,4 +38,13 @@ export interface RelatedPromptsXEvents {
    * Payload: The result that the user clicked.
    */
   UserClickedARelatedPromptAdd2Cart: Result
+  /**
+   * The response list of related prompts has changed.
+   * Payload: The new related-prompts list.
+   */
+  RelatedPromptsResponseChanged: RelatedPrompt[]
+  /**
+   * The related prompts has been unmounted.
+   */
+  RelatedPromptsUnmounted: void
 }

--- a/packages/x-components/src/x-modules/related-prompts/store/emitters.ts
+++ b/packages/x-components/src/x-modules/related-prompts/store/emitters.ts
@@ -9,4 +9,5 @@ import { relatedPromptsXStoreModule } from './module'
 export const relatedPromptsStoreEmitters = createStoreEmitters(relatedPromptsXStoreModule, {
   RelatedPromptsRequestUpdated: (_, getters) => getters.request,
   SelectedRelatedPromptChanged: state => state.selectedPrompt,
+  RelatedPromptsResponseChanged: state => state.relatedPrompts,
 })

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -266,6 +266,25 @@ export const trackNoResultsQueryWithFallbackWireDebounced = moduleDebounce(
 )
 
 /**
+ * Performs a track of a query with no results that used semantic queries as fallback.
+ * The totalHits will be changed to -1 if semantic queries are found in order to differentiate
+ * it from scenarios where the user encounters a no-results page without any semantic queries.
+ *
+ * @public
+ * @deprecated - Use {@link trackNoResultsQueryWithFallbackWire} instead.
+ */
+export const trackNoResultsQueryWithSemanticsWire = trackNoResultsQueryWithFallbackWire
+
+/**
+ * Debounced version of {@link trackNoResultsQueryWithFallbackWire}
+ *
+ * @public
+ * @deprecated - Use {@link trackNoResultsQueryWithFallbackWireDebounced} instead.
+ */
+export const trackNoResultsQueryWithSemanticsWireDebounced =
+  trackNoResultsQueryWithFallbackWireDebounced
+
+/**
  * Factory helper to create a wire for the track of the display click.
  *
  * @param property - Key of the tagging object to track.


### PR DESCRIPTION
…esults

<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
When we obtain a no-results scenario and related-prompts fallback is displayed, `totalHits` param in query tagging should be `-1` and if no fallback is displayed, `totalHits`value should be `0`.

This is the same scenario as semantic queries fallback.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [RST-3556](https://searchbroker.atlassian.net/browse/RST-3556)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Make the build of x-components in the X project and install it locally in a project with related-prompts (Conforama, Primor, FarmaciasDirect...) 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[RST-3556]: https://searchbroker.atlassian.net/browse/RST-3556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ