### PR TITLE
docs: Update x-modules components documentation (2/6)

### DIFF
--- a/packages/x-components/src/x-modules/extra-params/components/extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/extra-params.vue
@@ -56,22 +56,12 @@ _See how the event is triggered when the component is rendered._
   <ExtraParams :values="values" />
 </template>
 
-<script>
+<script setup>
 import { ExtraParams } from '@empathyco/x-components/extra-params'
-
-export default {
-  name: 'ExtraParamsDemo',
-  components: {
-    ExtraParams,
-  },
-  data() {
-    return {
-      values: {
-        warehouse: 1234,
-      },
-    }
-  },
-}
+import { reactive } from 'vue'
+const values = reactive({
+  warehouse: 1234,
+})
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/extra-params/components/renderless-extra-param.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/renderless-extra-param.vue
@@ -52,28 +52,16 @@ default value of it.
 
 ```vue
 <template>
-  <RenderlessExtraParam #default="{ value, updateValue }" name="store">
+  <RenderlessExtraParam v-slot="{ value, updateValue }" name="store">
     <BaseDropdown @update:modelValue="updateValue" :modelValue="value" :items="items" />
   </RenderlessExtraParam>
 </template>
 
-<script>
-import { RenderlessExtraParams } from '@empathyco/x-components/extra-params'
-import { BaseDropdown } from '@empathyco/x-components'
-
-export default {
-  name: 'RenderlessExtraParamsDemo',
-  components: {
-    RenderlessExtraParams,
-    BaseDropdown,
-  },
-  props: ['name'],
-  data() {
-    return {
-      items: ['spain', 'portugal'],
-    }
-  },
-}
+<script setup>
+import RenderlessExtraParam from '@empathyco/x-components/js/x-modules/extra-params/components/renderless-extra-param.vue'
+import BaseDropdown from '@empathyco/x-components/js/components/base-dropdown.vue'
+import { ref } from 'vue'
+const items = ref(['spain', 'portugal'])
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
+++ b/packages/x-components/src/x-modules/extra-params/components/snippet-config-extra-params.vue
@@ -73,26 +73,20 @@ _See how the snippet config is injected and passed to the SnippetConfigExtraPara
   </Provider>
 </template>
 
-<script>
+<script setup>
 import { SnippetConfigExtraParams } from '@empathyco/x-components/extra-params'
+import { defineComponent, provide } from 'vue'
 
-const Provider = {
-  provide: {
-    snippetConfig: {
+const Provider = defineComponent({
+  setup(_, { slots }) {
+    provide('snippetConfig', {
       instance: 'demo',
       lang: 'es',
       warehouse: 1234,
-    },
+    })
+    return () => slots.default?.()
   },
-}
-
-export default {
-  name: 'SnippetConfigExtraParamsDemo',
-  components: {
-    Provider,
-    SnippetConfigExtraParams,
-  },
-}
+})
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview-button.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview-button.vue
@@ -101,61 +101,35 @@ export default defineComponent({
 
 ### Basic example
 
-The component content has the query preview query as default
+The component content has the query preview query as default.
 
 ```vue
 <template>
-  <div>
-    <QueryPreviewButton queryPreviewInfo="queryPreviewInfo" />
-  </div>
+  <QueryPreviewButton queryPreviewInfo="queryPreviewInfo" />
 </template>
 
-<script>
+<script setup>
 import { QueryPreviewButton } from '@empathyco/x-components/queries-preview'
-
-export default {
-  components: {
-    QueryPreviewButton,
-  },
-  data: function () {
-    return {
-      queryPreviewInfo: {
-        query: 'shoes',
-      },
-    }
-  },
-}
+import { reactive } from 'vue'
+const queryPreviewInfo = reactive({ query: 'shoes' })
 </script>
 ```
 
 ### Customizing slots
 
-The content of the button is customizable via its default slot
+The content of the button is customizable via its default slot.
 
 ```vue
 <template>
-  <div>
-    <QueryPreviewButton queryPreviewInfo="queryPreviewInfo">
-      {{ `Search for: ${queryPreviewInfo.query}` }}
-    </QueryPreviewButton>
-  </div>
+  <QueryPreviewButton queryPreviewInfo="queryPreviewInfo">
+    {{ `Search for: ${queryPreviewInfo.query}` }}
+  </QueryPreviewButton>
 </template>
 
-<script>
+<script setup>
 import { QueryPreviewButton } from '@empathyco/x-components/queries-preview'
-
-export default {
-  components: {
-    QueryPreviewButton,
-  },
-  data: function () {
-    return {
-      queryPreviewInfo: {
-        query: 'shoes',
-      },
-    }
-  },
-}
+import { reactive } from 'vue'
+const queryPreviewInfo = reactive({ query: 'shoes' })
 </script>
 ```
 

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview-list.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview-list.vue
@@ -218,20 +218,14 @@ names of the results.
   <QueryPreviewList :queriesPreviewInfo="queriesPreviewInfo" />
 </template>
 
-<script>
+<script setup>
 import { QueryPreviewList } from '@empathyco/x-components/queries-preview'
-
-export default {
-  name: 'QueryPreviewListDemo',
-  components: {
-    QueryPreviewList,
-  },
-  data() {
-    return {
-      queriesPreviewInfo: [{ query: 'sandals' }, { query: 'tshirt' }, { query: 'jacket' }],
-    }
-  },
-}
+import { reactive } from 'vue'
+const queriesPreviewInfo = reactive([
+  { query: 'sandals' },
+  { query: 'tshirt' },
+  { query: 'jacket' },
+])
 </script>
 ```
 
@@ -261,24 +255,16 @@ In this example, the results will be rendered inside a sliding panel.
   </QueryPreviewList>
 </template>
 
-<script>
+<script setup>
 import { QueryPreviewList } from '@empathyco/x-components/queries-preview'
-import { BaseResultImage, BaseResultLink, SlidingPanel } from '@empathyco/x-components'
-
-export default {
-  name: 'QueryPreviewListDemoOverridingSlot',
-  components: {
-    BaseResultImage,
-    BaseResultLink,
-    QueryPreviewList,
-    SlidingPanel,
-  },
-  data() {
-    return {
-      queriesPreviewInfo: [{ query: 'sandals' }, { query: 'tshirt' }, { query: 'jacket' }],
-    }
-  },
-}
+import SlidingPanel from '@empathyco/x-components/sliding-panel.vue'
+import Result from '@empathyco/x-components/result.vue'
+import { reactive } from 'vue'
+const queriesPreviewInfo = reactive([
+  { query: 'sandals' },
+  { query: 'tshirt' },
+  { query: 'jacket' },
+])
 </script>
 ```
 
@@ -300,20 +286,14 @@ In this example, the ID of the results will be rendered along with the name.
   </QueryPreviewList>
 </template>
 
-<script>
+<script setup>
 import { QueryPreviewList } from '@empathyco/x-components/queries-preview'
-
-export default {
-  name: 'QueryPreviewListDemoOverridingResultSlot',
-  components: {
-    QueryPreviewList,
-  },
-  data() {
-    return {
-      queriesPreviewInfo: [{ query: 'sandals' }, { query: 'tshirt' }, { query: 'jacket' }],
-    }
-  },
-}
+import { reactive } from 'vue'
+const queriesPreviewInfo = reactive([
+  { query: 'sandals' },
+  { query: 'tshirt' },
+  { query: 'jacket' },
+])
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
+++ b/packages/x-components/src/x-modules/queries-preview/components/query-preview.vue
@@ -318,20 +318,10 @@ results.
   <QueryPreview :queryPreviewInfo="queryPreviewInfo" />
 </template>
 
-<script>
+<script setup>
 import { QueryPreview } from '@empathyco/x-components/queries-preview'
-
-export default {
-  name: 'QueryPreviewDemo',
-  components: {
-    QueryPreview,
-  },
-  data() {
-    return {
-      queryPreviewInfo: { query: 'sandals' },
-    }
-  },
-}
+import { reactive } from 'vue'
+const queryPreviewInfo = reactive({ query: 'sandals' })
 </script>
 ```
 
@@ -365,24 +355,11 @@ In this example, the results will be rendered inside a sliding panel.
   </QueryPreview>
 </template>
 
-<script>
+<script setup>
 import { QueryPreview } from '@empathyco/x-components/queries-preview'
 import { BaseResultImage, BaseResultLink, SlidingPanel } from '@empathyco/x-components'
-
-export default {
-  name: 'QueryPreviewDemoOverridingSlot',
-  components: {
-    BaseResultImage,
-    BaseResultLink,
-    QueryPreview,
-    SlidingPanel,
-  },
-  data() {
-    return {
-      queryPreviewInfo: { query: 'flip-flops' },
-    }
-  },
-}
+import { reactive } from 'vue'
+const queryPreviewInfo = reactive({ query: 'flip-flops' })
 </script>
 ```
 
@@ -400,20 +377,10 @@ In this example, the ID of the results will be rendered along with the name.
   </QueryPreview>
 </template>
 
-<script>
+<script setup>
 import { QueryPreview } from '@empathyco/x-components/queries-preview'
-
-export default {
-  name: 'QueryPreviewDemoOverridingResultSlot',
-  components: {
-    QueryPreview,
-  },
-  data() {
-    return {
-      queryPreviewInfo: { query: 'flip-flops' },
-    }
-  },
-}
+import { reactive } from 'vue'
+const queryPreviewInfo = reactive({ query: 'flip-flops' })
 </script>
 ```
 
@@ -436,25 +403,12 @@ In this example, the query preview has been limited to render a maximum of 4 res
   </QueryPreview>
 </template>
 
-<script>
+<script setup>
 import { BaseGrid, BaseResultImage, BaseResultLink } from '@empathyco/x-components'
 import { QueryPreview } from '@empathyco/x-components/queries-preview'
-
-export default {
-  name: 'QueryPreviewDemo',
-  components: {
-    BaseGrid,
-    BaseResultImage,
-    BaseResultLink,
-    QueryPreview,
-  },
-  data() {
-    return {
-      maxItemsToRender: 4,
-      queryPreviewInfo: { query: 'flip-flops' },
-    }
-  },
-}
+import { reactive } from 'vue'
+const maxItemsToRender = 4
+const queryPreviewInfo = reactive({ query: 'flip-flops' })
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestion.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestion.vue
@@ -87,23 +87,14 @@ Here you can see how a single query suggestion is rendered using the `suggestion
   <QuerySuggestion :suggestion="suggestion" />
 </template>
 
-<script>
+<script setup>
 import { QuerySuggestion } from '@empathyco/x-components/query-suggestions'
-export default {
-  name: 'QuerySuggestionDemo',
-  components: {
-    QuerySuggestion,
-  },
-  data() {
-    return {
-      suggestion: {
-        modelName: 'QuerySuggestion',
-        query: 'tshirt',
-        facets: [],
-      },
-    }
-  },
-}
+import { ref } from 'vue'
+const suggestion = ref({
+  modelName: 'QuerySuggestion',
+  query: 'tshirt',
+  facets: [],
+})
 </script>
 ```
 
@@ -119,23 +110,14 @@ In this example, we are adding an emoji next to the suggestion.
   </QuerySuggestion>
 </template>
 
-<script>
+<script setup>
 import { QuerySuggestion } from '@empathyco/x-components/query-suggestions'
-export default {
-  name: 'QuerySuggestionDemo',
-  components: {
-    QuerySuggestion,
-  },
-  data() {
-    return {
-      suggestion: {
-        modelName: 'QuerySuggestion',
-        query: 'tshirt',
-        facets: [],
-      },
-    }
-  },
-}
+import { ref } from 'vue'
+const suggestion = ref({
+  modelName: 'QuerySuggestion',
+  query: 'tshirt',
+  facets: [],
+})
 </script>
 ```
 
@@ -149,27 +131,16 @@ the `UserSelectedAQuerySuggestion` event has been triggered.
   <QuerySuggestion :suggestion="suggestion" @UserSelectedAQuerySuggestion="alertSuggestion" />
 </template>
 
-<script>
+<script setup>
 import { QuerySuggestion } from '@empathyco/x-components/query-suggestions'
-export default {
-  name: 'QuerySuggestionDemo',
-  components: {
-    QuerySuggestion,
-  },
-  data() {
-    return {
-      suggestion: {
-        modelName: 'QuerySuggestion',
-        query: 'tshirt',
-        facets: [],
-      },
-    }
-  },
-  methods: {
-    alertSuggestion(querySuggestion) {
-      alert(`You have clicked the query suggestion: ${querySuggestion.query}`)
-    },
-  },
+import { ref } from 'vue'
+const suggestion = ref({
+  modelName: 'QuerySuggestion',
+  query: 'tshirt',
+  facets: [],
+})
+function alertSuggestion(querySuggestion) {
+  alert(`You have clicked the query suggestion: ${querySuggestion.query}`)
 }
 </script>
 ```

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
@@ -158,17 +158,17 @@ you must implement the `UserAcceptedAQuery` and `UserSelectedAQuerySuggestion` e
 <script setup>
 import { QuerySuggestions } from '@empathyco/x-components/query-suggestions'
 import { SearchInput } from '@empathyco/x-components/search-box'
-import { useXBus } from '@empathyco/x-components'
+import { use$x } from '../../../composables/use-$x'
 
-const $x = useXBus()
+const x = use$x()
 function emitSuggestionClickedEvents(event, suggestion) {
-  $x.emit('UserAcceptedAQuery', suggestion.query, {
+  x.emit('UserAcceptedAQuery', suggestion.query, {
     target: event.target
   })
-  $x.emit('UserSelectedASuggestion', suggestion, {
+  x.emit('UserSelectedASuggestion', suggestion, {
     target: event.target
   })
-  $x.emit('UserSelectedAQuerySuggestion', suggestion, {
+  x.emit('UserSelectedAQuerySuggestion', suggestion, {
     target: event.target
   })
 }

--- a/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
+++ b/packages/x-components/src/x-modules/query-suggestions/components/query-suggestions.vue
@@ -85,23 +85,13 @@ _Type “sandal” or another fashion term in the input field to try it out!_
 
 ```vue live
 <template>
-  <div>
-    <SearchInput />
-    <QuerySuggestions />
-  </div>
+  <SearchInput />
+  <QuerySuggestions />
 </template>
 
-<script>
+<script setup>
 import { QuerySuggestions } from '@empathyco/x-components/query-suggestions'
 import { SearchInput } from '@empathyco/x-components/search-box'
-
-export default {
-  name: 'QuerySuggestionsDemo',
-  components: {
-    QuerySuggestions,
-    SearchInput,
-  },
-}
 </script>
 ```
 
@@ -114,27 +104,15 @@ _Type “lipstick” or another fashion term in the input field to try it out!_
 
 ```vue live
 <template>
-  <div>
-    <SearchInput />
-    <QuerySuggestions :animation="'StaggeredFadeAndSlide'" />
-  </div>
+  <SearchInput />
+  <QuerySuggestions :animation="StaggeredFadeAndSlide" />
 </template>
 
 <script>
 import Vue from 'vue'
 import { QuerySuggestions } from '@empathyco/x-components/query-suggestions'
 import { SearchInput } from '@empathyco/x-components/search-box'
-import { StaggeredFadeAndSlide } from '@empathyco/x-components'
-
-// Registering the animation as a global component
-Vue.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide)
-export default {
-  name: 'QuerySuggestionsDemo',
-  components: {
-    QuerySuggestions,
-    SearchInput,
-  },
-}
+import StaggeredFadeAndSlide from '@empathyco/x-components/animations/staggered-fade-and-slide.vue'
 </script>
 ```
 
@@ -146,27 +124,18 @@ _Type “bag” or another fashion term in the input field to try it out!_
 
 ```vue live
 <template>
-  <div>
-    <SearchInput />
-    <QuerySuggestions #suggestion="{ suggestion }">
-      <QuerySuggestion :suggestion="suggestion" #default="{ suggestion }">
-        <span>🔍</span>
-        <span>{{ suggestion.query }}</span>
-      </QuerySuggestion>
-    </QuerySuggestions>
-  </div>
+  <SearchInput />
+  <QuerySuggestions #suggestion="{ suggestion }">
+    <QuerySuggestion :suggestion="suggestion" #default="{ suggestion }">
+      <span>🔍</span>
+      <span>{{ suggestion.query }}</span>
+    </QuerySuggestion>
+  </QuerySuggestions>
 </template>
 
-<script>
+<script setup>
 import { QuerySuggestion, QuerySuggestions } from '@empathyco/x-components/query-suggestions'
-
-export default {
-  name: 'QuerySuggestionsDemo',
-  components: {
-    QuerySuggestion,
-    QuerySuggestions,
-  },
-}
+import { SearchInput } from '@empathyco/x-components/search-box'
 </script>
 ```
 
@@ -178,40 +147,31 @@ you must implement the `UserAcceptedAQuery` and `UserSelectedAQuerySuggestion` e
 
 ```vue live
 <template>
-  <div>
-    <SearchInput />
-    <QuerySuggestions #suggestion="{ suggestion }">
-      <button @click="emitSuggestionClickedEvents($event, suggestion)">
-        {{ suggestion.query }}
-      </button>
-    </QuerySuggestions>
-  </div>
+  <SearchInput />
+  <QuerySuggestions #suggestion="{ suggestion }">
+    <button @click="emitSuggestionClickedEvents($event, suggestion)">
+      {{ suggestion.query }}
+    </button>
+  </QuerySuggestions>
 </template>
 
-<script>
-  import { QuerySuggestions } from '@empathyco/x-components/query-suggestions';
-  import { SearchInput } from '@empathyco/x-components/search-box';
+<script setup>
+import { QuerySuggestions } from '@empathyco/x-components/query-suggestions'
+import { SearchInput } from '@empathyco/x-components/search-box'
+import { useXBus } from '@empathyco/x-components'
 
-  export default {
-    name: 'QuerySuggestionsDemo',
-    components: {
-      SearchInput,
-      QuerySuggestions
-    },
-    methods: {
-      emitSuggestionClickedEvents(event, suggestion) {
-        this.$x.emit('UserAcceptedAQuery', suggestion.query, {
-          target: event.target
-        });
-        this.$x.emit('UserSelectedASuggestion', suggestion, {
-          target: event.target
-        });
-        this.$x.emit('UserSelectedAQuerySuggestion', suggestion, {
-          target: event.target
-        });
-      }
-    }
-  };
+const $x = useXBus()
+function emitSuggestionClickedEvents(event, suggestion) {
+  $x.emit('UserAcceptedAQuery', suggestion.query, {
+    target: event.target
+  })
+  $x.emit('UserSelectedASuggestion', suggestion, {
+    target: event.target
+  })
+  $x.emit('UserSelectedAQuerySuggestion', suggestion, {
+    target: event.target
+  })
+}
 </script>
 ```
 
@@ -236,19 +196,10 @@ _Type “trousers” or another toy in the input field to try it out!_
   </div>
 </template>
 
-<script>
+<script setup>
 import { QuerySuggestions } from '@empathyco/x-components/query-suggestions'
 import { SearchInput } from '@empathyco/x-components/search-box'
 import { Highlight } from '@empathyco/x-components'
-
-export default {
-  name: 'QuerySuggestionsDemo',
-  components: {
-    SearchInput,
-    QuerySuggestions,
-    Highlight,
-  },
-}
 </script>
 ```
 
@@ -268,17 +219,9 @@ _Type “pants” or another toy in the input field to try it out!_
   </div>
 </template>
 
-<script>
+<script setup>
 import { QuerySuggestions } from '@empathyco/x-components/query-suggestions'
 import { SearchInput } from '@empathyco/x-components/search-box'
-
-export default {
-  name: 'QuerySuggestionsDemo',
-  components: {
-    SearchInput,
-    QuerySuggestions,
-  },
-}
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tag.vue
@@ -194,24 +194,14 @@ _Here you can see how the RelatedTag component is rendered._
   <RelatedTag :relatedTag="tag" />
 </template>
 
-<script>
+<script setup>
 import { RelatedTag } from '@empathyco/x-components/related-tags'
 
-export default {
-  name: 'RelatedTagDemo',
-  components: {
-    RelatedTag,
-  },
-  data() {
-    return {
-      tag: {
-        modelName: 'RelatedTag',
-        query: 'high heel',
-        isCurated: false,
-        tag: 'heel',
-      },
-    }
-  },
+const tag = {
+  modelName: 'RelatedTag',
+  query: 'high heel',
+  isCurated: false,
+  tag: 'heel',
 }
 </script>
 ```
@@ -229,24 +219,14 @@ _See how the related tag can be rendered._
   </RelatedTag>
 </template>
 
-<script>
+<script setup>
 import { RelatedTag } from '@empathyco/x-components/related-tags'
 
-export default {
-  name: 'RelatedTagDemo',
-  components: {
-    RelatedTag,
-  },
-  data() {
-    return {
-      tag: {
-        modelName: 'RelatedTag',
-        query: 'high heel',
-        isCurated: false,
-        tag: 'heel',
-      },
-    }
-  },
+const tag = {
+  modelName: 'RelatedTag',
+  query: 'high heel',
+  isCurated: false,
+  tag: 'heel',
 }
 </script>
 ```
@@ -263,29 +243,18 @@ _See how the event is triggered when the related tag is clicked._
   <RelatedTag :relatedTag="tag" @UserSelectedARelatedTag="alertRelatedTag" />
 </template>
 
-<script>
+<script setup>
 import { RelatedTag } from '@empathyco/x-components/related-tags'
 
-export default {
-  name: 'RelatedTagDemo',
-  components: {
-    RelatedTag,
-  },
-  data() {
-    return {
-      tag: {
-        modelName: 'RelatedTag',
-        query: 'high heel',
-        isCurated: false,
-        tag: 'heel',
-      },
-    }
-  },
-  methods: {
-    alertRelatedTag(relatedTag) {
-      alert(`You have clicked the related tag: ${relatedTag.query}`)
-    },
-  },
+const tag = {
+  modelName: 'RelatedTag',
+  query: 'high heel',
+  isCurated: false,
+  tag: 'heel',
+}
+
+function alertRelatedTag(relatedTag) {
+  alert(`You have clicked the related tag: ${relatedTag.query}`)
 }
 </script>
 ```

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -142,17 +142,9 @@ _Search for a fashion term like "sandal" or "lipstick"._
   </div>
 </template>
 
-<script>
+<script setup>
 import { SearchInput } from '@empathyco/x-components/search-box'
 import { RelatedTags } from '@empathyco/x-components/related-tags'
-
-export default {
-  name: 'RelatedTagsDemo',
-  components: {
-    SearchInput,
-    RelatedTags,
-  },
-}
 </script>
 ```
 
@@ -171,20 +163,16 @@ _Search for a fashion term and see the related tags with the animation effect._
   </div>
 </template>
 
-<script>
-import Vue from 'vue'
+<script setup>
 import { SearchInput } from '@empathyco/x-components/search-box'
 import { RelatedTags } from '@empathyco/x-components/related-tags'
 import { StaggeredFadeAndSlide } from '@empathyco/x-components'
 
-// Registering the animation as a global component
-Vue.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide)
-export default {
-  name: 'RelatedTagsDemo',
-  components: {
-    SearchInput,
-    RelatedTags,
-  },
+// Registering the animation as a global component (Vue 3)
+import { getCurrentInstance } from 'vue'
+const app = getCurrentInstance()?.appContext.app
+if (app) {
+  app.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide)
 }
 </script>
 ```
@@ -206,18 +194,9 @@ _Search for a fashion term and see how the related tags can be rendered._
   </div>
 </template>
 
-<script>
+<script setup>
 import { SearchInput } from '@empathyco/x-components/search-box'
 import { RelatedTags, RelatedTag } from '@empathyco/x-components/related-tags'
-
-export default {
-  name: 'RelatedTagsDemo',
-  components: {
-    SearchInput,
-    RelatedTags,
-    RelatedTag,
-  },
-}
 </script>
 ```
 
@@ -239,17 +218,9 @@ _Search for a fashion term and see how the related tags are rendered._
   </div>
 </template>
 
-<script>
+<script setup>
 import { SearchInput } from '@empathyco/x-components/search-box'
 import { RelatedTags } from '@empathyco/x-components/related-tags'
-
-export default {
-  name: 'RelatedTagsDemo',
-  components: {
-    SearchInput,
-    RelatedTags,
-  },
-}
 </script>
 ```
 
@@ -273,19 +244,10 @@ _Search for a fashion term and see how the related tags can be rendered._
   </div>
 </template>
 
-<script>
+<script setup>
 import { SearchInput } from '@empathyco/x-components/search-box'
 import { RelatedTags } from '@empathyco/x-components/related-tags'
 import { ResultsList } from '@empathyco/x-components/search'
-
-export default {
-  name: 'RelatedTagsDemo',
-  components: {
-    SearchInput,
-    RelatedTags,
-    ResultsList,
-  },
-}
 </script>
 ```
 
@@ -303,17 +265,9 @@ The `itemClass` prop can be used to add classes to the related tags.
   </div>
 </template>
 
-<script>
+<script setup>
 import { SearchInput } from '@empathyco/x-components/search-box'
 import { RelatedTags } from '@empathyco/x-components/related-tags'
-
-export default {
-  name: 'RelatedTagsDemo',
-  components: {
-    SearchInput,
-    RelatedTags,
-  },
-}
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
+++ b/packages/x-components/src/x-modules/related-tags/components/related-tags.vue
@@ -159,7 +159,7 @@ _Search for a fashion term and see the related tags with the animation effect._
 <template>
   <div>
     <SearchInput />
-    <RelatedTags :animation="'StaggeredFadeAndSlide'" :maxItemsToRender="3" />
+    <RelatedTags :animation="animation" :maxItemsToRender="3" />
   </div>
 </template>
 
@@ -168,12 +168,7 @@ import { SearchInput } from '@empathyco/x-components/search-box'
 import { RelatedTags } from '@empathyco/x-components/related-tags'
 import { StaggeredFadeAndSlide } from '@empathyco/x-components'
 
-// Registering the animation as a global component (Vue 3)
-import { getCurrentInstance } from 'vue'
-const app = getCurrentInstance()?.appContext.app
-if (app) {
-  app.component('StaggeredFadeAndSlide', StaggeredFadeAndSlide)
-}
+const animation = StaggeredFadeAndSlide
 </script>
 ```
 

--- a/packages/x-components/src/x-modules/semantic-queries/components/semantic-queries.vue
+++ b/packages/x-components/src/x-modules/semantic-queries/components/semantic-queries.vue
@@ -101,15 +101,8 @@ By default, the `SemanticQueries` component will render a list of semantic queri
   <SemanticQueries />
 </template>
 
-<script>
+<script setup>
 import { SemanticQueries } from '@empathyco/x-components/semantic-queries'
-
-export default {
-  name: 'SemanticQueriesDemo',
-  components: {
-    SemanticQueries,
-  },
-}
 </script>
 ```
 
@@ -117,25 +110,19 @@ export default {
 
 The component has the following props:
 
-- maxItemsToRender to limit the number of semantic queries to render.
-- animation to specify the animation to be used to animate the semantic queries.
+- `maxItemsToRender` to limit the number of semantic queries to render.
+- `animation` to specify the animation to be used to animate the semantic queries.
 
 ```vue live
 <template>
   <SemanticQueries :animation="animation" :maxItemsToRender="3" />
 </template>
 
-<script>
+<script setup>
+import { SemanticQueries } from '@empathyco/x-components/semantic-queries'
 import { FadeAndSlide } from '@empathyco/x-components'
 
-export default {
-  name: 'SemanticQueriesPropsDemo',
-  data() {
-    return {
-      animation: FadeAndSlide,
-    }
-  },
-}
+const animation = FadeAndSlide
 </script>
 ```
 
@@ -148,7 +135,7 @@ The default slot is used to overwrite the whole content of the component.
   <SemanticQueries #default="{ suggestions }">
     <section>
       <SlidingPanel>
-        <div v-for="suggestion in suggestions">
+        <div v-for="suggestion in suggestions" :key="suggestion.query">
           {{ suggestion.query }}
           {{ suggestion.distance }}
         </div>
@@ -157,17 +144,9 @@ The default slot is used to overwrite the whole content of the component.
   </SemanticQueries>
 </template>
 
-<script>
+<script setup>
 import { SemanticQueries } from '@empathyco/x-components/semantic-queries'
 import { SlidingPanel } from '@empathyco/x-components'
-
-export default {
-  name: 'SemanticQueriesDefaultSlotDemo',
-  components: {
-    SemanticQueries,
-    SlidingPanel,
-  },
-}
 </script>
 ```
 
@@ -183,8 +162,8 @@ semantic query to use it in another element.
     <section>
       <QueryPreviewList :queries="queries" #slot="{ query, results }">
         <div>
-          <SemanticQuery :semanticQuery="findSemanticQuery(query)" #default="{ query }">
-            {{ query.query }} ({{ query.distance }})
+          <SemanticQuery :suggestion="findSemanticQuery(query)" #default="{ suggestion }">
+            {{ suggestion.query }} ({{ suggestion.distance }})
           </SemanticQuery>
           <ul>
             <li v-for="result in results" :key="result.id">
@@ -197,18 +176,9 @@ semantic query to use it in another element.
   </SemanticQueries>
 </template>
 
-<script>
+<script setup>
 import { SemanticQueries, SemanticQuery } from '@empathyco/x-components/semantic-queries'
 import { QueryPreviewList } from '@empathyco/x-components/queries-preview'
-
-export default {
-  name: 'SemanticQueriesDefaultSlotDemo2',
-  components: {
-    SemanticQueries,
-    SemanticQuery,
-    QueryPreviewList,
-  },
-}
 </script>
 ```
 
@@ -228,20 +198,14 @@ In this example, the query will be rendered along with the distance.
   </SemanticQueries>
 </template>
 
-<script>
+<script setup>
 import { SemanticQueries } from '@empathyco/x-components/semantic-queries'
-export default {
-  name: 'SemanticQueriesItemSlotDemo',
-  components: {
-    SemanticQueries,
-  },
-}
 </script>
 ```
 
-### Play with the suggestion content slot
+### Play with the suggestion-content slot
 
-The suggsetion content slot can be used to override only the content, but keep using the
+The suggestion-content slot can be used to override only the content, but keep using the
 SemanticQuery component internally.
 
 ```vue live
@@ -254,14 +218,8 @@ SemanticQuery component internally.
   </SemanticQueries>
 </template>
 
-<script>
+<script setup>
 import { SemanticQueries } from '@empathyco/x-components/semantic-queries'
-export default {
-  name: 'SemanticQueriesItemSlotDemo',
-  components: {
-    SemanticQueries,
-  },
-}
 </script>
 ```
 </docs>

--- a/packages/x-components/src/x-modules/semantic-queries/components/semantic-query.vue
+++ b/packages/x-components/src/x-modules/semantic-queries/components/semantic-query.vue
@@ -72,30 +72,20 @@ A list of events that the component will emit:
 
 ## See it in action
 
-Here you can see that the semantic query query is rendered.
+Here you can see that the semantic query is rendered.
 
 ```vue live
 <template>
   <SemanticQuery :suggestion="semanticQuery" />
 </template>
 
-<script>
+<script setup>
 import { SemanticQuery } from '@empathyco/x-components/semantic-queries'
 
-export default {
-  name: 'SemanticQueryDemo',
-  components: {
-    SemanticQuery,
-  },
-  data() {
-    return {
-      semanticQuery: {
-        modelName: 'SemanticQuery',
-        query: 'jacket',
-        distance: 2,
-      },
-    }
-  },
+const semanticQuery = {
+  modelName: 'SemanticQuery',
+  query: 'jacket',
+  distance: 2,
 }
 </script>
 ```
@@ -112,23 +102,13 @@ In this example, we add the distance of the semantic query next to the query.
   </SemanticQuery>
 </template>
 
-<script>
+<script setup>
 import { SemanticQuery } from '@empathyco/x-components/semantic-queries'
 
-export default {
-  name: 'SemanticQueryDemoDefaultSlot',
-  components: {
-    SemanticQuery,
-  },
-  data() {
-    return {
-      semanticQuery: {
-        modelName: 'SemanticQuery',
-        query: 'jacket',
-        distance: 2,
-      },
-    }
-  },
+const semanticQuery = {
+  modelName: 'SemanticQuery',
+  query: 'jacket',
+  distance: 2,
 }
 </script>
 ```


### PR DESCRIPTION
[RST-5315](https://searchbroker.atlassian.net/browse/RST-5315)

Update to Vue 3 code examples from:
- [extra-params](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/extra-params)
- [queries-preview](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/queries-preview)
- [query-suggestions](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/query-suggestions)
- [related-tags](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/related-tags)
- [semantic-queries](https://github.com/empathyco/x/tree/main/packages/x-components/src/x-modules/semantic-queries)

[RST-5315]: https://searchbroker.atlassian.net/browse/RST-5315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ