### PR TITLE
chore: block eslint-config upgrades temporarily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
     {
       "matchPackageNames": ["/^@types/react*/"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["@empathyco/eslint-config"],
+      "allowedVersions": "1.8.0",
+      "description": "Pin to current version to avoid CI issues" // TODO: Remove when root cause is found
     }
   ]
 }


### PR DESCRIPTION
Upgrades on @empathyco/eslint-config are causing the CI to fail.

To avoid blocking the rest of the dependencies, we are disabling Renovate to upgrade this dependency till the root cause is found.

The issue with eslint-config was discovered in #1937, when rolling back the dependency to the previous version fixed the CI. (Commit: https://github.com/empathyco/x/pull/1937/changes/25dea36825470126ea25777fb42e4c34f1d2c626)

<img width="1161" height="726" alt="image" src="https://github.com/user-attachments/assets/c70b5cda-d958-4638-9b12-1377ccc4be1b" />

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
