### PR TITLE
fix(history-queries): use uiLang for dates and capitalize first letter

### DIFF
--- a/packages/x-components/src/x-modules/history-queries/components/my-history.vue
+++ b/packages/x-components/src/x-modules/history-queries/components/my-history.vue
@@ -132,8 +132,11 @@ export default defineComponent({
      */
     const usedLocale = computed(() => snippetConfig?.lang ?? props.locale)
 
+    const uiLocale = computed(() => snippetConfig?.uiLang ?? props.locale)
+
     /**
-     * Returns a record of history queries grouped by date.
+     * Returns a record of history queries grouped by date, using the UI language (`uiLang`) for locale.
+     * The first character of the date is capitalized to ensure proper display in languages like Spanish.
      *
      * @example
      * ```typescript
@@ -155,12 +158,13 @@ export default defineComponent({
      */
     const groupByDate = computed((): Dictionary<HistoryQueryType[]> => {
       return groupItemsBy(historyQueries.value as HistoryQueryType[], current => {
-        return new Date(current.timestamp).toLocaleDateString(usedLocale.value, {
+        const dateStr = new Date(current.timestamp).toLocaleDateString(uiLocale.value, {
           day: 'numeric',
           weekday: 'long',
           month: 'long',
           year: 'numeric',
         })
+        return dateStr.charAt(0).toUpperCase() + dateStr.slice(1)
       })
     })
 


### PR DESCRIPTION
**Problem:**
`MyHistory` was displaying dates using the `lang` parameter from SnippetConfig. In languages like Spanish, `toLocaleDateString` returns lowercase day names, so UI dates looked incosistent.

**Solution:**
- Use the `uiLang` parameter from SnippetConfig for all UI date formatting
- Capitalize the first character of the date string to ensure proper display in languages where `toLocaleDateString` does not automatically capitalize.
- Fallback to `props.locale` if `uiLang` is not provided.

**Before:**
`miércoles, 19 de octubre de 2022`

**After:**
`Miércoles, 19 de octubre de 2022`

**Notes:**
- No visual or functional changes outside of the date capitalization and locale usage.
- Fully backwards compatible; Englisch and other languages that capitalize automatically remain unaffected.