### PR TITLE
`query-preview` trade off

### DIFF
--- a/packages/x-components/src/x-modules/queries-preview/events.types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/events.types.ts
@@ -1,6 +1,6 @@
 import type { SearchRequest } from '@empathyco/x-types'
 import type { Dictionary } from '@empathyco/x-utils'
-import type { QueryPreviewInfo } from './store/index'
+import type { QueryPreviewInfo, QueryPreviewItem } from './store'
 
 /**
  * Dictionary of the events of QueriesPreview XModule, where each key is the event name, and the
@@ -36,4 +36,9 @@ export interface QueriesPreviewXEvents {
    * Payload: The query preview's unique id (query hash) and its cache value.
    */
   QueryPreviewUnmounted: { queryPreviewHash: string; cache: boolean }
+  /**
+   * The query preview has been changed.
+   * Payload: The query preview item.
+   */
+  QueriesPreviewChanged: Dictionary<QueryPreviewItem>
 }

--- a/packages/x-components/src/x-modules/queries-preview/store/emitters.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/emitters.ts
@@ -10,6 +10,7 @@ export const queriesPreviewEmitters = createStoreEmitters(queriesPreviewXStoreMo
   QueryPreviewUnselected: {
     selector: state =>
       !state.selectedQueryPreview ? state.params : state.selectedQueryPreview.extraParams!,
-    filter: (newValue, oldValue, state) => !state.selectedQueryPreview,
+    filter: (_newValue, _oldValue, state) => !state.selectedQueryPreview,
   },
+  QueriesPreviewChanged: (_state, getters) => getters.loadedQueriesPreview,
 })

--- a/packages/x-components/src/x-modules/queries-preview/store/module.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/module.ts
@@ -59,7 +59,7 @@ export const queriesPreviewXStoreModule: QueriesPreviewXStoreModule = {
       }
     },
     updateAQueryPreviewResult(state, { result, queryPreviewHash }) {
-      const queryPreviewResult = state.queriesPreview[queryPreviewHash.value]?.results.find(
+      const queryPreviewResult = state.queriesPreview[queryPreviewHash]?.results.find(
         resultPreview => resultPreview.id === result.id,
       )
       if (queryPreviewResult) {

--- a/packages/x-components/src/x-modules/queries-preview/store/types.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/types.ts
@@ -1,6 +1,5 @@
 import type { Result, SearchRequest, SearchResponse, TaggingRequest } from '@empathyco/x-types'
 import type { Dictionary } from '@empathyco/x-utils'
-import type { ComputedRef } from 'vue'
 import type { XActionContext } from '../../../store/actions.types'
 import type { XStoreModule } from '../../../store/store.types'
 import type { ConfigMutations } from '../../../store/utils/config-store.utils'
@@ -147,7 +146,7 @@ export interface QueriesPreviewMutations extends ConfigMutations<QueriesPreviewS
     queryPreviewHash,
   }: {
     result: Result
-    queryPreviewHash: ComputedRef<string>
+    queryPreviewHash: string
   }) => void
 }
 


### PR DESCRIPTION
This aligns the motive-x shopper-prices feature:
- Incorrect `hash` type: https://github.com/empathyco/motive-x/pull/833/files#diff-3d77749e76b4e377046a4fc01350f5112cf836523a9fcd8b9e9226305cf01d91R43
- New `QueriesPreviewChanged` event emitter: https://github.com/empathyco/motive-x/pull/833/files#diff-fe1bf04093efe44b1c44be6bbb1cb954bdbdc86c57c8e2c884eea050ebac24b7R5