### PR TITLE
fix: fire search only if Empathise is open

### DIFF
--- a/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
+++ b/packages/x-components/src/x-modules/empathize/components/__tests__/empathize.spec.ts
@@ -136,7 +136,7 @@ describe('testing empathize component', () => {
     jest.runAllTimers()
     await nextTick()
 
-    expect(emitSpy).toHaveBeenCalledWith('EmpathizeGotNoContent', '', expect.any(Object))
+    expect(emitSpy).toHaveBeenCalledWith('UserAcceptedAQuery', '', expect.any(Object))
     expect(emitSpy).toHaveBeenCalledWith('EmpathizeClosed', undefined, expect.any(Object))
   })
 
@@ -166,9 +166,9 @@ describe('testing empathize component', () => {
     jest.advanceTimersByTime(customDebounceTime - 100)
     await nextTick()
 
-    // Verify that EmpathizeGotNoContent and EmpathizeClosed have not been emitted yet
+    // Verify that UserAcceptedAQuery and EmpathizeClosed have not been emitted yet
     expect(emitSpy).not.toHaveBeenCalledWith(
-      'EmpathizeGotNoContent',
+      'UserAcceptedAQuery',
       expect.any(String),
       expect.any(Object),
     )
@@ -183,7 +183,7 @@ describe('testing empathize component', () => {
     await nextTick()
 
     // Now the events should have been emitted
-    expect(emitSpy).toHaveBeenCalledWith('EmpathizeGotNoContent', '', expect.any(Object))
+    expect(emitSpy).toHaveBeenCalledWith('UserAcceptedAQuery', '', expect.any(Object))
     expect(emitSpy).toHaveBeenCalledWith('EmpathizeClosed', undefined, expect.any(Object))
   })
 })

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -115,9 +115,11 @@ export default defineComponent({
 
     /** Debounced function to unwatch the search-box query and also search and close empathize. */
     const searchAndCloseDebounced = useDebounce(async () => {
-      unwatchSearchBoxQuery()
-      await $x.emit('UserAcceptedAQuery', $x.query.searchBox)
-      close()
+      if (isOpen.value) {
+        unwatchSearchBoxQuery()
+        await $x.emit('UserAcceptedAQuery', $x.query.searchBox)
+        close()
+      }
     }, props.searchAndCloseDebounceInMs)
 
     /**

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -116,7 +116,7 @@ export default defineComponent({
     /** Debounced function to unwatch the search-box query and also search and close empathize. */
     const searchAndCloseDebounced = useDebounce(async () => {
       unwatchSearchBoxQuery()
-      await $x.emit('EmpathizeGotNoContent', $x.query.searchBox)
+      await $x.emit('UserAcceptedAQuery', $x.query.searchBox)
       close()
     }, props.searchAndCloseDebounceInMs)
 

--- a/packages/x-components/src/x-modules/empathize/events.types.ts
+++ b/packages/x-components/src/x-modules/empathize/events.types.ts
@@ -20,9 +20,4 @@ export interface EmpathizeXEvents {
    * Payload: none.
    */
   UserClosedEmpathize: void
-  /**
-   * The empathize reached a state with no content (empty).
-   * Payload: The search box query at the time of the event.
-   */
-  EmpathizeGotNoContent: string
 }

--- a/packages/x-components/src/x-modules/search/wiring.ts
+++ b/packages/x-components/src/x-modules/search/wiring.ts
@@ -246,10 +246,6 @@ export const searchWiring = createWiring({
     setSearchQuery,
     saveOriginWire,
   },
-  EmpathizeGotNoContent: {
-    setSearchQuery,
-    saveOriginWire,
-  },
   UserAcceptedSpellcheckQuery: {
     resetSpellcheckQuery,
   },


### PR DESCRIPTION
This PR reverts #1894 since it doesn't completely fix the issue. (More modules need to be updated in that case, and if we define them all, we will end up in the same scenario as with `UserAcceptedAQuery`)

We will fire the fallback if the Empathyse is open, which is the time when the flow is blocked. That is what we intend to fix with the fallback.