### PR TITLE
feat(next-queries): add mutation and wiring to reset next queries state

### DIFF
--- a/packages/x-components/src/x-modules/next-queries/store/module.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/module.ts
@@ -62,6 +62,9 @@ export const nextQueriesXStoreModule: NextQueriesXStoreModule = {
     resetResultsPreview(state) {
       state.resultsPreview = {}
     },
+    resetNextQueries(state) {
+      state.nextQueries = []
+    },
     setConfig,
     mergeConfig,
   },

--- a/packages/x-components/src/x-modules/next-queries/store/types.ts
+++ b/packages/x-components/src/x-modules/next-queries/store/types.ts
@@ -95,6 +95,10 @@ export interface NextQueriesMutations
    * Resets the result's dictionary.
    */
   resetResultsPreview: () => void
+  /**
+   * Resets the next queries list to an empty array.
+   */
+  resetNextQueries: () => void
 }
 
 /**

--- a/packages/x-components/src/x-modules/next-queries/wiring.ts
+++ b/packages/x-components/src/x-modules/next-queries/wiring.ts
@@ -122,6 +122,13 @@ export const fetchAndSaveNextQueryPreviewWire = wireDispatch(
 export const resetResultsPreviewWire = wireCommitWithoutPayload('resetResultsPreview')
 
 /**
+ * Resets the next queries list to an empty array.
+ *
+ * @public
+ */
+export const resetNextQueriesWire = wireCommitWithoutPayload('resetNextQueries')
+
+/**
  * Sets the next queries state `searchedQueries` with the list of history queries.
  *
  * @public
@@ -142,6 +149,7 @@ export const nextQueriesWiring = createWiring({
   },
   UserAcceptedAQuery: {
     setNextQueriesQuery,
+    resetNextQueriesWire,
   },
   SelectedRelatedTagsChanged: {
     setNextQueriesRelatedTags,

--- a/packages/x-components/src/x-modules/next-queries/wiring.ts
+++ b/packages/x-components/src/x-modules/next-queries/wiring.ts
@@ -148,8 +148,8 @@ export const nextQueriesWiring = createWiring({
     resetResultsPreviewWire,
   },
   UserAcceptedAQuery: {
-    setNextQueriesQuery,
     resetNextQueriesWire,
+    setNextQueriesQuery,
   },
   SelectedRelatedTagsChanged: {
     setNextQueriesRelatedTags,


### PR DESCRIPTION
If the endpoint is too slow, we could see the older nextQueries from the previous query on the current query. Let's ensure this won't happen resetting the nextQueries state whenever a user Accepts a query

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
Describe the purpose of the change, the specific changes done in detail, and the issue you have fixed.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
