### PR TITLE
feat(utils): ensure `getDefaultHeaders` is SSR-friendly and add tests…

### DIFF
--- a/packages/x-adapter-platform/src/endpoint-adapters/__tests__/utils.spec.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/__tests__/utils.spec.ts
@@ -1,0 +1,60 @@
+import { getDefaultHeaders } from '../utils'
+
+describe('utils tests', () => {
+  describe('getDefaultHeaders', () => {
+    const globThis = globalThis as unknown as { window?: Window; location?: Location }
+    // Store original properties
+    let originalWindow: Window | undefined
+    let originalLocation: Location | undefined
+
+    beforeEach(() => {
+      // Save original window and location objects before each test
+      originalWindow = globThis.window
+      originalLocation = globThis.location
+    })
+
+    afterEach(() => {
+      // Restore original window and location after each test
+      if (originalWindow === undefined) {
+        delete globThis.window
+      } else {
+        globThis.window = originalWindow
+      }
+
+      if (originalLocation === undefined) {
+        delete globThis.location
+      } else {
+        globThis.location = originalLocation
+      }
+    })
+
+    it('should return headers with x-origin set to location.origin in browser environment', () => {
+      // Mock browser environment
+      globThis.window = {} as Window & typeof globalThis
+
+      // Create a mock location object with a getter for origin
+      Object.defineProperty(globThis, 'location', {
+        value: { origin: 'https://test.example.com' },
+        writable: true,
+      })
+
+      const headers = getDefaultHeaders()
+
+      expect(headers).toEqual({
+        'x-origin': 'https://test.example.com',
+      })
+    })
+
+    it('should return headers with x-origin set to fallback string in non-browser environment', () => {
+      // Mock non-browser environment
+      delete globThis.window
+      delete globThis.location
+
+      const headers = getDefaultHeaders()
+
+      expect(headers).toEqual({
+        'x-origin': 'non-browser',
+      })
+    })
+  })
+})

--- a/packages/x-adapter-platform/src/endpoint-adapters/utils.ts
+++ b/packages/x-adapter-platform/src/endpoint-adapters/utils.ts
@@ -62,12 +62,21 @@ export function getConfigServiceUrl(from: ExtraParamsRequest): string {
 
 /**
  * Returns the default headers for the endpoint adapters.
+ * This function is SSR-friendly and will always include the x-origin header.
+ * In a browser environment, it uses location.origin; otherwise, it uses a fallback string.
  *
  * @returns The default headers object.
  * @public
  */
 export function getDefaultHeaders(): Record<string, string> {
-  return {
-    'x-origin': location?.origin,
+  const headers: Record<string, string> = {}
+
+  // Add x-origin header with location.origin if in browser, otherwise use fallback
+  if (typeof window !== 'undefined' && typeof location !== 'undefined') {
+    headers['x-origin'] = location.origin
+  } else {
+    headers['x-origin'] = 'non-browser'
   }
+
+  return headers
 }


### PR DESCRIPTION
## Motivation and context
This pull request introduces a new utility function, `getDefaultHeaders`, to ensure SSR (Server-Side Rendering) compatibility by handling the `x-origin` header differently in browser and non-browser environments. Additionally, it includes comprehensive unit tests for this function.

### New Utility Function for SSR Compatibility:
* [`packages/x-adapter-platform/src/endpoint-adapters/utils.ts`](diffhunk://#diff-2cbef89cce178c19a12cc162ed17851451af7fb2a971a7957743871667f3c41cR65-R81): Added the `getDefaultHeaders` function, which dynamically sets the `x-origin` header based on the environment. It uses `location.origin` in a browser environment and a fallback value (`'non-browser'`) in non-browser environments.

### Unit Tests for `getDefaultHeaders`:
* [`packages/x-adapter-platform/src/endpoint-adapters/__tests__/utils.spec.ts`](diffhunk://#diff-47762f8ab420e2318250d222a6a477bfc147c4528be2c4a56853b93d416c838fR1-R60): Introduced unit tests for `getDefaultHeaders` to verify the behavior in both browser and non-browser environments. The tests include mocking `window` and `location` objects to simulate the respective environments.… for browser/non-browser behavior
<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
