### PR TITLE
fix(ai): export missing store things

### DIFF
--- a/packages/x-components/src/x-modules/ai/store/actions/fetch-and-save-ai-suggestions-search.action.ts
+++ b/packages/x-components/src/x-modules/ai/store/actions/fetch-and-save-ai-suggestions-search.action.ts
@@ -1,6 +1,15 @@
 import type { AiXStoreModule } from '../types'
 import { XPlugin } from '../../../../plugins'
 
+/**
+ * Default implementation for the {@link AiActions.fetchAndSaveAiSuggestionsSearch}.
+ *
+ * @param _ - The {@link https://vuex.vuejs.org/guide/actions.html | context} of the commits,
+ * provided by Vuex.
+ * @param request - The AI search request to make.
+ * @returns The AI search response.
+ * @public
+ */
 export const fetchAndSaveAiSuggestionsSearch: AiXStoreModule['actions']['fetchAndSaveAiSuggestionsSearch'] =
   async ({ commit }, request) => {
     if (!request) {

--- a/packages/x-components/src/x-modules/ai/store/actions/fetch-and-save-ai-suggestions.action.ts
+++ b/packages/x-components/src/x-modules/ai/store/actions/fetch-and-save-ai-suggestions.action.ts
@@ -31,7 +31,6 @@ type AnswerData =
  * provided by Vuex.
  * @param request - The AI request to make.
  * @returns The AI response.
- *
  * @public
  */
 export const fetchAndSaveAiSuggestions: AiXStoreModule['actions']['fetchAndSaveAiSuggestions'] =

--- a/packages/x-components/src/x-modules/ai/store/actions/index.ts
+++ b/packages/x-components/src/x-modules/ai/store/actions/index.ts
@@ -1,4 +1,4 @@
 export * from './fetch-and-save-ai-suggestions-search.action'
 export * from './fetch-and-save-ai-suggestions.action'
-export * from './save-origin.action'
-export * from './set-url-params.action'
+export { saveOrigin as saveAiOrigin } from './save-origin.action'
+export { setUrlParams as setAiUrlParams } from './set-url-params.action'

--- a/packages/x-components/src/x-modules/ai/store/actions/index.ts
+++ b/packages/x-components/src/x-modules/ai/store/actions/index.ts
@@ -1,0 +1,4 @@
+export * from './fetch-and-save-ai-suggestions-search.action'
+export * from './fetch-and-save-ai-suggestions.action'
+export * from './save-origin.action'
+export * from './set-url-params.action'

--- a/packages/x-components/src/x-modules/ai/store/index.ts
+++ b/packages/x-components/src/x-modules/ai/store/index.ts
@@ -1,3 +1,5 @@
+export * from './actions'
 export * from './emitters'
+export * from './getters'
 export * from './module'
 export * from './types'


### PR DESCRIPTION
To override getters or actions in client, sometimes we need the original ones to augment. This is to export the originals to be able to use there.