### PR TITLE
feat(ai-overview): make component more configurable

### DIFF
--- a/packages/x-components/src/x-modules/ai/components/__tests__/ai-overview.spec.ts
+++ b/packages/x-components/src/x-modules/ai/components/__tests__/ai-overview.spec.ts
@@ -1,7 +1,7 @@
 import type { ComponentMountingOptions } from '@vue/test-utils'
 import type { Ref } from 'vue'
 import { mount } from '@vue/test-utils'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import { getResultsStub } from '../../../../__stubs__/results-stubs.factory'
 import { getDataTestSelector } from '../../../../__tests__/utils'
 import {
@@ -263,22 +263,17 @@ describe('ai-overview component', () => {
   })
 
   it('should show suggestionText as title when title prop is empty, and hide the suggestionText span in content', async () => {
-    // Use empty title to trigger fallback in title and hide content span
-    const sut = render({ props: { ...propsStub, title: '' as unknown as string } })
+    const sut = render({ props: { ...propsStub, title: undefined } })
 
-    // Title should display suggestionText instead of empty title
     expect(sut.title.text()).toBe(useStateStub.suggestionText.value)
 
-    // Content span with suggestionText should not be rendered when title is falsy
     const contentSpan = sut.content.find('span')
-    expect(contentSpan.exists()).toBe(false)
+    expect(contentSpan.exists()).toBeFalsy()
 
-    // Response text should still be visible
     expect(sut.content.text()).toContain(useStateStub.responseText.value)
   })
 
   it('should not render query button nor sliding panel for queries without results', async () => {
-    // Add a query not present in suggestionsSearch so queriesResults lacks that key
     const queriesWithOrphan = ref([
       { query: 'suggestion 1' },
       { query: 'suggestion 2' },
@@ -292,15 +287,12 @@ describe('ai-overview component', () => {
 
     const sut = render()
 
-    // Expand to render the suggestions content
     await sut.toggleButton.trigger('click')
-    await sut.wrapper.vm.$nextTick()
+    await nextTick()
 
-    // Buttons and panels should match only existing suggestionsSearch (3), not queries (4)
     expect(sut.baseEventButtons).toHaveLength(useStateStub.suggestionsSearch.value.length)
     expect(sut.slidingPanels).toHaveLength(useStateStub.suggestionsSearch.value.length)
 
-    // Ensure none of the rendered buttons corresponds to the orphan query
     const buttonTexts = sut.baseEventButtons.map(b => b.text())
     expect(buttonTexts).not.toContain('orphan query (no results)')
   })

--- a/packages/x-components/src/x-modules/ai/components/ai-overview.vue
+++ b/packages/x-components/src/x-modules/ai/components/ai-overview.vue
@@ -16,7 +16,7 @@
         </span>
         <DisplayEmitter
           v-else
-          :payload="tagging?.toolingDisplay ?? {}"
+          :payload="tagging?.toolingDisplay ?? { url: '', params: {} }"
           :event-metadata="{
             feature: 'overview',
             displayOriginalQuery: query,
@@ -24,13 +24,13 @@
           }"
         >
           <span class="x-ai-overview-title" data-test="ai-overview-title">
-            <AIStarIcon class="x-ai-overview-title-icon" />{{ title }}
+            <AIStarIcon class="x-ai-overview-title-icon" />{{ !!title ? title : suggestionText }}
           </span>
         </DisplayEmitter>
       </Fade>
       <ChangeHeight>
         <div class="x-ai-overview-content" data-test="ai-overview-content">
-          <span>{{ suggestionText }}</span>
+          <span v-if="title">{{ suggestionText }}</span>
           <p>{{ responseText }}</p>
         </div>
       </ChangeHeight>
@@ -44,7 +44,7 @@
       <div v-show="expanded">
         <SpinnerIcon
           v-if="!suggestionsSearch.length"
-          class="x-m-auto x-size-10 x-animate-spin"
+          class="ai-overview-suggestions-loading"
           data-test="ai-overview-suggestions-loading"
         />
         <div v-else class="x-ai-overview-suggestions" data-test="ai-overview-suggestions-container">
@@ -54,40 +54,42 @@
             class="x-ai-overview-suggestion"
           >
             <BaseEventButton
+              v-if="queriesResults"
               class="x-ai-overview-suggestion-query-btn"
               :events="{ UserAcceptedAQuery: suggestionQuery }"
             >
-              {{ suggestionQuery
-              }}<ArrowRightIcon class="x-ai-overview-suggestion-query-btn-icon" />
+              {{ suggestionQuery }}
+              <ArrowRightIcon class="x-ai-overview-suggestion-query-btn-icon" />
             </BaseEventButton>
 
-            <SlidingPanel
-              v-if="queriesResults"
-              :class="slidingPanelsClasses"
-              :scroll-container-class="slidingPanelContainersClasses"
-              :button-class="slidingPanelButtonsClasses"
-              :reset-on-content-change="false"
-            >
-              <template #sliding-panel-addons="{ arrivedState }">
-                <slot name="sliding-panels-addons" :arrived-state="arrivedState" />
-              </template>
-              <template #sliding-panel-left-button>
-                <slot name="sliding-panels-left-button" />
-              </template>
-              <template #sliding-panel-right-button>
-                <slot name="sliding-panels-right-button" />
-              </template>
-              <ul class="x-ai-overview-suggestion-results">
-                <li
-                  v-for="result in queriesResults"
-                  :key="result.id"
-                  data-test="ai-overview-suggestion-result"
-                >
-                  <!-- @slot (required) result card -->
-                  <slot name="result" :result="result" />
-                </li>
-              </ul>
-            </SlidingPanel>
+            <slot v-if="queriesResults" name="sliding-panel" :results="queriesResults">
+              <SlidingPanel
+                :class="slidingPanelsClasses"
+                :scroll-container-class="slidingPanelContainersClasses"
+                :button-class="slidingPanelButtonsClasses"
+                :reset-on-content-change="false"
+              >
+                <template #sliding-panel-addons="{ arrivedState }">
+                  <slot name="sliding-panels-addons" :arrived-state="arrivedState" />
+                </template>
+                <template #sliding-panel-left-button>
+                  <slot name="sliding-panels-left-button" />
+                </template>
+                <template #sliding-panel-right-button>
+                  <slot name="sliding-panels-right-button" />
+                </template>
+                <ul class="x-ai-overview-suggestion-results">
+                  <li
+                    v-for="result in queriesResults"
+                    :key="result.id"
+                    data-test="ai-overview-suggestion-result"
+                  >
+                    <!-- @slot (required) result card -->
+                    <slot name="result" :result="result" />
+                  </li>
+                </ul>
+              </SlidingPanel>
+            </slot>
           </div>
         </div>
       </div>
@@ -316,5 +318,18 @@ export default defineComponent({
 }
 .x-ai-overview-suggestion-results {
   @apply x-flex x-gap-16 x-px-16;
+}
+
+.ai-overview-suggestions-loading {
+  width: 2.5rem /* 40px */;
+  height: 2.5rem /* 40px */;
+  margin: auto;
+  animation: x-spin 1s linear infinite;
+
+  @keyframes x-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
 }
 </style>

--- a/packages/x-components/src/x-modules/ai/components/ai-overview.vue
+++ b/packages/x-components/src/x-modules/ai/components/ai-overview.vue
@@ -54,7 +54,6 @@
             class="x-ai-overview-suggestion"
           >
             <BaseEventButton
-              v-if="queriesResults"
               class="x-ai-overview-suggestion-query-btn"
               :events="{ UserAcceptedAQuery: suggestionQuery }"
             >
@@ -62,7 +61,7 @@
               <ArrowRightIcon class="x-ai-overview-suggestion-query-btn-icon" />
             </BaseEventButton>
 
-            <slot v-if="queriesResults" name="sliding-panel" :results="queriesResults">
+            <slot name="sliding-panel" :results="queriesResults">
               <SlidingPanel
                 :class="slidingPanelsClasses"
                 :scroll-container-class="slidingPanelContainersClasses"
@@ -157,7 +156,6 @@ export default defineComponent({
      */
     title: {
       type: String as PropType<string>,
-      default: 'Empathy AI Overview',
     },
     /**
      * The text displayed when the question is loading.


### PR DESCRIPTION
- If `title` prop is empty: `suggestionText` as title and `responseText` as body
- If there is no `queriesResults`, suggestion hidden
- New `sliding-panel` slot to make it configurable with the customer sliding-panel (ex. `MotiveSlidingPanel`)
- `.ai-overview-suggestions-loading` with CSS for tailwind issues with motive-x

<img width="1392" height="692" alt="Screenshot 2025-09-18 at 4 02 10 PM" src="https://github.com/user-attachments/assets/ad0644f3-ec3f-4bf1-bc47-df6a384d33b0" />
