### PR TITLE
fix(base-teleport): fix shadowRoot support

### DIFF
--- a/packages/x-components/src/components/__tests__/base-teleport.spec.ts
+++ b/packages/x-components/src/components/__tests__/base-teleport.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import BaseTeleport from '../base-teleport.vue'
 
 /**
@@ -33,8 +33,10 @@ describe('testing BaseTeleport component', () => {
     document.body.appendChild(targetElement)
   })
 
-  it('renders content in the target element', () => {
+  it('renders content in the target element', async () => {
     renderBaseTeleport({ target: '#teleport-target' })
+
+    await flushPromises()
 
     expect(targetElement.querySelector('.x-base-teleport')).not.toBeNull()
     expect(targetElement.textContent).toContain('Teleport Content')

--- a/packages/x-components/src/components/base-teleport.vue
+++ b/packages/x-components/src/components/base-teleport.vue
@@ -54,7 +54,7 @@ export default defineComponent({
     let isIsolated = false
 
     // Before doing app.mount it is unknown if it will be mounted in a shadow so we need to wait.
-    if (instance?.appContext.app._container?.parentNode) {
+    if (instance?.appContext.app._container) {
       createHost()
     } else {
       afterAppMount(createHost)
@@ -133,7 +133,7 @@ export default defineComponent({
     /** Creates and sets the teleport host element */
     function createHost() {
       teleportHost.value = document.createElement('div')
-      isIsolated = instance?.appContext.app._container?.parentNode instanceof ShadowRoot
+      isIsolated = instance?.appContext.app._container instanceof ShadowRoot
       if (isIsolated) {
         teleportHost.value.attachShadow({ mode: 'open' })
         ;(window as any).xCSSInjector.addHost(teleportHost.value.shadowRoot)

--- a/packages/x-components/src/components/base-teleport.vue
+++ b/packages/x-components/src/components/base-teleport.vue
@@ -47,10 +47,13 @@ export default defineComponent({
   },
   setup(props) {
     const instance = getCurrentInstance()
+    /** Hook where the slot content will be teleported to. */
     const teleportHost = ref<Element>()
+    /** The page element where the teleport host will be inserted. */
     const targetElement = ref<Element>()
     let isIsolated = false
 
+    // Before doing app.mount it is unknown if it will be mounted in a shadow so we need to wait.
     if (instance?.appContext.app._container?.parentNode) {
       createHost()
     } else {
@@ -72,6 +75,7 @@ export default defineComponent({
       teleportHost.value?.remove()
     })
 
+    // Handles target prop changes and init the observers accordingly.
     watch(
       () => props.target,
       newTarget => {
@@ -87,6 +91,7 @@ export default defineComponent({
       { immediate: true },
     )
 
+    // Updates the teleport host when props change.
     watchEffect(() => {
       if (!teleportHost.value) {
         return
@@ -116,7 +121,7 @@ export default defineComponent({
       }
     }
 
-    /** Checks if the target was disconected from the DOM and updates the observers */
+    /** Checks if the target was disconnected from the DOM and updates the observers */
     function targetRemoved() {
       if (!targetElement.value?.isConnected) {
         targetRemovedObserver.disconnect()

--- a/packages/x-components/src/components/base-teleport.vue
+++ b/packages/x-components/src/components/base-teleport.vue
@@ -142,10 +142,15 @@ export default defineComponent({
     return { teleportHost }
   },
 })
-</script>
 
-<style lang="css">
-:has(> .x-base-teleport--onlychild) > *:not(.x-base-teleport) {
-  display: none;
-}
-</style>
+/** Teleport host styles should be injected outside our shadowRoots */
+document.addEventListener('DOMContentLoaded', () => {
+  const styleTag = document.createElement('style')
+  styleTag.textContent = `
+    :has(> .x-base-teleport--onlychild) > *:not(.x-base-teleport) {
+      display: none;
+    }
+  `
+  document.head.appendChild(styleTag)
+})
+</script>


### PR DESCRIPTION
# Pull request template
Issues fixed:

- Teleport could be created before `app.mount()` so it needs to wait for app mount to know if it is mounted on a `shadowRoot`
- Teleport Host Styles should be inserted into parent/target host (document or shadow) and not in the x-components hosts.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [x] Open issue. If applicable, link: https://searchbroker.atlassian.net/browse/RST-3381

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
