### PR TITLE
fix: selected tag being removed

### DIFF
--- a/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
+++ b/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
@@ -136,7 +136,7 @@ describe('testing empathize component', () => {
     jest.runAllTimers()
     await nextTick()
 
-    expect(emitSpy).toHaveBeenCalledWith('UserAcceptedAQuery', '', expect.any(Object))
+    expect(emitSpy).toHaveBeenCalledWith('EmpathizeGotNoContent', '', expect.any(Object))
     expect(emitSpy).toHaveBeenCalledWith('EmpathizeClosed', undefined, expect.any(Object))
   })
 
@@ -166,9 +166,9 @@ describe('testing empathize component', () => {
     jest.advanceTimersByTime(customDebounceTime - 100)
     await nextTick()
 
-    // Verify that UserAcceptedAQuery and EmpathizeClosed have not been emitted yet
+    // Verify that EmpathizeGotNoContent and EmpathizeClosed have not been emitted yet
     expect(emitSpy).not.toHaveBeenCalledWith(
-      'UserAcceptedAQuery',
+      'EmpathizeGotNoContent',
       expect.any(String),
       expect.any(Object),
     )
@@ -183,7 +183,7 @@ describe('testing empathize component', () => {
     await nextTick()
 
     // Now the events should have been emitted
-    expect(emitSpy).toHaveBeenCalledWith('UserAcceptedAQuery', '', expect.any(Object))
+    expect(emitSpy).toHaveBeenCalledWith('EmpathizeGotNoContent', '', expect.any(Object))
     expect(emitSpy).toHaveBeenCalledWith('EmpathizeClosed', undefined, expect.any(Object))
   })
 })

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -116,7 +116,7 @@ export default defineComponent({
     /** Debounced function to unwatch the search-box query and also search and close empathize. */
     const searchAndCloseDebounced = useDebounce(async () => {
       unwatchSearchBoxQuery()
-      await $x.emit('UserAcceptedAQuery', $x.query.searchBox)
+      await $x.emit('EmpathizeGotNoContent', $x.query.searchBox)
       close()
     }, props.searchAndCloseDebounceInMs)
 

--- a/packages/x-components/src/x-modules/empathize/events.types.ts
+++ b/packages/x-components/src/x-modules/empathize/events.types.ts
@@ -20,4 +20,9 @@ export interface EmpathizeXEvents {
    * Payload: none.
    */
   UserClosedEmpathize: void
+  /**
+   * The user closed the empathize.
+   * Payload: The search box query at the time of the event.
+   */
+  EmpathizeGotNoContent: string
 }

--- a/packages/x-components/src/x-modules/empathize/events.types.ts
+++ b/packages/x-components/src/x-modules/empathize/events.types.ts
@@ -21,7 +21,7 @@ export interface EmpathizeXEvents {
    */
   UserClosedEmpathize: void
   /**
-   * The user closed the empathize.
+   * The empathize reached a state with no content (empty).
    * Payload: The search box query at the time of the event.
    */
   EmpathizeGotNoContent: string

--- a/packages/x-components/src/x-modules/search/wiring.ts
+++ b/packages/x-components/src/x-modules/search/wiring.ts
@@ -246,6 +246,10 @@ export const searchWiring = createWiring({
     setSearchQuery,
     saveOriginWire,
   },
+  EmpathizeHasNoContent: {
+    setSearchQuery,
+    saveOriginWire,
+  },
   UserAcceptedSpellcheckQuery: {
     resetSpellcheckQuery,
   },

--- a/packages/x-components/src/x-modules/search/wiring.ts
+++ b/packages/x-components/src/x-modules/search/wiring.ts
@@ -246,7 +246,7 @@ export const searchWiring = createWiring({
     setSearchQuery,
     saveOriginWire,
   },
-  EmpathizeHasNoContent: {
+  EmpathizeGotNoContent: {
     setSearchQuery,
     saveOriginWire,
   },


### PR DESCRIPTION
After implementing the empathize fallback in #1833, we have discovered a corner case causing a malfunction on related tags.

If you encounter a query with an RT selected and it has no content on the empathize, it automatically runs the fallback, ignoring the RT.

For that issue, we decouple the fallback from the `UserAcceptedAQuery` event, which clears the RT, and create a new specific one for this case `EmpathizeGotNoContent` (Naming suggestions are welcomed).

Find in the Jira Ticket a video showing the malfunctioning: https://searchbroker.atlassian.net/browse/RST-4578
