### PR TITLE
feat: reset query field when UserBrowsedToCategory

### DIFF
--- a/packages/x-components/src/x-modules/ai/wiring.ts
+++ b/packages/x-components/src/x-modules/ai/wiring.ts
@@ -81,6 +81,10 @@ export const aiWiring = createWiring({
     resetAiQueryWire,
     resetSearchTotalResultsWire,
   },
+  UserBrowsedToCategory: {
+    resetAiQueryWire,
+    resetSearchTotalResultsWire,
+  },
   ResultsChanged: {
     setExcludedResultIdsWire,
   },

--- a/packages/x-components/src/x-modules/facets/wiring.ts
+++ b/packages/x-components/src/x-modules/facets/wiring.ts
@@ -142,6 +142,13 @@ const selectPreselectedFilterWire = wireFacetsService('selectPreselectedFilters'
 const setQuery = wireFacetsService('setQuery')
 
 /**
+ * Clear the facets state `query` .
+ *
+ * @public
+ */
+const clearQuery = wireFacetsService('setQuery', '')
+
+/**
  * Removes all the sticky filters from the state.
  *
  * @internal
@@ -224,6 +231,9 @@ export const facetsWiring = createWiring({
   UserClearedQuery: {
     clearAllFiltersButStickyWire,
     setQuery,
+  },
+  UserBrowsedToCategory: {
+    clearQuery,
   },
   UserClickedOpenX: {
     selectPreselectedFilterWire,

--- a/packages/x-components/src/x-modules/next-queries/wiring.ts
+++ b/packages/x-components/src/x-modules/next-queries/wiring.ts
@@ -162,6 +162,10 @@ export const nextQueriesWiring = createWiring({
     resetNextQueriesWire,
     resetNextQueriesQuery,
   },
+  UserBrowsedToCategory: {
+    resetNextQueriesWire,
+    resetNextQueriesQuery,
+  },
   SelectedRelatedTagsChanged: {
     setNextQueriesRelatedTags,
   },

--- a/packages/x-components/src/x-modules/query-suggestions/wiring.ts
+++ b/packages/x-components/src/x-modules/query-suggestions/wiring.ts
@@ -134,6 +134,10 @@ export const querySuggestionsWiring = createWiring({
     clearQuerySuggestionsQuery,
     cancelFetchAndSaveSuggestionsWire,
   },
+  UserBrowsedToCategory: {
+    clearQuerySuggestionsQuery,
+    cancelFetchAndSaveSuggestionsWire,
+  },
   QuerySuggestionsRequestUpdated: {
     fetchAndSaveSuggestionsWire,
   },

--- a/packages/x-components/src/x-modules/related-prompts/wiring.ts
+++ b/packages/x-components/src/x-modules/related-prompts/wiring.ts
@@ -25,6 +25,8 @@ const setExtraParams = wireCommit('setParams')
 
 /** Sets the related prompts state `query`. */
 const setRelatedPromptsQuery = wireCommit('setQuery')
+/** Sets the related prompts state `query` to a empty string. */
+const resetRelatedPromptsQuery = wireCommit('setQuery', '')
 /** Sets the related prompts state `query` from the payload. */
 const setRelatedPromptsQueryFromPreview = wireCommit(
   'setQuery',
@@ -77,6 +79,11 @@ export const relatedPromptsWiring = createWiring({
     cancelFetchAndSaveRelatedPrompts,
     resetRelatedPromptsState,
     setRelatedPromptsQuery,
+  },
+  UserBrowsedToCategory: {
+    cancelFetchAndSaveRelatedPrompts,
+    resetRelatedPromptsState,
+    resetRelatedPromptsQuery,
   },
   RelatedPromptsRequestUpdated: {
     fetchAndSaveRelatedPrompts,

--- a/packages/x-components/src/x-modules/related-tags/wiring.ts
+++ b/packages/x-components/src/x-modules/related-tags/wiring.ts
@@ -139,6 +139,11 @@ export const relatedTagsWiring = createWiring({
     clearRelatedTagsQuery,
     clearSelectedRelatedTags,
   },
+  UserBrowsedToCategory: {
+    cancelFetchAndSaveRelatedTagsWire,
+    clearRelatedTagsQuery,
+    clearSelectedRelatedTags,
+  },
   ExtraParamsChanged: {
     setRelatedTagsExtraParams,
   },

--- a/packages/x-components/src/x-modules/search-box/wiring.ts
+++ b/packages/x-components/src/x-modules/search-box/wiring.ts
@@ -102,6 +102,9 @@ export const searchBoxWiring = createWiring({
   UserClearedQuery: {
     transitionState: setInputStatus('UserClearedQuery'),
   },
+  UserBrowsedToCategory: {
+    transitionState: setInputStatus('UserClearedQuery'),
+  },
   UserFocusedSearchBox: {
     transitionState: setInputStatus('UserFocusedSearchBox'),
   },

--- a/packages/x-components/src/x-modules/url/wiring.ts
+++ b/packages/x-components/src/x-modules/url/wiring.ts
@@ -31,6 +31,13 @@ export const setUrlPrompt = wireCommit('setPrompt')
 export const setUrlQuery = wireCommit('setQuery')
 
 /**
+ * Sets to empathy string the query of the url module.
+ *
+ * @public
+ */
+export const resetUrlQuery = wireCommit('setQuery', '')
+
+/**
  * Sets the url state `query` with a selectedQueryPreview's query.
  *
  * @public
@@ -163,6 +170,7 @@ export const urlWiring = createWiring({
   },
   UserBrowsedToCategory: {
     setUrlBrowseCategory,
+    resetUrlQuery,
   },
   UserClickedCloseX: {
     resetUrlBrowseCategory,


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
<!--To help reviewers to understand the change you've made, you need to include **key information** in your PR.--> 
To make the stores of the modules consistent, when the browse mode (UserBrowsedToCategory) is activated, the search query defined in the different modules will be reset as if it had been deleted from the searchbox.

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [X] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
