### PR TITLE
ci(e2e): deactivate e2e to run in the ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
         run: pnpm run test:unit
 
       - name: Run e2e tests
+        if: false  # Temporarily disabled until the e2e are reviewed and updated so that it does not fail intermittently
         timeout-minutes: 15
         uses: ./.github/actions/run-e2e-tests
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,7 @@ jobs:
         run: pnpm run test:unit
 
       - name: Run e2e tests
+        if: false # Temporarily disabled until the e2e are reviewed and updated so that it does not fail intermittently
         timeout-minutes: 15
         uses: ./.github/actions/run-e2e-tests
 


### PR DESCRIPTION
Temporarily disabled until the e2e are reviewed and updated so that it does not fail intermittently