### PR TITLE
feat(x-adapter-platform): add default headers to endpoint adapters

### DIFF
--- a/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
+++ b/packages/x-adapter-platform/src/__tests__/platform.adapter.spec.ts
@@ -115,7 +115,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://search.internal.test.empathy.co/query/empathy/search?internal=true&query=chips&origin=popular_search%3Apredictive_layer&start=0&rows=0&sort=price+asc&filter=categoryIds%3Affc61e1e9__be257cb26&filter=gender%3Amen&filter=price%3A10.0-20.0&instance=empathy&env=test&lang=es&device=mobile&scope=mobile',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
     expect(response.totalResults).toBe(0)
     expect(response.facets).toStrictEqual([
@@ -181,7 +186,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://search.internal.test.empathy.co/query/empathy/empathize?internal=true&start=0&rows=24&instance=empathy&env=test&lang=en&device=tablet&scope=tablet',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
 
     expect(response).toStrictEqual({
@@ -227,7 +237,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://search.internal.test.empathy.co/query/empathy/empathize?internal=true&query=boots&start=0&rows=24&instance=empathy&env=test&lang=en&device=tablet&scope=tablet',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
 
     expect(response).toStrictEqual({
@@ -274,7 +289,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://search.internal.test.empathy.co/query/empathy/empathize?internal=true&query=boots&start=0&rows=24&instance=empathy&env=test&lang=en&device=tablet&scope=tablet',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
 
     expect(response).toStrictEqual({
@@ -322,7 +342,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.staging.empathy.co/nextqueries/empathy?internal=true&query=makeup&scope=mobile&instance=empathy&device=mobile&env=staging&lang=en',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
     expect(response).toStrictEqual({
       nextQueries: [
@@ -371,7 +396,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.staging.empathy.co/relatedtags/empathy?internal=true&query=jeans&device=mobile&env=staging&lang=en&scope=mobile&instance=empathy',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
     expect(response).toStrictEqual({
       relatedTags: [
@@ -406,7 +436,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.staging.empathy.co/search/v1/query/empathy/skusearch?internal=true&query=jeans&origin=search_box%3Anone&start=0&rows=24&instance=empathy&env=staging&lang=en&device=mobile&scope=mobile',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
 
     expect(response).toStrictEqual({
@@ -521,7 +556,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://search.internal.test.empathy.co/query/empathy/topclicked?internal=true&start=0&rows=24&origin=search_box%3Anone&instance=empathy&env=test&lang=en&device=desktop&scope=desktop',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
 
     expect(response).toStrictEqual({
@@ -572,7 +612,12 @@ describe('platformAdapter tests', () => {
     })
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.staging.empathy.co/tagging/v1/track/empathy/click?filtered=false&follow=false&lang=en&origin=search_box%3Anone&page=1&position=1&productId=12345-U&q=12345&scope=desktop&spellcheck=false&title=Xoxo+Women+Maroon+Pure+Georgette+Solid+Ready-to-wear+Saree',
-      { keepalive: true },
+      {
+        keepalive: true,
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
   })
 
@@ -606,7 +651,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.staging.empathy.co/semantics-api/search_single/empathy?q=test&lang=en&instance=empathy&env=staging',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
 
     expect(response).toStrictEqual({
@@ -645,7 +695,12 @@ describe('platformAdapter tests', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.staging.empathy.co/config/v1/public/configs?service=xcontrols&instance=empathy&env=staging',
-      { signal: expect.anything() },
+      {
+        signal: expect.anything(),
+        headers: {
+          'x-origin': expect.anything(),
+        },
+      },
     )
     expect(response).toStrictEqual({
       controls: {

--- a/packages/x-adapter-platform/src/endpoint-adapters/experience-controls.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/experience-controls.endpoint-adapter.ts
@@ -2,7 +2,7 @@ import type { ExperienceControlsRequest, ExperienceControlsResponse } from '@emp
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
 import { experienceControlsRequestMapper } from '../mappers/requests/experience-controls-request.mapper'
 import { experienceControlsResponseMapper } from '../mappers/responses/experience-controls-response.mapper'
-import { getConfigServiceUrl } from './utils'
+import { getConfigServiceUrl, getDefaultHeaders } from './utils'
 
 /**.
  * Default adapter for the experience controls endpoint.
@@ -18,6 +18,9 @@ export const experienceControlsEndpointAdapter = endpointAdapterFactory<
   responseMapper: experienceControlsResponseMapper,
   defaultRequestOptions: {
     id: 'experience-controls',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       service: 'xcontrols',
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/identifier-results.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/identifier-results.endpoint-adapter.ts
@@ -1,10 +1,8 @@
 import type { IdentifierResultsRequest, IdentifierResultsResponse } from '@empathyco/x-types'
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
-
 import { identifierResultsRequestMapper } from '../mappers/requests/identifier-results-request.mapper'
-
 import { identifierResultsResponseMapper } from '../mappers/responses/identifier-results-response.mapper'
-import { getSearchServiceUrl } from './utils'
+import { getDefaultHeaders, getSearchServiceUrl } from './utils'
 
 /**
  * Default adapter for the identifier results endpoint.
@@ -21,6 +19,9 @@ export const identifierResultsEndpointAdapter = endpointAdapterFactory<
   responseMapper: identifierResultsResponseMapper,
   defaultRequestOptions: {
     id: 'identifier-results',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       internal: true,
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/next-queries.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/next-queries.endpoint-adapter.ts
@@ -2,7 +2,7 @@ import type { NextQueriesRequest, NextQueriesResponse } from '@empathyco/x-types
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
 import { nextQueriesRequestMapper } from '../mappers/requests/next-queries-request.mapper'
 import { nextQueriesResponseMapper } from '../mappers/responses/next-queries-response.mapper'
-import { getBeaconServiceUrl } from './utils'
+import { getBeaconServiceUrl, getDefaultHeaders } from './utils'
 
 /**
  * This endpoint does not support pagination in the request.
@@ -19,6 +19,9 @@ export const nextQueriesEndpointAdapter = endpointAdapterFactory<
   responseMapper: nextQueriesResponseMapper,
   defaultRequestOptions: {
     id: 'next-queries',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       internal: true,
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/popular-searches.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/popular-searches.endpoint-adapter.ts
@@ -1,9 +1,8 @@
 import type { PopularSearchesRequest, PopularSearchesResponse } from '@empathyco/x-types'
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
 import { popularSearchesRequestMapper } from '../mappers/requests/popular-searches-request.mapper'
-
 import { popularSearchesResponseMapper } from '../mappers/responses/popular-searches-response.mapper'
-import { getSearchServiceUrl } from './utils'
+import { getDefaultHeaders, getSearchServiceUrl } from './utils'
 
 /**
  * Default adapter for the popular searches endpoint.
@@ -20,6 +19,9 @@ export const popularSearchesEndpointAdapter = endpointAdapterFactory<
   responseMapper: popularSearchesResponseMapper,
   defaultRequestOptions: {
     id: 'popular-searches',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       internal: true,
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/query-suggestions.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/query-suggestions.endpoint-adapter.ts
@@ -1,10 +1,8 @@
 import type { QuerySuggestionsRequest, QuerySuggestionsResponse } from '@empathyco/x-types'
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
-
 import { querySuggestionsRequestMapper } from '../mappers/requests/query-suggestions-request.mapper'
-
 import { querySuggestionsResponseMapper } from '../mappers/responses/query-suggestions-response.mapper'
-import { getSearchServiceUrl } from './utils'
+import { getDefaultHeaders, getSearchServiceUrl } from './utils'
 
 /**
  * Default adapter for the query suggestions endpoint.
@@ -21,6 +19,9 @@ export const querySuggestionsEndpointAdapter = endpointAdapterFactory<
   responseMapper: querySuggestionsResponseMapper,
   defaultRequestOptions: {
     id: 'query-suggestions',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       internal: true,
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/recommendations.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/recommendations.endpoint-adapter.ts
@@ -1,9 +1,8 @@
 import type { RecommendationsRequest, RecommendationsResponse } from '@empathyco/x-types'
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
 import { recommendationsRequestMapper } from '../mappers/requests/recommendations-request.mapper'
-
 import { recommendationsResponseMapper } from '../mappers/responses/recommendations-response.mapper'
-import { getSearchServiceUrl } from './utils'
+import { getDefaultHeaders, getSearchServiceUrl } from './utils'
 
 /**
  * Default adapter for the recommendations' endpoint.
@@ -20,6 +19,9 @@ export const recommendationsEndpointAdapter = endpointAdapterFactory<
   responseMapper: recommendationsResponseMapper,
   defaultRequestOptions: {
     id: 'recommendations',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       internal: true,
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/related-prompts.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/related-prompts.endpoint-adapter.ts
@@ -2,7 +2,7 @@ import type { RelatedPromptsRequest, RelatedPromptsResponse } from '@empathyco/x
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
 import { relatedPromptsRequestMapper } from '../mappers/index'
 import { relatedPromptsResponseMapper } from '../mappers/responses/related-prompts-response.mapper'
-import { getBeaconServiceUrl } from './utils'
+import { getBeaconServiceUrl, getDefaultHeaders } from './utils'
 
 /**
  * Default adapter for the related prompt endpoint.
@@ -20,6 +20,9 @@ export const relatedPromptsEndpointAdapter = endpointAdapterFactory<
   responseMapper: relatedPromptsResponseMapper,
   defaultRequestOptions: {
     id: 'related-prompts',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       internal: true,
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/related-tags.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/related-tags.endpoint-adapter.ts
@@ -2,7 +2,7 @@ import type { RelatedTagsRequest, RelatedTagsResponse } from '@empathyco/x-types
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
 import { relatedTagsRequestMapper } from '../mappers/requests/related-tags-request.mapper'
 import { relatedTagsResponseMapper } from '../mappers/responses/related-tags-response.mapper'
-import { getBeaconServiceUrl } from './utils'
+import { getBeaconServiceUrl, getDefaultHeaders } from './utils'
 
 /**
  * This endpoint does not support pagination in the request.
@@ -19,6 +19,9 @@ export const relatedTagsEndpointAdapter = endpointAdapterFactory<
   responseMapper: relatedTagsResponseMapper,
   defaultRequestOptions: {
     id: 'related-tags',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       internal: true,
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/search.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/search.endpoint-adapter.ts
@@ -2,7 +2,7 @@ import type { SearchRequest, SearchResponse } from '@empathyco/x-types'
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
 import { searchRequestMapper } from '../mappers/requests/search-request.mapper'
 import { searchResponseMapper } from '../mappers/responses/search-response.mapper'
-import { getSearchServiceUrl } from './utils'
+import { getDefaultHeaders, getSearchServiceUrl } from './utils'
 
 /**
  * Default adapter for the search endpoint.
@@ -16,6 +16,9 @@ export const searchEndpointAdapter = endpointAdapterFactory<SearchRequest, Searc
   responseMapper: searchResponseMapper,
   defaultRequestOptions: {
     id: 'search',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
     parameters: {
       internal: true,
     },

--- a/packages/x-adapter-platform/src/endpoint-adapters/semantic-queries.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/semantic-queries.endpoint-adapter.ts
@@ -1,9 +1,8 @@
 import type { SemanticQueriesRequest, SemanticQueriesResponse } from '@empathyco/x-types'
 import { endpointAdapterFactory, interpolate } from '@empathyco/x-adapter'
 import { semanticQueriesRequestMapper } from '../mappers/requests/semantic-queries-request.mapper'
-
 import { semanticQueriesResponseMapper } from '../mappers/responses/semantic-queries-response.mapper'
-import { getSemanticsServiceUrl } from './utils'
+import { getDefaultHeaders, getSemanticsServiceUrl } from './utils'
 
 /**
  * Default adapter for the semantic queries endpoint.
@@ -20,5 +19,8 @@ export const semanticQueriesEndpointAdapter = endpointAdapterFactory<
   responseMapper: semanticQueriesResponseMapper,
   defaultRequestOptions: {
     id: 'semantic-queries',
+    properties: {
+      headers: getDefaultHeaders(),
+    },
   },
 })

--- a/packages/x-adapter-platform/src/endpoint-adapters/tagging.endpoint-adapter.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/tagging.endpoint-adapter.ts
@@ -1,6 +1,7 @@
 import type { TaggingRequest } from '@empathyco/x-types'
 import { endpointAdapterFactory } from '@empathyco/x-adapter'
 import { taggingRequestMapper } from '../mappers/requests/tagging-request.mapper'
+import { getDefaultHeaders } from './utils'
 
 /**
  * Default adapter for the tagging endpoint.
@@ -13,6 +14,9 @@ export const taggingEndpointAdapter = endpointAdapterFactory<TaggingRequest, voi
   defaultRequestOptions: {
     id: 'tagging',
     cancelable: false,
-    properties: { keepalive: true },
+    properties: {
+      keepalive: true,
+      headers: getDefaultHeaders(),
+    },
   },
 })

--- a/packages/x-adapter-platform/src/endpoint-adapters/utils.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/utils.ts
@@ -59,3 +59,15 @@ export function getConfigServiceUrl(from: ExtraParamsRequest): string {
     ? 'https://config-service.internal.test.empathy.co'
     : 'https://api.{extraParams.env(.)}empathy.co/config/v1'
 }
+
+/**
+ * Returns the default headers for the endpoint adapters.
+ *
+ * @returns The default headers object.
+ * @public
+ */
+export function getDefaultHeaders(): Record<string, string> {
+  return {
+    'x-empathy-origin': location?.origin,
+  }
+}

--- a/packages/x-adapter-platform/src/endpoint-adapters/utils.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/utils.ts
@@ -68,6 +68,6 @@ export function getConfigServiceUrl(from: ExtraParamsRequest): string {
  */
 export function getDefaultHeaders(): Record<string, string> {
   return {
-    'x-empathy-origin': location?.origin,
+    'x-origin': location?.origin,
   }
 }


### PR DESCRIPTION
Platform team requested some kind of header to identify requests from the consumers of the frontend, so we can identify traffic from bots or direct API calls.

Copilot summary:
This pull request introduces a new utility function, `getDefaultHeaders`, and integrates it into multiple endpoint adapters to standardize the inclusion of default headers across the platform. The changes enhance consistency and maintainability of the request configurations.

### Addition of `getDefaultHeaders` Utility:
* [`packages/x-adapter-platform/src/endpoint-adapters/utils.ts`](diffhunk://#diff-2cbef89cce178c19a12cc162ed17851451af7fb2a971a7957743871667f3c41cR62-R73): Added the `getDefaultHeaders` function to provide a standardized set of headers, including the `x-empathy-origin` header derived from the browser's location.

### Integration of `getDefaultHeaders` into Endpoint Adapters:
* **Experience Controls**: Updated the `experienceControlsEndpointAdapter` to include default headers via `getDefaultHeaders`. [[1]](diffhunk://#diff-38de6fd09890493532ea3898bad6d31c30e831fe4f1da1c44f654dde6ac2b455L5-R5) [[2]](diffhunk://#diff-38de6fd09890493532ea3898bad6d31c30e831fe4f1da1c44f654dde6ac2b455R21-R23)
* **Identifier Results**: Modified the `identifierResultsEndpointAdapter` to use `getDefaultHeaders` for its headers configuration. [[1]](diffhunk://#diff-0db8f2460449f1f8b0da904500fdb1e38a2c0da498a296ac83b07ade68dcd9f6L3-R5) [[2]](diffhunk://#diff-0db8f2460449f1f8b0da904500fdb1e38a2c0da498a296ac83b07ade68dcd9f6R22-R24)
* **Next Queries**: Incorporated `getDefaultHeaders` into the `nextQueriesEndpointAdapter` for consistent header management. [[1]](diffhunk://#diff-1028fdc46b13b008baa78e3c8bd3d194aaff9c99de767f86d933da0115b302f2L5-R5) [[2]](diffhunk://#diff-1028fdc46b13b008baa78e3c8bd3d194aaff9c99de767f86d933da0115b302f2R22-R24)
* **Popular Searches**: Integrated `getDefaultHeaders` into the `popularSearchesEndpointAdapter`. [[1]](diffhunk://#diff-92634ea29a45c220837834d514b95572a42aa1eeded60233be64315249243593L4-R5) [[2]](diffhunk://#diff-92634ea29a45c220837834d514b95572a42aa1eeded60233be64315249243593R22-R24)
* **Query Suggestions**: Applied `getDefaultHeaders` in the `querySuggestionsEndpointAdapter`. [[1]](diffhunk://#diff-4eda90ad4edca3b7874aedc55bb1b86d57377838d1c1184cbde9a866211948aaL3-R5) [[2]](diffhunk://#diff-4eda90ad4edca3b7874aedc55bb1b86d57377838d1c1184cbde9a866211948aaR22-R24)
* **Recommendations**: Updated the `recommendationsEndpointAdapter` to include `getDefaultHeaders`. [[1]](diffhunk://#diff-6a8f06b4a81c8027bdd0bdef9279dc1b8570b0605ae0c616108f59bbc82e10ffL4-R5) [[2]](diffhunk://#diff-6a8f06b4a81c8027bdd0bdef9279dc1b8570b0605ae0c616108f59bbc82e10ffR22-R24)
* **Related Prompts**: Added `getDefaultHeaders` to the `relatedPromptsEndpointAdapter`. [[1]](diffhunk://#diff-36717e6fee71dfd48941e6a82de5b73433f3f62042c5ad538369f82c6200101bL5-R5) [[2]](diffhunk://#diff-36717e6fee71dfd48941e6a82de5b73433f3f62042c5ad538369f82c6200101bR23-R25)
* **Related Tags**: Integrated `getDefaultHeaders` into the `relatedTagsEndpointAdapter`. [[1]](diffhunk://#diff-d381d3fb2ac25b3d281c5a23637d7c1d9dc5cb29db6cc6667cdcecd461d1a768L5-R5) [[2]](diffhunk://#diff-d381d3fb2ac25b3d281c5a23637d7c1d9dc5cb29db6cc6667cdcecd461d1a768R22-R24)
* **Search**: Modified the `searchEndpointAdapter` to include `getDefaultHeaders`. [[1]](diffhunk://#diff-c38d9aac87e7c87a29c9db33efbcb4bff9b7677d5db136eda8afe11bec0d1875L5-R5) [[2]](diffhunk://#diff-c38d9aac87e7c87a29c9db33efbcb4bff9b7677d5db136eda8afe11bec0d1875R19-R21)
* **Semantic Queries**: Incorporated `getDefaultHeaders` into the `semanticQueriesEndpointAdapter`. [[1]](diffhunk://#diff-bb121db9bb07c6001563566f089b6f4cb79c0cd548b804a46d5bd90213cacd85L4-R5) [[2]](diffhunk://#diff-bb121db9bb07c6001563566f089b6f4cb79c0cd548b804a46d5bd90213cacd85R22-R24)
* **Tagging**: Updated the `taggingEndpointAdapter` to use `getDefaultHeaders` while retaining the `keepalive` property. [[1]](diffhunk://#diff-c2ea94a26158af0cd3f2f32e76b9f33310ec02e19add1080bfbc24005a9f4612R4) [[2]](diffhunk://#diff-c2ea94a26158af0cd3f2f32e76b9f33310ec02e19add1080bfbc24005a9f4612L16-R20)

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: https://searchbroker.atlassian.net/browse/RST-3599

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
