### PR TITLE
feat(empathize): implement search and close fallback on no-content state

### DIFF
--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@empathyco/x-components",
-  "version": "6.0.0-alpha.120",
+  "version": "6.0.0-alpha.119",
   "description": "Empathy X Components",
   "author": "Empathy Systems Corporation S.L.",
   "license": "Apache-2.0",

--- a/packages/x-components/package.json
+++ b/packages/x-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@empathyco/x-components",
-  "version": "6.0.0-alpha.119",
+  "version": "6.0.0-alpha.120",
   "description": "Empathy X Components",
   "author": "Empathy Systems Corporation S.L.",
   "license": "Apache-2.0",

--- a/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
+++ b/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
@@ -2,12 +2,19 @@ import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import { getDataTestSelector, installNewXPlugin } from '../../../../__tests__/utils'
 import { getXComponentXModuleName, isXComponent } from '../../../../components'
-import { XPlugin } from '../../../../plugins/index'
+import { XPlugin } from '../../../../plugins'
 import Empathize from '../empathize.vue'
 
 function render({
-  eventsToOpenEmpathize = ['UserClickedSearchBox'],
-  eventsToCloseEmpathize = ['UserClosedEmpathize'],
+  eventsToOpenEmpathize = ['UserFocusedSearchBox', 'UserIsTypingAQuery', 'UserClickedSearchBox'],
+  eventsToCloseEmpathize = [
+    'UserClosedEmpathize',
+    'UserSelectedASuggestion',
+    'UserPressedEnterKey',
+    'UserBlurredSearchBox',
+  ],
+  hasContent = true,
+  searchAndCloseOnNoContent = false,
   template = `
     <Empathize v-bind="$attrs">
       <template #default>
@@ -28,6 +35,8 @@ function render({
       props: {
         eventsToOpenEmpathize,
         eventsToCloseEmpathize,
+        hasContent,
+        searchAndCloseOnNoContent,
       },
       global: {
         plugins: [installNewXPlugin()],
@@ -36,7 +45,15 @@ function render({
   )
 
   return {
-    wrapper: wrapper.findComponent(Empathize),
+    emitSpy: jest.spyOn(XPlugin.bus, 'emit'),
+    wrapper,
+    empathize: wrapper.findComponent(Empathize),
+    get empathizeContainer() {
+      return wrapper.find(getDataTestSelector('empathize'))
+    },
+    get empathizeContent() {
+      return wrapper.find(getDataTestSelector('empathize-content'))
+    },
   }
 }
 
@@ -49,43 +66,77 @@ describe('testing empathize component', () => {
   })
 
   it('is an XComponent which has an XModule', () => {
-    const { wrapper } = render()
+    const { empathize } = render()
 
-    expect(isXComponent(wrapper.vm)).toBeTruthy()
-    expect(getXComponentXModuleName(wrapper.vm)).toEqual('empathize')
+    expect(isXComponent(empathize.vm)).toBeTruthy()
+    expect(getXComponentXModuleName(empathize.vm)).toEqual('empathize')
   })
 
   it('will not open empathize if there is no content to render', async () => {
     const template = `<Empathize v-bind="$attrs"/>`
-    const { wrapper } = render({ template })
+    const { empathizeContainer, empathizeContent, emitSpy } = render({
+      template,
+      hasContent: false,
+    })
 
     await XPlugin.bus.emit('UserClickedSearchBox', undefined)
+    jest.runAllTimers()
+    await nextTick()
 
-    expect(wrapper.find(getDataTestSelector('empathize')).exists()).toBeTruthy()
-    expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBeFalsy()
+    expect(empathizeContainer.exists()).toBeTruthy()
+    expect(empathizeContainer.element).not.toBeVisible()
+    expect(empathizeContent.exists()).toBeFalsy()
+    expect(emitSpy).toHaveBeenCalledTimes(1) // 'UserClickedSearchBox' event
   })
 
-  it('listens to UserOpenedEmpathize and UserClosedEmpathize by default', async () => {
-    const { wrapper } = render()
+  it('listens to default events to open and close empathize', async () => {
+    const { empathizeContainer, empathizeContent, emitSpy } = render()
 
+    // Test opening with one of the default open events
     await XPlugin.bus.emit('UserClickedSearchBox', undefined)
     jest.runAllTimers()
     await nextTick()
 
     // Both should exist and be visible
-    expect(wrapper.find(getDataTestSelector('empathize')).exists()).toBeTruthy()
-    expect(wrapper.find(getDataTestSelector('empathize')).element).toBeVisible()
-    expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBeTruthy()
-    expect(wrapper.find(getDataTestSelector('empathize-content')).element).toBeVisible()
+    expect(empathizeContainer.exists()).toBeTruthy()
+    expect(empathizeContainer.element).toBeVisible()
+    expect(empathizeContent.exists()).toBeTruthy()
+    expect(empathizeContent.element).toBeVisible()
+    expect(emitSpy).toHaveBeenCalledWith('EmpathizeOpened', undefined, expect.any(Object))
 
+    // Test closing with one of the default close events
     await XPlugin.bus.emit('UserClosedEmpathize', undefined)
     jest.runAllTimers()
     await nextTick()
 
     // Both should exist, as v-show doesn't remove the elements in the DOM, and not be visible
-    expect(wrapper.find(getDataTestSelector('empathize')).exists()).toBeTruthy()
-    expect(wrapper.find(getDataTestSelector('empathize')).element).not.toBeVisible()
-    expect(wrapper.find(getDataTestSelector('empathize-content')).exists()).toBeTruthy()
-    expect(wrapper.find(getDataTestSelector('empathize-content')).element).not.toBeVisible()
+    expect(empathizeContainer.exists()).toBeTruthy()
+    expect(empathizeContainer.element).not.toBeVisible()
+    expect(empathizeContent.exists()).toBeTruthy()
+    expect(empathizeContent.element).not.toBeVisible()
+    expect(emitSpy).toHaveBeenCalledWith('EmpathizeClosed', undefined, expect.any(Object))
+  })
+
+  it('should search and close empathize fallback when has no content', async () => {
+    const { wrapper, empathizeContainer, emitSpy } = render({
+      hasContent: true,
+      searchAndCloseOnNoContent: true,
+      template: `<Empathize v-bind="$attrs"/>`,
+    })
+
+    await empathizeContainer.trigger('focusin')
+    jest.runAllTimers()
+    await nextTick()
+
+    expect(empathizeContainer.exists()).toBeTruthy()
+    expect(empathizeContainer.element).toBeVisible()
+    expect(emitSpy).toHaveBeenCalledWith('EmpathizeOpened', undefined, expect.any(Object))
+
+    await wrapper.setProps({ hasContent: false } as any)
+    jest.runAllTimers()
+    await nextTick()
+
+    expect(emitSpy).toHaveBeenCalledWith('UserAcceptedAQuery', '', expect.any(Object))
+    expect(emitSpy).toHaveBeenCalledWith('EmpathizeClosed', undefined, expect.any(Object))
   })
 })

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -16,13 +16,13 @@
 </template>
 
 <script lang="ts">
-import type { PropType } from 'vue'
+import type { PropType, WatchStopHandle } from 'vue'
 import type { XEvent } from '../../../wiring'
-import { computed, defineComponent, ref } from 'vue'
+import { defineComponent, ref, watch } from 'vue'
 import { NoAnimation } from '../../../components'
 import { use$x, useDebounce } from '../../../composables'
 import { AnimationProp } from '../../../types'
-import { getActiveElement } from '../../../utils/html'
+import { getActiveElement } from '../../../utils'
 import { empathizeXModule } from '../x-module'
 
 /**
@@ -55,14 +55,21 @@ export default defineComponent({
       type: AnimationProp,
       default: () => NoAnimation,
     },
+    /** Whether the empathize has content or not. As it is only known in the client, it is a prop. */
+    hasContent: {
+      type: Boolean,
+      default: true,
+    },
+    /** Fallback flag to trigger a search and close the empathize when has no-content. */
+    searchAndCloseOnNoContent: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
     const $x = use$x()
-
-    const empathizeRef = ref<HTMLDivElement>()
-
+    const empathizeRef = ref<HTMLDivElement | null>(null)
     const isOpen = ref(false)
-    const hasContent = computed(() => !!empathizeRef.value?.children?.length)
 
     /**
      * Changes the state of {@link Empathize.isOpen} assigning to it the value of `newOpen`
@@ -74,6 +81,7 @@ export default defineComponent({
     const changeOpen = useDebounce((newOpen: boolean) => {
       if (isOpen.value !== newOpen) {
         isOpen.value = newOpen
+        // TODO - review isOpen && hasContent to emit event
         const empathizeEvent = isOpen.value ? 'EmpathizeOpened' : 'EmpathizeClosed'
         $x.emit(empathizeEvent, undefined, { target: empathizeRef.value })
       }
@@ -81,13 +89,10 @@ export default defineComponent({
 
     /**
      * Open empathize. This method will be executed on any event in
-     * {@link Empathize.eventsToOpenEmpathize} and on DOM event `focusin` on Empathize root
-     * element.
+     * {@link Empathize.eventsToOpenEmpathize} and on DOM event `focusin` on Empathize root element.
      */
     function open() {
-      if (hasContent.value) {
-        changeOpen(true)
-      }
+      changeOpen(true)
     }
 
     /**
@@ -105,13 +110,50 @@ export default defineComponent({
     props.eventsToOpenEmpathize.forEach(event => $x.on(event, false).subscribe(open))
     props.eventsToCloseEmpathize.forEach(event => $x.on(event, false).subscribe(close))
 
-    return {
-      close,
-      empathizeRef,
-      hasContent,
-      isOpen,
-      open,
-    }
+    let unwatchSearchBoxQuery: WatchStopHandle = () => {}
+
+    /**
+     * This function unwatch the search-box query and also search and close empathize wrapped
+     * under a debounced function.
+     */
+    const searchAndCloseDebounced = useDebounce(async () => {
+      // eslint-disable-next-line no-console
+      console.log('UserAcceptedAQuery', $x.query.searchBox)
+
+      unwatchSearchBoxQuery()
+      await $x.emit('UserAcceptedAQuery', $x.query.searchBox)
+      close()
+    }, 1000)
+
+    /**
+     * Watcher triggered when `hasContent` change and the `searchAndCloseOnNoContent` flag is active
+     * with the following casuistics:
+     * 1. Empathize has content: cancel debounced search and unwatch the search-box query.
+     * 2. Empathize has NO content: create a watcher for the search-box query. It is to debounce the
+     * search fallback when the user types in the search-box during debounced time.
+     */
+    watch(
+      () => props.hasContent,
+      () => {
+        // eslint-disable-next-line no-console
+        console.log('hasContent', props.hasContent)
+        // eslint-disable-next-line no-console
+        console.log('props.closeAndSearchOnNoContent', props.searchAndCloseOnNoContent)
+
+        if (props.searchAndCloseOnNoContent) {
+          if (props.hasContent) {
+            unwatchSearchBoxQuery()
+            searchAndCloseDebounced.cancel()
+          } else {
+            unwatchSearchBoxQuery = watch(() => $x.query.searchBox, searchAndCloseDebounced, {
+              immediate: true,
+            })
+          }
+        }
+      },
+    )
+
+    return { isOpen, close, open }
   },
 })
 </script>

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -64,6 +64,11 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    /** Debounce time in milliseconds to search and close the empathize when has no-content. */
+    searchAndCloseDebounceInMs: {
+      type: Number,
+      default: 1000,
+    },
   },
   setup(props) {
     const $x = use$x()
@@ -113,7 +118,7 @@ export default defineComponent({
       unwatchSearchBoxQuery()
       await $x.emit('UserAcceptedAQuery', $x.query.searchBox)
       close()
-    }, 1000)
+    }, props.searchAndCloseDebounceInMs)
 
     /**
      * Watcher triggered when `hasContent` change and the `searchAndCloseOnNoContent` flag is active
@@ -212,12 +217,15 @@ The component rendering the query suggestions, popular searches and history quer
 navigation. It also configures `searchAndCloseOnNoContent` to trigger a search and close the empathize
 when has no-content as fallback behaviour. To do that, `hasContent` prop must be reactive to know
 if the empathize has content or not.
+It also configures `searchAndCloseDebounceInMs` to 500ms as debounce time to search and close the
+empathize when has no-content.
 
 ```vue
 <Empathize
   :animation="empathizeAnimation"
   :events-to-close-empathize="empathizeCloseEvents"
   :has-content="showEmpathize"
+  :search-and-close-debounce-in-ms="500"
   search-and-close-on-no-content
 >
   <BaseKeyboardNavigation>

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -74,11 +74,6 @@ export default defineComponent({
 
     /** Emit 'EmpathizeOpened' or 'EmpathizeClosed' event when computed changes. */
     watch(isOpenAndHasContent, () => {
-      // TODO - Remove consoles.
-      /* eslint-disable no-console */
-      console.log('isOpenAndHasContent', isOpenAndHasContent.value)
-      console.log('EVENT', isOpenAndHasContent.value ? 'EmpathizeOpened' : 'EmpathizeClosed')
-
       const empathizeEvent = isOpenAndHasContent.value ? 'EmpathizeOpened' : 'EmpathizeClosed'
       $x.emit(empathizeEvent, undefined, { target: empathizeRef.value })
     })
@@ -113,11 +108,8 @@ export default defineComponent({
 
     let unwatchSearchBoxQuery: WatchStopHandle = () => {}
 
-    /** Debounced function to unwatch the search-box query and also search and close empathize */
+    /** Debounced function to unwatch the search-box query and also search and close empathize. */
     const searchAndCloseDebounced = useDebounce(async () => {
-      // TODO - Remove console.
-      console.log('UserAcceptedAQuery', $x.query.searchBox)
-
       unwatchSearchBoxQuery()
       await $x.emit('UserAcceptedAQuery', $x.query.searchBox)
       close()
@@ -133,10 +125,6 @@ export default defineComponent({
     watch(
       () => props.hasContent,
       () => {
-        // TODO - Remove consoles.
-        console.log('hasContent', props.hasContent)
-        console.log('props.closeAndSearchOnNoContent', props.searchAndCloseOnNoContent)
-
         if (props.searchAndCloseOnNoContent) {
           if (props.hasContent) {
             unwatchSearchBoxQuery()
@@ -161,11 +149,11 @@ export default defineComponent({
 A list of events that the component will emit:
 
 - [`EmpathizeOpened`](https://github.com/empathyco/x/blob/main/packages/x-components/src/wiring/events.types.ts):
-  the event is emitted after receiving an event to change the state `isOpen` to `true`. The event
-  payload is undefined and can have a metadata with the module and the element that emitted it.
+  the event is emitted after receiving an event to change the state `isOpen` to `true` and `hasContent` to `true`.
+  The event payload is undefined and can have a metadata with the module and the element that emitted it.
 - [`EmpathizeClosed`](https://github.com/empathyco/x/blob/main/packages/x-components/src/wiring/events.types.ts):
-  the event is emitted after receiving an event to change the state `isOpen` to `false`. The event
-  payload is undefined and can have a metadata with the module and the element that emitted it.
+  the event is emitted after receiving an event to change the state `isOpen` to `false` and `hasContent` to `true`.
+  The event payload is undefined and can have a metadata with the module and the element that emitted it.
 
 ## Examples
 
@@ -173,9 +161,8 @@ This component will listen to the configured events in `eventsToOpenEmpathize` a
 `eventsToCloseEmpathize` props and open/close itself accordingly. By default, those props values
 are:
 
-- Open: `UserFocusedSearchBox`, `'`UserIsTypingAQuery`, `'`UserClickedSearchBox` and
-- Close: `UserClosedEmpathize`, `UserSelectedASuggestion`, `UserPressedEnter`,
-  'UserBlurredSearchBox`
+- Open: `UserFocusedSearchBox`, `UserIsTypingAQuery`, `UserClickedSearchBox`
+- Close: `UserClosedEmpathize`, `UserSelectedASuggestion`, `UserPressedEnter` and 'UserBlurredSearchBox`
 
 ### Basic examples
 
@@ -216,6 +203,28 @@ be a Component with a `Transition` with a slot inside:
   <template #default>
     <PopularSearches/>
   </template>
+</Empathize>
+```
+
+### Advance examples
+
+The component rendering the query suggestions, popular searches and history queries with keyboard
+navigation. It also configures `searchAndCloseOnNoContent` to trigger a search and close the empathize
+when has no-content as fallback behaviour. To do that, `hasContent` prop must be reactive to know
+if the empathize has content or not.
+
+```vue
+<Empathize
+  :animation="empathizeAnimation"
+  :events-to-close-empathize="empathizeCloseEvents"
+  :has-content="showEmpathize"
+  search-and-close-on-no-content
+>
+  <BaseKeyboardNavigation>
+    <QuerySuggestions/>
+    <PopularSearches/>
+    <HistoryQueries/>
+  </BaseKeyboardNavigation>
 </Empathize>
 ```
 </docs>


### PR DESCRIPTION
Added `searchAndCloseOnNoContent` fallback on `empathize`. It is when the `empathize` has no-content, as soon as the user finishes typing, the empathize is closed programmatically and a search request is performed. It is a fallback mechanism.