### PR TITLE
docs: Update x-modules components documentation (1/6)

### DIFF
--- a/packages/x-components/src/x-modules/ai/components/ai-overview.vue
+++ b/packages/x-components/src/x-modules/ai/components/ai-overview.vue
@@ -526,7 +526,7 @@ export default defineComponent({
 <docs lang="mdx">
 ## AI Overview Examples
 
-The `ai-overview` component provides an AI-generated summary and suggestions for queries. Below are usage examples in Vue 3 style, matching the format of previous documentation files.
+The `ai-overview` component provides an AI-generated summary and suggestions for queries.
 
 ### Basic usage
 
@@ -587,11 +587,4 @@ import AiOverview from '@empathyco/x-components/js/x-modules/ai/components/ai-ov
 import ResultCard from './ResultCard.vue'
 </script>
 ```
-
-### Notes
-
-- The component is designed for Vue 3 and uses `<script setup>` syntax in all examples.
-- All props are reactive and can be updated dynamically.
-- The `result` slot is required for rendering each result card.
-- You can use other named slots to customize loading, extra content, and sliding panel controls.
 </docs>

--- a/packages/x-components/src/x-modules/ai/components/ai-overview.vue
+++ b/packages/x-components/src/x-modules/ai/components/ai-overview.vue
@@ -522,3 +522,76 @@ export default defineComponent({
   }
 }
 </style>
+
+<docs lang="mdx">
+## AI Overview Examples
+
+The `ai-overview` component provides an AI-generated summary and suggestions for queries. Below are usage examples in Vue 3 style, matching the format of previous documentation files.
+
+### Basic usage
+
+```vue
+<template>
+  <AiOverview
+    :title="'AI Overview'"
+    :title-loading="'Generating with Empathy AI'"
+    :expand-text="'Show more'"
+    :collapse-text="'Show less'"
+    :content-classes="'my-content-class'"
+    :sliding-panels-classes="'my-sliding-panel-class'"
+    :sliding-panel-containers-classes="'my-sliding-panel-container-class'"
+    :sliding-panel-buttons-classes="'my-sliding-panel-button-class'"
+  >
+    <template #result="{ result }">
+      <ResultCard :result="result" />
+    </template>
+  </AiOverview>
+</template>
+
+<script setup>
+import AiOverview from '@empathyco/x-components/js/x-modules/ai/components/ai-overview.vue'
+import ResultCard from './ResultCard.vue'
+</script>
+```
+
+### Customizing slots
+
+You can customize the loading title, extra content, and sliding panel slots:
+
+```vue
+<template>
+  <AiOverview
+    :title="'AI Overview'"
+    :title-loading="'Loading... Please wait'"
+    :expand-text="'Show more'"
+    :collapse-text="'Show less'"
+  >
+    <template #title-loading>
+      <span>Custom loading title...</span>
+    </template>
+    <template #extra-content>
+      <div>Extra content below the main overview</div>
+    </template>
+    <template #sliding-panels-addons="{ arrivedState }">
+      <span v-if="arrivedState.left">Left end reached</span>
+      <span v-if="arrivedState.right">Right end reached</span>
+    </template>
+    <template #result="{ result }">
+      <ResultCard :result="result" />
+    </template>
+  </AiOverview>
+</template>
+
+<script setup>
+import AiOverview from '@empathyco/x-components/js/x-modules/ai/components/ai-overview.vue'
+import ResultCard from './ResultCard.vue'
+</script>
+```
+
+### Notes
+
+- The component is designed for Vue 3 and uses `<script setup>` syntax in all examples.
+- All props are reactive and can be updated dynamically.
+- The `result` slot is required for rendering each result card.
+- You can use other named slots to customize loading, extra content, and sliding panel controls.
+</docs>

--- a/packages/x-components/src/x-modules/device/components/device-detector.vue
+++ b/packages/x-components/src/x-modules/device/components/device-detector.vue
@@ -177,24 +177,14 @@ _Try resizing the browser window!_
   </div>
 </template>
 
-<script>
+<script setup>
 import { DeviceDetector } from '@empathyco/x-components/device'
-
-export default {
-  name: 'DeviceDemo',
-  components: {
-    DeviceDetector,
-  },
-  data() {
-    return {
-      breakpoints: {
-        mobile: 600,
-        tablet: 900,
-        desktop: Number.POSITIVE_INFINITY,
-      },
-    }
-  },
-}
+import { reactive } from 'vue'
+const breakpoints = reactive({
+  mobile: 600,
+  tablet: 900,
+  desktop: Number.POSITIVE_INFINITY,
+})
 </script>
 ```
 
@@ -213,31 +203,21 @@ _Try resizing the window to check that it never changes_
   </div>
 </template>
 
-<script>
+<script setup>
 import { DeviceDetector } from '@empathyco/x-components/device'
-
-export default {
-  name: 'DeviceDemo',
-  components: {
-    DeviceDetector,
-  },
-  data() {
-    return {
-      breakpoints: {
-        mobile: 600,
-        tablet: 900,
-        desktop: Number.POSITIVE_INFINITY,
-      },
-    }
-  },
-}
+import { reactive } from 'vue'
+const breakpoints = reactive({
+  mobile: 600,
+  tablet: 900,
+  desktop: Number.POSITIVE_INFINITY,
+})
 </script>
 ```
 
 ### Play with events
 
 In this example, the `DeviceDetector` will emit a `DeviceProvided` event, with the new device as the
-payload. This device is stored in a data variable and then displayed.
+payload. This device is stored in a ref and then displayed.
 
 _Try resizing the browser window!_
 
@@ -249,29 +229,17 @@ _Try resizing the browser window!_
   </div>
 </template>
 
-<script>
+<script setup>
 import { DeviceDetector } from '@empathyco/x-components/device'
-
-export default {
-  name: 'DeviceDemo',
-  components: {
-    DeviceDetector,
-  },
-  data() {
-    return {
-      device: 'unknown',
-      breakpoints: {
-        mobile: 600,
-        tablet: 900,
-        desktop: Number.POSITIVE_INFINITY,
-      },
-    }
-  },
-  methods: {
-    storeDevice(device) {
-      this.device = device
-    },
-  },
+import { reactive, ref } from 'vue'
+const device = ref('unknown')
+const breakpoints = reactive({
+  mobile: 600,
+  tablet: 900,
+  desktop: Number.POSITIVE_INFINITY,
+})
+function storeDevice(newDevice) {
+  device.value = newDevice
 }
 </script>
 ```

--- a/packages/x-components/src/x-modules/device/components/device-detector.vue
+++ b/packages/x-components/src/x-modules/device/components/device-detector.vue
@@ -173,13 +173,16 @@ _Try resizing the browser window!_
 <template>
   <div>
     <DeviceDetector :breakpoints="breakpoints" />
-    {{ $x.device }}
+    {{ x.device }}
   </div>
 </template>
 
 <script setup>
-import { DeviceDetector } from '@empathyco/x-components/device'
 import { reactive } from 'vue'
+import { DeviceDetector } from '@empathyco/x-components/device'
+import { use$x } from '../../../composables/use-$x'
+
+const x = use$x()
 const breakpoints = reactive({
   mobile: 600,
   tablet: 900,
@@ -199,13 +202,16 @@ _Try resizing the window to check that it never changes_
 <template>
   <div>
     <DeviceDetector force="mobile" :breakpoints="breakpoints" />
-    {{ $x.device }}
+    {{ x.device }}
   </div>
 </template>
 
 <script setup>
-import { DeviceDetector } from '@empathyco/x-components/device'
 import { reactive } from 'vue'
+import { DeviceDetector } from '@empathyco/x-components/device'
+import { use$x } from '../../../composables/use-$x'
+
+const x = use$x()
 const breakpoints = reactive({
   mobile: 600,
   tablet: 900,

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -169,72 +169,102 @@ This component will listen to the configured events in `eventsToOpenEmpathize` a
 are:
 
 - Open: `UserFocusedSearchBox`, `UserIsTypingAQuery`, `UserClickedSearchBox`
-- Close: `UserClosedEmpathize`, `UserSelectedASuggestion`, `UserPressedEnter` and 'UserBlurredSearchBox`
+- Close: `UserClosedEmpathize`, `UserSelectedASuggestion`, `UserPressedEnterKey`, `UserBlurredSearchBox`
 
-### Basic examples
+### Basic example
 
 The component rendering the query suggestions, popular searches and history queries with keyboard
 navigation.
 
 ```vue
-<Empathize>
-  <template #default>
+<template>
+  <Empathize>
     <BaseKeyboardNavigation>
-      <QuerySuggestions/>
-      <PopularSearches/>
-      <HistoryQueries/>
+      <QuerySuggestions />
+      <PopularSearches />
+      <HistoryQueries />
     </BaseKeyboardNavigation>
-  </template>
-</Empathize>
+  </Empathize>
+</template>
+
+<script setup>
+import Empathize from '@empathyco/x-components/js/x-modules/empathize/components/empathize.vue'
+import BaseKeyboardNavigation from '@empathyco/x-components/js/components/base-keyboard-navigation.vue'
+import QuerySuggestions from '@empathyco/x-components/js/x-modules/query-suggestions/components/query-suggestions.vue'
+import PopularSearches from '@empathyco/x-components/js/x-modules/popular-searches/components/popular-searches.vue'
+import HistoryQueries from '@empathyco/x-components/js/x-modules/history-queries/components/history-queries.vue'
+</script>
 ```
 
-Defining custom values for the events to open and close the Empathize. For example opening it when
+Defining custom values for the events to open and close the Empathize. For example, opening it when
 the search box loses the focus and closing it when the search box receives the focus:
 
 ```vue
-<Empathize
-  :eventsToOpenEmpathize="['UserBlurredSearchBox']"
-  :eventsToCloseEmpathize="['UserFocusedSearchBox']"
->
-  <template #default>
+<template>
+  <Empathize
+    :events-to-open-empathize="['UserBlurredSearchBox']"
+    :events-to-close-empathize="['UserFocusedSearchBox']"
+  >
     Please, type a query in the Search Box.
-  </template>
-</Empathize>
+  </Empathize>
+</template>
+
+<script setup>
+import Empathize from '@empathyco/x-components/js/x-modules/empathize/components/empathize.vue'
+</script>
 ```
 
-An animation can be used for the opening and closing using the `animation` prop. The animation, must
-be a Component with a `Transition` with a slot inside:
+An animation can be used for the opening and closing using the `animation` prop. The animation must
+be a component with a `Transition` and a slot inside:
 
 ```vue
-<Empathize :animation="collapseFromTop">
-  <template #default>
-    <PopularSearches/>
-  </template>
-</Empathize>
+<template>
+  <Empathize :animation="collapseFromTop">
+    <PopularSearches />
+  </Empathize>
+</template>
+
+<script setup>
+import Empathize from '@empathyco/x-components/js/x-modules/empathize/components/empathize.vue'
+import PopularSearches from '@empathyco/x-components/js/x-modules/popular-searches/components/popular-searches.vue'
+import collapseFromTop from './collapseFromTop.vue'
+</script>
 ```
 
-### Advance examples
+### Advanced example
 
 The component rendering the query suggestions, popular searches and history queries with keyboard
 navigation. It also configures `searchAndCloseOnNoContent` to trigger a search and close the empathize
-when has no-content as fallback behaviour. To do that, `hasContent` prop must be reactive to know
-if the empathize has content or not.
-It also configures `searchAndCloseDebounceInMs` to 500ms as debounce time to search and close the
-empathize when has no-content.
+when it has no content as fallback behaviour. To do that, `hasContent` prop must be reactive to know
+if the empathize has content or not. It also configures `searchAndCloseDebounceInMs` to 500ms as debounce time to search and close the empathize when it has no content.
 
 ```vue
-<Empathize
-  :animation="empathizeAnimation"
-  :events-to-close-empathize="empathizeCloseEvents"
-  :has-content="showEmpathize"
-  :search-and-close-debounce-in-ms="500"
-  search-and-close-on-no-content
->
-  <BaseKeyboardNavigation>
-    <QuerySuggestions/>
-    <PopularSearches/>
-    <HistoryQueries/>
-  </BaseKeyboardNavigation>
-</Empathize>
+<template>
+  <Empathize
+    :animation="empathizeAnimation"
+    :events-to-close-empathize="empathizeCloseEvents"
+    :has-content="showEmpathize"
+    :search-and-close-debounce-in-ms="500"
+    search-and-close-on-no-content
+  >
+    <BaseKeyboardNavigation>
+      <QuerySuggestions />
+      <PopularSearches />
+      <HistoryQueries />
+    </BaseKeyboardNavigation>
+  </Empathize>
+</template>
+
+<script setup>
+import Empathize from '@empathyco/x-components/js/x-modules/empathize/components/empathize.vue'
+import BaseKeyboardNavigation from '@empathyco/x-components/js/components/base-keyboard-navigation.vue'
+import QuerySuggestions from '@empathyco/x-components/js/x-modules/query-suggestions/components/query-suggestions.vue'
+import PopularSearches from '@empathyco/x-components/js/x-modules/popular-searches/components/popular-searches.vue'
+import HistoryQueries from '@empathyco/x-components/js/x-modules/history-queries/components/history-queries.vue'
+import { ref } from 'vue'
+const empathizeAnimation = null // Provide your animation component
+const empathizeCloseEvents = ['UserClosedEmpathize', 'UserSelectedASuggestion']
+const showEmpathize = ref(true)
+</script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/empathize/components/empathize.vue
+++ b/packages/x-components/src/x-modules/empathize/components/empathize.vue
@@ -227,7 +227,8 @@ be a component with a `Transition` and a slot inside:
 <script setup>
 import Empathize from '@empathyco/x-components/js/x-modules/empathize/components/empathize.vue'
 import PopularSearches from '@empathyco/x-components/js/x-modules/popular-searches/components/popular-searches.vue'
-import collapseFromTop from './collapseFromTop.vue'
+import CollapseFromTop from './collapseFromTop.vue'
+const animation = CollapseFromTop
 </script>
 ```
 
@@ -261,8 +262,9 @@ import BaseKeyboardNavigation from '@empathyco/x-components/js/components/base-k
 import QuerySuggestions from '@empathyco/x-components/js/x-modules/query-suggestions/components/query-suggestions.vue'
 import PopularSearches from '@empathyco/x-components/js/x-modules/popular-searches/components/popular-searches.vue'
 import HistoryQueries from '@empathyco/x-components/js/x-modules/history-queries/components/history-queries.vue'
+import CollapseFromTop from './collapseFromTop.vue'
 import { ref } from 'vue'
-const empathizeAnimation = null // Provide your animation component
+const empathizeAnimation = CollapseFromTop
 const empathizeCloseEvents = ['UserClosedEmpathize', 'UserSelectedASuggestion']
 const showEmpathize = ref(true)
 </script>

--- a/packages/x-components/src/x-modules/experience-controls/components/experience-controls.vue
+++ b/packages/x-components/src/x-modules/experience-controls/components/experience-controls.vue
@@ -43,15 +43,9 @@ This component will fire the events received in the `ExperienceControlsEventsCha
 <template>
   <ExperienceControls />
 </template>
-<script>
-import { ExperienceControls } from '@empathyco/x-components/experience-controls'
 
-export default {
-  name: 'ExperienceControlsDemo',
-  components: {
-    ExperienceControls,
-  },
-}
+<script setup>
+import { ExperienceControls } from '@empathyco/x-components/experience-controls'
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-result.vue
@@ -80,11 +80,21 @@ export default defineComponent({
 ## Examples
 
 This component renders an identifier result value and highlights its matching part with the query
-from the state. Receives as prop the result data
+from the state. Receives as prop the result data.
 
-### Basic usage:
+### Basic usage
 
 ```vue
-<IdentifierResult v-bind="{ result }" />
+<template>
+  <IdentifierResult :result="result" />
+</template>
+
+<script setup>
+import IdentifierResult from '@empathyco/x-components/js/x-modules/identifier-results/components/identifier-result.vue'
+const result = {
+  identifier: { value: 'ABC-123-XYZ' },
+  // ...other result properties
+}
+</script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
@@ -97,22 +97,32 @@ export default defineComponent({
 <docs lang="mdx">
 ## Examples
 
-### Play with slot
-
 A IdentifierResult **must** be used inside the IdentifierResults component. In the example below the
 BaseResultLink is used as a wrapper and its default slot is filled with the IdentifierResult
 component.
 
+### Play with slot
+
 ```vue
-<IdentifierResults :animation="fadeAndSlide">
-  <template #default="{ identifierResult }">
-    <BaseResultLink :result="identifierResult">
-      <template #default="{ result }">
-        <IdentifierResult :result="result"/>
-      </template>
-    </BaseResultLink>
-  </template>
-</IdentifierResults>
+<template>
+  <IdentifierResults :animation="fadeAndSlide">
+    <template #default="{ identifierResult }">
+      <BaseResultLink :result="identifierResult">
+        <template #default="{ result }">
+          <IdentifierResult :result="result" />
+        </template>
+      </BaseResultLink>
+    </template>
+  </IdentifierResults>
+</template>
+
+<script setup>
+import IdentifierResults from '@empathyco/x-components/js/x-modules/identifier-results/components/identifier-results.vue'
+import IdentifierResult from '@empathyco/x-components/js/x-modules/identifier-results/components/identifier-result.vue'
+import BaseResultLink from '@empathyco/x-components/js/components/base-result-link.vue'
+// Example fadeAndSlide animation import
+import fadeAndSlide from '@empathyco/x-components/js/animations/fade-and-slide.vue'
+</script>
 ```
 
 ### Play with props
@@ -121,21 +131,16 @@ In this example, the identifier results have been limited to render a maximum of
 
 ```vue
 <template>
-  <IdentifierResults #default="{ identifierResult }" :maxItemsToRender="3">
-    <IdentifierResult :result="identifierResult" />
+  <IdentifierResults :max-items-to-render="3">
+    <template #default="{ identifierResult }">
+      <IdentifierResult :result="identifierResult" />
+    </template>
   </IdentifierResults>
 </template>
 
-<script>
-import { IdentifierResults, IdentifierResult } from '@empathyco/x-components'
-
-export default {
-  name: 'IdentifierResultsDemo',
-  components: {
-    IdentifierResults,
-    IdentifierResult,
-  },
-}
+<script setup>
+import IdentifierResults from '@empathyco/x-components/js/x-modules/identifier-results/components/identifier-results.vue'
+import IdentifierResult from '@empathyco/x-components/js/x-modules/identifier-results/components/identifier-result.vue'
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
+++ b/packages/x-components/src/x-modules/identifier-results/components/identifier-results.vue
@@ -105,7 +105,7 @@ component.
 
 ```vue
 <template>
-  <IdentifierResults :animation="fadeAndSlide">
+  <IdentifierResults :animation="animation">
     <template #default="{ identifierResult }">
       <BaseResultLink :result="identifierResult">
         <template #default="{ result }">
@@ -120,8 +120,9 @@ component.
 import IdentifierResults from '@empathyco/x-components/js/x-modules/identifier-results/components/identifier-results.vue'
 import IdentifierResult from '@empathyco/x-components/js/x-modules/identifier-results/components/identifier-result.vue'
 import BaseResultLink from '@empathyco/x-components/js/components/base-result-link.vue'
-// Example fadeAndSlide animation import
-import fadeAndSlide from '@empathyco/x-components/js/animations/fade-and-slide.vue'
+import FadeAndSlide from '@empathyco/x-components/js/animations/fade-and-slide.vue'
+
+const animation = FadeAndSlide
 </script>
 ```
 

--- a/packages/x-components/src/x-modules/next-queries/components/next-query.vue
+++ b/packages/x-components/src/x-modules/next-queries/components/next-query.vue
@@ -104,12 +104,12 @@ A list of events that the component will emit:
 
 ## Examples
 
-This components expects just a suggestion as a prop to be rendered. It has a slot to override the
+This component expects just a suggestion as a prop to be rendered. It has a slot to override the
 content. By default, it renders the suggestion query of the next query. It also has an optional
 prop, `highlightCurated`, to indicate if the curated Next Queries should be differentiated with a
 CSS class.
 
-### Basic Usage
+### Basic usage
 
 Using default slot:
 
@@ -118,28 +118,18 @@ Using default slot:
   <NextQuery :suggestion="suggestion" />
 </template>
 
-<script>
+<script setup>
 import { NextQuery } from '@empathyco/x-components/next-queries'
-
-export default {
-  name: 'NextQueryDemo',
-  components: {
-    NextQuery,
-  },
-  data() {
-    return {
-      suggestion: {
-        modelName: 'NextQuery',
-        query: 'tshirt',
-        facets: [],
-      },
-    }
-  },
-}
+import { ref } from 'vue'
+const suggestion = ref({
+  modelName: 'NextQuery',
+  query: 'tshirt',
+  facets: [],
+})
 </script>
 ```
 
-### Overriding default slot.
+### Overriding default slot
 
 The default slot allows you to replace the content of the suggestion button.
 
@@ -153,26 +143,15 @@ The default slot allows you to replace the content of the suggestion button.
   </NextQuery>
 </template>
 
-<script>
+<script setup>
 import { NextQuery } from '@empathyco/x-components/next-queries'
 import { TrendingIcon } from '@empathyco/x-components'
-
-export default {
-  name: 'NextQueryDemo',
-  components: {
-    NextQuery,
-    TrendingIcon,
-  },
-  data() {
-    return {
-      suggestion: {
-        modelName: 'NextQuery',
-        query: 'tshirt',
-        facets: [],
-      },
-    }
-  },
-}
+import { ref } from 'vue'
+const suggestion = ref({
+  modelName: 'NextQuery',
+  query: 'tshirt',
+  facets: [],
+})
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-search.vue
@@ -74,37 +74,28 @@ A list of events that the component will emit:
 
 ## Examples
 
-This components expects just a suggestion as a prop to be rendered. It has a slot to override the
+This component expects just a suggestion as a prop to be rendered. It has a slot to override the
 content. By default, it renders the suggestion query of the popular search.
 
-### Basic Usage
+### Basic usage
 
 ```vue live
 <template>
   <PopularSearch :suggestion="suggestion" />
 </template>
 
-<script>
+<script setup>
 import { PopularSearch } from '@empathyco/x-components/popular-searches'
-export default {
-  name: 'PopularSearchDemo',
-  components: {
-    PopularSearch,
-  },
-  data() {
-    return {
-      suggestion: {
-        modelName: 'PopularSearch',
-        query: 'tshirt',
-        facets: [],
-      },
-    }
-  },
-}
+import { ref } from 'vue'
+const suggestion = ref({
+  modelName: 'PopularSearch',
+  query: 'tshirt',
+  facets: [],
+})
 </script>
 ```
 
-### Custom Usage
+### Custom usage
 
 ```vue live
 <template>
@@ -116,26 +107,15 @@ export default {
   </PopularSearch>
 </template>
 
-<script>
+<script setup>
 import { PopularSearch } from '@empathyco/x-components/popular-searches'
 import { TrendingIcon } from '@empathyco/x-components'
-
-export default {
-  name: 'PopularSearchDemo',
-  components: {
-    PopularSearch,
-    TrendingIcon,
-  },
-  data() {
-    return {
-      suggestion: {
-        modelName: 'PopularSearch',
-        query: 'tshirt',
-        facets: [],
-      },
-    }
-  },
-}
+import { ref } from 'vue'
+const suggestion = ref({
+  modelName: 'PopularSearch',
+  query: 'tshirt',
+  facets: [],
+})
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -99,7 +99,7 @@ The component has two optional props. `animation` to render the component with a
 
 ```vue live
 <template>
-  <PopularSearches :animation="FadeAndSlide" :max-items-to-render="10" />
+  <PopularSearches :animation="FadeAndSlide" :maxItemsToRender="10" />
 </template>
 
 <script setup>

--- a/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
+++ b/packages/x-components/src/x-modules/popular-searches/components/popular-searches.vue
@@ -89,14 +89,8 @@ searches it will show them.
   <PopularSearches />
 </template>
 
-<script>
+<script setup>
 import { PopularSearches } from '@empathyco/x-components/popular-searches'
-export default {
-  name: 'PopularSearchesDemo',
-  components: {
-    PopularSearches,
-  },
-}
 </script>
 ```
 
@@ -105,23 +99,12 @@ The component has two optional props. `animation` to render the component with a
 
 ```vue live
 <template>
-  <PopularSearches :animation="'FadeAndSlide'" :maxItemsToRender="10" />
+  <PopularSearches :animation="FadeAndSlide" :max-items-to-render="10" />
 </template>
 
-<script>
-import Vue from 'vue'
+<script setup>
 import { PopularSearches } from '@empathyco/x-components/popular-searches'
-import FadeAndSlide from '@empathyco/x-components'
-
-// Registering the animation as a global component
-Vue.component('FadeAndSlide', FadeAndSlide)
-export default {
-  name: 'PopularSearchesDemo',
-  components: {
-    PopularSearches,
-    FadeAndSlide,
-  },
-}
+import FadeAndSlide from '@empathyco/x-components/animations/fade-and-slide.vue'
 </script>
 ```
 
@@ -141,17 +124,9 @@ query of the Popular Search's suggestion.
   </PopularSearches>
 </template>
 
-<script>
+<script setup>
 import { PopularSearches } from '@empathyco/x-components/popular-searches'
 import { TrendingIcon } from '@empathyco/x-components'
-
-export default {
-  name: 'PopularSearchesDemo',
-  components: {
-    PopularSearches,
-    TrendingIcon,
-  },
-}
 </script>
 ```
 
@@ -178,18 +153,9 @@ Search component.
   </PopularSearches>
 </template>
 
-<script>
+<script setup>
 import { PopularSearches, PopularSearch } from '@empathyco/x-components/popular-searches'
 import { TrendingIcon } from '@empathyco/x-components'
-
-export default {
-  name: 'PopularSearchesDemo',
-  components: {
-    PopularSearches,
-    PopularSearch,
-    TrendingIcon,
-  },
-}
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
+++ b/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
@@ -156,7 +156,7 @@ In this example, the component will render a maximum of 4 result recommendations
 <template>
   <Recommendations
     v-slot="{ recommendation }"
-    :max-items-to-render="4"
+    :maxItemsToRender="4"
     :animation="StaggeredFadeAndSlide"
   >
     <BaseResultLink :result="recommendation" class="x-recommendations__link">

--- a/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
+++ b/packages/x-components/src/x-modules/recommendations/components/recommendations.vue
@@ -123,31 +123,27 @@ To use this component, the Topclicked service must be implemented.
 
 Here you have a basic example on how the recommendations are rendered. You can customize how each
 result is rendered by using the `default` slot. It is highly recommended to use base components such
-as the `BaseResultLink` or the `BaseResultAddToCart`, as they provides integration with other
-modules such like the `tagging` one.
+as the `BaseResultLink` or the `BaseResultAddToCart`, as they provide integration with other
+modules such as the `tagging` one.
 
 ```vue live
 <template>
-  <Recommendations #default="{ recommendation }">
+  <Recommendations v-slot="{ recommendation }">
     <BaseResultLink :result="recommendation" class="x-recommendations__link">
-      <img :src="recommendation.images[0]" class="x-recommendations__image" />
+      <img
+        :src="recommendation.images[0]"
+        :alt="recommendation.name"
+        class="x-recommendations__image"
+      />
       <span class="x-recommendations__title">{{ recommendation.name }}</span>
     </BaseResultLink>
-    <BaseResultAddToCart>Add to cart</BaseResultAddToCart>
+    <BaseResultAddToCart :result="recommendation">Add to cart</BaseResultAddToCart>
   </Recommendations>
 </template>
-<script>
+
+<script setup>
 import { Recommendations } from '@empathyco/x-components/recommendations'
 import { BaseResultLink, BaseResultAddToCart } from '@empathyco/x-components'
-
-export default {
-  name: 'RecommendationsDemo',
-  components: {
-    Recommendations,
-    BaseResultLink,
-    BaseResultAddToCart,
-  },
-}
 </script>
 ```
 
@@ -159,43 +155,38 @@ In this example, the component will render a maximum of 4 result recommendations
 ```vue live
 <template>
   <Recommendations
-    #default="{ recommendation }"
-    :maxItemsToRender="4"
-    animation="StaggeredFadeAndSlide"
+    v-slot="{ recommendation }"
+    :max-items-to-render="4"
+    :animation="StaggeredFadeAndSlide"
   >
     <BaseResultLink :result="recommendation" class="x-recommendations__link">
-      <img :src="recommendation.images[0]" class="x-recommendations__image" />
+      <img
+        :src="recommendation.images[0]"
+        :alt="recommendation.name"
+        class="x-recommendations__image"
+      />
       <span class="x-recommendations__title">{{ recommendation.name }}</span>
     </BaseResultLink>
-    <BaseResultAddToCart>Add to cart</BaseResultAddToCart>
+    <BaseResultAddToCart :result="recommendation">Add to cart</BaseResultAddToCart>
   </Recommendations>
 </template>
-<script>
-import Vue from 'vue'
+
+<script setup>
 import { Recommendations } from '@empathyco/x-components/recommendations'
 import { BaseResultLink, BaseResultAddToCart } from '@empathyco/x-components'
-
-Vue.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide)
-export default {
-  name: 'RecommendationsDemo',
-  components: {
-    Recommendations,
-    BaseResultLink,
-    BaseResultAddToCart,
-  },
-}
+import StaggeredFadeAndSlide from '@empathyco/x-components/animations/staggered-fade-and-slide.vue'
 </script>
 ```
 
 ### Play with the layout
 
 In this example you can build your own layout, and the `Recommendations` component will just act as
-a provider of the result recommendations data. Using the component this way, and due to Vue 2
-limitations you will only be allowed to render a single element inside the `layout` slot.
+a provider of the result recommendations data. Using the component this way, you can render any
+layout you want using the `layout` slot.
 
 ```vue live
 <template>
-  <Recommendations #layout="{ recommendations }">
+  <Recommendations v-slot:layout="{ recommendations }">
     <div class="x-recommendations">
       <article
         class="x-recommendations-list"
@@ -203,26 +194,22 @@ limitations you will only be allowed to render a single element inside the `layo
         :key="recommendation.id"
       >
         <BaseResultLink :result="recommendation" class="x-recommendations__link">
-          <img :src="recommendation.images[0]" class="x-recommendations__image" />
+          <img
+            :src="recommendation.images[0]"
+            :alt="recommendation.name"
+            class="x-recommendations__image"
+          />
           <span class="x-recommendations__title">{{ recommendation.name }}</span>
         </BaseResultLink>
-        <BaseResultAddToCart>Add to cart</BaseResultAddToCart>
+        <BaseResultAddToCart :result="recommendation">Add to cart</BaseResultAddToCart>
       </article>
     </div>
   </Recommendations>
 </template>
-<script>
+
+<script setup>
 import { Recommendations } from '@empathyco/x-components/recommendations'
 import { BaseResultLink, BaseResultAddToCart } from '@empathyco/x-components'
-
-export default {
-  name: 'RecommendationsDemo',
-  components: {
-    Recommendations,
-    BaseResultLink,
-    BaseResultAddToCart,
-  },
-}
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/tagging/components/tagging.vue
+++ b/packages/x-components/src/x-modules/tagging/components/tagging.vue
@@ -128,15 +128,8 @@ doesn't render elements to the DOM.
   <Tagging />
 </template>
 
-<script>
+<script setup>
 import { Tagging } from '@empathyco/x-components/tagging'
-
-export default {
-  name: 'TaggingDemo',
-  components: {
-    Tagging,
-  },
-}
 </script>
 ```
 
@@ -144,7 +137,7 @@ export default {
 
 In this example, the `Tagging` component will emit `ConsentProvided` with payload false by default
 if the consent is not provided, the `TaggingConfigProvided` event will be emitted only if the props
-`queryTaggingDebounceMs`, `sessionDurationMs`, `storageTTLMs` or `storageKey`are defined.
+`queryTaggingDebounceMs`, `sessionDurationMs`, `storageTTLMs` or `storageKey` are defined.
 
 Every time the user clicks a result or adds a result to the cart, the information for the product
 will be stored on the browser during 30 seconds which is the default value for the prop
@@ -156,15 +149,8 @@ will be used since `storageKey` default value is 'url'.
   <Tagging :consent="true" :queryTaggingDebounceMs="300" :sessionDurationMs="30000" />
 </template>
 
-<script>
+<script setup>
 import { Tagging } from '@empathyco/x-components/tagging'
-
-export default {
-  name: 'TaggingDemo',
-  components: {
-    Tagging,
-  },
-}
 </script>
 ```
 
@@ -176,15 +162,8 @@ during 60 seconds and the product id will be used as storage key
   <Tagging :storageTTLMs="60000" :storageKey="'id'" />
 </template>
 
-<script>
+<script setup>
 import { Tagging } from '@empathyco/x-components/tagging'
-
-export default {
-  name: 'TaggingDemo',
-  components: {
-    Tagging,
-  },
-}
 </script>
 ```
 

--- a/packages/x-components/src/x-modules/url/components/url-handler.vue
+++ b/packages/x-components/src/x-modules/url/components/url-handler.vue
@@ -388,25 +388,18 @@ This component emits the following events:
 ## See it in action
 
 This component manages the browser URL parameters to preserve them through reloads and browser
-history navigation. It allow to configure the default url parameter names using its attributes. This
+history navigation. It allows you to configure the default URL parameter names using its attributes. This
 component doesn't render elements to the DOM.
 
-_Try to make some requests and take a look to the url!_
+_Try to make some requests and take a look at the URL!_
 
 ```vue
 <template>
   <UrlHandler />
 </template>
 
-<script>
+<script setup>
 import { UrlHandler } from '@empathyco/x-components/url-handler'
-
-export default {
-  name: 'UrlHandlerDemo',
-  components: {
-    UrlHandler,
-  },
-}
 </script>
 ```
 
@@ -416,25 +409,18 @@ In this example, the `UrlHandler` component changes the following query paramete
 
 - `query` to be `q`.
 - `page` to be `p`.
-- `filter` to be `f`
-- `sort` to be `s`
+- `filter` to be `f`.
+- `sort` to be `s`.
 
-_Try to make some requests and take a look to the url!_
+_Try to make some requests and take a look at the URL!_
 
 ```vue
 <template>
   <UrlHandler query="q" page="p" filter="f" sort="s" />
 </template>
 
-<script>
+<script setup>
 import { UrlHandler } from '@empathyco/x-components/url-handler'
-
-export default {
-  name: 'UrlHandlerDemo',
-  components: {
-    UrlHandler,
-  },
-}
 </script>
 ```
 
@@ -443,7 +429,7 @@ export default {
 The `UrlHandler` will emit the `ParamsLoadedFromUrl` when the page is loaded.
 
 The `UrlHandler` will emit the `ExtraParamsLoadedFromUrl` when the page is loaded with an extra
-param configured and with a value in URL.
+param configured and with a value in the URL.
 
 The `UrlHandler` will emit the `UserOpenXProgrammatically` when the page is loaded with a query in
 the URL.


### PR DESCRIPTION
[RST-5315](https://searchbroker.atlassian.net/browse/RST-5315)

Update to Vue 3 code examples from:
- [ai](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/ai)
- [device](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/device)
- [empathize](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/empathize)
- [experience-controls](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/experience-controls)
- [identifier-results](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/identifier-results)
- [popular-searches](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/popular-searches)
- [recommendations](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/recommendations)
- [tagging](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/tagging)
- [url](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/url)

[RST-5315]: https://searchbroker.atlassian.net/browse/RST-5315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ