### PR TITLE
chore: switch @empathyco/x to @empathyco/frontend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Unless a later match takes precedence,
 # These owners will be requested for review when someone opens a pull request.
 
-* @empathyco/x
+* @empathyco/frontend


### PR DESCRIPTION
## Summary
- Replace `@empathyco/x` with `@empathyco/frontend` in `.github/CODEOWNERS`.

## Test plan
- N/A (config change)
