### PR TITLE
refactor(queries-preview): include whole extraParams object in queries preview hash generation

### DIFF
--- a/packages/x-components/src/views/home/Home.vue
+++ b/packages/x-components/src/views/home/Home.vue
@@ -423,12 +423,12 @@
                                 </DisplayEmitter>
                               </template>
                             </RelatedPromptsTagList>
-                            <LocationProvider location="related-prompts">
+                            <LocationProvider location="related_prompts">
                               <QueryPreviewList
                                 v-if="selectedPrompt !== -1"
                                 v-slot="{ queryPreviewInfo, totalResults, results }"
                                 :queries-preview-info="relatedPromptsQueriesPreviewInfo"
-                                query-feature="related-prompts"
+                                query-feature="related_prompts"
                               >
                                 <div class="x-flex x-flex-col x-gap-8 x-mb-16">
                                   <QueryPreviewButton
@@ -448,6 +448,7 @@
                                   >
                                     <SlidingPanel :reset-on-content-change="false">
                                       <DisplayClickProvider
+                                        result-feature="related_prompts"
                                         :tooling-display-tagging="
                                           getToolingDisplayClickTagging(queryPreviewInfo)
                                         "

--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview-list.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview-list.spec.ts
@@ -9,12 +9,14 @@ import { queriesPreviewXModule } from '../../x-module'
 import QueryPreviewList from '../query-preview-list.vue'
 import QueryPreview from '../query-preview.vue'
 
+const extraParams = { instance: 'empathy', lang: 'en' }
+
 function renderQueryPreviewList({
   template = `
     <QueryPreviewList #default="{ queryPreviewInfo, results }">
       {{ queryPreviewInfo.query }} - {{results[0].name}}
     </QueryPreviewList>`,
-  queriesPreviewInfo = [{ query: 'milk' }] as QueryPreviewInfo[],
+  queriesPreviewInfo = [{ query: 'milk', extraParams }] as QueryPreviewInfo[],
   results = { milk: getResultsStub(1) } as Record<string, Result[]>,
   debounceTimeMs = 0,
   persistInCache = true,
@@ -62,7 +64,7 @@ function renderQueryPreviewList({
 describe('testing QueryPreviewList', () => {
   it('renders a list of queries one by one', async () => {
     const { getQueryPreviewItemWrappers } = renderQueryPreviewList({
-      queriesPreviewInfo: [{ query: 'shirt' }, { query: 'jeans' }],
+      queriesPreviewInfo: [{ query: 'shirt', extraParams }, { query: 'jeans' }],
       results: { shirt: [createResultStub('Cool shirt')], jeans: [createResultStub('Sick jeans')] },
     })
 
@@ -91,7 +93,7 @@ describe('testing QueryPreviewList', () => {
     const queryFeatureStub: QueryFeature = 'history_query'
     const maxItemsToRenderStub = 2
     const { getQueryPreviewItemWrappers } = renderQueryPreviewList({
-      queriesPreviewInfo: [{ query: 'shirt' }, { query: 'jeans' }],
+      queriesPreviewInfo: [{ query: 'shirt', extraParams }, { query: 'jeans' }],
       results: { shirt: [createResultStub('Cool shirt')], jeans: [createResultStub('Sick jeans')] },
       debounceTimeMs: debounceTimeMsStub,
       persistInCache: persistInCacheStub,
@@ -104,7 +106,7 @@ describe('testing QueryPreviewList', () => {
     const queryPreviews = getQueryPreviewItemWrappers()
 
     queryPreviews.forEach(queryPreview => {
-      const queryPreviewProps = queryPreview.props() as typeof QueryPreview
+      const queryPreviewProps = queryPreview.props() as unknown as typeof QueryPreview
       expect(queryPreviewProps.debounceTimeMs).toEqual(debounceTimeMsStub)
       expect(queryPreviewProps.persistInCache).toEqual(persistInCacheStub)
       expect(queryPreviewProps.queryFeature).toEqual(queryFeatureStub)
@@ -114,7 +116,7 @@ describe('testing QueryPreviewList', () => {
 
   it('hides queries with no results', async () => {
     const { getQueryPreviewItemWrappers } = renderQueryPreviewList({
-      queriesPreviewInfo: [{ query: 'noResults' }, { query: 'shoes' }],
+      queriesPreviewInfo: [{ query: 'noResults', extraParams }, { query: 'shoes' }],
       results: { noResults: [], shoes: [createResultStub('Crazy shoes')] },
     })
 
@@ -132,7 +134,7 @@ describe('testing QueryPreviewList', () => {
 
   it('hides queries that failed', async () => {
     const { adapter, getQueryPreviewItemWrappers } = renderQueryPreviewList({
-      queriesPreviewInfo: [{ query: 'willFail' }, { query: 'shoes' }],
+      queriesPreviewInfo: [{ query: 'willFail', extraParams }, { query: 'shoes' }],
       results: {
         willFail: [createResultStub('Will fail')],
         shoes: [createResultStub('Crazy shoes')],
@@ -155,7 +157,7 @@ describe('testing QueryPreviewList', () => {
 
   it('load next batch when it contains duplicates', async () => {
     const { getQueryPreviewItemWrappers, wrapper } = renderQueryPreviewList({
-      queriesPreviewInfo: [{ query: 'shirt' }, { query: 'jeans' }],
+      queriesPreviewInfo: [{ query: 'shirt', extraParams }, { query: 'jeans' }],
       results: {
         shirt: [createResultStub('Cool shirt')],
         jeans: [createResultStub('Sick jeans')],
@@ -168,7 +170,7 @@ describe('testing QueryPreviewList', () => {
     expect(queryPreviews).toHaveLength(2)
 
     await wrapper.setProps({
-      queriesPreviewInfo: [{ query: 'shirt' }, { query: 'jeans' }, { query: 'dress' }],
+      queriesPreviewInfo: [{ query: 'shirt', extraParams }, { query: 'jeans' }, { query: 'dress' }],
     } as any)
     await flushPromises()
 

--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
@@ -117,7 +117,6 @@ describe('query preview', () => {
       persistInCache: true,
       queryPreviewInfo: {
         query: 'shoes',
-        extraParams: { directory: 'Magrathea' },
         filters: ['fit:regular'],
       },
     })

--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
@@ -19,7 +19,7 @@ import { queriesPreviewXModule } from '../../x-module'
 import QueryPreview from '../query-preview.vue'
 import { resetXQueriesPreviewStateWith } from './utils'
 
-const requestParams = { instance: 'empathy', lang: 'en' }
+const extraParams = { instance: 'empathy', lang: 'en' }
 
 async function render({
   template = `<QueryPreview :queryPreviewInfo="queryPreviewInfo" :queryFeature="queryFeature" :maxItemsToRender="maxItemsToRender" :debounceTimeMs="debounceTimeMs" :persistInCache="persistInCache"/>`,
@@ -66,12 +66,12 @@ async function render({
     },
   )
 
-  const queryPreviewInfoHash = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
+  const queryPreviewInfoHash = getHashFromQueryPreviewInfo(queryPreviewInfo, extraParams)
   queryPreviewInState.request = { query: queryPreviewInfo.query }
   resetXQueriesPreviewStateWith(store, {
     queriesPreview: { [queryPreviewInfoHash]: queryPreviewInState },
   })
-  store.commit('x/queriesPreview/setParams', requestParams)
+  store.commit('x/queriesPreview/setParams', extraParams)
   await nextTick()
 
   const queryPreviewRequestUpdatedSpy = jest.fn()
@@ -120,7 +120,7 @@ describe('query preview', () => {
         filters: ['fit:regular'],
       },
     })
-    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
+    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, extraParams)
 
     expect(queryPreviewRequestUpdatedSpy).toHaveBeenCalledTimes(0)
     expect(queryPreviewWrapper.emitted('load')?.length).toEqual(1)
@@ -160,7 +160,7 @@ describe('query preview', () => {
     await wrapper.setProps({
       queryPreviewInfo: {
         query: 'shoes',
-        extraParams: { directory: 'Magrathea', ...requestParams },
+        extraParams: { directory: 'Magrathea', ...extraParams },
         filters: ['fit:regular'],
       },
     })
@@ -338,7 +338,7 @@ describe('query preview', () => {
         totalResults: 100,
       },
     })
-    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
+    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, extraParams)
 
     await flushPromises()
 
@@ -360,7 +360,7 @@ describe('query preview', () => {
         instances: 1,
       },
     })
-    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
+    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, extraParams)
 
     await flushPromises()
 
@@ -383,7 +383,7 @@ describe('query preview', () => {
         totalResults: 100,
       },
     })
-    const query = getHashFromQueryPreviewInfo({ query: 'milk' }, requestParams)
+    const query = getHashFromQueryPreviewInfo({ query: 'milk' }, extraParams)
 
     await flushPromises()
 

--- a/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/components/__tests__/query-preview.spec.ts
@@ -19,6 +19,8 @@ import { queriesPreviewXModule } from '../../x-module'
 import QueryPreview from '../query-preview.vue'
 import { resetXQueriesPreviewStateWith } from './utils'
 
+const requestParams = { instance: 'empathy', lang: 'en' }
+
 async function render({
   template = `<QueryPreview :queryPreviewInfo="queryPreviewInfo" :queryFeature="queryFeature" :maxItemsToRender="maxItemsToRender" :debounceTimeMs="debounceTimeMs" :persistInCache="persistInCache"/>`,
   queryPreviewInfo = { query: 'milk' } as QueryPreviewInfo,
@@ -64,12 +66,12 @@ async function render({
     },
   )
 
-  const queryPreviewInfoHash = getHashFromQueryPreviewInfo(queryPreviewInfo, 'en')
+  const queryPreviewInfoHash = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
   queryPreviewInState.request = { query: queryPreviewInfo.query }
   resetXQueriesPreviewStateWith(store, {
     queriesPreview: { [queryPreviewInfoHash]: queryPreviewInState },
   })
-  store.commit('x/queriesPreview/setParams', { lang: 'en' })
+  store.commit('x/queriesPreview/setParams', requestParams)
   await nextTick()
 
   const queryPreviewRequestUpdatedSpy = jest.fn()
@@ -119,7 +121,7 @@ describe('query preview', () => {
         filters: ['fit:regular'],
       },
     })
-    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, 'en')
+    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
 
     expect(queryPreviewRequestUpdatedSpy).toHaveBeenCalledTimes(0)
     expect(queryPreviewWrapper.emitted('load')?.length).toEqual(1)
@@ -159,7 +161,7 @@ describe('query preview', () => {
     await wrapper.setProps({
       queryPreviewInfo: {
         query: 'shoes',
-        extraParams: { directory: 'Magrathea' },
+        extraParams: { directory: 'Magrathea', ...requestParams },
         filters: ['fit:regular'],
       },
     })
@@ -170,6 +172,7 @@ describe('query preview', () => {
       extraParams: {
         directory: 'Magrathea',
         lang: 'en',
+        instance: 'empathy',
       },
       filters: {
         fit: [{ id: 'fit:regular', modelName: 'RawFilter', selected: true }],
@@ -189,6 +192,7 @@ describe('query preview', () => {
       extraParams: {
         directory: 'Magrathea',
         lang: 'en',
+        instance: 'empathy',
       },
       filters: {
         fit: [{ id: 'fit:regular', modelName: 'RawFilter', selected: true }],
@@ -204,6 +208,8 @@ describe('query preview', () => {
     expect(queryPreviewRequestUpdatedSpy).toHaveBeenNthCalledWith(3, {
       extraParams: {
         directory: 'Magrathea',
+        lang: 'en',
+        instance: 'empathy',
         store: 'Uganda',
       },
       filters: {
@@ -237,7 +243,7 @@ describe('query preview', () => {
     jest.advanceTimersToNextTimer()
 
     expect(queryPreviewRequestUpdatedSpy).toHaveBeenNthCalledWith(1, {
-      extraParams: { lang: 'en' },
+      extraParams: { lang: 'en', instance: 'empathy' },
       filters: undefined,
       origin: 'query_suggestion:predictive_layer',
       query: 'shoes',
@@ -333,7 +339,7 @@ describe('query preview', () => {
         totalResults: 100,
       },
     })
-    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, 'en')
+    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
 
     await flushPromises()
 
@@ -355,7 +361,7 @@ describe('query preview', () => {
         instances: 1,
       },
     })
-    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, 'en')
+    const query = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
 
     await flushPromises()
 
@@ -378,7 +384,7 @@ describe('query preview', () => {
         totalResults: 100,
       },
     })
-    const query = getHashFromQueryPreviewInfo({ query: 'milk' }, 'en')
+    const query = getHashFromQueryPreviewInfo({ query: 'milk' }, requestParams)
 
     await flushPromises()
 
@@ -399,7 +405,7 @@ describe('query preview', () => {
 
       expect(queryPreviewRequestUpdatedSpy).toHaveBeenCalledTimes(1)
       expect(queryPreviewRequestUpdatedSpy).toHaveBeenNthCalledWith(1, {
-        extraParams: { lang: 'en' },
+        extraParams: { lang: 'en', instance: 'empathy' },
         query: 'bull',
         rows: 24,
       })
@@ -417,7 +423,7 @@ describe('query preview', () => {
       jest.advanceTimersByTime(1) // 250ms since mounting the component, the debounce tested
       expect(queryPreviewRequestUpdatedSpy).toHaveBeenCalledTimes(1)
       expect(queryPreviewRequestUpdatedSpy).toHaveBeenNthCalledWith(1, {
-        extraParams: { lang: 'en' },
+        extraParams: { lang: 'en', instance: 'empathy' },
         query: 'bull',
         rows: 24,
       })
@@ -439,7 +445,7 @@ describe('query preview', () => {
       jest.advanceTimersByTime(251)
       expect(queryPreviewRequestUpdatedSpy).toHaveBeenCalledTimes(2)
       expect(queryPreviewRequestUpdatedSpy).toHaveBeenNthCalledWith(2, {
-        extraParams: { lang: 'en' },
+        extraParams: { lang: 'en', instance: 'empathy' },
         query: 'secallona',
         rows: 24,
       })

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview-list.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview-list.vue
@@ -118,7 +118,7 @@ export default defineComponent({
      */
     const queries = computed((): string[] =>
       props.queriesPreviewInfo.map(item =>
-        getHashFromQueryPreviewInfo(item, params.value.lang as string),
+        getHashFromQueryPreviewInfo(item, { ...params.value, ...item.extraParams }),
       ),
     )
 
@@ -130,7 +130,10 @@ export default defineComponent({
      */
     const renderedQueryPreviews = computed((): QueryPreviewInfo[] => {
       return props.queriesPreviewInfo.filter(item => {
-        const queryPreviewHash = getHashFromQueryPreviewInfo(item, params.value.lang as string)
+        const queryPreviewHash = getHashFromQueryPreviewInfo(item, {
+          ...params.value,
+          ...item.extraParams,
+        })
         return (
           queriesStatus.value[queryPreviewHash] === 'success' ||
           queriesStatus.value[queryPreviewHash] === 'loading'

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -95,7 +95,10 @@ export default defineComponent({
      * @returns The query hash.
      */
     const queryPreviewHash = computed(() =>
-      getHashFromQueryPreviewInfo(props.queryPreviewInfo, params.value.lang as string),
+      getHashFromQueryPreviewInfo(props.queryPreviewInfo, {
+        ...params.value,
+        ...props.queryPreviewInfo.extraParams,
+      }),
     )
 
     provide('queryPreviewHash', queryPreviewHash)

--- a/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
@@ -21,7 +21,7 @@ import { getHashFromQueryPreviewInfo } from '../../utils/get-hash-from-query-pre
 import { queriesPreviewXModule } from '../../x-module'
 import { queriesPreviewXStoreModule } from '../module'
 
-const requestParams = { instance: 'empathy', lang: 'en' }
+const extraParams = { instance: 'empathy', lang: 'en' }
 
 const store: SafeStore<
   QueriesPreviewState,
@@ -140,10 +140,10 @@ describe('testing queries preview module actions', () => {
     })
 
     it('should send multiple requests if the queries are different', async () => {
-      const extraParams = { extraParam: 'extra param', ...requestParams }
+      const customExtraParams = { extraParam: 'extra param', ...extraParams }
       const { store } = renderQueryPreviewActions()
-      const firstQuery = getHashFromQueryPreviewInfo({ query: 'milk' }, extraParams)
-      const secondQuery = getHashFromQueryPreviewInfo({ query: 'cookies' }, extraParams)
+      const firstQuery = getHashFromQueryPreviewInfo({ query: 'milk' }, customExtraParams)
+      const secondQuery = getHashFromQueryPreviewInfo({ query: 'cookies' }, customExtraParams)
 
       const firstRequest = store.dispatch('fetchAndSaveQueryPreview', {
         query: 'milk',

--- a/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/__tests__/actions.spec.ts
@@ -21,6 +21,8 @@ import { getHashFromQueryPreviewInfo } from '../../utils/get-hash-from-query-pre
 import { queriesPreviewXModule } from '../../x-module'
 import { queriesPreviewXStoreModule } from '../module'
 
+const requestParams = { instance: 'empathy', lang: 'en' }
+
 const store: SafeStore<
   QueriesPreviewState,
   QueriesPreviewGetters,
@@ -86,7 +88,7 @@ describe('testing queries preview module actions', () => {
       const request = getQueryPreviewRequest(queryPreview.query)
       await nextTick()
       const stateResults = store.state.queriesPreview
-      const queryId = getHashFromQueryPreviewInfo(queryPreview, request.extraParams?.lang as string)
+      const queryId = getHashFromQueryPreviewInfo(queryPreview, request.extraParams!)
       const expectedResults: QueryPreviewItem = {
         totalResults: mockedSearchResponse.totalResults,
         results: mockedSearchResponse.results,
@@ -131,21 +133,24 @@ describe('testing queries preview module actions', () => {
       adapter.search.mockRejectedValueOnce('Generic error')
       const queryPreview: QueryPreviewInfo = { query: 'sandals' }
       const request = getQueryPreviewRequest(queryPreview.query)
-      const queryId = getHashFromQueryPreviewInfo(queryPreview, request.extraParams?.lang as string)
+      const queryId = getHashFromQueryPreviewInfo(queryPreview, request.extraParams!)
 
       await store.dispatch('fetchAndSaveQueryPreview', request)
       expect(store.state.queriesPreview[queryId].status).toEqual('error')
     })
 
     it('should send multiple requests if the queries are different', async () => {
+      const extraParams = { extraParam: 'extra param', ...requestParams }
       const { store } = renderQueryPreviewActions()
-      const firstQuery = getHashFromQueryPreviewInfo({ query: 'milk' }, 'en')
-      const secondQuery = getHashFromQueryPreviewInfo({ query: 'cookies' }, 'en')
+      const firstQuery = getHashFromQueryPreviewInfo({ query: 'milk' }, extraParams)
+      const secondQuery = getHashFromQueryPreviewInfo({ query: 'cookies' }, extraParams)
+
       const firstRequest = store.dispatch('fetchAndSaveQueryPreview', {
         query: 'milk',
         rows: 3,
         extraParams: {
           extraParam: 'extra param',
+          instance: 'empathy',
           lang: 'en',
         },
       })
@@ -154,6 +159,7 @@ describe('testing queries preview module actions', () => {
         rows: 3,
         extraParams: {
           extraParam: 'extra param',
+          instance: 'empathy',
           lang: 'en',
         },
       })

--- a/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/actions/fetch-and-save-query-preview.action.ts
@@ -44,8 +44,7 @@ export const fetchAndSaveQueryPreview: QueriesPreviewXStoreModule['actions']['fe
       })
       .catch(error => {
         console.error(error)
-        const lang = request.extraParams ? request.extraParams.lang : ''
-        const queryPreviewHash = getHashFromQueryPreviewItem(queryPreviewItem, lang as string)
+        const queryPreviewHash = getHashFromQueryPreviewItem(queryPreviewItem)
         commit('setStatus', { queryPreviewHash, status: 'error' })
       })
   }

--- a/packages/x-components/src/x-modules/queries-preview/store/module.ts
+++ b/packages/x-components/src/x-modules/queries-preview/store/module.ts
@@ -32,9 +32,7 @@ export const queriesPreviewXStoreModule: QueriesPreviewXStoreModule = {
       state.params = params
     },
     setQueryPreviewCached(state, queryPreview) {
-      state.queriesPreview[
-        getHashFromQueryPreviewItem(queryPreview, queryPreview.request.extraParams?.lang as string)
-      ] = queryPreview
+      state.queriesPreview[getHashFromQueryPreviewItem(queryPreview)] = queryPreview
     },
     setStatus(state, { queryPreviewHash, status }) {
       state.queriesPreview[queryPreviewHash].status = status

--- a/packages/x-components/src/x-modules/queries-preview/utils/__tests__/get-hash-from-query-preview.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/utils/__tests__/get-hash-from-query-preview.spec.ts
@@ -22,7 +22,7 @@ import {
   getHashFromQueryPreviewItem,
 } from '../get-hash-from-query-preview'
 
-const requestParams = { instance: 'empathy', lang: 'en' }
+const extraParams = { instance: 'empathy', lang: 'en' }
 
 const store: SafeStore<
   QueriesPreviewState,
@@ -74,7 +74,7 @@ describe('testing queries preview module utils', () => {
           ],
         },
         rows: 3,
-        extraParams: requestParams,
+        extraParams,
       },
     }
     const queryHash = getHashFromQueryPreviewItem(queryPreviewItem)
@@ -87,7 +87,7 @@ describe('testing queries preview module utils', () => {
   it('should check if a query hash from a QueryPreviewInfo is created correctly', () => {
     const queryPreviewInfo: QueryPreviewInfo = { query: 'tshirt', filters: ['fit:regular'] }
 
-    const queryPreviewHash = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
+    const queryPreviewHash = getHashFromQueryPreviewInfo(queryPreviewInfo, extraParams)
 
     expect(queryPreviewHash).toBe('9072526d15ae91731b4c8764aeeaf95e')
   })
@@ -110,13 +110,14 @@ describe('testing queries preview module utils', () => {
             },
           ],
         },
+        extraParams,
         rows: 3,
       },
     }
     const queryPreviewItemHash = getHashFromQueryPreviewItem(queryPreviewItem)
 
     const queryPreviewInfo: QueryPreviewInfo = { query: 'tshirt', filters: ['fit:regular'] }
-    const queryPreviewInfoHash = getHashFromQueryPreviewInfo(queryPreviewInfo, {})
+    const queryPreviewInfoHash = getHashFromQueryPreviewInfo(queryPreviewInfo, extraParams)
 
     expect(queryPreviewItemHash).toBe(queryPreviewInfoHash)
   })

--- a/packages/x-components/src/x-modules/queries-preview/utils/__tests__/utils.spec.ts
+++ b/packages/x-components/src/x-modules/queries-preview/utils/__tests__/utils.spec.ts
@@ -22,6 +22,8 @@ import {
   getHashFromQueryPreviewItem,
 } from '../get-hash-from-query-preview'
 
+const requestParams = { instance: 'empathy', lang: 'en' }
+
 const store: SafeStore<
   QueriesPreviewState,
   QueriesPreviewGetters,
@@ -72,12 +74,10 @@ describe('testing queries preview module utils', () => {
           ],
         },
         rows: 3,
-        extraParams: {
-          lang: 'en',
-        },
+        extraParams: requestParams,
       },
     }
-    const queryHash = getHashFromQueryPreviewItem(queryPreviewItem, 'en')
+    const queryHash = getHashFromQueryPreviewItem(queryPreviewItem)
 
     await store.dispatch('fetchAndSaveQueryPreview', queryPreviewItem.request)
 
@@ -87,9 +87,9 @@ describe('testing queries preview module utils', () => {
   it('should check if a query hash from a QueryPreviewInfo is created correctly', () => {
     const queryPreviewInfo: QueryPreviewInfo = { query: 'tshirt', filters: ['fit:regular'] }
 
-    const queryPreviewHash = getHashFromQueryPreviewInfo(queryPreviewInfo, 'en')
+    const queryPreviewHash = getHashFromQueryPreviewInfo(queryPreviewInfo, requestParams)
 
-    expect(queryPreviewHash).toBe('3ed535c606cfe71ff84ebd2c4271fb9c')
+    expect(queryPreviewHash).toBe('9072526d15ae91731b4c8764aeeaf95e')
   })
 
   it('should check if a query hash from a QueryPreviewInfo and from a QueryPreviewItem is the same', () => {
@@ -113,10 +113,10 @@ describe('testing queries preview module utils', () => {
         rows: 3,
       },
     }
-    const queryPreviewItemHash = getHashFromQueryPreviewItem(queryPreviewItem, 'en')
+    const queryPreviewItemHash = getHashFromQueryPreviewItem(queryPreviewItem)
 
     const queryPreviewInfo: QueryPreviewInfo = { query: 'tshirt', filters: ['fit:regular'] }
-    const queryPreviewInfoHash = getHashFromQueryPreviewInfo(queryPreviewInfo, 'en')
+    const queryPreviewInfoHash = getHashFromQueryPreviewInfo(queryPreviewInfo, {})
 
     expect(queryPreviewItemHash).toBe(queryPreviewInfoHash)
   })

--- a/packages/x-components/src/x-modules/queries-preview/utils/get-hash-from-query-preview.ts
+++ b/packages/x-components/src/x-modules/queries-preview/utils/get-hash-from-query-preview.ts
@@ -1,18 +1,15 @@
+import type { Dictionary } from '@empathyco/x-utils'
 import type { QueryPreviewInfo, QueryPreviewItem } from '../store/index'
 import { md5 } from 'js-md5'
 
 /**
  * Creates a query hash to store a QueryPreview, so the same query
- * with different filters can be saved more than once in the state.
+ * with different filters and extra params can be saved more than once in the state.
  *
  * @param queryPreview - The {@link QueryPreviewItem | QueryPreviewItem} used in the request.
- * @param lang - The language used in the request.
  * @returns A unique id that will be used as a key to store the QueryPreviewItem in the state.
  */
-export const getHashFromQueryPreviewItem = (
-  queryPreview: QueryPreviewItem,
-  lang: string,
-): string => {
+export const getHashFromQueryPreviewItem = (queryPreview: QueryPreviewItem): string => {
   const queryPreviewFilters = queryPreview.request.filters
     ? Object.values(queryPreview.request.filters)
         .flat()
@@ -20,21 +17,35 @@ export const getHashFromQueryPreviewItem = (
         .join('-')
     : ''
 
-  return md5(queryPreview.request.query.concat(queryPreviewFilters).concat(lang))
+  const queriesPreviewExtraParams = getJoinedParams(queryPreview.request.extraParams)
+
+  return md5(
+    queryPreview.request.query.concat(queryPreviewFilters).concat(queriesPreviewExtraParams),
+  )
 }
 
 /**
  * Creates a query hash to check if a QueryPreview has already been saved in the state.
  *
  * @param queryPreviewInfo - The {@link QueryPreviewInfo | QueryPreviewInfo} of a QueryPreview.
- * @param lang - The language used in the request.
+ * @param extraParams - The extra params used in the request.
  * @returns A unique id that will be used as a key to check the QueryPreview in the state.
  */
 export const getHashFromQueryPreviewInfo = (
   queryPreviewInfo: QueryPreviewInfo,
-  lang: string,
+  extraParams: Dictionary<unknown>,
 ): string => {
   const queryPreviewFilters = queryPreviewInfo.filters ? queryPreviewInfo.filters.join('-') : ''
+  const queriesPreviewExtraParams = getJoinedParams(extraParams)
 
-  return md5(queryPreviewInfo.query.concat(queryPreviewFilters).concat(lang))
+  return md5(queryPreviewInfo.query.concat(queryPreviewFilters).concat(queriesPreviewExtraParams))
+}
+
+function getJoinedParams(params?: Record<string, unknown>): string {
+  return params
+    ? Object.values(params)
+        .flat()
+        .map(param => param?.toString() ?? '')
+        .join('-')
+    : ''
 }

--- a/packages/x-components/src/x-modules/queries-preview/utils/get-hash-from-query-preview.ts
+++ b/packages/x-components/src/x-modules/queries-preview/utils/get-hash-from-query-preview.ts
@@ -10,13 +10,7 @@ import { md5 } from 'js-md5'
  * @returns A unique id that will be used as a key to store the QueryPreviewItem in the state.
  */
 export const getHashFromQueryPreviewItem = (queryPreview: QueryPreviewItem): string => {
-  const queryPreviewFilters = queryPreview.request.filters
-    ? Object.values(queryPreview.request.filters)
-        .flat()
-        .map(filter => filter.id.toString())
-        .join('-')
-    : ''
-
+  const queryPreviewFilters = getJoinedParams(queryPreview.request.filters)
   const queriesPreviewExtraParams = getJoinedParams(queryPreview.request.extraParams)
 
   return md5(
@@ -41,11 +35,27 @@ export const getHashFromQueryPreviewInfo = (
   return md5(queryPreviewInfo.query.concat(queryPreviewFilters).concat(queriesPreviewExtraParams))
 }
 
+/**
+ * Joins the values of the given parameters object into a single string, separated by hyphens.
+ *
+ * - If `params` is provided, its values are flattened (if they are arrays), converted to strings,
+ *   and concatenated with hyphens (`-`) as separators.
+ * - If `params` is not provided, returns an empty string.
+ * - If a value has an `id` property (like Filter objects), the `id` is used instead of the whole object.
+ *
+ * @param params - An optional object whose values will be joined into a string.
+ * @returns A string containing the joined parameter values, or an empty string if no parameters are provided.
+ */
 function getJoinedParams(params?: Record<string, unknown>): string {
   return params
     ? Object.values(params)
         .flat()
-        .map(param => param?.toString() ?? '')
+        .map(param => {
+          if (param && typeof param === 'object' && 'id' in param) {
+            return (param as { id: unknown }).id?.toString() ?? ''
+          }
+          return param?.toString() ?? ''
+        })
         .join('-')
     : ''
 }


### PR DESCRIPTION
This pull request updates the query preview hashing logic to ensure that all extra request parameters are included when generating unique hashes for query previews. This change improves the accuracy of caching and state management, especially when multiple parameters (such as `lang`, `instance`, and any potential `custom param`) are involved. The update is reflected across the core hashing utility, Vue components, store actions, mutations, and associated tests.

These changes ensure that query preview caching and retrieval are robust and correctly scoped to all relevant request parameters, reducing the risk of cache collisions.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->
This change is motivated by a scenario where custom extra parameters are modified at runtime, affecting the query preview response and leading to inconsistencies in the displayed visualization.

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [x] I have **commented** my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [x] I have added **tests** that prove my fix is effective or that my feature works.
- [x] New and existing **unit tests pass locally** with my changes.
