### PR TITLE
feat(skills): add basic agent skills (skills-npm convention) to all publishable packages

### DIFF
--- a/packages/x-adapter-platform/package.json
+++ b/packages/x-adapter-platform/package.json
@@ -21,7 +21,8 @@
   "types": "dist/types/index.d.ts",
   "files": [
     "dist",
-    "report"
+    "report",
+    "skills"
   ],
   "engines": {
     "node": ">=22"

--- a/packages/x-adapter-platform/skills/x-adapter-platform/SKILL.md
+++ b/packages/x-adapter-platform/skills/x-adapter-platform/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: x-adapter-platform
+description: "Use when importing, using, or debugging components from x-adapter-platform."
+---
+
+# x-adapter-platform
+
+Adapter para la Empathy Platform API construido sobre `x-adapter`: contiene la configuración, mappers y schemas de los endpoints de la plataforma. Es el adapter por defecto usado en `x-archetype`.
+
+## Componentes disponibles
+
+- `platformAdapter` — objeto con todos los `EndpointAdapter` de la plataforma:
+  - `search` — búsqueda de resultados.
+  - `browse` — browsing sin query.
+  - `facets` — facets disponibles para la query.
+  - `popularSearches` — búsquedas populares.
+  - `recommendations` — productos más clicados.
+  - `nextQueries` — queries que suelen hacerse a continuación.
+  - `querySuggestions` — sugerencias de query.
+  - `relatedTags` — tags para refinar la query.
+  - `relatedPrompts` — prompts relacionados.
+  - `semanticQueries` — queries semánticas.
+  - `identifierResults` — búsqueda por identificador (SKU).
+  - `experienceControls` — experience controls del snippet.
+  - `aiSuggestions` / `aiSuggestionsSearch` — sugerencias AI.
+  - `tagging` — envío de eventos de métricas.
+- `resultSchema`, `facetsSchema`, etc. — `MutableSchemas` de request/response que se pueden modificar con `$extends`, `$override` y `$replace`.
+- `mapFilters`, `getFacetConfig`, `extractUrlParameters`, `getTaggingInfoFromUrl` — helpers de mapeo y utilidades.
+
+## Instalación
+
+```
+npm install @empathyco/x-adapter-platform
+```

--- a/packages/x-adapter-platform/skills/x-adapter-platform/SKILL.md
+++ b/packages/x-adapter-platform/skills/x-adapter-platform/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-adapter-platform
-description: "Use when importing, using, or debugging components from x-adapter-platform."
+description: 'Use when importing, using, or debugging components from x-adapter-platform.'
 ---
 
 # x-adapter-platform

--- a/packages/x-adapter/package.json
+++ b/packages/x-adapter/package.json
@@ -20,7 +20,8 @@
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "engines": {
     "node": ">=22"

--- a/packages/x-adapter/skills/x-adapter/SKILL.md
+++ b/packages/x-adapter/skills/x-adapter/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: x-adapter
+description: "Use when importing, using, or debugging components from x-adapter."
+---
+
+# x-adapter
+
+Librería de utilidades para crear un cliente de cualquier API: configura endpoints, mapea peticiones y respuestas (con o sin schemas) y reutiliza mappers.
+
+## Componentes disponibles
+
+- `endpointAdapterFactory` — crea un `EndpointAdapter` (función de petición) a partir de `endpoint`, `httpClient` y mappers.
+- `schemaMapperFactory` — genera mappers de petición/respuesta a partir de un `Schema` (dictcionario de paths o funciones).
+- `createMutableSchema` — crea un `MutableSchema` reutilizable con los métodos `$extends`, `$override` y `$replace`.
+- `identityMapper` / `combineMappers` — mappers auxiliares para identidad y composición.
+- `fetchHttpClient` / `fetchRawHttpClient` — clientes HTTP por defecto basados en la Fetch API.
+- `buildUrl` / `interpolate` — utilidades para construir URLs y parametrizar endpoints (`https://api/{id}`).
+
+## Instalación
+
+```
+npm install @empathyco/x-adapter
+```

--- a/packages/x-adapter/skills/x-adapter/SKILL.md
+++ b/packages/x-adapter/skills/x-adapter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-adapter
-description: "Use when importing, using, or debugging components from x-adapter."
+description: 'Use when importing, using, or debugging components from x-adapter.'
 ---
 
 # x-adapter

--- a/packages/x-archetype-utils/package.json
+++ b/packages/x-archetype-utils/package.json
@@ -19,7 +19,8 @@
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "engines": {
     "node": ">=22"

--- a/packages/x-archetype-utils/skills/x-archetype-utils/SKILL.md
+++ b/packages/x-archetype-utils/skills/x-archetype-utils/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-archetype-utils
-description: "Use when importing, using, or debugging components from x-archetype-utils."
+description: 'Use when importing, using, or debugging components from x-archetype-utils.'
 ---
 
 # x-archetype-utils

--- a/packages/x-archetype-utils/skills/x-archetype-utils/SKILL.md
+++ b/packages/x-archetype-utils/skills/x-archetype-utils/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: x-archetype-utils
+description: "Use when importing, using, or debugging components from x-archetype-utils."
+---
+
+# x-archetype-utils
+
+Utilidades para el desarrollo de `x-archetype`: configuración de builds (Rollup/webpack), inyección de CSS e i18n.
+
+## Componentes disponibles
+
+- `webpackConfig` — configuración base de webpack para x-archetype.
+- `rollupCssInjectorConfig` — configuración de Rollup con el CSS injector.
+- `CssInjector` / `cssInjector` — inyección de CSS en runtime.
+- `I18n` — clase de configuración de internacionalización (vue-i18n).
+
+## Instalación
+
+```
+npm install @empathyco/x-archetype-utils
+```

--- a/packages/x-components/build/rollup.config.ts
+++ b/packages/x-components/build/rollup.config.ts
@@ -99,7 +99,7 @@ export const rollupConfig: RollupOptions = {
     copy({
       targets: [
         { src: ['build/tools'], dest: buildPath },
-        { src: ['CHANGELOG.md', 'package.json', 'README.md', 'docs'], dest: buildPath },
+        { src: ['CHANGELOG.md', 'package.json', 'README.md', 'docs', 'skills'], dest: buildPath },
       ],
       hook: 'writeBundle',
     }),

--- a/packages/x-components/skills/x-components/SKILL.md
+++ b/packages/x-components/skills/x-components/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: x-components
+description: "Use when importing, using, or debugging components from x-components."
+---
+
+# x-components
+
+Biblioteca de componentes Vue 3 para combinar y crear tu propia experiencia de búsqueda (o cualquier otra interfaz). También se documenta en https://docs.empathy.co (build search UI → web x components).
+
+## Componentes disponibles
+
+- `AutoProgressBar` — barra de progreso automática para peticiones en curso.
+- `BaseDropdown` — dropdown reutilizable con items.
+- `BaseEventButton` — botón que emite eventos al hacer clic.
+- `BaseGrid` — grid para mostrar una lista de results.
+- `BaseKeyboardNavigation` — navegación por teclado dentro de un componente.
+- `BaseRating` — valoración tipo estrellas.
+- `BaseSlider` — slider (basado en noUiSlider) para rangos numéricos.
+- `BaseSwitch` — switch/toggle accesible.
+- `BaseTeleport` — wrapper para teleportar contenido.
+- `BaseVariableColumnGrid` — grid con número de columnas variable.
+- `BaseColumnPickerDropdown` / `BaseColumnPickerList` — selectores de columnas del grid.
+- `BaseCurrency` — formatea un precio en la divisa configurada.
+- `Highlight` — resalta el texto de una query dentro de un resultado.
+- `ItemsList` — lista básica de items (suggestions, etc.).
+- `Message` — mensaje de estado (loading, error, vacío).
+- `PageLoaderButton` — botón para cargar la siguiente página.
+- `PageSelector` — selector de página del paginador.
+- `SlidingPanel` — panel lateral deslizante.
+- `BaseTogglePanel` / `BaseHeaderTogglePanel` / `BaseTabsPanel` / `BaseIdTogglePanel` — paneles colapsables y por pestañas.
+- `BaseModal` / `MainModal` — modales con eventos de abrir/cerrar.
+- `SortDropdown` / `SortList` / `SortPickerList` — selectores de ordenación.
+- `BaseSuggestions` / `BaseSuggestion` — lista e item de sugerencias.
+- `BaseResult*` — piezas del resultado: `image`, `fallback-image`, `placeholder-image`, `current-price`, `previous-price`, `rating`, `link`, `add-to-cart`.
+- `ResultVariantSelector` / `ResultVariantsProvider` — selección de variantes de producto.
+- `BaseScroll` — scroll con estado de posición.
+- `SnippetCallbacks` — callbacks de ciclo de vida del snippet.
+- `LocationProvider` / `DisplayClickProvider` / `DisplayEmitter` — providers/emitter de contexto.
+- `GlobalXBus` — instancia global del X-Bus de eventos.
+- `Icons` — iconos SVG inline (search, cart, chevron, sort, etc.).
+- `Animations` — animaciones reutilizables (fade, cross-fade, collapse, staggered, etc.).
+
+## Instalación
+
+```
+npm install @empathyco/x-components
+```

--- a/packages/x-components/skills/x-components/SKILL.md
+++ b/packages/x-components/skills/x-components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-components
-description: "Use when importing, using, or debugging components from x-components."
+description: 'Use when importing, using, or debugging components from x-components.'
 ---
 
 # x-components

--- a/packages/x-design-system/package.json
+++ b/packages/x-design-system/package.json
@@ -20,7 +20,8 @@
     ".": "./index.css"
   },
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "engines": {
     "node": ">=22"

--- a/packages/x-design-system/skills/x-design-system/SKILL.md
+++ b/packages/x-design-system/skills/x-design-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-design-system
-description: "Use when importing, using, or debugging components from x-design-system."
+description: 'Use when importing, using, or debugging components from x-design-system.'
 ---
 
 # x-design-system

--- a/packages/x-design-system/skills/x-design-system/SKILL.md
+++ b/packages/x-design-system/skills/x-design-system/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: x-design-system
+description: "Use when importing, using, or debugging components from x-design-system."
+---
+
+# x-design-system
+
+Design system basado en Tailwind CSS v4 para construir interfaces de Empathy X consistentes y accesibles. Todas las utilidades usan el prefijo `xds:` para evitar conflictos.
+
+## Componentes disponibles
+
+Componentes pre-estilizados disponibles con la clase `xds:`:
+
+- Button — estilos de botón primary, secondary y tertiary.
+- Button Group — layouts de botones agrupados.
+- Badge — badges de estado y notificaciones.
+- Input — estilos de campos de texto.
+- Input Group — layouts de inputs agrupados.
+- Tag — tags eliminables y chips.
+- Icon — contenedor y sizing de iconos.
+- Picture — imagen responsive.
+- Typography — estilos de headings y texto.
+- Highlight — resaltado de texto.
+- Suggestion — items de sugerencia de búsqueda.
+- Suggestion Group — sugerencias agrupadas.
+- Filter Facet — componentes UI de filtrado.
+- Progress Bar — indicadores de carga y progreso.
+- Scroll — estilos de scrollbar.
+- Sliding Panel — panel lateral y drawer.
+- Attach — estilos de archivos adjuntos.
+- Layout — layouts de grid y contenedores.
+
+Además expone variables CSS de tema (`--xds-color-*`, `--xds-border-radius-*`, `--xds-font-size-*`...).
+
+## Instalación
+
+```
+npm install @empathyco/x-design-system
+```

--- a/packages/x-types/package.json
+++ b/packages/x-types/package.json
@@ -22,7 +22,8 @@
   "files": [
     "dist",
     "report",
-    "schemas"
+    "schemas",
+    "skills"
   ],
   "engines": {
     "node": ">=22"

--- a/packages/x-types/skills/x-types/SKILL.md
+++ b/packages/x-types/skills/x-types/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: x-types
+description: "Use when importing, using, or debugging components from x-types."
+---
+
+# x-types
+
+Tipos de modelo, type guards y schemas para usar de forma segura en el proyecto X. Define los contratos de datos (requests, responses, results, facets, filters, tagging...) que comparten los demás paquetes.
+
+## Componentes disponibles
+
+- Modelos de datos: `Result`, `Facet`, `Filter` (y sus variantes `SimpleFilter`, `HierarchicalFilter`, `BooleanFilter`, `NumberRangeFilter`, `EditableNumberRangeFilter`), `Suggestion`, `Query`, `NextQuery`, `RelatedTag`, `HistoryQuery`, `Banner`, `Sort`, `Tagging`/`Taggable`, requests y responses de cada endpoint.
+- Type guards: `isSimpleFilter`, `isHierarchicalFilter`, `isBooleanFilter`, `isNumberRangeFilter`, `isEditableNumberRangeFilter`, `isSimpleFacet`, `isHierarchicalFacet`, `isBooleanFacet`, `isNumberRangeFacet`, `isEditableNumberRangeFacet`, `isRawFilter`, `isFacetFilter`, etc.
+- Schemas de validación (submódulo `@empathyco/x-types/schemas`): `FilterSchema`, `FacetSchema`, `ResultSchema`, `RecommendationSchema`, `SuggestionSchema`, `RelatedTagSchema`, `TaggingSchema`, `NextQuerySchema`, etc., para validar objetos con Jest/Vitest.
+
+## Instalación
+
+```
+npm install @empathyco/x-types
+```

--- a/packages/x-types/skills/x-types/SKILL.md
+++ b/packages/x-types/skills/x-types/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-types
-description: "Use when importing, using, or debugging components from x-types."
+description: 'Use when importing, using, or debugging components from x-types.'
 ---
 
 # x-types

--- a/packages/x-utils/package.json
+++ b/packages/x-utils/package.json
@@ -19,7 +19,8 @@
   "types": "types/index.d.ts",
   "files": [
     "dist",
-    "types"
+    "types",
+    "skills"
   ],
   "engines": {
     "node": ">=22"

--- a/packages/x-utils/package.json
+++ b/packages/x-utils/package.json
@@ -19,8 +19,8 @@
   "types": "types/index.d.ts",
   "files": [
     "dist",
-    "types",
-    "skills"
+    "skills",
+    "types"
   ],
   "engines": {
     "node": ">=22"

--- a/packages/x-utils/skills/x-utils/SKILL.md
+++ b/packages/x-utils/skills/x-utils/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: x-utils
+description: "Use when importing, using, or debugging components from x-utils."
+---
+
+# x-utils
+
+Paquete de utilidades para el proyecto de búsqueda de Empathy: servicios de sesión y almacenamiento, y helpers para manipular objetos de forma segura.
+
+## Componentes disponibles
+
+- `DefaultSessionService` — servicio de sesión por defecto (implementa `SessionService`).
+- `BrowserStorageService` / `InMemoryStorageService` — implementaciones de `StorageService` para `localStorage` y memoria.
+- `deepMerge`, `replaceBehaviour`, `deepMergeBehaviour` — fusión profunda de objetos.
+- `forEach`, `reduce`, `map`, `cleanUndefined`, `cleanEmpty`, `objectFilter`, `every`, `flatObject`, `rename`, `deepEqual`, `getNewAndUpdatedKeys` — helpers de manipulación de objetos.
+- `getSafePropertyChain` — obtiene valores por path de forma segura.
+- `isArray`, `isFunction`, `isObject`, `isPath` — type guards.
+
+## Instalación
+
+```
+npm install @empathyco/x-utils
+```

--- a/packages/x-utils/skills/x-utils/SKILL.md
+++ b/packages/x-utils/skills/x-utils/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-utils
-description: "Use when importing, using, or debugging components from x-utils."
+description: 'Use when importing, using, or debugging components from x-utils.'
 ---
 
 # x-utils


### PR DESCRIPTION
## Summary

Adds **Agent Skills** (SKILL.md, [skills-npm](https://github.com/antfu/skills-npm) convention)
scaffolding to all 7 publishable packages, so consumers (Claude Code, Cursor, skilld,
skills-npm, ...) can pick them up straight from `node_modules` once the package is installed.

This is **scaffolding only** — minimal content (1-2 line description, available
components list, install command) based on each package's README/docs/exports.
Content will be iterated once the flow is proven end-to-end in a real client.
No `references/` folders, no "Best practices" / "API changes" sections yet.

## Changes

- `packages/<pkg>/skills/<pkg>/SKILL.md` for: x-components, x-adapter,
  x-adapter-platform, x-types, x-utils, x-archetype-utils, x-design-system
- `files: ["skills"]` added to each `package.json` (only key touched)
- **x-components special case**: it publishes from `dist/`
  (`publishConfig.directory`), and the build copies the root `package.json`
  into `dist/`. A `files` whitelist there would have **excluded all package
  code** (`js/`, `core/`, `types/`, ...) from the tarball (verified empirically
  with `npm pack`). Instead, `skills/` is copied into `dist/` at build time via
  `rollup-plugin-copy`, same mechanism already used for `docs/`.

## Verification

- `pnpm build` → `packages/x-components/empathyco-x-components-8.13.4.tgz`
  contains `package/skills/x-components/SKILL.md`
- `npm pack` in each other package → tarball contains `package/skills/<pkg>/SKILL.md`
- End-to-end in the `empathy-x` demo project:
  1. `npm run install:x-components:local` (installs the built tgz)
  2. `npx skilld add npm:@empathyco/x-components`
  3. `.claude/skills/x-components/SKILL.md` is linked and registered in
     `skilld-lock.yaml` with `source: shipped`; `skilld update` in the
     `prepare` hook keeps it in sync on subsequent installs

## Consuming the skills

Once the package is installed in a project, its skill lives at
`node_modules/@empathyco/<pkg>/skills/<pkg>/SKILL.md`. Consumers register it
with their tool of choice:

### skilld

```bash
# one-time registration (links the shipped skill into the agent's skills dir,
# e.g. .claude/skills/ — no LLM regeneration, no network)
npx skilld add npm:@empathyco/x-components

# keep it in sync; `skilld prepare` in the `prepare` hook already does this
# on every install, once the skill is in the lockfile
npx skilld update
```

### skills-npm (antfu)

```bash
npm i -D skills-npm
npx skills-npm setup
```

Discovers any skill following the skills-npm convention in `node_modules`
and exposes it to the configured agent.

Both work identically — the skill only needs to be present in the tarball
(guaranteed by the `files` array / dist copy in this PR).

## Test plan

- [x] `pnpm build` succeeds for all 7 packages
- [x] `npm pack` tarballs include `skills/` for the 6 root-published packages
- [x] x-components tarball (from build) includes `skills/` and still ships all
      its code (no `files` whitelist regression)
- [x] Consumer flow verified in `empathy-x` with skilld 2.1.0