### PR TITLE
chore: add debug logging for emitted events based on xdebug query param

### DIFF
--- a/packages/x-components/src/x-bus/x-bus.ts
+++ b/packages/x-components/src/x-bus/x-bus.ts
@@ -197,6 +197,11 @@ export class XPriorityBus<
 
           emitter.next(payloadObj)
 
+          if (this.isXDebugEnabled()) {
+            // eslint-disable-next-line no-console
+            console.debug('XEvent', key, payloadObj)
+          }
+
           this.emitCallbacks.forEach(callback => {
             callback(key, payloadObj)
           })
@@ -218,6 +223,21 @@ export class XPriorityBus<
   private clearPendingPopsIds(): void {
     this.pendingPopsIds.forEach(clearTimeout)
     this.pendingPopsIds.length = 0
+  }
+
+  /**
+   * Checks whether the `xdebug` query param is set to `true` in the current URL, to
+   * enable debug logging of the emitted events.
+   *
+   * @returns True if the `xdebug` query param is set to `true` in the URL.
+   *
+   * @internal
+   */
+  private isXDebugEnabled(): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      new URLSearchParams(window.location.search).get('xdebug') === 'true'
+    )
   }
 
   /**


### PR DESCRIPTION
<!--Please provide a general summary of changes in the PR title -->

# Pull request template
Add debug option to check emitted events

## Motivation and context
<!--Include information on the purpose of the change and any background information that may help. Why is this change required? What problem does it solve? -->

<!-- List any dependencies that are required for this change. If the change fixes an **open** issue, please link to the issue here.-->

- [ ] Dependencies. If any, specify:
- [ ] Open issue. If applicable, link:

## Type of change
<!-- Indicate the type of change involved in the PR -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Change requires a documentation update

## What is the destination branch of this PR?
<!-- Although this may seem obvious, please include the destination branch as an extra check to ensure your PR targets the right branch.-->
- [ ] `Main`
- [ ] Other. Specify:

## How has this been tested?

<!-- Please describe in detail how you tested your changes. Include details of your testing environment, the test cases used, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tests performed according to [testing guidelines](./contributing/tests.md): 

## Checklist:

- [ ] My code follows the **[style guidelines](./CONTRIBUTING.md#style-guides)** of this project.
- [ ] I have performed a **self-review** on my own code.
- [ ] I have **commented** my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the **[documentation](./CONTRIBUTING.md#documentation-style-guide)**.
- [ ] My changes generate **no new warnings**.
- [ ] I have added **tests** that prove my fix is effective or that my feature works.
- [ ] New and existing **unit tests pass locally** with my changes.
