### PR TITLE
fix: duplicated font-family breaks font fallback order

### DIFF
--- a/packages/x-tailwindcss/src/x-tailwind-plugin/theme.ts
+++ b/packages/x-tailwindcss/src/x-tailwind-plugin/theme.ts
@@ -66,10 +66,10 @@ export default {
     },
   },
   fontFamily: {
-    main: ['Inter', 'sans-serif'],
-    alternative: ['Lora', 'serif'],
-    extra: ['Poppins', 'sans-serif'],
-    special: ['Bree Serif', 'serif'],
+    main: 'Inter, sans-serif',
+    alternative: 'Lora, serif',
+    extra: 'Poppins, sans-serif',
+    special: 'Bree Serif, serif',
     icon: 'font-awesome',
   },
   fontSize: {


### PR DESCRIPTION
After #1658 a duplicated _font-family_ is created when building the styles, breaking the fallback order of the font.

![image](https://github.com/user-attachments/assets/67ca5316-65f4-4b07-8a37-328f3e8e87fe)

This pull request includes a small change to the `packages/x-tailwindcss/src/x-tailwind-plugin/theme.ts` file. The change updates the `fontFamily` definitions by replacing array notation with string notation for consistency and simplicity.

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
