### PR TITLE
feat(related-prompts): add related prompts images as default

### DIFF
--- a/packages/x-components/src/x-modules/related-prompts/components/related-prompt.vue
+++ b/packages/x-components/src/x-modules/related-prompts/components/related-prompt.vue
@@ -4,7 +4,16 @@
      @slot related-prompt-extra-content - The slot to render related prompt extra information.
      @prop {Object} relatedPrompt - The related prompt object.
     -->
-    <slot name="related-prompt-extra-content" :related-prompt="relatedPrompt" />
+    <slot name="related-prompt-extra-content" :related-prompt="relatedPrompt">
+      <img
+        v-if="relatedPrompt.suggestionImageUrl"
+        :width="56"
+        :height="56"
+        :src="relatedPrompt.suggestionImageUrl"
+        :alt="relatedPrompt.nextQueries[0]"
+        class="x-related-prompts-item-image"
+      />
+    </slot>
     <span
       v-typing="{ text: relatedPrompt.suggestionText, speed: 50 }"
       class="x-related-prompt-text"
@@ -82,5 +91,14 @@ export default defineComponent({
   height: 24px;
   flex-shrink: 0;
   align-self: start;
+}
+
+.x-related-prompts-item-image {
+  aspect-ratio: 1 / 1;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-radius: 50%;
+  background-color: white;
+  object-fit: cover;
 }
 </style>


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Since the related prompt images have been a huge success, the team has decided to display them by default.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

If you want a compleate example, you can try to make the x-components build and install it locally into x-farmaciasdirect setup. (also update `x-adapter-platform` from 1.1.0-alpha.15 to **1.1.0-alpha.17**, `x-types` from 10.1.0-alpha.12 to **10.1.0-alpha.13**)

And try with `?env=live&query=tengo%20dolor%20cabeza`

![Screenshot 2025-06-25 at 15 50 14](https://github.com/user-attachments/assets/22078166-ca37-4bd1-9587-e219f30a89c7)


## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
