### PR TITLE
fix(base-teleport): add style tag after DOMContentLoaded was fired

### DIFF
--- a/packages/x-components/src/components/base-teleport.vue
+++ b/packages/x-components/src/components/base-teleport.vue
@@ -149,13 +149,8 @@ export default defineComponent({
 })
 
 /** Teleport host styles should be injected outside our shadowRoots */
-document.addEventListener('DOMContentLoaded', () => {
-  const styleTag = document.createElement('style')
-  styleTag.textContent = `
-    :has(> .x-base-teleport--onlychild) > *:not(.x-base-teleport) {
-      display: none;
-    }
-  `
-  document.head.appendChild(styleTag)
-})
+const css = document.createElement('style')
+css.textContent = ':has(> .x-base-teleport--onlychild) > *:not(.x-base-teleport) { display: none; }'
+document.head?.appendChild(css) ||
+  document.addEventListener('DOMContentLoaded', () => document.head.appendChild(css))
 </script>


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template

Support for adding `base-teleport` component styles after DOMContentLoaded was fired

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
