### PR TITLE
ci(build): dedupe pr workflow run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: ci
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,15 @@
 name: ci
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoid running the workflow for each commit
FROM: 2 executions (push event and pr event)
![image](https://github.com/user-attachments/assets/f5cd4c08-1371-478f-bada-d4b9c982878a)
TO: `1 ci/buld` execution
<img width="578" alt="image" src="https://github.com/user-attachments/assets/8559c76a-3862-4283-b854-f4f98849d931" />

