### PR TITLE
feat(ai): add `extra-content` slot to ai-overview and use in home view

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -271,6 +271,11 @@
                 <template #result="{ result }">
                   <Result :result="result" class="x-w-[150px]" />
                 </template>
+                <template #extra-content>
+                  <button class="x-bg-lead-50 x-absolute x-bottom-0 x-right-0 x-translate-y-full">
+                    extra content
+                  </button>
+                </template>
               </AiOverview>
             </LocationProvider>
             <template v-if="!x.query.searchBox">

--- a/packages/x-components/src/x-modules/ai/components/ai-overview.vue
+++ b/packages/x-components/src/x-modules/ai/components/ai-overview.vue
@@ -44,6 +44,7 @@
             <p>{{ responseText }}</p>
           </div>
         </ChangeHeight>
+        <slot name="extra-content" />
       </div>
       <CollapseHeight
         :style="{


### PR DESCRIPTION
In order to have a way to put something always in the ai overview, even is not expanded, we added a extra-content slot
<img width="987" height="314" alt="Screenshot 2025-10-27 at 17 13 11" src="https://github.com/user-attachments/assets/124b2c08-87c6-46e8-b35f-490d80e68332" />


# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
