### PR TITLE
feat(ai): perform suggestions search on expand and track queries

### DIFF
--- a/packages/x-components/src/x-modules/ai/components/ai-overview.vue
+++ b/packages/x-components/src/x-modules/ai/components/ai-overview.vue
@@ -330,7 +330,6 @@ export default defineComponent({
       suggestionsLoading,
       suggestionsSearch,
       suggestionText,
-      setExpanded,
       onExpandButtonClick,
       shouldAnimateSuggestion,
       query,

--- a/packages/x-components/src/x-modules/ai/events.types.ts
+++ b/packages/x-components/src/x-modules/ai/events.types.ts
@@ -1,4 +1,9 @@
-import type { AiSuggestionsRequest, AiSuggestionsSearchRequest, Result } from '@empathyco/x-types'
+import type {
+  AiSuggestionSearch,
+  AiSuggestionsRequest,
+  AiSuggestionsSearchRequest,
+  Result,
+} from '@empathyco/x-types'
 
 /**
  * Dictionary of the events of AI XModule, where each key is the event name, and the value is
@@ -9,6 +14,7 @@ import type { AiSuggestionsRequest, AiSuggestionsSearchRequest, Result } from '@
 export interface AiXEvents {
   AiSuggestionsRequestUpdated: AiSuggestionsRequest | null
   AiSuggestionsSearchRequestUpdated: AiSuggestionsSearchRequest | null
+  SuggestionsSearchChanged: AiSuggestionSearch[]
   UserClickedAiOverviewExpandButton: boolean
   UserClickedAnAiOverviewResult: Result
   AiOverviewMounted: void

--- a/packages/x-components/src/x-modules/ai/events.types.ts
+++ b/packages/x-components/src/x-modules/ai/events.types.ts
@@ -14,7 +14,7 @@ import type {
 export interface AiXEvents {
   AiSuggestionsRequestUpdated: AiSuggestionsRequest | null
   AiSuggestionsSearchRequestUpdated: AiSuggestionsSearchRequest | null
-  SuggestionsSearchChanged: AiSuggestionSearch[]
+  AiSuggestionsSearchChanged: AiSuggestionSearch[]
   UserClickedAiOverviewExpandButton: boolean
   UserClickedAnAiOverviewResult: Result
   AiOverviewMounted: void

--- a/packages/x-components/src/x-modules/ai/store/actions/fetch-and-save-ai-suggestions-search.action.ts
+++ b/packages/x-components/src/x-modules/ai/store/actions/fetch-and-save-ai-suggestions-search.action.ts
@@ -2,20 +2,21 @@ import type { AiXStoreModule } from '../types'
 import { XPlugin } from '../../../../plugins'
 
 /**
- * Default implementation for the {@link AiActions.fetchAndSaveAiSuggestionsSearch}.
+ * Default implementation for the `AiActions.fetchAndSaveAiSuggestionsSearch`.
  *
- * @param _ - The {@link https://vuex.vuejs.org/guide/actions.html | context} of the commits,
- * provided by Vuex.
- * @param request - The AI search request to make.
+ * @param _ - The {@link https://vuex.vuejs.org/guide/actions.html | context} of the commits and
+ * getters provided by Vuex.
  * @returns The AI search response.
  * @public
  */
 export const fetchAndSaveAiSuggestionsSearch: AiXStoreModule['actions']['fetchAndSaveAiSuggestionsSearch'] =
-  async ({ commit }, request) => {
+  async ({ commit, getters }) => {
+    const request = getters.suggestionsSearchRequest
     if (!request) {
       return
     }
     commit('setSuggestionsSearchLoading', true)
+
     return XPlugin.adapter
       .aiSuggestionsSearch(request)
       .then(response => {

--- a/packages/x-components/src/x-modules/ai/store/emitters.ts
+++ b/packages/x-components/src/x-modules/ai/store/emitters.ts
@@ -9,5 +9,5 @@ import { aiXStoreModule } from './module'
 export const aiEmitters = createStoreEmitters(aiXStoreModule, {
   AiSuggestionsRequestUpdated: (_, getters) => getters.suggestionsRequest,
   AiSuggestionsSearchRequestUpdated: (_, getters) => getters.suggestionsSearchRequest,
-  SuggestionsSearchChanged: state => state.suggestionsSearch,
+  AiSuggestionsSearchChanged: state => state.suggestionsSearch,
 })

--- a/packages/x-components/src/x-modules/ai/store/emitters.ts
+++ b/packages/x-components/src/x-modules/ai/store/emitters.ts
@@ -9,4 +9,5 @@ import { aiXStoreModule } from './module'
 export const aiEmitters = createStoreEmitters(aiXStoreModule, {
   AiSuggestionsRequestUpdated: (_, getters) => getters.suggestionsRequest,
   AiSuggestionsSearchRequestUpdated: (_, getters) => getters.suggestionsSearchRequest,
+  SuggestionsSearchChanged: state => state.suggestionsSearch,
 })

--- a/packages/x-components/src/x-modules/ai/store/types.ts
+++ b/packages/x-components/src/x-modules/ai/store/types.ts
@@ -177,14 +177,12 @@ export interface AiActions {
    * @param request - The ai suggestions request.
    */
   fetchAndSaveAiSuggestions: (request: AiSuggestionsRequest | null) => void
-
   /**
-   * Requests suggestions search for the module ai.
+   * Requests suggestions search for the module AI.
    *
-   * @param request - The ai suggestions search request.
+   * @param expanded - The expanded state of the AI overview.
    */
-  fetchAndSaveAiSuggestionsSearch: (request: AiSuggestionsSearchRequest | null) => void
-
+  fetchAndSaveAiSuggestionsSearch: (expanded: boolean) => void
   /**
    * Checks if the URL has params on it and then updates the state with these values.
    *

--- a/packages/x-components/src/x-modules/ai/wiring.ts
+++ b/packages/x-components/src/x-modules/ai/wiring.ts
@@ -1,5 +1,6 @@
 import {
   createWiring,
+  filterTruthyPayload,
   namespacedWireCommit,
   namespacedWireCommitWithoutPayload,
   namespacedWireDispatch,
@@ -29,7 +30,9 @@ const setAiQueryFromPreviewWire = wireCommit('setQuery', ({ eventPayload: { quer
 const fetchAndSaveAiSuggestionsWire = wireDispatch('fetchAndSaveAiSuggestions')
 
 /** Fetches and save the AI suggestions search response. */
-const fetchAndSaveAiSuggestionsSearchWire = wireDispatch('fetchAndSaveAiSuggestionsSearch')
+const fetchAndSaveAiSuggestionsSearchWire = filterTruthyPayload(
+  wireDispatch('fetchAndSaveAiSuggestionsSearch'),
+)
 
 /** Sets the AI state `relatedTags`.*/
 const setAiRelatedTagsWire = wireCommit('setAiRelatedTags')
@@ -68,7 +71,8 @@ export const aiWiring = createWiring({
     resetAiStateWire,
     fetchAndSaveAiSuggestionsWire,
   },
-  AiSuggestionsSearchRequestUpdated: {
+  // Formerly AiSuggestionsSearchRequestUpdated
+  UserClickedAiOverviewExpandButton: {
     fetchAndSaveAiSuggestionsSearchWire,
   },
   SelectedRelatedTagsChanged: {

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -1,4 +1,5 @@
 import type {
+  AiSuggestionSearch,
   RelatedPrompt,
   Result,
   SemanticQuery,
@@ -447,6 +448,10 @@ export function createSetQueryTaggingFromQueryPreview(): Wire<Taggable> {
   )
 }
 
+export const trackSuggestionsSearchWire = wireDispatch('track', ({ eventPayload }) =>
+  (eventPayload as AiSuggestionSearch[]).map(({ tagging }) => tagging.query),
+)
+
 /**
  * Wiring configuration for the {@link TaggingXModule | tagging module}.
  *
@@ -516,6 +521,9 @@ export const taggingWiring = createWiring({
   },
   UserSelectedARelatedPrompt: {
     trackRelatedPromptToolingDisplayClickWire,
+  },
+  SuggestionsSearchChanged: {
+    trackSuggestionsSearchWire,
   },
   UserClickedAiOverviewExpandButton: {
     trackAiOverviewButtonClickedWire,

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -448,6 +448,10 @@ export function createSetQueryTaggingFromQueryPreview(): Wire<Taggable> {
   )
 }
 
+/**
+ * Tracks query tagging of the suggestions-search.
+ * @public
+ */
 export const trackSuggestionsSearchWire = wireDispatch('track', ({ eventPayload }) =>
   (eventPayload as AiSuggestionSearch[]).map(({ tagging }) => tagging.query),
 )

--- a/packages/x-components/src/x-modules/tagging/wiring.ts
+++ b/packages/x-components/src/x-modules/tagging/wiring.ts
@@ -449,10 +449,10 @@ export function createSetQueryTaggingFromQueryPreview(): Wire<Taggable> {
 }
 
 /**
- * Tracks query tagging of the suggestions-search.
+ * Tracks query tagging of the AI suggestions-search.
  * @public
  */
-export const trackSuggestionsSearchWire = wireDispatch('track', ({ eventPayload }) =>
+export const trackAiSuggestionsSearchWire = wireDispatch('track', ({ eventPayload }) =>
   (eventPayload as AiSuggestionSearch[]).map(({ tagging }) => tagging.query),
 )
 
@@ -526,8 +526,8 @@ export const taggingWiring = createWiring({
   UserSelectedARelatedPrompt: {
     trackRelatedPromptToolingDisplayClickWire,
   },
-  SuggestionsSearchChanged: {
-    trackSuggestionsSearchWire,
+  AiSuggestionsSearchChanged: {
+    trackAiSuggestionsSearchWire,
   },
   UserClickedAiOverviewExpandButton: {
     trackAiOverviewButtonClickedWire,


### PR DESCRIPTION
- Perform `suggestions-search` when `ai-overview` is expanded by the user
- Track every `suggestions-search` query on request
- Add `autoExpandInSearchNoResults` feature
<img width="1063" height="158" alt="Screenshot 2025-10-27 at 9 05 16 PM" src="https://github.com/user-attachments/assets/e04472e3-7a69-469e-a38b-0bb5cbe89e2e" />
