### PR TITLE
fix(x-components): add optional sliding panel fade for related prompts

### DIFF
--- a/packages/x-components/src/components/__tests__/sliding-panel.spec.ts
+++ b/packages/x-components/src/components/__tests__/sliding-panel.spec.ts
@@ -39,6 +39,7 @@ function renderSlidingPanel({
   showButtons = true,
   scrollFactor = 0.7,
   resetOnContentChange = true,
+  fade = true,
   buttonClass = '',
   scrollContainerClass = '',
 }: RenderSlidingPanelOptions = {}) {
@@ -47,6 +48,7 @@ function renderSlidingPanel({
       showButtons,
       scrollFactor,
       resetOnContentChange,
+      fade,
       buttonClass,
       scrollContainerClass,
     } as any,
@@ -139,6 +141,23 @@ describe('testing SlidingPanel component', () => {
     expect(getRightButton().classes()).toContain('custom-button')
   })
 
+  it('applies edge fade class on the scroll container when fade is true (default)', () => {
+    const { getScroll } = renderSlidingPanel({
+      slots: { default: '<div>Content</div>' },
+    })
+
+    expect(getScroll().classes()).toContain('xds:sliding-panel-fade')
+  })
+
+  it('does not apply edge fade class when fade is false', () => {
+    const { getScroll } = renderSlidingPanel({
+      fade: false,
+      slots: { default: '<div>Content</div>' },
+    })
+
+    expect(getScroll().classes()).not.toContain('xds:sliding-panel-fade')
+  })
+
   it('resets the scroll to 0 when content changes and resetOnContentChange is true', async () => {
     const { wrapper, triggerMutation } = renderSlidingPanel({
       slots: { default: '<div>Content</div>' },
@@ -164,6 +183,7 @@ interface RenderSlidingPanelOptions {
   showButtons?: boolean
   scrollFactor?: number
   resetOnContentChange?: boolean
+  fade?: boolean
   buttonClass?: string
   scrollContainerClass?: string
 }

--- a/packages/x-components/src/components/sliding-panel.vue
+++ b/packages/x-components/src/components/sliding-panel.vue
@@ -2,8 +2,8 @@
   <div v-if="slots.default" class="xds:sliding-panel" :class="cssClasses" data-test="sliding-panel">
     <div
       ref="scrollContainerRef"
-      :class="scrollContainerClass"
-      class="x-sliding-panel__scroll xds:sliding-panel-fade"
+      class="x-sliding-panel__scroll"
+      :class="[scrollContainerClass, { 'xds:sliding-panel-fade': fade }]"
       data-test="sliding-panel-scroll"
     >
       <!-- @slot (Required) Sliding panel content -->
@@ -75,6 +75,13 @@ export default defineComponent({
      * the scroll position to 0.
      */
     resetOnContentChange: {
+      type: Boolean,
+      default: true,
+    },
+    /**
+     * When true, applies the design-system edge fade mask to the scroll container.
+     */
+    fade: {
       type: Boolean,
       default: true,
     },

--- a/packages/x-components/src/x-modules/related-prompts/components/__tests__/related-prompts-tag-list.spec.ts
+++ b/packages/x-components/src/x-modules/related-prompts/components/__tests__/related-prompts-tag-list.spec.ts
@@ -284,5 +284,21 @@ describe('relatedPromptsTagList component', () => {
     expect(sut.relatedPrompts[0].props().selected).toBeTruthy()
   })
 
+  it('passes fade to SlidingPanel when and only when no related prompt is selected', async () => {
+    selectedPromptIndexStub.value = -1
+    const noneSelected = render()
+    vi.runAllTimers()
+    await nextTick()
+    expect(noneSelected.slidingPanel.props().fade).toBe(true)
+    noneSelected.wrapper.unmount()
+
+    selectedPromptIndexStub.value = 2
+    const withSelection = render()
+    vi.runAllTimers()
+    await nextTick()
+    expect(withSelection.slidingPanel.props().fade).toBe(false)
+    withSelection.wrapper.unmount()
+  })
+
   // TODO: Test the transition group callbacks
 })

--- a/packages/x-components/src/x-modules/related-prompts/components/related-prompts-tag-list.vue
+++ b/packages/x-components/src/x-modules/related-prompts/components/related-prompts-tag-list.vue
@@ -1,6 +1,7 @@
 <template>
   <SlidingPanel
     :key="x.query.search"
+    :fade="selectedPromptIndex === -1"
     :reset-on-content-change="false"
     :button-class="buttonClass"
     :show-buttons="showButtons && selectedPromptIndex === -1"


### PR DESCRIPTION
## Motivation and context

The sliding panel always applied the design-system edge fade mask on the scroll container. For the related prompts tag list, that fade is undesirable when a prompt is selected because it obscure the border and hides the remove button.

<img width="858" height="403" alt="image" src="https://github.com/user-attachments/assets/fee82420-218d-472d-a6ee-46fe1cae9ee8" />

This change introduces a `fade` prop on `SlidingPanel` (default `true` for backward compatibility) and passes `:fade="selectedPromptIndex === -1"` from the related prompts tag list so the fade is only shown when no prompt is selected.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?

- [x] `Main`
- [ ] Other. Specify:

## How has this been tested?

Pre-commit hooks (`format:check`, `lint:check`) were run successfully as part of `git commit`. Manual UI verification in the demo or consuming app is recommended for scroll and fade behavior with and without a selected related prompt.

Tests performed according to [testing guidelines](./contributing/tests.md): not run beyond repository hooks in this environment.

## Checklist

- [x] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [x] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [x] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.