### PR TITLE
feat: save filtered related prompts in the related prompts state

### DIFF
--- a/packages/x-components/src/x-modules/related-prompts/components/related-prompts-tag-list.vue
+++ b/packages/x-components/src/x-modules/related-prompts/components/related-prompts-tag-list.vue
@@ -144,15 +144,32 @@ export default defineComponent({
       type: Number,
       default: 700,
     },
+    /**
+     * The boolean prop to handle if we should use the relatedPromptsFiltered or relatedPrompts.
+     *
+     * @public
+     */
+    useFilteredRelatedPrompts: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
     const x = use$x()
-    const { relatedPrompts, selectedPrompt: selectedPromptIndex } = useState('relatedPrompts')
+    const {
+      relatedPrompts,
+      relatedPromptsFiltered,
+      selectedPrompt: selectedPromptIndex,
+    } = useState('relatedPrompts')
 
     const clickedListItemIndex = ref<number | null>(null)
     const initialOffsetLefts: Record<number, number> = {}
     const isAnimating = ref(false)
     const listItems = ref<HTMLElement[]>([])
+
+    const relatedPromptsList = computed(() =>
+      props.useFilteredRelatedPrompts ? relatedPromptsFiltered.value : relatedPrompts.value,
+    )
 
     const sortedListItems = computed<HTMLElement[]>(() =>
       [...listItems.value].sort(
@@ -169,12 +186,12 @@ export default defineComponent({
       () =>
         props.animationDurationInMs /
         (clickedListItemIndex.value !== null
-          ? relatedPrompts.value.length - 1
-          : relatedPrompts.value.length),
+          ? relatedPromptsList.value.length - 1
+          : relatedPromptsList.value.length),
     )
 
     const indexRelatedPrompts = computed(() =>
-      relatedPrompts.value.map((relatedPrompt, index) => ({ ...relatedPrompt, index })),
+      relatedPromptsList.value.map((relatedPrompt, index) => ({ ...relatedPrompt, index })),
     )
 
     const visibleRelatedPrompts = computed(() =>
@@ -238,7 +255,7 @@ export default defineComponent({
         // Synchronize the transition delay of the selected element with the last
         // element to leave
         selected.style.transitionDelay = `${
-          (relatedPrompts.value.length > 1 ? relatedPrompts.value.length - 2 : 0) *
+          (relatedPromptsList.value.length > 1 ? relatedPromptsList.value.length - 2 : 0) *
           singleAnimationDurationInMs.value
         }ms`
 
@@ -267,7 +284,7 @@ export default defineComponent({
       }
 
       x.emit('UserSelectedARelatedPrompt', selectedIndex, {
-        relatedPrompt: relatedPrompts.value[selectedIndex],
+        relatedPrompt: relatedPromptsList.value[selectedIndex],
         selectedPrompt: selectedPromptIndex.value,
       })
     }

--- a/packages/x-components/src/x-modules/related-prompts/store/actions/fetch-and-save-related-prompts.action.ts
+++ b/packages/x-components/src/x-modules/related-prompts/store/actions/fetch-and-save-related-prompts.action.ts
@@ -1,6 +1,7 @@
 import type { RelatedPrompt, RelatedPromptsRequest } from '@empathyco/x-types'
 import type { RelatedPromptsActionContext } from '../types'
 import { createFetchAndSaveActions } from '../../../../store/utils/fetch-and-save-action.utils'
+import { getRelatedPromptsByQuery } from '../utils/related-prompts.utils'
 
 const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   RelatedPromptsActionContext,
@@ -10,9 +11,13 @@ const { fetchAndSave, cancelPrevious } = createFetchAndSaveActions<
   async fetch({ dispatch }, request) {
     return dispatch('fetchRelatedPrompts', request)
   },
-  onSuccess({ commit }, relatedPrompts) {
+  onSuccess({ commit, state }, relatedPrompts) {
     if (relatedPrompts) {
       commit('setRelatedPromptsProducts', relatedPrompts)
+      commit(
+        'setFilteredRelatedPromptsProducts',
+        getRelatedPromptsByQuery(relatedPrompts, state.query),
+      )
     }
   },
 })

--- a/packages/x-components/src/x-modules/related-prompts/store/module.ts
+++ b/packages/x-components/src/x-modules/related-prompts/store/module.ts
@@ -19,6 +19,7 @@ export const relatedPromptsXStoreModule: RelatedPromptsXStoreModule = {
   state: () => ({
     query: '',
     relatedPrompts: [],
+    relatedPromptsFiltered: [],
     selectedPrompt: -1,
     selectedQuery: -1,
     status: 'initial',
@@ -37,6 +38,9 @@ export const relatedPromptsXStoreModule: RelatedPromptsXStoreModule = {
     },
     setRelatedPromptsProducts(state, products) {
       state.relatedPrompts = products
+    },
+    setFilteredRelatedPromptsProducts(state, products) {
+      state.relatedPromptsFiltered = products
     },
     setSelectedPrompt(state, selectedPrompt) {
       state.selectedPrompt = state.selectedPrompt === selectedPrompt ? -1 : selectedPrompt

--- a/packages/x-components/src/x-modules/related-prompts/store/types.ts
+++ b/packages/x-components/src/x-modules/related-prompts/store/types.ts
@@ -13,6 +13,8 @@ import type { UrlParams } from '../../../types'
 export interface RelatedPromptsState extends StatusState, QueryState {
   /** The list of the related-prompts, related to the `query` property of the state. */
   relatedPrompts: RelatedPrompt[]
+  /** The list of the filtered related-prompts, related to the `query` property of the state. */
+  relatedPromptsFiltered: RelatedPrompt[]
   /** The index of the selected related-prompt. */
   selectedPrompt: number
   /** The index of the selected next query. */
@@ -56,6 +58,12 @@ export interface RelatedPromptsMutations extends StatusMutations, QueryMutations
    * @param products - The new related prompts to save to the state.
    */
   setRelatedPromptsProducts: (products: RelatedPrompt[]) => void
+  /**
+   * Sets the filtered related prompts of the module.
+   *
+   * @param products - The new related prompts to save to the state.
+   */
+  setFilteredRelatedPromptsProducts: (products: RelatedPrompt[]) => void
   /**
    * Sets the selected related prompt.
    *

--- a/packages/x-components/src/x-modules/related-prompts/store/utils/related-prompts.utils.ts
+++ b/packages/x-components/src/x-modules/related-prompts/store/utils/related-prompts.utils.ts
@@ -1,0 +1,76 @@
+import type { RelatedPrompt } from '@empathyco/x-types'
+
+/**
+ * Filters and sorts related prompts based on whether their next queries include
+ * any word from the given query.
+ *
+ * @param relatedPrompts - Array of RelatedPrompt objects to filter and sort.
+ * @param query - The query string to match against next queries.
+ * @returns Array of RelatedPrompt objects with sorted nextQueries.
+ */
+export function getRelatedPromptsByQuery(
+  relatedPrompts: Array<RelatedPrompt>,
+  query: string,
+): Array<RelatedPrompt> {
+  const curatedRelatedPrompts = removeDuplicatesByNextQueries(relatedPrompts)
+  return curatedRelatedPrompts
+    .filter(relatedPrompt =>
+      relatedPrompt.nextQueries.some((nextQuery: string) => isQueryIncluded(nextQuery, query)),
+    )
+    .map(relatedPrompt => ({
+      ...relatedPrompt,
+      nextQueries: relatedPrompt.nextQueries.sort((a, b) => {
+        const foundInA = isQueryIncluded(a, query)
+        const foundInB = isQueryIncluded(b, query)
+
+        if (foundInA === foundInB) {
+          return 0
+        }
+
+        return foundInA ? -1 : 1
+      }),
+    }))
+}
+
+/**
+ * Checks if any word from the query is included in the given text.
+ *
+ * @param text - The text to search within.
+ * @param query - The query string containing words to search for.
+ * @returns True if any word from the query is found in the text, otherwise false.
+ */
+function isQueryIncluded(text: string, query: string): boolean {
+  const queryWords = query.trim().toLowerCase().split(' ')
+  const textWords = text.trim().toLowerCase().split(' ')
+  return queryWords.some(queryWord => textWords.includes(queryWord))
+}
+
+/**
+ * Removes related prompts that mach at leat 2 nextQueries with another relatedPrompt.
+ *
+ * @param relatedPrompts - Array of RelatedPrompt objects to remove duplicated nextQueries.
+ * @returns Array of RelatedPrompt objects with no duplicated nextQueries.
+ */
+function removeDuplicatesByNextQueries(relatedPrompts: Array<RelatedPrompt>): Array<RelatedPrompt> {
+  const uniquePromptsMap: Array<RelatedPrompt> = []
+
+  for (const currentPrompt of relatedPrompts) {
+    let hasMatch = false
+
+    for (const previousPrompt of uniquePromptsMap) {
+      const matches = currentPrompt.nextQueries.filter(query =>
+        previousPrompt.nextQueries.includes(query),
+      )
+      if (matches.length >= 2) {
+        hasMatch = true
+        break
+      }
+    }
+
+    if (!hasMatch) {
+      uniquePromptsMap.push(currentPrompt)
+    }
+  }
+
+  return uniquePromptsMap
+}


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
If we filter related prompts in no/low results scenarios, we are limiting the fallback and taking away the user's ability to continue browsing.

So we are going to display Question in low/no results scenarios exactly as in the response, and in scenarios with many results we will continue filtering Questions.

I propose to save in the Related Prompts State another object (f.e. relatedPromptsFiltered), where we will save the relatedPrompts with the filters applied and then keep the relatedPrompts object with the questions from the response.

The components of the related promtps will use relatedPrompts object if it’s a no/low results scenario and relatedPromptsFiltered if it’s a many results scenario.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [X] Open issue. If applicable, link: [RST-4000](https://searchbroker.atlassian.net/browse/RST-4000)

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.


[RST-4000]: https://searchbroker.atlassian.net/browse/RST-4000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ